### PR TITLE
fix: broadcast context handling and accurate response status codes

### DIFF
--- a/routes/fiber/routes.go
+++ b/routes/fiber/routes.go
@@ -127,9 +127,17 @@ func (r *Routes) handlePostTx(c *fiber.Ctx) error {
 		return r.handleSubmitError(c, err)
 	}
 
-	status.StatusCode = http.StatusOK
-	status.Title = "OK"
-	return c.JSON(status)
+	// Preserve the StatusCode set by the service (which reflects the actual
+	// broadcast outcome — 2xx for success, 4xx for rejection, 5xx for service
+	// failure). Mirror it to the HTTP response so downstream consumers can
+	// distinguish success from failure without parsing txStatus.
+	if status.StatusCode == 0 {
+		status.StatusCode = http.StatusOK
+	}
+	if status.Title == "" {
+		status.Title = defaultTitleForStatus(status.Status)
+	}
+	return c.Status(status.StatusCode).JSON(status)
 }
 
 // handlePostTxs submits multiple transactions
@@ -175,11 +183,40 @@ func (r *Routes) handlePostTxs(c *fiber.Ctx) error {
 		return r.handleSubmitError(c, err)
 	}
 
+	// Per-tx StatusCode is preserved from the service so each entry in the
+	// array reflects its own outcome. The HTTP envelope itself stays 200 —
+	// the batch request succeeded, per-tx results are inside.
 	for _, s := range statuses {
-		s.StatusCode = http.StatusOK
-		s.Title = "OK"
+		if s.StatusCode == 0 {
+			s.StatusCode = http.StatusOK
+		}
+		if s.Title == "" {
+			s.Title = defaultTitleForStatus(s.Status)
+		}
 	}
 	return c.JSON(statuses)
+}
+
+// defaultTitleForStatus returns a human-readable title for a tx outcome when
+// the service did not set one. Used as a fallback so clients see something
+// meaningful in the response Title field.
+func defaultTitleForStatus(s models.Status) string {
+	switch s {
+	case models.StatusMined, models.StatusImmutable, models.StatusSeenOnNetwork,
+		models.StatusAcceptedByNetwork, models.StatusSentToNetwork,
+		models.StatusReceived:
+		return "OK"
+	case models.StatusRejected:
+		return "Transaction rejected"
+	case models.StatusDoubleSpendAttempted:
+		return "Double spend attempted"
+	case models.StatusServiceError:
+		return "Service error"
+	case models.StatusUnknown:
+		return "Unknown"
+	default:
+		return string(s)
+	}
 }
 
 // handleSubmitError returns an appropriate HTTP response for transaction submission errors.

--- a/service/embedded/embedded.go
+++ b/service/embedded/embedded.go
@@ -211,8 +211,7 @@ func (e *Embedded) SubmitTransaction(ctx context.Context, rawTx []byte, opts *mo
 		slog.Duration("timeout", 15*time.Second),
 	)
 	resultCh := make(chan *models.TransactionStatus, len(endpoints))
-	submitCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
+	broadcastCtx, broadcastCancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 
 	broadcastStart := time.Now()
 	var wg sync.WaitGroup
@@ -221,7 +220,7 @@ func (e *Embedded) SubmitTransaction(ctx context.Context, rawTx []byte, opts *mo
 		go func(ep string) {
 			defer wg.Done()
 			epStart := time.Now()
-			status := e.submitToTeranodeSync(submitCtx, ep, tx.Bytes(), txid)
+			status := e.submitToTeranodeSync(broadcastCtx, ep, tx.Bytes(), txid)
 			if status != nil {
 				e.logger.Debug("endpoint responded",
 					slog.String("txid", txid),
@@ -230,80 +229,62 @@ func (e *Embedded) SubmitTransaction(ctx context.Context, rawTx []byte, opts *mo
 					slog.Duration("elapsed", time.Since(epStart)),
 				)
 			}
-			select {
-			case resultCh <- status:
-			case <-submitCtx.Done():
-				return
-			}
+			resultCh <- status
 		}(endpoint)
 	}
 
-	// Close channel when all goroutines complete
+	// Clean up when all goroutines complete
 	go func() {
 		wg.Wait()
+		broadcastCancel()
 		close(resultCh)
 	}()
 
 	// Collect results:
-	// - Success (ACCEPTED/SENT): return immediately
+	// - Success (ACCEPTED/SENT): return immediately, goroutines continue propagating
 	// - Rejected (4xx): return immediately, tx is invalid
 	// - Service error (5xx): wait for other endpoints
-	// - All service errors / timeout: return last error
+	// - All failed: return last error
 	var lastError *models.TransactionStatus
-	for {
-		select {
-		case status, ok := <-resultCh:
-			if !ok {
-				// All endpoints responded, none succeeded
-				if lastError == nil {
-					lastError, _ = e.store.GetStatus(ctx, txid)
-				}
-				e.logger.Debug("broadcast failed on all endpoints",
-					slog.String("txid", txid),
-					slog.String("status", string(lastError.Status)),
-					slog.Duration("elapsed", time.Since(broadcastStart)),
-				)
-				e.applyBroadcastResult(ctx, txid, lastError)
-				return lastError, nil
-			}
-			if status == nil {
-				continue
-			}
-			switch status.Status {
-			case models.StatusAcceptedByNetwork, models.StatusSentToNetwork:
-				e.logger.Debug("broadcast complete",
-					slog.String("txid", txid),
-					slog.String("status", string(status.Status)),
-					slog.Duration("elapsed", time.Since(broadcastStart)),
-				)
-				e.applyBroadcastResult(ctx, txid, status)
-				return status, nil
-			case models.StatusRejected:
-				e.logger.Debug("transaction rejected by network",
-					slog.String("txid", txid),
-					slog.Duration("elapsed", time.Since(broadcastStart)),
-				)
-				e.applyBroadcastResult(ctx, txid, status)
-				return status, nil
-			case models.StatusServiceError:
-				lastError = status
-			case models.StatusUnknown, models.StatusReceived, models.StatusSeenOnNetwork,
-				models.StatusDoubleSpendAttempted, models.StatusMined, models.StatusImmutable:
-				lastError = status
-			}
-		case <-submitCtx.Done():
-			if lastError == nil {
-				lastError, _ = e.store.GetStatus(ctx, txid)
-			}
-			e.logger.Warn("broadcast timeout",
+	for status := range resultCh {
+		if status == nil {
+			continue
+		}
+		switch status.Status {
+		case models.StatusAcceptedByNetwork, models.StatusSentToNetwork:
+			e.logger.Debug("broadcast complete",
 				slog.String("txid", txid),
-				slog.Int("endpoints", len(endpoints)),
+				slog.String("status", string(status.Status)),
 				slog.Duration("elapsed", time.Since(broadcastStart)),
 			)
-			e.applyBroadcastResult(ctx, txid, lastError)
-			return lastError, nil
+			e.applyBroadcastResult(ctx, txid, status)
+			return status, nil
+		case models.StatusRejected:
+			e.logger.Debug("transaction rejected by network",
+				slog.String("txid", txid),
+				slog.Duration("elapsed", time.Since(broadcastStart)),
+			)
+			e.applyBroadcastResult(ctx, txid, status)
+			return status, nil
+		case models.StatusServiceError:
+			lastError = status
+		case models.StatusUnknown, models.StatusReceived, models.StatusSeenOnNetwork,
+			models.StatusDoubleSpendAttempted, models.StatusMined, models.StatusImmutable:
+			lastError = status
 		}
 	}
+
+	// All endpoints responded, none succeeded
+	if lastError == nil {
+		lastError, _ = e.store.GetStatus(ctx, txid)
+	}
+	e.logger.Debug("broadcast failed on all endpoints",
+		slog.String("txid", txid),
+		slog.String("status", string(lastError.Status)),
+		slog.Duration("elapsed", time.Since(broadcastStart)),
+	)
+	e.applyBroadcastResult(ctx, txid, lastError)
+	return lastError, nil
 }
 
 // SubmitTransactions submits multiple transactions for broadcast.
@@ -410,10 +391,6 @@ func (e *Embedded) SubmitTransactions(ctx context.Context, rawTxs [][]byte, opts
 		txInfos = append(txInfos, txInfo{tx: tx, rawTx: rawTx, txid: txid, isNew: isNew, status: existingStatus})
 	}
 
-	// Submit all to teranode synchronously with timeout
-	submitCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-
 	var responses []*models.TransactionStatus
 	for _, info := range txInfos {
 		// Skip rebroadcast if already confirmed on network or rejected
@@ -433,22 +410,20 @@ func (e *Embedded) SubmitTransactions(ctx context.Context, rawTxs [][]byte, opts
 
 		endpoints := e.teranodeClient.GetEndpoints()
 		resultCh := make(chan *models.TransactionStatus, len(endpoints))
+		broadcastCtx, broadcastCancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 		var wg sync.WaitGroup
 		for _, endpoint := range endpoints {
 			wg.Add(1)
 			go func(ep string) {
 				defer wg.Done()
-				status := e.submitToTeranodeSync(submitCtx, ep, rawTx, info.txid)
-				select {
-				case resultCh <- status:
-				case <-submitCtx.Done():
-					return
-				}
+				status := e.submitToTeranodeSync(broadcastCtx, ep, rawTx, info.txid)
+				resultCh <- status
 			}(endpoint)
 		}
 
 		go func() {
 			wg.Wait()
+			broadcastCancel()
 			close(resultCh)
 		}()
 
@@ -557,6 +532,15 @@ func (e *Embedded) submitToTeranodeSync(ctx context.Context, endpoint string, ra
 		if statusCode >= 400 && statusCode < 500 {
 			status = models.StatusRejected
 		}
+		// Map missing HTTP status to appropriate code
+		switch {
+		case statusCode != 0:
+			// pass through actual HTTP status
+		case ctx.Err() != nil:
+			statusCode = http.StatusGatewayTimeout
+		default:
+			statusCode = http.StatusServiceUnavailable
+		}
 		e.logger.Debug("endpoint broadcast failed",
 			slog.String("txid", txid),
 			slog.String("endpoint", endpoint),
@@ -565,10 +549,11 @@ func (e *Embedded) submitToTeranodeSync(ctx context.Context, endpoint string, ra
 			slog.String("error", err.Error()),
 		)
 		return &models.TransactionStatus{
-			TxID:      txid,
-			Status:    status,
-			Timestamp: time.Now(),
-			ExtraInfo: err.Error(),
+			TxID:       txid,
+			Status:     status,
+			StatusCode: statusCode,
+			Timestamp:  time.Now(),
+			ExtraInfo:  err.Error(),
 		}
 	}
 
@@ -588,8 +573,9 @@ func (e *Embedded) submitToTeranodeSync(ctx context.Context, endpoint string, ra
 	}
 
 	return &models.TransactionStatus{
-		TxID:      txid,
-		Status:    txStatus,
-		Timestamp: time.Now(),
+		TxID:       txid,
+		Status:     txStatus,
+		StatusCode: http.StatusOK,
+		Timestamp:  time.Now(),
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the broadcast pipeline so the Fiber route response actually reflects what happened upstream, rather than always claiming HTTP 200 / \"OK\". Two related commits on this branch:

1. **`f568353` — broadcast context and StatusCode at construction** *(prior commit)*
   - Detaches broadcast goroutines from request context so client disconnect doesn't cancel in-flight broadcasts
   - Sets `TransactionStatus.StatusCode` in `submitToTeranodeSync`: pass-through teranode HTTP codes, 503 on network failure, 504 on timeout

2. **`f85be2e` — preserve service-set StatusCode/Title in route handlers**
   - `handlePostTx` no longer overwrites `StatusCode` to 200 and `Title` to \"OK\". The body's `StatusCode` is preserved (already correctly set at construction by the prior commit) and mirrored to the HTTP response status.
   - `handlePostTxs` preserves per-tx `StatusCode` inside the response array; HTTP envelope stays 200 (batch request itself succeeded; per-tx outcomes are inside).
   - Adds `defaultTitleForStatus` to fill `Title` with a human-readable string derived from `txStatus` when the service didn't set one.

## Why

Currently every response — including SERVICE_ERROR and REJECTED — comes back wrapped as HTTP 200 with body `status: 200, title: \"OK\"`. Downstream consumers like go-sdk's Arc broadcaster check \`response.Status == 200\` to determine success, so they treat broken-broadcast outcomes as accepted. That cascade burned us in BSV21 deploy testing where a teranode-rejected tx was reported as successful through every layer until manual investigation.

After this PR:
- ARC-compatible broadcasters (which already check `txStatus == REJECTED` and `Status == 200`) classify outcomes correctly.
- Operators tailing logs / curl-checking endpoints see real status codes.
- HTTP-status-aware infra (load balancers, monitoring) can distinguish success from failure without parsing JSON.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all passing)
- [ ] End-to-end with go-sdk Arc broadcaster against a running arcade instance: confirm SERVICE_ERROR and REJECTED come back as failure
- [ ] Sanity-check the batch endpoint preserves per-tx outcomes