### PR TITLE
fix(bump/datahub): cap response body size (#65)

### DIFF
--- a/bump/datahub.go
+++ b/bump/datahub.go
@@ -17,18 +17,49 @@ import (
 
 var httpClient = &http.Client{Timeout: 5 * time.Minute}
 
+// DefaultMaxBlockBytes caps a single /block/<hash> binary response from a
+// DataHub endpoint. The endpoint serves block metadata: 80-byte header,
+// transaction-count varints, the 32-byte subtree-hash list, the coinbase
+// transaction, and the coinbase BUMP. Even on a Teranode network with
+// millions of subtrees per block this stays well under a hundred MiB; 1 GiB
+// is two-plus orders of magnitude of headroom while still bounding memory
+// against a hostile or malfunctioning DataHub. See finding F-007.
+const DefaultMaxBlockBytes int64 = 1 * 1024 * 1024 * 1024 // 1 GiB
+
+// maxErrorBodyBytes caps how much of a non-200 response body we read into the
+// returned error string. The HTTP status itself carries the diagnostic
+// signal — body is just for human debugging — so a small cap is fine and
+// stops a hostile server from inflating arcade's log lines.
+const maxErrorBodyBytes int64 = 512
+
 // FetchBlockDataForBUMP fetches subtree hashes, coinbase BUMP, and the block's
 // header merkle root from the binary block endpoint, trying all DataHub URLs.
 // Each attempt emits a Debug-level log line so operators can see which URLs
 // were tried, the HTTP status, elapsed time, and per-URL error. logger may be
 // nil — in that case the per-attempt logs are silently dropped.
 //
+// Response bodies are read through an io.LimitReader and Content-Length is
+// inspected before reading, so a hostile or malfunctioning DataHub cannot
+// exhaust process memory by returning an unbounded body. The cap is the
+// package-level default (DefaultMaxBlockBytes); use FetchBlockDataForBUMPWithCap
+// to override from configuration.
+//
 // Binary format: header (80) | txCount (varint) | sizeBytes (varint) |
 // subtreeCount (varint) | subtreeHashes (N×32) | coinbaseTx (variable) |
 // blockHeight (varint) | coinbaseBUMPLen (varint) | coinbaseBUMP (variable)
 func FetchBlockDataForBUMP(ctx context.Context, datahubURLs []string, blockHash string, logger *zap.Logger) (subtreeHashes []chainhash.Hash, coinbaseBUMP []byte, headerMerkleRoot *chainhash.Hash, err error) {
+	return FetchBlockDataForBUMPWithCap(ctx, datahubURLs, blockHash, DefaultMaxBlockBytes, logger)
+}
+
+// FetchBlockDataForBUMPWithCap is the cap-aware variant of FetchBlockDataForBUMP.
+// maxBlockBytes <= 0 selects DefaultMaxBlockBytes — passing zero/negative does
+// not silently disable the protection.
+func FetchBlockDataForBUMPWithCap(ctx context.Context, datahubURLs []string, blockHash string, maxBlockBytes int64, logger *zap.Logger) (subtreeHashes []chainhash.Hash, coinbaseBUMP []byte, headerMerkleRoot *chainhash.Hash, err error) {
 	if logger == nil {
 		logger = zap.NewNop()
+	}
+	if maxBlockBytes <= 0 {
+		maxBlockBytes = DefaultMaxBlockBytes
 	}
 	if len(datahubURLs) == 0 {
 		return nil, nil, nil, fmt.Errorf("no DataHub URLs configured (static + discovered list is empty) for block %s", blockHash)
@@ -36,12 +67,13 @@ func FetchBlockDataForBUMP(ctx context.Context, datahubURLs []string, blockHash 
 	var urlErrors []string
 	for i, dataHubURL := range datahubURLs {
 		start := time.Now()
-		hashes, cbBUMP, root, status, fetchErr := fetchBlockBinary(ctx, dataHubURL, blockHash)
+		hashes, cbBUMP, root, status, fetchErr := fetchBlockBinary(ctx, dataHubURL, blockHash, maxBlockBytes)
 		logger.Debug("datahub fetch attempt",
 			zap.Int("idx", i),
 			zap.String("url", dataHubURL),
 			zap.Int("status", status),
 			zap.Duration("elapsed", time.Since(start)),
+			zap.Int64("max_block_bytes", maxBlockBytes),
 			zap.Error(fetchErr),
 		)
 		if fetchErr == nil {
@@ -56,7 +88,13 @@ func FetchBlockDataForBUMP(ctx context.Context, datahubURLs []string, blockHash 
 // subtree hashes, coinbase BUMP, and the header merkle root from the response.
 // Returns the HTTP status code (0 on transport error before a response was
 // received) so the caller can include it in its per-attempt log line.
-func fetchBlockBinary(ctx context.Context, baseURL, blockHash string) ([]chainhash.Hash, []byte, *chainhash.Hash, int, error) {
+//
+// maxBlockBytes bounds the response body size: Content-Length is rejected
+// before reading when advertised oversize, and the body itself is read
+// through an io.LimitReader of maxBlockBytes+1 so we can distinguish
+// "exactly at cap" (allowed) from "exceeded cap" (rejected) without ever
+// buffering more than the cap.
+func fetchBlockBinary(ctx context.Context, baseURL, blockHash string, maxBlockBytes int64) ([]chainhash.Hash, []byte, *chainhash.Hash, int, error) {
 	url := fmt.Sprintf("%s/block/%s", baseURL, blockHash)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -70,14 +108,27 @@ func fetchBlockBinary(ctx context.Context, baseURL, blockHash string) ([]chainha
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 		return nil, nil, nil, resp.StatusCode, fmt.Errorf("GET %s: status %d (body: %s)", url, resp.StatusCode, string(body))
 	}
 
-	// Read entire response into memory so we can use NewTransactionFromStream
-	data, err := io.ReadAll(resp.Body)
+	// Reject advertised oversize responses without reading any of the body.
+	// resp.ContentLength is -1 when the server omits the header or uses
+	// chunked encoding; in that case we fall through to the LimitReader
+	// check below, which still bounds memory.
+	if resp.ContentLength >= 0 && resp.ContentLength > maxBlockBytes {
+		return nil, nil, nil, resp.StatusCode, fmt.Errorf("GET %s: Content-Length %d exceeds cap of %d bytes", url, resp.ContentLength, maxBlockBytes)
+	}
+
+	// Read entire response into memory so we can use NewTransactionFromStream.
+	// Read maxBlockBytes+1 so a body that lands exactly at the cap is
+	// accepted but anything larger is detected and rejected.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxBlockBytes+1))
 	if err != nil {
 		return nil, nil, nil, resp.StatusCode, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if int64(len(data)) > maxBlockBytes {
+		return nil, nil, nil, resp.StatusCode, fmt.Errorf("GET %s: response body exceeds %d bytes", url, maxBlockBytes)
 	}
 
 	hashes, cb, root, parseErr := parseBlockBinary(data)

--- a/bump/datahub_test.go
+++ b/bump/datahub_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -73,5 +74,168 @@ func TestFetchBlockDataForBUMP_EmptySliceFailsClearly(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no DataHub URLs") {
 		t.Errorf("expected explicit empty-list error, got %q", err.Error())
+	}
+}
+
+// --- Response body size cap tests (F-007) --------------------------------
+
+// minimalValidBlockBytes returns a minimal binary-block payload that
+// parseBlockBinary accepts: 80-byte header + four varints (txCount=0,
+// sizeBytes=0, subtreeCount=0, blockHeight=0) + zero-length coinbase tx
+// fragments. The coinbase parse will fail (no tx bytes), which the parser
+// treats as "no coinbase BUMP available" — fine for size-cap tests where
+// we only care that the read succeeded.
+func minimalValidBlockBytes(t *testing.T) []byte {
+	t.Helper()
+	// 80 bytes of zeroed header (bytes 36..68 carry the merkle root, but
+	// chainhash.NewHash only validates length, so any 32 bytes work) plus
+	// three single-byte varints: txCount=0, sizeBytes=0, subtreeCount=0.
+	out := make([]byte, 83)
+	out[80], out[81], out[82] = 0x00, 0x00, 0x00
+	return out
+}
+
+// padToSize right-pads payload with zero bytes so the response body is
+// exactly size bytes long.
+func padToSize(payload []byte, size int) []byte {
+	if len(payload) >= size {
+		return payload[:size]
+	}
+	out := make([]byte, size)
+	copy(out, payload)
+	return out
+}
+
+// TestFetchBlockDataForBUMP_BodyExceedsCap verifies that a response body
+// larger than the cap is rejected with an error mentioning the cap, and
+// that the error does not embed the response content.
+func TestFetchBlockDataForBUMP_BodyExceedsCap(t *testing.T) {
+	const maxBytes = 256
+	// Distinctive content so we can assert it does not leak into the error.
+	oversize := strings.Repeat("A", maxBytes+1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Don't set Content-Length so the cap is enforced by LimitReader,
+		// not the pre-read Content-Length check (covered separately).
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(oversize))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, _, _, err := FetchBlockDataForBUMPWithCap(
+		context.Background(),
+		[]string{srv.URL},
+		"deadbeef",
+		maxBytes,
+		zap.NewNop(),
+	)
+	if err == nil {
+		t.Fatal("expected error for oversize response body")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("expected error mentioning the cap, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "AAAA") {
+		t.Errorf("error must not embed response content, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(maxBytes)) {
+		t.Errorf("expected error to include the cap (%d), got: %v", maxBytes, err)
+	}
+}
+
+// TestFetchBlockDataForBUMP_BodyAtCap verifies that a body exactly at the
+// cap is accepted (the LimitReader+1 trick must not reject the boundary
+// case).
+func TestFetchBlockDataForBUMP_BodyAtCap(t *testing.T) {
+	payload := minimalValidBlockBytes(t)
+	// Pad up to a known size (>= header+3 varints, which is 83 bytes).
+	const target = 256
+	body := padToSize(payload, target)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	hashes, _, root, err := FetchBlockDataForBUMPWithCap(
+		context.Background(),
+		[]string{srv.URL},
+		"deadbeef",
+		int64(target),
+		zap.NewNop(),
+	)
+	if err != nil {
+		t.Fatalf("expected success at cap boundary, got: %v", err)
+	}
+	// subtreeCount=0 so hashes is empty; the merkle-root pointer is always
+	// populated when the header parses, even if the coinbase tail does not.
+	if len(hashes) != 0 {
+		t.Errorf("expected 0 subtree hashes, got %d", len(hashes))
+	}
+	if root == nil {
+		t.Errorf("expected non-nil header merkle root")
+	}
+}
+
+// TestFetchBlockDataForBUMP_ContentLengthExceedsCap verifies that an
+// advertised oversize Content-Length is rejected before the body is read.
+func TestFetchBlockDataForBUMP_ContentLengthExceedsCap(t *testing.T) {
+	const maxBytes = 256
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Advertise an oversize Content-Length explicitly. The body itself
+		// stays small — the client must reject based on the header alone.
+		w.Header().Set("Content-Length", strconv.Itoa(1<<20)) // 1 MiB
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(make([]byte, 1024))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, _, _, err := FetchBlockDataForBUMPWithCap(
+		context.Background(),
+		[]string{srv.URL},
+		"deadbeef",
+		maxBytes,
+		zap.NewNop(),
+	)
+	if err == nil {
+		t.Fatal("expected error for advertised oversize Content-Length")
+	}
+	if !strings.Contains(err.Error(), "Content-Length") || !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("expected error mentioning Content-Length and exceeds, got: %v", err)
+	}
+}
+
+// TestFetchBlockDataForBUMP_ZeroCapUsesDefault confirms the cap-aware
+// variant falls back to DefaultMaxBlockBytes when a non-positive cap is
+// passed, instead of silently disabling the protection. The default is
+// 1 GiB so a tiny payload is trivially within it.
+func TestFetchBlockDataForBUMP_ZeroCapUsesDefault(t *testing.T) {
+	payload := minimalValidBlockBytes(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, _, _, err := FetchBlockDataForBUMPWithCap(
+		context.Background(),
+		[]string{srv.URL},
+		"deadbeef",
+		0,
+		zap.NewNop(),
+	); err != nil {
+		t.Fatalf("zero cap should select the default and succeed, got: %v", err)
+	}
+	if _, _, _, err := FetchBlockDataForBUMPWithCap(
+		context.Background(),
+		[]string{srv.URL},
+		"deadbeef",
+		-1,
+		zap.NewNop(),
+	); err != nil {
+		t.Fatalf("negative cap should select the default and succeed, got: %v", err)
 	}
 }

--- a/config.example.standalone.yaml
+++ b/config.example.standalone.yaml
@@ -99,6 +99,8 @@ chaintracks_server:
 
 bump_builder:
   grace_window_ms: 30000
+  # Cap on DataHub /block/<hash> response bodies (bytes). Default 1 GiB.
+  # Mitigates F-007. datahub_max_block_bytes: 1073741824
 
 # propagation:
 #   # Per-endpoint circuit-breaker for datahub URLs. Bad peers are sidelined

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -126,6 +126,14 @@ bump_builder:
   # Grace window after BLOCK_PROCESSED before reading STUMPs, to allow for
   # late merkle-service retries of any STUMPs that initially got a 5xx.
   grace_window_ms: 30000
+  # Maximum response body size, in bytes, accepted from a DataHub
+  # /block/<hash> endpoint. The endpoint serves block metadata (header +
+  # subtree-hash list + coinbase tx + coinbase BUMP), so the default
+  # 1 GiB leaves two-plus orders of magnitude of headroom over realistic
+  # Teranode payloads while bounding memory against a hostile or
+  # malfunctioning endpoint. Set <= 0 to use the built-in default.
+  # Mitigates F-007.
+  # datahub_max_block_bytes: 1073741824
 
 # Shared on-disk root for arcade state. Chaintracks headers default to
 # <storage_path>/chaintracks/.

--- a/config/config.go
+++ b/config/config.go
@@ -310,6 +310,15 @@ type EndpointHealthConfig struct {
 // giving merkle-service retries time to land for any STUMPs that initially got a 5xx.
 type BumpBuilderConfig struct {
 	GraceWindowMs int `mapstructure:"grace_window_ms"`
+	// DataHubMaxBlockBytes caps a single /block/<hash> response body fetched
+	// from a DataHub endpoint, in bytes. The DataHub serves block metadata
+	// (header + subtree-hash list + coinbase tx + coinbase BUMP), so the
+	// default of 1 GiB is two-plus orders of magnitude over a realistic
+	// Teranode payload while still bounding memory against a hostile or
+	// malfunctioning endpoint. A value <= 0 selects bump.DefaultMaxBlockBytes.
+	// Mitigates F-007 (DataHub block fetch reads unbounded response bodies
+	// into memory).
+	DataHubMaxBlockBytes int64 `mapstructure:"datahub_max_block_bytes"`
 }
 
 // WebhookConfig tunes the HTTP webhook delivery service. The service
@@ -480,6 +489,11 @@ func setDefaults() {
 	var ct chaintracksconfig.Config
 	ct.SetDefaults(viper.GetViper(), "chaintracks")
 	viper.SetDefault("bump_builder.grace_window_ms", 30000)
+	// 1 GiB — DataHub /block/<hash> responses contain block metadata
+	// (header + subtree hashes + coinbase tx + coinbase BUMP). 1 GiB is
+	// two-plus orders of magnitude of headroom over a realistic payload
+	// while still bounding memory against a hostile DataHub. See F-007.
+	viper.SetDefault("bump_builder.datahub_max_block_bytes", int64(1*1024*1024*1024))
 }
 
 func validate(cfg *Config) error {

--- a/services/bump_builder/builder.go
+++ b/services/bump_builder/builder.go
@@ -161,7 +161,7 @@ func (b *Builder) handleMessage(ctx context.Context, msg *kafka.Message) error {
 	}
 	logger.Debug("fetching block data from datahub", zap.Strings("datahub_urls", endpoints))
 	fetchStart := time.Now()
-	subtreeHashes, coinbaseBUMP, headerMerkleRoot, err := bump.FetchBlockDataForBUMP(ctx, endpoints, blockHash, logger)
+	subtreeHashes, coinbaseBUMP, headerMerkleRoot, err := bump.FetchBlockDataForBUMPWithCap(ctx, endpoints, blockHash, b.cfg.BumpBuilder.DataHubMaxBlockBytes, logger)
 	metrics.BumpBuilderDatahubFetchDuration.Observe(time.Since(fetchStart).Seconds())
 	if err != nil {
 		outcome = "fetch_failed"


### PR DESCRIPTION
## Summary
- Wraps `resp.Body` reads in `io.LimitReader` and inspects `Content-Length` before reading the body, so a hostile or malfunctioning DataHub cannot exhaust process memory by streaming an unbounded response.
- Per-endpoint caps:
  - `/block/<hash>` (binary block metadata: 80-byte header + subtree-hash list + coinbase tx + coinbase BUMP) — default **1 GiB** via `bump.DefaultMaxBlockBytes`. The endpoint serves block metadata only, so 1 GiB is two-plus orders of magnitude over a realistic Teranode payload while still bounding memory.
  - The 5xx-body diagnostic read (already capped at 512 bytes pre-fix) is preserved.
- Configurable via `bump_builder.datahub_max_block_bytes` (`BumpBuilderConfig.DataHubMaxBlockBytes`); default applied via Viper. A value `<= 0` falls back to `bump.DefaultMaxBlockBytes` so a misconfigured zero never silently disables the protection.
- New tests in `bump/datahub_test.go`:
  - body larger than the cap (chunked, no `Content-Length`) is rejected with an error mentioning `exceeds` and the cap, and the error does **not** embed the response content;
  - body exactly at the cap is accepted (`LimitReader(max+1)` boundary);
  - advertised oversize `Content-Length` is rejected before any body bytes are read;
  - zero/negative caps fall back to the default rather than disabling the protection.
- Mirrors the merkle-service fix in PR #21 / commit 19241ad.

Closes #65

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./bump/... -race`
- [x] `go test ./... -race` (full suite)
- [x] `golangci-lint run ./bump/... ./config/... ./services/bump_builder/...`
- [ ] Reviewer to confirm operational caps (1 GiB for `/block/<hash>` is generous; tighten if Teranode's realistic max-block-metadata payload is lower for your fleet).