### PR TITLE
fix(api,callback): SSRF guards at registration and dial (#75)

### DIFF
--- a/callbackurl/callbackurl.go
+++ b/callbackurl/callbackurl.go
@@ -1,0 +1,128 @@
+// Package callbackurl centralizes the SSRF guard used by the api-server
+// (registration-time validation of X-CallbackUrl) and by the webhook
+// delivery client (dial-time refusal). One blocking predicate keeps the
+// two layers from drifting and ensures a host that survives validation
+// can't sneak past delivery via DNS rebinding.
+//
+// Threat model: arcade is reachable by clients that we don't fully trust,
+// and the callback URL they register is dialed from inside our network.
+// Without a guard, an attacker can register a callback that points at
+// loopback (`127.0.0.1`), link-local (`169.254.0.0/16` — including the
+// AWS/GCP/Azure metadata endpoint at `169.254.169.254`), RFC1918 ranges,
+// or `0.0.0.0`/`::`, and turn arcade into a blind SSRF primitive.
+package callbackurl
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"syscall"
+)
+
+// ErrBlockedHost is returned when an URL's host or a dial target resolves
+// to an IP class that the SSRF guard refuses to talk to.
+var ErrBlockedHost = errors.New("callback host resolves to a blocked address")
+
+// ValidateURL parses raw, enforces http/https, and rejects the URL when
+// its literal host parses as a blocked IP. DNS names are accepted at
+// this layer — operators may legitimately use internal-looking DNS
+// names that resolve to public IPs, and the dial-time guard catches
+// the rebinding case where the name resolves to a private address.
+//
+// allowPrivate=true short-circuits the IP-class check for operators
+// whose deployment intentionally posts callbacks to internal services
+// (testing, k8s service-DNS, internal webhooks). The default is false.
+func ValidateURL(raw string, allowPrivate bool) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return errors.New("callback url is empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse callback url: %w", err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("callback url scheme %q not allowed (only http/https)", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return errors.New("callback url has no host")
+	}
+	if allowPrivate {
+		return nil
+	}
+	if ip := net.ParseIP(host); ip != nil && IsBlockedIP(ip) {
+		return fmt.Errorf("%w: %s", ErrBlockedHost, host)
+	}
+	return nil
+}
+
+// IsBlockedIP reports whether ip falls into a class arcade refuses to
+// dial when the SSRF guard is active. The set:
+//
+//   - loopback (127.0.0.0/8, ::1)
+//   - unspecified (0.0.0.0, ::)
+//   - link-local unicast (169.254.0.0/16 — covers cloud metadata at
+//     169.254.169.254 — and fe80::/10)
+//   - RFC1918 / RFC4193 private (IP.IsPrivate())
+//   - multicast (224.0.0.0/4, ff00::/8)
+//   - interface-local multicast (covered by IsInterfaceLocalMulticast)
+//
+// Treating all of these as "blocked" intentionally errs on the side of
+// safety; an operator who needs to dial one explicitly opts in via
+// callback.allow_private_ips.
+func IsBlockedIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() ||
+		ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsPrivate() {
+		return true
+	}
+	// IPv4-mapped IPv6 (::ffff:127.0.0.1) — re-check the underlying v4.
+	if v4 := ip.To4(); v4 != nil && !v4.Equal(ip) {
+		if v4.IsLoopback() || v4.IsUnspecified() || v4.IsLinkLocalUnicast() || v4.IsPrivate() {
+			return true
+		}
+	}
+	return false
+}
+
+// DialControl returns a net.Dialer.Control function that refuses to
+// connect to a blocked IP. It runs after DNS resolution, so it catches
+// the rebinding case where a hostname resolved to a now-private address
+// even though ValidateURL accepted the literal hostname at registration
+// time.
+//
+// allowPrivate=true makes the control a no-op so operators can opt out.
+func DialControl(allowPrivate bool) func(network, address string, c syscall.RawConn) error {
+	if allowPrivate {
+		return func(string, string, syscall.RawConn) error { return nil }
+	}
+	return func(network, address string, _ syscall.RawConn) error {
+		// The Go resolver hands us "<ip>:<port>" — both v4 ("1.2.3.4:80")
+		// and v6 ("[::1]:80") flavors go through net.SplitHostPort.
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return fmt.Errorf("dial %s: parsing address %q: %w", network, address, err)
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			// Should not happen — Dialer.Control runs after resolution —
+			// but if a custom resolver hands us a name, fail closed.
+			return fmt.Errorf("%w: dial target %q is not an IP literal", ErrBlockedHost, host)
+		}
+		if IsBlockedIP(ip) {
+			return fmt.Errorf("%w: dial %s", ErrBlockedHost, ip)
+		}
+		return nil
+	}
+}

--- a/callbackurl/callbackurl_test.go
+++ b/callbackurl/callbackurl_test.go
@@ -1,0 +1,207 @@
+package callbackurl
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestValidateURL exercises every IP class the registration-time guard
+// is supposed to reject, plus the obvious wins (https://example.com and
+// the allow-private opt-in).
+func TestValidateURL(t *testing.T) {
+	cases := []struct {
+		name         string
+		raw          string
+		allowPrivate bool
+		wantErr      bool
+	}{
+		// Accept paths.
+		{"public https accepted", "https://example.com/foo", false, false},
+		{"public http accepted", "http://example.com:8080/cb", false, false},
+		{"dns name treated as public at validation", "http://internal.corp.local/cb", false, false},
+		// Reject paths — IP-class.
+		{"loopback v4 rejected", "http://127.0.0.1/cb", false, true},
+		{"loopback v4 alt", "http://127.5.6.7/cb", false, true},
+		{"loopback v6 rejected", "http://[::1]/cb", false, true},
+		{"unspecified v4 rejected", "http://0.0.0.0/cb", false, true},
+		{"unspecified v6 rejected", "http://[::]/cb", false, true},
+		{"metadata 169.254.169.254 rejected", "http://169.254.169.254/latest/meta-data/", false, true},
+		{"link-local v4 rejected", "http://169.254.1.1/cb", false, true},
+		{"link-local v6 rejected", "http://[fe80::1]/cb", false, true},
+		{"rfc1918 10.x rejected", "http://10.0.0.5/cb", false, true},
+		{"rfc1918 172.16 rejected", "http://172.16.0.1/cb", false, true},
+		{"rfc1918 192.168 rejected", "http://192.168.1.1/cb", false, true},
+		{"unique local v6 rejected", "http://[fc00::1]/cb", false, true},
+		{"ipv4-mapped loopback rejected", "http://[::ffff:127.0.0.1]/cb", false, true},
+		// Reject paths — scheme.
+		{"ftp scheme rejected", "ftp://example.com/cb", false, true},
+		{"file scheme rejected", "file:///etc/passwd", false, true},
+		{"empty scheme rejected", "example.com/cb", false, true},
+		// Reject paths — structural.
+		{"empty url rejected", "", false, true},
+		{"whitespace-only rejected", "    ", false, true},
+		{"missing host rejected", "http://", false, true},
+		// Allow-private opt-in.
+		{"loopback accepted with opt-in", "http://127.0.0.1/cb", true, false},
+		{"rfc1918 accepted with opt-in", "http://192.168.1.1/cb", true, false},
+		{"metadata accepted with opt-in", "http://169.254.169.254/", true, false},
+		{"file scheme still rejected with opt-in", "file:///etc/passwd", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateURL(tc.raw, tc.allowPrivate)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateURL(%q, allowPrivate=%v) = nil, want error", tc.raw, tc.allowPrivate)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateURL(%q, allowPrivate=%v) unexpected error: %v", tc.raw, tc.allowPrivate, err)
+			}
+		})
+	}
+}
+
+// TestIsBlockedIP covers the predicate directly so callers can rely on
+// it standalone (e.g. an operator-friendly validator that takes a parsed
+// net.IP).
+func TestIsBlockedIP(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1", "127.255.255.255", "::1",
+		"0.0.0.0", "::",
+		"169.254.169.254", "169.254.1.1",
+		"fe80::1",
+		"10.0.0.1", "172.16.0.1", "172.31.255.255", "192.168.0.1",
+		"fc00::1", "fd00::1",
+		"224.0.0.1", "ff02::1",
+	}
+	for _, s := range blocked {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			t.Fatalf("test bug: %q does not parse", s)
+		}
+		if !IsBlockedIP(ip) {
+			t.Errorf("IsBlockedIP(%s) = false, want true", s)
+		}
+	}
+	allowed := []string{
+		"8.8.8.8", "1.1.1.1", "203.0.113.5",
+		"2606:4700:4700::1111",
+	}
+	for _, s := range allowed {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			t.Fatalf("test bug: %q does not parse", s)
+		}
+		if IsBlockedIP(ip) {
+			t.Errorf("IsBlockedIP(%s) = true, want false", s)
+		}
+	}
+	if IsBlockedIP(nil) {
+		t.Error("IsBlockedIP(nil) = true, want false")
+	}
+}
+
+// TestDialControlBlocksLoopback wires DialControl into a live
+// http.Transport and confirms that a request to an httptest.Server
+// listening on 127.0.0.1 is refused at the dial step. This is the
+// dial-time layer that catches DNS rebinding — even if a registered
+// hostname survives ValidateURL, the dialer still says no.
+func TestDialControlBlocksLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: time.Second,
+				Control: DialControl(false),
+			}).DialContext,
+		},
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatalf("expected dial to be refused for %s, got status %d", srv.URL, resp.StatusCode)
+	}
+	if !strings.Contains(err.Error(), "blocked") && !errors.Is(err, ErrBlockedHost) {
+		t.Errorf("expected error to mention blocked host, got: %v", err)
+	}
+}
+
+// TestDialControlAllowPrivate verifies the opt-in path: with
+// allowPrivate=true, a request to a 127.0.0.1 listener succeeds.
+func TestDialControlAllowPrivate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: time.Second,
+				Control: DialControl(true),
+			}).DialContext,
+		},
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("expected dial to succeed with allowPrivate=true, got: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestDialControlBlocksMetadataIP exercises the dial-time guard with a
+// fake address — we don't actually open a socket to 169.254.169.254;
+// the Control hook fires before connect and returns an error that
+// surfaces as net.OpError via the dialer.
+func TestDialControlBlocksMetadataIP(t *testing.T) {
+	ctrl := DialControl(false)
+	err := ctrl("tcp", "169.254.169.254:80", fakeRawConn{})
+	if err == nil {
+		t.Fatal("expected DialControl to reject metadata IP, got nil")
+	}
+	if !errors.Is(err, ErrBlockedHost) {
+		t.Errorf("expected ErrBlockedHost, got %v", err)
+	}
+}
+
+// fakeRawConn is a no-op stand-in; DialControl never touches the
+// syscall.RawConn, it just inspects the address string.
+type fakeRawConn struct{}
+
+func (fakeRawConn) Control(func(uintptr)) error { return nil }
+func (fakeRawConn) Read(func(uintptr) bool) error {
+	return errors.New("not implemented")
+}
+
+func (fakeRawConn) Write(func(uintptr) bool) error {
+	return errors.New("not implemented")
+}
+
+var _ syscall.RawConn = fakeRawConn{}

--- a/cmd/arcade/main.go
+++ b/cmd/arcade/main.go
@@ -230,7 +230,7 @@ func buildServices(
 	// deployment ships callbacks without extra config) but can be split into
 	// its own pod by setting mode=webhook.
 	if shouldRun("api-server") || shouldRun("webhook") {
-		svcs = append(svcs, webhook.New(cfg.Webhook, logger, publisher, st))
+		svcs = append(svcs, webhook.New(cfg.Webhook, cfg.Callback, logger, publisher, st))
 	}
 	// p2p_client is its own service; it's needed both by mode=propagation
 	// (where it feeds the local teranode.Client directly) and by mode=p2p-client

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -97,6 +97,16 @@ p2p:
 health:
   port: 8081
 
+# SSRF guard for client-supplied callback URLs. The api-server rejects
+# X-CallbackUrl values whose host is loopback / link-local / RFC1918 /
+# cloud-metadata, and the webhook delivery client refuses to dial those
+# IPs at connection time (catches DNS rebinding). Set
+# allow_private_ips: true if your deployment intentionally posts
+# callbacks to internal services (testing, k8s service DNS, intranet
+# webhooks). See finding F-017 / issue #75.
+# callback:
+#   allow_private_ips: false
+
 # propagation:
 #   # Per-endpoint circuit-breaker for the datahub URL list. Endpoints that
 #   # accumulate `failure_threshold` consecutive failures are marked unhealthy

--- a/config/config.go
+++ b/config/config.go
@@ -121,6 +121,7 @@ type Config struct {
 	TxValidator   TxValidatorConfig   `mapstructure:"tx_validator"`
 	BumpBuilder   BumpBuilderConfig   `mapstructure:"bump_builder"`
 	Webhook       WebhookConfig       `mapstructure:"webhook"`
+	Callback      CallbackConfig      `mapstructure:"callback"`
 	// ChaintracksServer gates whether the embedded go-chaintracks HTTP API
 	// runs alongside api-server. Default is on so the refactor is a drop-in
 	// replacement for the original single-binary arcade.
@@ -335,6 +336,21 @@ type WebhookConfig struct {
 	HTTPTimeoutMs int `mapstructure:"http_timeout_ms"`
 }
 
+// CallbackConfig governs the SSRF guard that protects api-server's
+// X-CallbackUrl registration and the webhook delivery client's outbound
+// dials. Both layers share the same knob so an operator who opts in
+// for internal-network callbacks doesn't have to remember to flip a
+// matching flag elsewhere. See finding F-017 / issue #75.
+type CallbackConfig struct {
+	// AllowPrivateIPs, when true, disables the SSRF guard. Default false:
+	// X-CallbackUrl values whose host parses as a loopback / link-local /
+	// metadata / RFC1918 IP are rejected at submit time, and the webhook
+	// delivery http.Client refuses to dial those IPs at connect time.
+	// Operators running purely against internal services (testing rigs,
+	// k8s service DNS, intranet webhooks) can set this true.
+	AllowPrivateIPs bool `mapstructure:"allow_private_ips"`
+}
+
 // TxValidatorConfig tunes the parallel batch validation pipeline. Parallelism
 // caps how many transactions are parsed and validated concurrently inside a
 // single flush window — bounded so a huge in-flight batch can't open more
@@ -472,6 +488,12 @@ func setDefaults() {
 	viper.SetDefault("webhook.initial_backoff_ms", 5000)
 	viper.SetDefault("webhook.max_backoff_ms", 300000)
 	viper.SetDefault("webhook.http_timeout_ms", 10000)
+
+	// Callback SSRF guard defaults to enabled (allow_private_ips=false). See
+	// finding F-017 / issue #75 — accepting any X-CallbackUrl turned arcade
+	// into a blind SSRF primitive against internal services and cloud
+	// metadata endpoints.
+	viper.SetDefault("callback.allow_private_ips", false)
 
 	viper.SetDefault("storage_path", "~/.arcade")
 	viper.SetDefault("chaintracks_server.enabled", true)

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 
+	"github.com/bsv-blockchain/arcade/callbackurl"
 	"github.com/bsv-blockchain/arcade/kafka"
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/teranode"
@@ -37,6 +38,33 @@ func extractSubmitOptions(c *gin.Context) submitOptions {
 		CallbackToken:     c.GetHeader("X-CallbackToken"),
 		FullStatusUpdates: c.GetHeader("X-FullStatusUpdates") == "true",
 	}
+}
+
+// validateCallbackURL applies the SSRF guard to the X-CallbackUrl header
+// before the request is allowed to register a subscription. Empty URLs
+// pass through — token-only subscriptions don't trigger an outbound dial,
+// so there's no SSRF surface to protect. The shared callbackurl predicate
+// is the same one the webhook delivery client uses at dial time, so a host
+// that survives this check still gets re-validated at connection time
+// (catches DNS rebinding).
+//
+// Returns a 400 to the client on failure and reports false; callers should
+// abort processing in that case. The unsafe URL is logged at debug (not
+// the value itself, just the host) so operators can correlate refusals
+// without leaking attacker-controlled strings into structured logs.
+func (s *Server) validateCallbackURL(c *gin.Context, url string) bool {
+	if url == "" {
+		return true
+	}
+	if err := callbackurl.ValidateURL(url, s.cfg.Callback.AllowPrivateIPs); err != nil {
+		s.logger.Warn("rejecting submit due to unsafe callback url",
+			zap.String("client_ip", c.ClientIP()),
+			zap.Error(err),
+		)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid callback url: " + err.Error()})
+		return false
+	}
+	return true
 }
 
 // hasSubscription reports whether the request asked for callback / SSE
@@ -360,6 +388,15 @@ const (
 // handleSubmitTransaction accepts transactions for validation and propagation.
 // Supports application/octet-stream, text/plain (hex), and JSON.
 func (s *Server) handleSubmitTransaction(c *gin.Context) {
+	// SSRF guard: reject before reading the body so a hostile client can't
+	// exhaust ingress bandwidth alongside a banned callback host. The same
+	// predicate runs again at dial time on the webhook delivery client to
+	// catch DNS rebinding.
+	opts := extractSubmitOptions(c)
+	if !s.validateCallbackURL(c, opts.CallbackURL) {
+		return
+	}
+
 	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxSingleTxBytes)
 
 	var rawTx []byte
@@ -435,7 +472,7 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 	// txid or callbackToken. A late InsertSubmission would race with the
 	// validator and risk silently dropping the first few status events for
 	// fast-path transactions.
-	s.recordSubmission(c.Request.Context(), txid, extractSubmitOptions(c))
+	s.recordSubmission(c.Request.Context(), txid, opts)
 
 	msg := map[string]interface{}{
 		"action": "submit",
@@ -454,6 +491,13 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 func (s *Server) handleSubmitTransactions(c *gin.Context) {
 	if !strings.Contains(c.ContentType(), "octet-stream") {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Content-Type must be application/octet-stream"})
+		return
+	}
+
+	// SSRF guard: reject early so a hostile client posting a 256 MiB batch
+	// with a banned callback host doesn't get to consume any ingress.
+	opts := extractSubmitOptions(c)
+	if !s.validateCallbackURL(c, opts.CallbackURL) {
 		return
 	}
 
@@ -508,8 +552,8 @@ func (s *Server) handleSubmitTransactions(c *gin.Context) {
 
 	// Record one submission per parsed txid before the batch publish so the
 	// downstream services can resolve callback preferences as soon as
-	// status updates start flowing back.
-	opts := extractSubmitOptions(c)
+	// status updates start flowing back. opts was extracted (and the URL
+	// validated) at the top of the handler.
 	if opts.hasSubscription() {
 		ctx := c.Request.Context()
 		for _, m := range msgs {

--- a/services/api_server/handlers_ssrf_test.go
+++ b/services/api_server/handlers_ssrf_test.go
@@ -1,0 +1,220 @@
+package api_server
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/kafka"
+)
+
+// setupServerWithCallbackCfg builds a test Server whose Callback config
+// is the caller's. Mirrors setupServerWithStore but lets the SSRF tests
+// flip allow_private_ips on and off.
+func setupServerWithCallbackCfg(broker *kafka.RecordingBroker, ms *mockStore, cb config.CallbackConfig) (*Server, *gin.Engine) {
+	gin.SetMode(gin.TestMode)
+	producer := kafka.NewProducer(broker)
+	srv := &Server{
+		cfg:      &config.Config{Callback: cb},
+		logger:   zap.NewNop(),
+		producer: producer,
+		store:    ms,
+	}
+	router := gin.New()
+	srv.registerRoutes(router)
+	return srv, router
+}
+
+// blockedURLs is the canonical set of X-CallbackUrl values the SSRF guard
+// must reject when callback.allow_private_ips is false. Mirrors the threat
+// model section of issue #75: loopback, link-local, RFC1918, cloud
+// metadata, and unspecified addresses.
+var blockedURLs = []struct {
+	name string
+	url  string
+}{
+	{"loopback v4", "http://127.0.0.1/cb"},
+	{"loopback v6", "http://[::1]/cb"},
+	{"unspecified v4", "http://0.0.0.0/cb"},
+	{"unspecified v6", "http://[::]/cb"},
+	{"metadata 169.254.169.254", "http://169.254.169.254/latest/meta-data/"},
+	{"link-local v4", "http://169.254.1.1/cb"},
+	{"link-local v6", "http://[fe80::1]/cb"},
+	{"rfc1918 10/8", "http://10.0.0.1/cb"},
+	{"rfc1918 172.16/12", "http://172.16.5.5/cb"},
+	{"rfc1918 192.168/16", "http://192.168.1.1/cb"},
+	{"non-http scheme", "ftp://example.com/cb"},
+	{"file scheme", "file:///etc/passwd"},
+}
+
+// TestSubmitTransaction_RejectsBlockedCallbackURLs verifies the
+// registration-time SSRF guard on POST /tx: every blocked URL class must
+// be rejected with 400, no Kafka publish, and no submission record.
+func TestSubmitTransaction_RejectsBlockedCallbackURLs(t *testing.T) {
+	tx := makeRealTx(t)
+	rawHex := hex.EncodeToString(tx.Bytes())
+	body, err := json.Marshal(map[string]string{"rawTx": rawHex})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	for _, c := range blockedURLs {
+		t.Run(c.name, func(t *testing.T) {
+			broker := &kafka.RecordingBroker{}
+			ms := &mockStore{}
+			_, router := setupServerWithCallbackCfg(broker, ms, config.CallbackConfig{AllowPrivateIPs: false})
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/tx", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-CallbackUrl", c.url)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+			}
+			if !strings.Contains(strings.ToLower(w.Body.String()), "callback") {
+				t.Errorf("expected error mentioning callback, got: %s", w.Body.String())
+			}
+			if len(broker.Sends) != 0 {
+				t.Errorf("expected no Kafka send for blocked url, got %d", len(broker.Sends))
+			}
+			if len(ms.insertedSubmissions) != 0 {
+				t.Errorf("expected no submission insert for blocked url, got %d", len(ms.insertedSubmissions))
+			}
+		})
+	}
+}
+
+// TestSubmitTransaction_AcceptsPublicCallbackURL is the positive control:
+// a public https URL flows through to a Kafka send and a submission insert.
+func TestSubmitTransaction_AcceptsPublicCallbackURL(t *testing.T) {
+	tx := makeRealTx(t)
+	rawHex := hex.EncodeToString(tx.Bytes())
+	body, err := json.Marshal(map[string]string{"rawTx": rawHex})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	broker := &kafka.RecordingBroker{}
+	ms := &mockStore{}
+	_, router := setupServerWithCallbackCfg(broker, ms, config.CallbackConfig{AllowPrivateIPs: false})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/tx", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-CallbackUrl", "https://example.com/foo")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if len(broker.Sends) != 1 {
+		t.Errorf("expected 1 Kafka send, got %d", len(broker.Sends))
+	}
+	if len(ms.insertedSubmissions) != 1 {
+		t.Errorf("expected 1 submission insert, got %d", len(ms.insertedSubmissions))
+	}
+}
+
+// TestSubmitTransaction_AllowPrivateIPs_OptIn confirms the operator
+// escape hatch: with callback.allow_private_ips=true, a previously
+// rejected URL flows through to Kafka and the submission store.
+func TestSubmitTransaction_AllowPrivateIPs_OptIn(t *testing.T) {
+	tx := makeRealTx(t)
+	rawHex := hex.EncodeToString(tx.Bytes())
+	body, err := json.Marshal(map[string]string{"rawTx": rawHex})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	broker := &kafka.RecordingBroker{}
+	ms := &mockStore{}
+	_, router := setupServerWithCallbackCfg(broker, ms, config.CallbackConfig{AllowPrivateIPs: true})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/tx", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-CallbackUrl", "http://127.0.0.1:9000/cb")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if len(broker.Sends) != 1 {
+		t.Errorf("expected 1 Kafka send (opt-in allows private), got %d", len(broker.Sends))
+	}
+	if len(ms.insertedSubmissions) != 1 {
+		t.Errorf("expected 1 submission insert (opt-in allows private), got %d", len(ms.insertedSubmissions))
+	}
+}
+
+// TestSubmitTransactions_RejectsBlockedCallbackURLs covers the batch endpoint.
+// Same predicate, same rejection — verified once for each blocked class to
+// guard against accidental drift between /tx and /txs.
+func TestSubmitTransactions_RejectsBlockedCallbackURLs(t *testing.T) {
+	tx := makeRealTx(t)
+	body := tx.Bytes()
+
+	for _, c := range blockedURLs {
+		t.Run(c.name, func(t *testing.T) {
+			broker := &kafka.RecordingBroker{}
+			ms := &mockStore{}
+			_, router := setupServerWithCallbackCfg(broker, ms, config.CallbackConfig{AllowPrivateIPs: false})
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/txs", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/octet-stream")
+			req.Header.Set("X-CallbackUrl", c.url)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+			}
+			if len(broker.Batches) != 0 || len(broker.Sends) != 0 {
+				t.Errorf("expected no Kafka activity for blocked url")
+			}
+			if len(ms.insertedSubmissions) != 0 {
+				t.Errorf("expected no submission insert for blocked url, got %d", len(ms.insertedSubmissions))
+			}
+		})
+	}
+}
+
+// TestSubmitTransaction_TokenOnlySubscriptionStillAllowed makes sure the
+// SSRF guard doesn't penalize SSE-only subscribers who provide just a
+// callback token (no URL). They never trigger an outbound dial, so
+// there's no SSRF surface to defend.
+func TestSubmitTransaction_TokenOnlySubscriptionStillAllowed(t *testing.T) {
+	tx := makeRealTx(t)
+	rawHex := hex.EncodeToString(tx.Bytes())
+	body, err := json.Marshal(map[string]string{"rawTx": rawHex})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	broker := &kafka.RecordingBroker{}
+	ms := &mockStore{}
+	_, router := setupServerWithCallbackCfg(broker, ms, config.CallbackConfig{AllowPrivateIPs: false})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/tx", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-CallbackToken", "tok-1") // no X-CallbackUrl
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if len(ms.insertedSubmissions) != 1 {
+		t.Errorf("expected 1 submission insert (token-only), got %d", len(ms.insertedSubmissions))
+	}
+}

--- a/services/webhook/service.go
+++ b/services/webhook/service.go
@@ -12,12 +12,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"sync"
 	"time"
 
 	"go.uber.org/zap"
 
+	"github.com/bsv-blockchain/arcade/callbackurl"
 	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/events"
 	"github.com/bsv-blockchain/arcade/models"
@@ -41,7 +43,13 @@ type Service struct {
 // New constructs a Service. publisher must be non-nil; store provides
 // submission lookup and retry persistence. The HTTP client is constructed
 // here so each Service has its own pool — keeps tests hermetic.
-func New(cfg config.WebhookConfig, logger *zap.Logger, publisher events.Publisher, st store.Store) *Service {
+//
+// callbackCfg threads the SSRF guard through to the dialer: when
+// AllowPrivateIPs is false (the default), the underlying transport
+// refuses to connect to loopback / link-local / RFC1918 / metadata IPs
+// even if a host previously survived registration-time validation
+// (catches DNS rebinding). See finding F-017 / issue #75.
+func New(cfg config.WebhookConfig, callbackCfg config.CallbackConfig, logger *zap.Logger, publisher events.Publisher, st store.Store) *Service {
 	timeout := time.Duration(cfg.HTTPTimeoutMs) * time.Millisecond
 	if timeout <= 0 {
 		timeout = 10 * time.Second
@@ -51,7 +59,32 @@ func New(cfg config.WebhookConfig, logger *zap.Logger, publisher events.Publishe
 		logger:    logger.Named("webhook"),
 		publisher: publisher,
 		store:     st,
-		client:    &http.Client{Timeout: timeout},
+		client:    newCallbackClient(timeout, callbackCfg.AllowPrivateIPs),
+	}
+}
+
+// newCallbackClient builds an http.Client whose dialer enforces the SSRF
+// guard. The Dialer.Control hook fires after DNS resolution but before
+// connect(), so a hostname that resolves to a banned IP fails fast with
+// an error from the callbackurl package — the request never leaves the
+// machine. Pulled out of New so tests can construct an equivalent client
+// without instantiating the whole Service.
+func newCallbackClient(timeout time.Duration, allowPrivate bool) *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+		Control:   callbackurl.DialControl(allowPrivate),
+	}
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			DialContext:           dialer.DialContext,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: timeout,
+			ExpectContinueTimeout: 1 * time.Second,
+			ForceAttemptHTTP2:     true,
+			IdleConnTimeout:       90 * time.Second,
+		},
 	}
 }
 

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -161,7 +161,13 @@ func TestDeliverSuccess(t *testing.T) {
 			}},
 		},
 	}
-	svc := New(config.WebhookConfig{HTTPTimeoutMs: 1000, MaxRetries: 3, InitialBackoffMs: 1}, zap.NewNop(), recordingPub{}, st)
+	svc := New(
+		config.WebhookConfig{HTTPTimeoutMs: 1000, MaxRetries: 3, InitialBackoffMs: 1},
+		// httptest.Server listens on 127.0.0.1 — opt into private dials so
+		// the SSRF guard doesn't block the test client.
+		config.CallbackConfig{AllowPrivateIPs: true},
+		zap.NewNop(), recordingPub{}, st,
+	)
 
 	svc.handleUpdate(t.Context(), &models.TransactionStatus{
 		TxID:      "txA",
@@ -207,7 +213,11 @@ func TestSkipIntermediateWhenNotFullUpdates(t *testing.T) {
 			}},
 		},
 	}
-	svc := New(config.WebhookConfig{HTTPTimeoutMs: 1000}, zap.NewNop(), recordingPub{}, st)
+	svc := New(
+		config.WebhookConfig{HTTPTimeoutMs: 1000},
+		config.CallbackConfig{AllowPrivateIPs: true},
+		zap.NewNop(), recordingPub{}, st,
+	)
 
 	svc.handleUpdate(t.Context(), &models.TransactionStatus{
 		TxID:      "txA",
@@ -233,7 +243,11 @@ func TestRetryOnFailure(t *testing.T) {
 			"txA": {{SubmissionID: "sub-1", TxID: "txA", CallbackURL: srv.URL}},
 		},
 	}
-	svc := New(config.WebhookConfig{HTTPTimeoutMs: 1000, MaxRetries: 5, InitialBackoffMs: 50, MaxBackoffMs: 1000}, zap.NewNop(), recordingPub{}, st)
+	svc := New(
+		config.WebhookConfig{HTTPTimeoutMs: 1000, MaxRetries: 5, InitialBackoffMs: 50, MaxBackoffMs: 1000},
+		config.CallbackConfig{AllowPrivateIPs: true},
+		zap.NewNop(), recordingPub{}, st,
+	)
 
 	before := time.Now()
 	svc.handleUpdate(t.Context(), &models.TransactionStatus{
@@ -274,7 +288,11 @@ func TestDedupOnRepeatedStatus(t *testing.T) {
 			}},
 		},
 	}
-	svc := New(config.WebhookConfig{HTTPTimeoutMs: 1000, MaxRetries: 3}, zap.NewNop(), recordingPub{}, st)
+	svc := New(
+		config.WebhookConfig{HTTPTimeoutMs: 1000, MaxRetries: 3},
+		config.CallbackConfig{AllowPrivateIPs: true},
+		zap.NewNop(), recordingPub{}, st,
+	)
 
 	svc.handleUpdate(t.Context(), &models.TransactionStatus{
 		TxID:      "txA",
@@ -284,5 +302,55 @@ func TestDedupOnRepeatedStatus(t *testing.T) {
 
 	if hits.Load() != 0 {
 		t.Errorf("expected 0 hits (deduped), got %d", hits.Load())
+	}
+}
+
+// TestSSRFGuardBlocksLoopbackDial confirms the dial-time SSRF guard:
+// with AllowPrivateIPs=false (the default), a delivery whose target is
+// 127.0.0.1 — i.e. an httptest.Server — is refused at dial time, the
+// callback never reaches the server, and the failure is recorded as a
+// retryable delivery (RetryCount bumped).
+//
+// This is the second layer of defense: registration-time validation
+// catches IP-literal callback URLs, and this dial-time check catches
+// the DNS-rebinding case where a hostname resolved to a private IP.
+func TestSSRFGuardBlocksLoopbackDial(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	st := &fakeStore{
+		subs: map[string][]*models.Submission{
+			"txA": {{
+				SubmissionID: "sub-1",
+				TxID:         "txA",
+				CallbackURL:  srv.URL, // 127.0.0.1:<port>
+			}},
+		},
+	}
+	svc := New(
+		config.WebhookConfig{HTTPTimeoutMs: 1000, MaxRetries: 3, InitialBackoffMs: 1, MaxBackoffMs: 100},
+		// Default-safe: SSRF guard ON.
+		config.CallbackConfig{AllowPrivateIPs: false},
+		zap.NewNop(), recordingPub{}, st,
+	)
+
+	svc.handleUpdate(t.Context(), &models.TransactionStatus{
+		TxID:      "txA",
+		Status:    models.StatusMined,
+		Timestamp: time.Now(),
+	})
+
+	if hits.Load() != 0 {
+		t.Errorf("expected 0 hits (dial refused), got %d", hits.Load())
+	}
+	if len(st.deliveries) != 1 {
+		t.Fatalf("expected 1 delivery record (retry scheduled), got %d", len(st.deliveries))
+	}
+	if st.deliveries[0].RetryCount != 1 {
+		t.Errorf("RetryCount = %d, want 1", st.deliveries[0].RetryCount)
 	}
 }


### PR DESCRIPTION
## Summary
- Callback URLs from `X-CallbackUrl` are now rejected when the host parses as a loopback, unspecified, link-local, RFC1918/RFC4193, multicast, or cloud-metadata IP, or when the scheme is not http/https.
- The webhook delivery `http.Client` installs a `net.Dialer.Control` that re-applies the same predicate at connect time, catching DNS rebinding (a hostname that survives registration but resolves to a private IP).
- New config knob `callback.allow_private_ips` (default `false`) for operators with internal callbacks (testing rigs, k8s service DNS, intranet webhooks).
- Shared predicate lives in `callbackurl/` so registration-time and dial-time stay in lockstep.
- Tests cover every blocked IP class for `ValidateURL`, dial-time refusal of a 127.0.0.1 `httptest.Server` (in both the helper and in webhook delivery), the opt-in path, and `/tx` + `/txs` rejection at the api-server.

Closes #75

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race`
- [x] `golangci-lint run ./...`
- [ ] Reviewer to confirm the threat model