### PR TITLE
fix(store): protect terminal transaction statuses from overwrite (#61)

### DIFF
--- a/models/transaction.go
+++ b/models/transaction.go
@@ -84,21 +84,124 @@ const (
 	StatusImmutable = Status("IMMUTABLE")
 )
 
-// DisallowedPreviousStatuses returns statuses that CANNOT transition to this status
-// Used in UPDATE queries to prevent invalid status transitions
+// terminalStatuses lists statuses that represent a final outcome for a
+// transaction. A row already in one of these states must never be overwritten
+// by a lower-priority update (e.g. a late SEEN_ON_NETWORK callback arriving
+// after MINED). The only allowed transition out of a terminal status is the
+// MINED → IMMUTABLE promotion handled explicitly by CanTransitionFrom.
+var terminalStatuses = map[Status]struct{}{
+	StatusRejected:             {},
+	StatusDoubleSpendAttempted: {},
+	StatusMined:                {},
+	StatusImmutable:            {},
+}
+
+// IsTerminal reports whether this status is a final outcome that should not be
+// overwritten by later, lower-priority updates.
+func (s Status) IsTerminal() bool {
+	_, ok := terminalStatuses[s]
+	return ok
+}
+
+// DisallowedPreviousStatuses returns statuses that CANNOT transition to this status.
+// Used by stores' UpdateStatus implementations (and CanTransitionFrom) to prevent
+// invalid status transitions — most importantly, to prevent terminal statuses
+// (MINED, IMMUTABLE, REJECTED, DOUBLE_SPEND_ATTEMPTED) from being silently
+// overwritten by a later, lower-priority update such as SEEN_ON_NETWORK.
 func (s Status) DisallowedPreviousStatuses() []Status {
 	switch s {
 	case StatusUnknown, StatusReceived:
-		return []Status{}
+		// Going back to UNKNOWN/RECEIVED is never valid once the tx has any
+		// further status — only an initial insert should set these.
+		return []Status{
+			StatusSentToNetwork, StatusAcceptedByNetwork,
+			StatusSeenOnNetwork, StatusSeenMultipleNodes,
+			StatusPendingRetry, StatusStumpProcessing,
+			StatusRejected, StatusDoubleSpendAttempted,
+			StatusMined, StatusImmutable,
+		}
 	case StatusSentToNetwork:
-		return []Status{StatusSentToNetwork, StatusAcceptedByNetwork, StatusSeenOnNetwork, StatusSeenMultipleNodes, StatusRejected, StatusPendingRetry, StatusDoubleSpendAttempted, StatusMined}
+		// PENDING_RETRY → SENT_TO_NETWORK is the reaper republishing a retry-
+		// queued tx, so it must be allowed; everything to the right of
+		// SENT_TO_NETWORK in the forward order is a regression.
+		return []Status{
+			StatusSentToNetwork, StatusAcceptedByNetwork,
+			StatusSeenOnNetwork, StatusSeenMultipleNodes,
+			StatusRejected, StatusDoubleSpendAttempted,
+			StatusMined, StatusImmutable,
+		}
 	case StatusAcceptedByNetwork:
-		return []Status{StatusAcceptedByNetwork, StatusSeenOnNetwork, StatusSeenMultipleNodes, StatusRejected, StatusDoubleSpendAttempted, StatusMined}
-	case StatusSeenOnNetwork, StatusSeenMultipleNodes, StatusRejected, StatusDoubleSpendAttempted, StatusMined, StatusImmutable, StatusPendingRetry, StatusStumpProcessing:
+		return []Status{
+			StatusAcceptedByNetwork,
+			StatusSeenOnNetwork, StatusSeenMultipleNodes,
+			StatusRejected, StatusDoubleSpendAttempted,
+			StatusMined, StatusImmutable,
+		}
+	case StatusSeenOnNetwork:
+		// SEEN_ON_NETWORK is a forward step from earlier states only — once a
+		// tx has progressed to SEEN_MULTIPLE_NODES, a terminal state, or is in
+		// the retry side-branch it must not regress to SEEN_ON_NETWORK.
+		return []Status{
+			StatusSeenOnNetwork, StatusSeenMultipleNodes,
+			StatusPendingRetry,
+			StatusRejected, StatusDoubleSpendAttempted,
+			StatusMined, StatusImmutable,
+		}
+	case StatusSeenMultipleNodes:
+		return []Status{
+			StatusSeenMultipleNodes,
+			StatusPendingRetry,
+			StatusRejected, StatusDoubleSpendAttempted,
+			StatusMined, StatusImmutable,
+		}
+	case StatusPendingRetry:
+		// PENDING_RETRY is only valid for txs that are still in flight — never
+		// from a terminal state, and never from an already-confirmed state.
+		return []Status{
+			StatusSeenOnNetwork, StatusSeenMultipleNodes,
+			StatusRejected, StatusDoubleSpendAttempted,
+			StatusMined, StatusImmutable,
+		}
+	case StatusStumpProcessing:
+		// STUMP_PROCESSING relates to mined-block bump building. It is only
+		// meaningful for in-flight txs; once a tx is terminal it must not be
+		// pushed back into STUMP_PROCESSING.
+		return []Status{
+			StatusRejected, StatusDoubleSpendAttempted,
+			StatusMined, StatusImmutable,
+		}
+	case StatusRejected, StatusDoubleSpendAttempted:
+		// Rejection paths can override any non-terminal in-flight state, but
+		// must not be able to clobber an already-confirmed (MINED/IMMUTABLE)
+		// transaction.
+		return []Status{StatusMined, StatusImmutable}
+	case StatusMined:
+		// MINED can be set from any in-flight state, but a transient miner-
+		// reorg-style regression must not pull a tx out of IMMUTABLE.
+		return []Status{StatusImmutable}
+	case StatusImmutable:
+		// IMMUTABLE is the highest-priority sink — reachable from anything.
 		return []Status{}
 	default:
 		return []Status{}
 	}
+}
+
+// CanTransitionFrom reports whether moving from prev → s is allowed by the
+// status lattice. An empty prev (i.e. no existing row) is always allowed —
+// the very first write for a txid bypasses the lattice. Re-asserting the same
+// status (prev == s) is also allowed: it is an idempotent no-op for callers
+// that may receive duplicate callbacks.
+func (s Status) CanTransitionFrom(prev Status) bool {
+	if prev == "" || prev == s {
+		return true
+	}
+	for _, banned := range s.DisallowedPreviousStatuses() {
+		if banned == prev {
+			return false
+		}
+	}
+	return true
 }
 
 // Submission represents a client's submission and subscription preferences

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -1,0 +1,134 @@
+package models
+
+import "testing"
+
+// TestStatus_IsTerminal pins the set of statuses that the system treats as
+// terminal — i.e. statuses that callers must not silently overwrite with a
+// later lower-priority update.
+func TestStatus_IsTerminal(t *testing.T) {
+	cases := []struct {
+		s    Status
+		want bool
+	}{
+		{StatusUnknown, false},
+		{StatusReceived, false},
+		{StatusSentToNetwork, false},
+		{StatusAcceptedByNetwork, false},
+		{StatusSeenOnNetwork, false},
+		{StatusSeenMultipleNodes, false},
+		{StatusPendingRetry, false},
+		{StatusStumpProcessing, false},
+		{StatusRejected, true},
+		{StatusDoubleSpendAttempted, true},
+		{StatusMined, true},
+		{StatusImmutable, true},
+	}
+	for _, c := range cases {
+		if got := c.s.IsTerminal(); got != c.want {
+			t.Errorf("IsTerminal(%s) = %v, want %v", c.s, got, c.want)
+		}
+	}
+}
+
+// TestStatus_CanTransitionFrom_TerminalStaysTerminal is the regression for
+// F-003: once a tx is MINED/IMMUTABLE/REJECTED/DOUBLE_SPEND_ATTEMPTED, no
+// in-flight status update may regress it.
+func TestStatus_CanTransitionFrom_TerminalStaysTerminal(t *testing.T) {
+	terminals := []Status{
+		StatusRejected,
+		StatusDoubleSpendAttempted,
+		StatusMined,
+		StatusImmutable,
+	}
+	regressions := []Status{
+		StatusUnknown,
+		StatusReceived,
+		StatusSentToNetwork,
+		StatusAcceptedByNetwork,
+		StatusSeenOnNetwork,
+		StatusSeenMultipleNodes,
+		StatusPendingRetry,
+		StatusStumpProcessing,
+	}
+	for _, prev := range terminals {
+		for _, next := range regressions {
+			if next.CanTransitionFrom(prev) {
+				t.Errorf("regression allowed: %s → %s should be rejected", prev, next)
+			}
+		}
+	}
+}
+
+// TestStatus_CanTransitionFrom_Immutable verifies IMMUTABLE is a true sink:
+// every other status (including MINED and the other terminals) must fail to
+// overwrite it.
+func TestStatus_CanTransitionFrom_Immutable(t *testing.T) {
+	all := []Status{
+		StatusUnknown, StatusReceived, StatusSentToNetwork,
+		StatusAcceptedByNetwork, StatusSeenOnNetwork, StatusSeenMultipleNodes,
+		StatusPendingRetry, StatusStumpProcessing,
+		StatusRejected, StatusDoubleSpendAttempted, StatusMined,
+	}
+	for _, next := range all {
+		if next.CanTransitionFrom(StatusImmutable) {
+			t.Errorf("IMMUTABLE → %s must be rejected", next)
+		}
+	}
+	// IMMUTABLE → IMMUTABLE is an idempotent no-op and must be allowed.
+	if !StatusImmutable.CanTransitionFrom(StatusImmutable) {
+		t.Errorf("IMMUTABLE → IMMUTABLE must be allowed (idempotent)")
+	}
+}
+
+// TestStatus_CanTransitionFrom_HappyPath spot-checks the forward edges that
+// the propagation/api_server/tracker code paths actually rely on.
+func TestStatus_CanTransitionFrom_HappyPath(t *testing.T) {
+	allowed := []struct {
+		prev, next Status
+	}{
+		{"", StatusReceived},                              // initial insert
+		{StatusReceived, StatusSentToNetwork},             // propagation broadcast
+		{StatusSentToNetwork, StatusAcceptedByNetwork},    // datahub ack
+		{StatusAcceptedByNetwork, StatusSeenOnNetwork},    // p2p inv
+		{StatusSeenOnNetwork, StatusSeenMultipleNodes},    // 2nd peer
+		{StatusSeenMultipleNodes, StatusMined},            // mined notification
+		{StatusMined, StatusImmutable},                    // confirmation depth
+		{StatusSentToNetwork, StatusRejected},             // datahub reject
+		{StatusSeenOnNetwork, StatusDoubleSpendAttempted}, // double-spend detected
+		{StatusSentToNetwork, StatusPendingRetry},         // retryable failure
+		{StatusPendingRetry, StatusSentToNetwork},         // reaper retry
+		{StatusReceived, StatusReceived},                  // idempotent dup
+		{StatusMined, StatusMined},                        // idempotent dup
+	}
+	for _, c := range allowed {
+		if !c.next.CanTransitionFrom(c.prev) {
+			t.Errorf("forward transition wrongly rejected: %s → %s", c.prev, c.next)
+		}
+	}
+}
+
+// TestStatus_CanTransitionFrom_Regressions covers the specific scenario
+// flagged by F-003 plus a few sibling cases.
+func TestStatus_CanTransitionFrom_Regressions(t *testing.T) {
+	regressions := []struct {
+		prev, next Status
+		reason     string
+	}{
+		{StatusMined, StatusSeenOnNetwork, "F-003: late SEEN callback after MINED"},
+		{StatusMined, StatusSeenMultipleNodes, "F-003: late SEEN_MULTIPLE callback after MINED"},
+		{StatusMined, StatusPendingRetry, "delayed retry attempt after MINED"},
+		{StatusMined, StatusRejected, "late rejection after MINED"},
+		{StatusImmutable, StatusMined, "MINED must not pull tx out of IMMUTABLE"},
+		{StatusImmutable, StatusSeenOnNetwork, "late SEEN after IMMUTABLE"},
+		{StatusRejected, StatusSeenOnNetwork, "late SEEN after REJECTED"},
+		{StatusRejected, StatusSentToNetwork, "republish after REJECTED"},
+		{StatusDoubleSpendAttempted, StatusSeenOnNetwork, "late SEEN after DOUBLE_SPEND_ATTEMPTED"},
+		{StatusSeenMultipleNodes, StatusSeenOnNetwork, "single-peer downgrade"},
+		{StatusAcceptedByNetwork, StatusSentToNetwork, "regress to pre-ack state"},
+	}
+	for _, c := range regressions {
+		if c.next.CanTransitionFrom(c.prev) {
+			t.Errorf("%s: %s → %s should be rejected", c.reason, c.prev, c.next)
+		}
+	}
+}

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	aero "github.com/aerospike/aerospike-client-go/v7"
+	"github.com/aerospike/aerospike-client-go/v7/types"
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/transaction"
 
@@ -21,6 +22,26 @@ import (
 
 func isKeyNotFound(err error) bool {
 	return errors.Is(err, aero.ErrKeyNotFound)
+}
+
+// isGenerationErr is true when an Aerospike write fails because the record was
+// modified between our read and our CAS write (EXPECT_GEN_EQUAL mismatch).
+func isGenerationErr(err error) bool {
+	var aerr aero.Error
+	if errors.As(err, &aerr) {
+		return aerr.Matches(types.GENERATION_ERROR)
+	}
+	return false
+}
+
+// isKeyExistsErr is true when an Aerospike CREATE_ONLY write fails because
+// another writer raced us in and the record now exists.
+func isKeyExistsErr(err error) bool {
+	var aerr aero.Error
+	if errors.As(err, &aerr) {
+		return aerr.Matches(types.KEY_EXISTS_ERROR)
+	}
+	return false
 }
 
 const (
@@ -350,7 +371,44 @@ func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStat
 		bins["merkle_path"] = []byte(status.MerklePath)
 	}
 
-	return s.client.Put(s.writePolicy(ctx), key, bins)
+	// Enforce the status lattice: refuse to overwrite a terminal status with a
+	// later, lower-priority update (e.g. a stray SEEN_ON_NETWORK callback after
+	// MINED). Read-then-CAS-write using the record's generation guarantees the
+	// pre-write check and the write are atomic with respect to other writers.
+	// See models.Status.CanTransitionFrom and #61 / F-003.
+	if status.Status == "" {
+		return s.client.Put(s.writePolicy(ctx), key, bins)
+	}
+	for {
+		rec, gerr := s.client.Get(s.readPolicy(ctx), key, "status")
+		if gerr != nil && !isKeyNotFound(gerr) {
+			return fmt.Errorf("read status for lattice check %s: %w", status.TxID, gerr)
+		}
+		policy := s.writePolicy(ctx)
+		if rec != nil {
+			existing := models.Status(getString(rec, "status"))
+			if !status.Status.CanTransitionFrom(existing) {
+				return nil
+			}
+			policy.GenerationPolicy = aero.EXPECT_GEN_EQUAL
+			policy.Generation = rec.Generation
+		} else {
+			// No existing row: only create if the row is genuinely absent. If
+			// another writer races us in, retry the read-modify-write so the
+			// lattice check covers the new state too.
+			policy.RecordExistsAction = aero.CREATE_ONLY
+		}
+		if err := s.client.Put(policy, key, bins); err != nil {
+			// Generation mismatch / create-only conflict means another writer
+			// landed between our read and our put. Re-read and re-evaluate the
+			// lattice rather than silently clobbering their write.
+			if isGenerationErr(err) || isKeyExistsErr(err) {
+				continue
+			}
+			return fmt.Errorf("update tx %s: %w", status.TxID, err)
+		}
+		return nil
+	}
 }
 
 func (s *Store) GetStatus(ctx context.Context, txid string) (*models.TransactionStatus, error) {

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -345,6 +345,16 @@ func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStat
 		return err
 	}
 
+	// Enforce the status lattice: a later, lower-priority update (e.g. a stray
+	// SEEN_ON_NETWORK callback arriving after a tx has already been MINED) must
+	// not overwrite a terminal status. See models.Status.CanTransitionFrom and
+	// issue #61 / F-003.
+	if existing != nil && status.Status != "" {
+		if !status.Status.CanTransitionFrom(models.Status(existing.Status)) {
+			return nil
+		}
+	}
+
 	merged := mergeStatus(existing, status)
 	payload, err := json.Marshal(merged)
 	if err != nil {

--- a/store/pebble/pebble_test.go
+++ b/store/pebble/pebble_test.go
@@ -138,6 +138,98 @@ func TestUpdateStatus_ClearsOldStatusIndex(t *testing.T) {
 	_ = v
 }
 
+// TestUpdateStatus_TerminalNotOverwritten is the regression for F-003 (#61):
+// once a tx is in a terminal status (MINED, IMMUTABLE, REJECTED,
+// DOUBLE_SPEND_ATTEMPTED), a later lower-priority UpdateStatus call (e.g. a
+// stray SEEN_ON_NETWORK callback) must be a silent no-op rather than a clobber.
+func TestUpdateStatus_TerminalNotOverwritten(t *testing.T) {
+	terminals := []models.Status{
+		models.StatusMined,
+		models.StatusImmutable,
+		models.StatusRejected,
+		models.StatusDoubleSpendAttempted,
+	}
+	regressions := []models.Status{
+		models.StatusSeenOnNetwork,
+		models.StatusSeenMultipleNodes,
+		models.StatusSentToNetwork,
+		models.StatusPendingRetry,
+	}
+	for _, terminal := range terminals {
+		for _, regression := range regressions {
+			name := string(terminal) + "_then_" + string(regression)
+			t.Run(name, func(t *testing.T) {
+				s := newTestStore(t)
+				ctx := context.Background()
+				txid := "tx-" + name
+
+				// Seed a row in the terminal state.
+				if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+					TxID: txid, Status: models.StatusReceived,
+				}); err != nil {
+					t.Fatal(err)
+				}
+				if err := s.UpdateStatus(ctx, &models.TransactionStatus{
+					TxID: txid, Status: terminal, Timestamp: time.Now(),
+				}); err != nil {
+					t.Fatalf("seed terminal: %v", err)
+				}
+
+				// A late lower-priority callback must not regress the row.
+				if err := s.UpdateStatus(ctx, &models.TransactionStatus{
+					TxID: txid, Status: regression, Timestamp: time.Now(),
+				}); err != nil {
+					t.Fatalf("regression update: %v", err)
+				}
+
+				got, err := s.GetStatus(ctx, txid)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got.Status != terminal {
+					t.Fatalf("terminal status %s was overwritten by %s (got %s)",
+						terminal, regression, got.Status)
+				}
+			})
+		}
+	}
+}
+
+// TestUpdateStatus_ForwardTransitionsStillWork sanity-checks that the lattice
+// guard does not break legitimate forward transitions.
+func TestUpdateStatus_ForwardTransitionsStillWork(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	txid := "tx-forward"
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusReceived,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, st := range []models.Status{
+		models.StatusSentToNetwork,
+		models.StatusAcceptedByNetwork,
+		models.StatusSeenOnNetwork,
+		models.StatusSeenMultipleNodes,
+		models.StatusMined,
+		models.StatusImmutable,
+	} {
+		if err := s.UpdateStatus(ctx, &models.TransactionStatus{
+			TxID: txid, Status: st, Timestamp: time.Now(),
+		}); err != nil {
+			t.Fatalf("forward transition to %s: %v", st, err)
+		}
+		got, err := s.GetStatus(ctx, txid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != st {
+			t.Fatalf("forward transition lost: expected %s, got %s", st, got.Status)
+		}
+	}
+}
+
 func TestPendingRetryLifecycle(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -316,7 +316,7 @@ func (s *Store) BatchUpdateStatus(ctx context.Context, statuses []*models.Transa
 		return nil
 	}
 
-	const colsPerRow = 6 // txid, status, block_hash, block_height, extra_info, timestamp_at + merkle_path
+	const colsPerRow = 7 // txid, status, block_hash, block_height, extra_info, merkle_path, timestamp_at, disallowed_prev
 
 	args := make([]any, 0, len(statuses)*(colsPerRow+1))
 	now := time.Now()
@@ -329,6 +329,14 @@ func (s *Store) BatchUpdateStatus(ctx context.Context, statuses []*models.Transa
 		if len(st.MerklePath) > 0 {
 			mp = []byte(st.MerklePath)
 		}
+		// disallowed previous statuses for this row's lattice guard. A nil/
+		// empty slice means "no constraint" — the AND clause uses ALL() so an
+		// empty array is satisfied trivially (status <> ALL('{}'::text[]) is
+		// true for every row).
+		disallowed := disallowedPrevAsStrings(st.Status)
+		if disallowed == nil {
+			disallowed = []string{}
+		}
 		args = append(args,
 			st.TxID,
 			string(st.Status),
@@ -337,6 +345,7 @@ func (s *Store) BatchUpdateStatus(ctx context.Context, statuses []*models.Transa
 			st.ExtraInfo,
 			mp,
 			ts,
+			disallowed,
 		)
 	}
 
@@ -346,14 +355,18 @@ func (s *Store) BatchUpdateStatus(ctx context.Context, statuses []*models.Transa
 			values.WriteString(", ")
 		}
 		base := i * (colsPerRow + 1)
-		// Cast text/bytea/bigint/timestamptz so Postgres can pick the right
-		// types for the VALUES alias columns.
+		// Cast text/bytea/bigint/timestamptz/text[] so Postgres can pick the
+		// right types for the VALUES alias columns.
 		fmt.Fprintf(&values,
-			"($%d::text,$%d::text,$%d::text,$%d::bigint,$%d::text,$%d::bytea,$%d::timestamptz)",
-			base+1, base+2, base+3, base+4, base+5, base+6, base+7,
+			"($%d::text,$%d::text,$%d::text,$%d::bigint,$%d::text,$%d::bytea,$%d::timestamptz,$%d::text[])",
+			base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8,
 		)
 	}
 
+	// Lattice guard (status <> ALL(v.disallowed_prev)) is applied in the
+	// WHERE clause: rows whose existing status appears in the per-row disallowed
+	// list are silently skipped. See models.Status.DisallowedPreviousStatuses
+	// and #61 / F-003.
 	q := `
 UPDATE transactions t SET
     status       = v.status,
@@ -362,8 +375,8 @@ UPDATE transactions t SET
     extra_info   = COALESCE(NULLIF(v.extra_info, ''),     t.extra_info),
     merkle_path  = COALESCE(v.merkle_path,                t.merkle_path),
     timestamp_at = v.timestamp_at
-FROM (VALUES ` + values.String() + `) AS v(txid, status, block_hash, block_height, extra_info, merkle_path, timestamp_at)
-WHERE t.txid = v.txid`
+FROM (VALUES ` + values.String() + `) AS v(txid, status, block_hash, block_height, extra_info, merkle_path, timestamp_at, disallowed_prev)
+WHERE t.txid = v.txid AND t.status <> ALL(v.disallowed_prev)`
 
 	if _, err := s.pool.Exec(ctx, q, args...); err != nil {
 		return fmt.Errorf("batch update: %w", err)
@@ -398,6 +411,7 @@ func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStat
 	if len(status.MerklePath) > 0 {
 		sets = append(sets, fmt.Sprintf("merkle_path = $%d", idx))
 		args = append(args, []byte(status.MerklePath))
+		idx++
 	}
 
 	q := "UPDATE transactions SET "
@@ -409,11 +423,37 @@ func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStat
 	}
 	q += " WHERE txid = $1"
 
+	// Enforce the status lattice atomically inside the same UPDATE: refuse to
+	// overwrite a terminal status (MINED/IMMUTABLE/REJECTED/DOUBLE_SPEND_ATTEMPTED)
+	// with a later, lower-priority update such as a stray SEEN_ON_NETWORK
+	// callback. See models.Status.DisallowedPreviousStatuses and #61 / F-003.
+	if disallowed := disallowedPrevAsStrings(status.Status); len(disallowed) > 0 {
+		q += fmt.Sprintf(" AND status <> ALL($%d::text[])", idx)
+		args = append(args, disallowed)
+	}
+
 	_, err := s.pool.Exec(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf("update tx %s: %w", status.TxID, err)
 	}
 	return nil
+}
+
+// disallowedPrevAsStrings is a small adapter so UpdateStatus / BatchUpdateStatus
+// can drop the lattice into a parameterised text[] clause.
+func disallowedPrevAsStrings(s models.Status) []string {
+	if s == "" {
+		return nil
+	}
+	prev := s.DisallowedPreviousStatuses()
+	if len(prev) == 0 {
+		return nil
+	}
+	out := make([]string, len(prev))
+	for i, p := range prev {
+		out[i] = string(p)
+	}
+	return out
 }
 
 func (s *Store) GetStatus(ctx context.Context, txid string) (*models.TransactionStatus, error) {

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -496,3 +496,114 @@ func TestDatahubEndpoints_UpsertOverwrites(t *testing.T) {
 		t.Errorf("last_seen not overwritten: got %v want %v", out[0].LastSeen, t2)
 	}
 }
+
+// TestUpdateStatus_TerminalNotOverwritten is the regression for F-003 (#61):
+// once a tx is in a terminal status (MINED, IMMUTABLE, REJECTED,
+// DOUBLE_SPEND_ATTEMPTED), a later lower-priority UpdateStatus call (e.g. a
+// stray SEEN_ON_NETWORK callback) must be a silent no-op rather than a clobber.
+func TestUpdateStatus_TerminalNotOverwritten(t *testing.T) {
+	terminals := []models.Status{
+		models.StatusMined,
+		models.StatusImmutable,
+		models.StatusRejected,
+		models.StatusDoubleSpendAttempted,
+	}
+	regressions := []models.Status{
+		models.StatusSeenOnNetwork,
+		models.StatusSeenMultipleNodes,
+		models.StatusSentToNetwork,
+		models.StatusPendingRetry,
+	}
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, terminal := range terminals {
+		for _, regression := range regressions {
+			name := string(terminal) + "_then_" + string(regression)
+			t.Run(name, func(t *testing.T) {
+				txid := "tx-" + name
+
+				if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+					TxID: txid, Status: models.StatusReceived,
+				}); err != nil {
+					t.Fatal(err)
+				}
+				if err := s.UpdateStatus(ctx, &models.TransactionStatus{
+					TxID: txid, Status: terminal, Timestamp: time.Now(),
+				}); err != nil {
+					t.Fatalf("seed terminal: %v", err)
+				}
+
+				if err := s.UpdateStatus(ctx, &models.TransactionStatus{
+					TxID: txid, Status: regression, Timestamp: time.Now(),
+				}); err != nil {
+					t.Fatalf("regression update: %v", err)
+				}
+
+				got, err := s.GetStatus(ctx, txid)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got.Status != terminal {
+					t.Fatalf("terminal status %s overwritten by %s (got %s)",
+						terminal, regression, got.Status)
+				}
+			})
+		}
+	}
+}
+
+// TestBatchUpdateStatus_TerminalNotOverwritten covers the same F-003
+// regression for the batched code path.
+func TestBatchUpdateStatus_TerminalNotOverwritten(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	type row struct {
+		txid     string
+		seedTerm models.Status
+		regress  models.Status
+	}
+	rows := []row{
+		{"tx-mined", models.StatusMined, models.StatusSeenOnNetwork},
+		{"tx-immutable", models.StatusImmutable, models.StatusSeenOnNetwork},
+		{"tx-rejected", models.StatusRejected, models.StatusSeenMultipleNodes},
+		{"tx-dsa", models.StatusDoubleSpendAttempted, models.StatusPendingRetry},
+	}
+
+	// Seed each row in its terminal status.
+	for _, r := range rows {
+		if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+			TxID: r.txid, Status: models.StatusReceived,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.UpdateStatus(ctx, &models.TransactionStatus{
+			TxID: r.txid, Status: r.seedTerm, Timestamp: time.Now(),
+		}); err != nil {
+			t.Fatalf("seed %s: %v", r.txid, err)
+		}
+	}
+
+	// One batched lower-priority update for the whole set.
+	updates := make([]*models.TransactionStatus, len(rows))
+	for i, r := range rows {
+		updates[i] = &models.TransactionStatus{
+			TxID: r.txid, Status: r.regress, Timestamp: time.Now(),
+		}
+	}
+	if err := s.BatchUpdateStatus(ctx, updates); err != nil {
+		t.Fatalf("BatchUpdateStatus: %v", err)
+	}
+
+	for _, r := range rows {
+		got, err := s.GetStatus(ctx, r.txid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != r.seedTerm {
+			t.Errorf("%s: terminal %s overwritten by batch %s (got %s)",
+				r.txid, r.seedTerm, r.regress, got.Status)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes F-003: a tx in a terminal status (`MINED`, `IMMUTABLE`, `REJECTED`, `DOUBLE_SPEND_ATTEMPTED`) could be silently downgraded by a later callback such as `SEEN_ON_NETWORK`. Both halves of the bug were live: `DisallowedPreviousStatuses` returned an empty list for `SEEN_ON_NETWORK`, `SEEN_MULTIPLE_NODES`, `PENDING_RETRY`, and `STUMP_PROCESSING`, *and* no store implementation actually consulted the lattice — every `UpdateStatus` unconditionally overwrote the row.
- Tightened the lattice in `models/transaction.go` so terminal statuses block every regression path; added `Status.IsTerminal()` and `Status.CanTransitionFrom(prev)` helpers; idempotent re-assertions and the `MINED → IMMUTABLE` promotion remain allowed.
- Enforced the lattice atomically in each backend's `UpdateStatus` (and `BatchUpdateStatus` for postgres):
  - **postgres**: appends `AND status <> ALL($N::text[])` to the `UPDATE` (per-row `text[]` column for the batched form), so the guard runs in the same statement as the write — no read-modify-write race.
  - **pebble**: reuses the existing per-txid mutex + `readStoredStatus`, returning a silent no-op when the proposed status fails `CanTransitionFrom`.
  - **aerospike**: read-then-CAS-write using `EXPECT_GEN_EQUAL` (and `CREATE_ONLY` when the row is absent), retrying on `GENERATION_ERROR` / `KEY_EXISTS_ERROR` so a racing writer can't slip a regression through.
- Added regression tests:
  - `models/transaction_test.go` — table-driven coverage of every terminal × regression pair, the `IMMUTABLE` sink, and the happy-path forward edges (initial insert, `RECEIVED → SENT_TO_NETWORK → ... → MINED → IMMUTABLE`, retry republish).
  - `store/pebble/pebble_test.go` — 16 sub-tests covering every (terminal, regression) pair plus a forward-transition smoke test.
  - `store/postgres/postgres_test.go` — single-row regression coverage plus a `BatchUpdateStatus` variant.

Closes #61

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./models/... ./store/... ./services/... -count=1 -race`
- [x] `go test -tags=postgres ./store/postgres/... -count=1 -race`
- [x] `golangci-lint run ./models/... ./store/...` (0 issues)
- [ ] Reviewer to confirm the terminal-status set is complete (`MINED`, `IMMUTABLE`, `REJECTED`, `DOUBLE_SPEND_ATTEMPTED`) and that the new `SEEN_ON_NETWORK` ← `SEEN_MULTIPLE_NODES` block (no SEEN downgrades) matches operator intent.
- [ ] Aerospike integration tests (`-tags=integration`) cannot run locally; reviewer to verify in an env with Aerospike.