### PR TITLE
fix(ci): disable Nancy until OSS Index credentials are configured

### DIFF
--- a/.github/env/00-core.env
+++ b/.github/env/00-core.env
@@ -87,7 +87,12 @@ ENABLE_YAML_LINT=true
 # Security Scanning
 ENABLE_SECURITY_SCAN_GITLEAKS=true
 ENABLE_SECURITY_SCAN_GOVULNCHECK=true
-ENABLE_SECURITY_SCAN_NANCY=true
+# Nancy is disabled because Sonatype's OSS Index now requires authentication
+# and returns 402 Payment Required for unauthenticated requests. Re-enable
+# once OSSI_USERNAME and OSSI_TOKEN repository secrets are configured (see
+# fortress-security-scans.yml ask-nancy job which already wires them in).
+# Go dependency vulnerabilities are still covered by govulncheck above.
+ENABLE_SECURITY_SCAN_NANCY=false
 
 # Documentation & Publishing
 ENABLE_GODOCS_PUBLISHING=true


### PR DESCRIPTION
## Summary
Nancy is currently failing on every PR (and on `main`) with `[402 Payment Required] error accessing OSS Index`. Sonatype's OSS Index now requires an authenticated account; the unauthenticated rate limit returns 402.

The `ask-nancy` job in `fortress-security-scans.yml` already wires `OSSI_USERNAME` / `OSSI_TOKEN` secrets (lines 150-151), but those secrets aren't configured in this repo (only `CODECOV_TOKEN` exists), so the scan can't run.

This change flips `ENABLE_SECURITY_SCAN_NANCY=false` so PRs stop failing on a CI gate that has no path to passing. **govulncheck** stays enabled and covers Go-dependency vulnerabilities, so the dependency-security posture is preserved.

## How to re-enable
1. Register a free account at https://ossindex.sonatype.org/
2. Add `OSSI_USERNAME` and `OSSI_TOKEN` as repository secrets
3. Flip `ENABLE_SECURITY_SCAN_NANCY` back to `true` in `.github/env/00-core.env`

## Test plan
- [x] Diff is a single env-var flip with an explanatory comment
- [ ] CI passes on this PR (the new value applies to this PR's own run, so Nancy should now skip)
- [ ] After merge, rebase open PRs (#101) and confirm Nancy no longer blocks

Unblocks auto-merge for the open code-review remediation PRs.