### PR TITLE
fix(config): allow empty merkle_service.url for standalone profiles (#59)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -509,9 +509,13 @@ func validate(cfg *Config) error {
 	default:
 		return fmt.Errorf("unknown store.backend %q (expected aerospike, pebble, or postgres)", cfg.Store.Backend)
 	}
-	if cfg.MerkleService.URL == "" {
-		return fmt.Errorf("merkle_service.url is required")
-	}
+	// merkle_service.url is intentionally optional: an empty value means the
+	// Merkle integration is disabled. The runtime treats URL-presence as the
+	// toggle — cmd/arcade/main.go only constructs a merkleservice.Client when
+	// the URL is set, and propagation.Propagator nil-guards every dereference
+	// of the client. The documented standalone and zero-dependency profiles
+	// (config.example.standalone.yaml) ship with merkle_service.url: "" for
+	// exactly this reason. See issue #59 / finding F-001.
 	if cfg.Network == "" {
 		cfg.Network = NetworkMainnet
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,19 +18,28 @@ func baseValidConfig() *Config {
 	return cfg
 }
 
-// merkle_service.url is mandatory: the merkle service is always enabled, and
-// startup with an unconfigured URL would silently produce a nil client and
-// fail later in obscure ways. Catching it at config load surfaces the misconfig
-// immediately.
-func TestValidate_RequiresMerkleServiceURL(t *testing.T) {
+// merkle_service.url is optional: URL-presence is the runtime toggle for the
+// Merkle integration. cmd/arcade/main.go only constructs a merkleservice.Client
+// when the URL is set, and propagation nil-guards every dereference. The
+// documented standalone profile ships with merkle_service.url: "" — validation
+// must accept that, otherwise the standalone binary refuses to start (issue #59
+// / finding F-001).
+func TestValidate_AllowsEmptyMerkleServiceURL(t *testing.T) {
 	cfg := baseValidConfig()
 	cfg.MerkleService.URL = ""
-	err := validate(cfg)
-	if err == nil {
-		t.Fatal("expected error when merkle_service.url is unset")
+	if err := validate(cfg); err != nil {
+		t.Fatalf("empty merkle_service.url should be accepted, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "merkle_service.url") {
-		t.Errorf("error should mention merkle_service.url, got: %v", err)
+}
+
+// A populated merkle_service.url is the production path and must continue to
+// validate cleanly so the "set the URL to enable Merkle" toggle stays symmetric
+// with the empty-URL case above.
+func TestValidate_AcceptsPopulatedMerkleServiceURL(t *testing.T) {
+	cfg := baseValidConfig()
+	cfg.MerkleService.URL = "http://merkle.local"
+	if err := validate(cfg); err != nil {
+		t.Fatalf("populated merkle_service.url should be accepted, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The unconditional `merkle_service.url is required` validation in `config.validate` blocked the documented standalone and zero-dependency configs (`config.example.standalone.yaml`), which intentionally ship with `merkle_service.url: ""` because they don't construct a Merkle client.
- Fix shape: dropped the requirement (Shape 2). URL-presence already serves as the runtime toggle — `cmd/arcade/main.go` only constructs a `merkleservice.Client` when the URL is non-empty (`main.go:127-131`), and `services/propagation/propagator.go:263` nil-guards every dereference (`if p.merkleClient != nil && p.cfg.CallbackURL != "" { ... }`). Existing tests `TestProcessBatch_NilMerkleClient_SkipsRegistration` and `TestHandleMessage_NoMerkleClient_SkipsRegistration` already lock in the nil-client behaviour at runtime, so no runtime changes were needed.
- Inverted the now-stale `TestValidate_RequiresMerkleServiceURL` regression into `TestValidate_AllowsEmptyMerkleServiceURL` and added `TestValidate_AcceptsPopulatedMerkleServiceURL` for the populated-URL sanity case.
- Replaced the validation with a comment explaining the URL-presence-as-toggle contract so a future contributor doesn't reintroduce it.

Closes #59

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./config/... -count=1 -race`
- [x] `golangci-lint run ./config/...` (0 issues)
- [ ] Reviewer sanity check: confirm no runtime path will dereference an empty Merkle URL. The only call site is `services/propagation/propagator.go:263` and it is already nil-guarded; the standalone example configs (`config.example.yaml` and `config.example.standalone.yaml`) both already document `merkle_service.url: ""`, so no doc changes were required.