### PR TITLE
fix(kafka): preserve offset when DLQ publish fails (#69)

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -164,6 +164,12 @@
                 },
                 {
                     "linters": [
+                        "containedctx"
+                    ],
+                    "path": "kafka/consumer_test\\.go"
+                },
+                {
+                    "linters": [
                         "bodyclose"
                     ],
                     "path": "teranode/client\\.go"

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -133,7 +133,21 @@ func (c *ConsumerGroup) processOne(claim Claim, msg *Message) {
 	metrics.KafkaMessagesTotal.WithLabelValues(msg.Topic, "consume").Inc()
 	metrics.KafkaMessageBytes.WithLabelValues(msg.Topic, "consume").Observe(float64(len(msg.Value)))
 	if err := c.processWithRetry(claim.Context(), msg); err != nil {
-		c.sendToDLQ(msg, err)
+		// If DLQ publish also fails (e.g. transient outage on the DLQ
+		// topic) we deliberately do NOT mark the offset. Leaving it
+		// uncommitted causes Kafka to redeliver on the next session,
+		// which is preferable to silent message loss. The next
+		// rebalance / pod restart will retry from the same offset.
+		if dlqErr := c.sendToDLQ(msg, err); dlqErr != nil {
+			metrics.KafkaDLQPublishFailures.WithLabelValues(msg.Topic).Inc()
+			c.logger.Error("DLQ publish failed; leaving offset uncommitted for redelivery",
+				zap.String("topic", msg.Topic),
+				zap.Int32("partition", msg.Partition),
+				zap.Int64("offset", msg.Offset),
+				zap.Error(dlqErr),
+			)
+			return
+		}
 	}
 	claim.MarkMessage(msg)
 }
@@ -177,13 +191,21 @@ func (c *ConsumerGroup) processWithRetry(ctx context.Context, msg *Message) erro
 // sendToDLQ publishes the failed message envelope to <topic>.dlq via the
 // Broker. Routing through Broker (not the sync Sarama producer) keeps DLQ
 // working in standalone mode where there's no Sarama at all.
-func (c *ConsumerGroup) sendToDLQ(msg *Message, processErr error) {
+//
+// Returns an error when the DLQ publish itself failed so the caller can
+// decide whether the original Kafka offset is safe to commit. If no
+// producer is configured (DLQ disabled by deployment choice), this
+// returns nil — the caller treats the failed message as best-effort
+// dropped, which preserves the historical behavior for that mode.
+// Marshal failures also return nil because retrying will not help and
+// dropping is the only sane outcome.
+func (c *ConsumerGroup) sendToDLQ(msg *Message, processErr error) error {
 	if c.producer == nil {
 		c.logger.Error("no producer configured for DLQ — dropping failed message",
 			zap.String("topic", msg.Topic),
 			zap.Int64("offset", msg.Offset),
 		)
-		return
+		return nil
 	}
 	dlqTopic := DLQTopic(msg.Topic)
 	dlqMsg := map[string]any{
@@ -197,14 +219,14 @@ func (c *ConsumerGroup) sendToDLQ(msg *Message, processErr error) {
 	data, err := json.Marshal(dlqMsg)
 	if err != nil {
 		c.logger.Error("failed to marshal DLQ message", zap.Error(err))
-		return
+		return nil
 	}
 	if err := c.producer.SendRaw(dlqTopic, string(msg.Key), data); err != nil {
 		c.logger.Error("failed to send to DLQ",
 			zap.String("dlq_topic", dlqTopic),
 			zap.Error(err),
 		)
-		return
+		return fmt.Errorf("publishing to DLQ %q: %w", dlqTopic, err)
 	}
 	metrics.KafkaMessagesTotal.WithLabelValues(msg.Topic, "dlq").Inc()
 	c.logger.Info("message sent to DLQ",
@@ -213,4 +235,5 @@ func (c *ConsumerGroup) sendToDLQ(msg *Message, processErr error) {
 		zap.Int32("partition", msg.Partition),
 		zap.Int64("offset", msg.Offset),
 	)
+	return nil
 }

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -3,11 +3,33 @@ package kafka
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/metrics"
 )
+
+// fakeClaim is a Claim that tracks whether MarkMessage was invoked. Tests
+// assert on Marked to verify that processOne preserves the offset on DLQ
+// publish failure.
+type fakeClaim struct {
+	ctx    context.Context
+	ch     chan *Message
+	marked atomic.Int32
+}
+
+func newFakeClaim() *fakeClaim {
+	return &fakeClaim{ctx: context.Background(), ch: make(chan *Message, 1)}
+}
+
+func (c *fakeClaim) Messages() <-chan *Message { return c.ch }
+func (c *fakeClaim) Context() context.Context  { return c.ctx }
+func (c *fakeClaim) MarkMessage(_ *Message)    { c.marked.Add(1) }
+func (c *fakeClaim) Marked() int               { return int(c.marked.Load()) }
 
 func TestProcessWithRetry_BackoffDelaysBetweenAttempts(t *testing.T) {
 	attempts := 0
@@ -92,5 +114,133 @@ func TestProcessWithRetry_SuccessOnFirstAttempt_NoDelay(t *testing.T) {
 	}
 	if elapsed > 50*time.Millisecond {
 		t.Errorf("successful first attempt should be instant, took %v", elapsed)
+	}
+}
+
+// TestProcessOne_DLQPublishFailureDoesNotMark — when handler retries are
+// exhausted AND the DLQ publish itself fails, the offset MUST NOT be
+// committed. Otherwise a transient DLQ outage silently loses the message
+// (issue #69 / F-011). The DLQ-failure metric is also asserted.
+func TestProcessOne_DLQPublishFailureDoesNotMark(t *testing.T) {
+	const topic = "test.dlq-publish-fails"
+
+	handler := func(_ context.Context, _ *Message) error {
+		return errors.New("permanent handler failure")
+	}
+
+	// RecordingBroker with SendErr forces every Send (including the DLQ
+	// publish via Producer.SendRaw) to fail.
+	rec := &RecordingBroker{SendErr: errors.New("dlq topic offline")}
+	producer := NewProducer(rec)
+
+	c := &ConsumerGroup{
+		handler:    handler,
+		maxRetries: 2,
+		logger:     zap.NewNop(),
+		producer:   producer,
+	}
+
+	claim := newFakeClaim()
+	msg := &Message{Topic: topic, Partition: 0, Offset: 42, Value: []byte("payload")}
+
+	before := testutil.ToFloat64(metrics.KafkaDLQPublishFailures.WithLabelValues(topic))
+
+	c.processOne(claim, msg)
+
+	if claim.Marked() != 0 {
+		t.Fatalf("MarkMessage was called %d times; expected 0 so Kafka redelivers", claim.Marked())
+	}
+
+	after := testutil.ToFloat64(metrics.KafkaDLQPublishFailures.WithLabelValues(topic))
+	if after-before != 1 {
+		t.Errorf("KafkaDLQPublishFailures delta = %v, want 1", after-before)
+	}
+}
+
+// TestProcessOne_DLQPublishSuccessMarks — when handler retries are
+// exhausted but DLQ publish succeeds, MarkMessage must run so we don't
+// reprocess the poison message forever.
+func TestProcessOne_DLQPublishSuccessMarks(t *testing.T) {
+	const topic = "test.dlq-publish-ok"
+
+	handler := func(_ context.Context, _ *Message) error {
+		return errors.New("permanent handler failure")
+	}
+
+	rec := &RecordingBroker{} // no error → DLQ publish succeeds
+	producer := NewProducer(rec)
+
+	c := &ConsumerGroup{
+		handler:    handler,
+		maxRetries: 2,
+		logger:     zap.NewNop(),
+		producer:   producer,
+	}
+
+	claim := newFakeClaim()
+	msg := &Message{Topic: topic, Partition: 0, Offset: 7, Value: []byte("payload")}
+
+	before := testutil.ToFloat64(metrics.KafkaDLQPublishFailures.WithLabelValues(topic))
+
+	c.processOne(claim, msg)
+
+	if claim.Marked() != 1 {
+		t.Fatalf("MarkMessage was called %d times; expected 1 (DLQ succeeded)", claim.Marked())
+	}
+
+	rec.Lock()
+	sends := len(rec.Sends)
+	var sentTopic string
+	if sends > 0 {
+		sentTopic = rec.Sends[0].Topic
+	}
+	rec.Unlock()
+	if sends != 1 {
+		t.Errorf("expected 1 DLQ Send, got %d", sends)
+	}
+	if sentTopic != DLQTopic(topic) {
+		t.Errorf("DLQ send topic = %q, want %q", sentTopic, DLQTopic(topic))
+	}
+
+	// DLQ-failure counter must NOT increment when the publish succeeded.
+	after := testutil.ToFloat64(metrics.KafkaDLQPublishFailures.WithLabelValues(topic))
+	if after != before {
+		t.Errorf("KafkaDLQPublishFailures changed by %v on success; expected 0", after-before)
+	}
+}
+
+// TestProcessOne_HappyPathMarks — handler succeeds on first attempt: no
+// DLQ activity, MarkMessage is called once.
+func TestProcessOne_HappyPathMarks(t *testing.T) {
+	const topic = "test.happy-path"
+
+	handler := func(_ context.Context, _ *Message) error {
+		return nil
+	}
+
+	rec := &RecordingBroker{}
+	producer := NewProducer(rec)
+
+	c := &ConsumerGroup{
+		handler:    handler,
+		maxRetries: 5,
+		logger:     zap.NewNop(),
+		producer:   producer,
+	}
+
+	claim := newFakeClaim()
+	msg := &Message{Topic: topic, Partition: 0, Offset: 99, Value: []byte("payload")}
+
+	c.processOne(claim, msg)
+
+	if claim.Marked() != 1 {
+		t.Fatalf("MarkMessage was called %d times; expected 1", claim.Marked())
+	}
+
+	rec.Lock()
+	sends := len(rec.Sends)
+	rec.Unlock()
+	if sends != 0 {
+		t.Errorf("expected 0 Sends on happy path, got %d", sends)
 	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -294,6 +294,16 @@ var KafkaProduceErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "Kafka producer error count, by topic.",
 }, []string{"topic"})
 
+// KafkaDLQPublishFailures counts DLQ publish failures by original topic. A
+// non-zero rate means the DLQ topic is rejecting publishes — investigate Kafka
+// availability. The consumer leaves the offset uncommitted on these failures,
+// so they correlate with rising consumer lag on the primary topic until
+// publishing recovers.
+var KafkaDLQPublishFailures = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_kafka_dlq_publish_failures_total",
+	Help: "Kafka DLQ publish failure count, by original topic.",
+}, []string{"topic"})
+
 // ---------------------------------------------------------------------------
 // p2p_client
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `processOne` no longer `MarkMessage`s when `sendToDLQ` returns an error; the offset stays uncommitted so Kafka redelivers on the next session / pod restart.
- `sendToDLQ` now returns an error from broker publish failures (marshal failures and the no-producer-configured branch still return nil since retrying does not help).
- New counter `arcade_kafka_dlq_publish_failures_total{topic}` so operators can alert on DLQ outages.
- Three new tests cover the failure mode (no Mark, metric incremented), the recovery path (Mark, no metric increment), and the happy path (Mark, no DLQ traffic). The existing `processWithRetry` tests still pass.

Closes #69

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./kafka/... -race`
- [x] `golangci-lint run ./kafka/... ./metrics/...` (0 issues)
- [ ] Reviewer to confirm metric naming convention