### PR TITLE
fix(api_server/sse): avoid send on closed client channel (#78)

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -244,6 +244,21 @@ var APIRequestBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Buckets: bytesBuckets,
 }, []string{"route"})
 
+// APISSEDroppedTotal counts SSE fan-out events that were dropped without
+// being delivered to a client. Reasons:
+//   - "slow_client": the client's send buffer was full (the consumer goroutine
+//     wasn't draining it fast enough).
+//   - "client_gone": the client was unregistering concurrently and its context
+//     had already been canceled by the time fan-out reached it.
+//
+// A non-zero "client_gone" rate is normal under churn; a sustained
+// "slow_client" rate indicates a consumer that can't keep up with the publish
+// rate and may need a larger buffer or a backpressure strategy.
+var APISSEDroppedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_api_sse_dropped_total",
+	Help: "SSE fan-out events dropped without delivery, by reason.",
+}, []string{"reason"}) // slow_client, client_gone
+
 // ---------------------------------------------------------------------------
 // teranode (HTTP client)
 // ---------------------------------------------------------------------------

--- a/services/api_server/sse.go
+++ b/services/api_server/sse.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/bsv-blockchain/arcade/events"
+	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/store"
 )
@@ -22,10 +23,25 @@ import (
 // `ch` and writes frames to the wire; the manager pushes onto `ch` from its
 // fan-out goroutine. token narrows the stream to txids associated with that
 // callback token; empty means unfiltered.
+//
+// ctx is derived from the manager's parent context so we can broadcast
+// "client is gone" to fan-out without racing the consumer-side close. The
+// consumer (handleEventsSSE) calls cancel() via unregister on disconnect,
+// which causes any concurrent fan-out send to fall through the ctx.Done()
+// arm of its select rather than blocking or panicking. The channel is
+// intentionally NOT closed: senders always race the close otherwise (F-020).
+// The buffered channel is left to the GC once no goroutine references it.
 type sseClient struct {
 	id    int64
 	token string
 	ch    chan *models.TransactionStatus
+	// ctx and cancel intentionally live on the struct: this is the
+	// per-client cancel signal that fan-out selects on to avoid sending
+	// onto a no-longer-drained channel (F-020). The standard "don't
+	// store contexts" guidance doesn't apply to long-lived cancellation
+	// handles owned by a registry entry.
+	ctx    context.Context    //nolint:containedctx // see comment above
+	cancel context.CancelFunc //nolint:containedctx // paired with ctx above
 }
 
 // sseManager owns the per-pod registry of SSE clients listening on /events.
@@ -42,6 +58,11 @@ type sseManager struct {
 	publisher events.Publisher
 	store     store.Store
 	logger    *zap.Logger
+
+	// parentCtx is the long-lived context that owns the manager goroutine.
+	// Per-client contexts are derived from it so canceling the manager
+	// also cancels every registered client's fan-out path.
+	parentCtx context.Context //nolint:containedctx // long-lived registry root
 
 	nextClientID atomic.Int64
 
@@ -61,6 +82,7 @@ func newSSEManager(ctx context.Context, publisher events.Publisher, st store.Sto
 		publisher: publisher,
 		store:     st,
 		logger:    logger.Named("sse"),
+		parentCtx: ctx,
 		clients:   make(map[int64]*sseClient),
 	}
 	ch, err := publisher.Subscribe(ctx)
@@ -95,6 +117,14 @@ func (m *sseManager) run(ctx context.Context, in <-chan *models.TransactionStatu
 // submission registered under that token (mirrors the old arcade's
 // txBelongsToToken behavior). Sends are non-blocking — slow consumers drop
 // the event and recover via Last-Event-ID catchup on reconnect.
+//
+// Concurrency contract (F-020): we snapshot the client list under RLock and
+// release the lock before sending. A client may unregister between the
+// snapshot and the send. Each client owns a context that unregister cancels;
+// the send selects on ctx.Done() so a canceled-and-gone client takes the
+// drop arm instead of blocking or panicking. The send channel is never
+// closed by the manager — closing would race this exact send. Slow clients
+// fall through `default` and increment the dropped-by-reason counter.
 func (m *sseManager) fanOut(ctx context.Context, status *models.TransactionStatus) {
 	m.mu.RLock()
 	clients := make([]*sseClient, 0, len(m.clients))
@@ -104,12 +134,27 @@ func (m *sseManager) fanOut(ctx context.Context, status *models.TransactionStatu
 	m.mu.RUnlock()
 
 	for _, c := range clients {
+		// Quick out for already-gone clients: avoids the token lookup work
+		// for connections we know are unwinding. The send-site re-checks
+		// ctx.Done() to handle the race where cancel happens between here
+		// and the channel select.
+		if c.ctx.Err() != nil {
+			metrics.APISSEDroppedTotal.WithLabelValues("client_gone").Inc()
+			continue
+		}
 		if c.token != "" && !m.txBelongsToToken(ctx, status.TxID, c.token) {
 			continue
 		}
 		select {
 		case c.ch <- status:
+		case <-c.ctx.Done():
+			// Client unregistered concurrently. Drop without sending —
+			// the channel may already be unreferenced by the consumer.
+			metrics.APISSEDroppedTotal.WithLabelValues("client_gone").Inc()
 		default:
+			// Buffer is full: consumer is slow. Drop and let
+			// Last-Event-ID catchup recover on reconnect.
+			metrics.APISSEDroppedTotal.WithLabelValues("slow_client").Inc()
 			m.logger.Warn("dropping update for slow SSE client",
 				zap.Int64("client_id", c.id),
 				zap.String("txid", status.TxID),
@@ -141,29 +186,48 @@ func (m *sseManager) txBelongsToToken(ctx context.Context, txid, token string) b
 	return false
 }
 
-// register adds a client to the registry and returns its assigned id.
+// register adds a client to the registry.
 func (m *sseManager) register(c *sseClient) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.clients[c.id] = c
 }
 
-// unregister removes a client and closes its channel.
+// unregister removes a client and signals any in-flight fan-out send to drop
+// rather than push onto the channel. We deliberately do NOT close c.ch:
+// closing would race with concurrent fanOut sends (F-020). The consumer
+// goroutine in handleEventsSSE selects on its request ctx (which is what
+// drives the unregister) so it exits without needing a channel-close signal;
+// the unreferenced channel is reclaimed by the GC.
 func (m *sseManager) unregister(id int64) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	if c, ok := m.clients[id]; ok {
+	c, ok := m.clients[id]
+	if ok {
 		delete(m.clients, id)
-		close(c.ch)
+	}
+	m.mu.Unlock()
+	if ok {
+		c.cancel()
 	}
 }
 
-// newClient assembles a client with a fresh id and buffered channel.
+// newClient assembles a client with a fresh id, buffered channel, and a
+// per-client cancel handle. The client context is derived from the
+// manager's parent ctx so a manager shutdown propagates to every client.
 func (m *sseManager) newClient(token string) *sseClient {
+	parent := m.parentCtx
+	if parent == nil {
+		parent = context.Background()
+	}
+	// The cancel func is stored on sseClient and invoked by unregister;
+	// the linter can't trace that flow, so silence the warning explicitly.
+	ctx, cancel := context.WithCancel(parent) //nolint:gosec // cancel called by sseManager.unregister
 	return &sseClient{
-		id:    m.nextClientID.Add(1),
-		token: token,
-		ch:    make(chan *models.TransactionStatus, 64),
+		id:     m.nextClientID.Add(1),
+		token:  token,
+		ch:     make(chan *models.TransactionStatus, 64),
+		ctx:    ctx,
+		cancel: cancel,
 	}
 }
 
@@ -220,13 +284,18 @@ func (s *Server) handleEventsSSE(c *gin.Context) {
 	keepalive := time.NewTicker(15 * time.Second)
 	defer keepalive.Stop()
 
+	// The channel is intentionally never closed by the manager (see F-020),
+	// so the loop exits via the request ctx — that's what triggers the
+	// deferred unregister, which cancels the client context. Reads from a
+	// non-closed, no-longer-written channel just block until ctx.Done()
+	// wins the select.
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case status, ok := <-client.ch:
-			if !ok {
-				return
+		case status := <-client.ch:
+			if status == nil {
+				continue
 			}
 			if err := writeSSEStatus(writer, status); err != nil {
 				return

--- a/services/api_server/sse_test.go
+++ b/services/api_server/sse_test.go
@@ -9,15 +9,18 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"go.uber.org/zap"
 
 	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
 )
 
@@ -275,6 +278,188 @@ func TestSSENoPublisher(t *testing.T) {
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestSSEFanOutConcurrentUnregister stresses the F-020 fix: many clients
+// register, then half are unregistered concurrently with a fan-out push. The
+// previous implementation closed c.ch on unregister, which races a fan-out
+// send and panics with "send on closed channel". With the fix, fan-out
+// selects on the per-client ctx and bails cleanly when a client is gone, so
+// no panic ever occurs even under aggressive interleaving.
+func TestSSEFanOutConcurrentUnregister(t *testing.T) {
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{},
+		statusByTx:  map[string]*models.TransactionStatus{},
+	}
+	_, _, _, cancel := setupSSEServer(t, st)
+	defer cancel()
+
+	// Build a manager directly (bypass HTTP) so we can drive register /
+	// unregister / fanOut on the same struct the production path uses.
+	ctx, mgrCancel := context.WithCancel(t.Context())
+	defer mgrCancel()
+	mgr, err := newSSEManager(ctx, &fakePublisher{}, st, zap.NewNop())
+	if err != nil {
+		t.Fatalf("newSSEManager: %v", err)
+	}
+
+	const N = 200
+	clients := make([]*sseClient, N)
+	for i := 0; i < N; i++ {
+		c := mgr.newClient("") // empty token → no store filter
+		mgr.register(c)
+		clients[i] = c
+	}
+
+	startGoroutines := runtime.NumGoroutine()
+
+	status := &models.TransactionStatus{
+		TxID:      "race-tx",
+		Status:    models.StatusMined,
+		Timestamp: time.Unix(0, 1700000000000000000).UTC(),
+	}
+
+	// Race: half the clients unregister while a stream of fan-outs happens.
+	// Repeat enough times to exercise the interleaving.
+	const iterations = 50
+	for it := 0; it < iterations; it++ {
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < N; i += 2 {
+				mgr.unregister(clients[i].id)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			// fanOut must not panic even though half the clients are
+			// being unregistered (and previously had their ch closed)
+			// concurrently.
+			mgr.fanOut(ctx, status)
+		}()
+		wg.Wait()
+
+		// Re-register fresh clients in those slots so the next iteration
+		// has another batch to race.
+		for i := 0; i < N; i += 2 {
+			c := mgr.newClient("")
+			mgr.register(c)
+			clients[i] = c
+		}
+	}
+
+	// Drain remaining: cancel ctx → manager goroutine exits, all client
+	// ctxs cancel via parent. Allow scheduler a beat to clean up.
+	mgrCancel()
+	cancel()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= startGoroutines+2 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	// Best-effort goroutine-leak check: we don't pin an exact count
+	// (httptest / runtime can spawn helpers) but we tolerate a small
+	// fudge. The real assertion is "no panic" above.
+	t.Logf("goroutines start=%d end=%d (fudge tolerated)", startGoroutines, runtime.NumGoroutine())
+}
+
+// TestSSEFanOutSlowClientDrops verifies that a client whose buffer is full
+// causes fan-out to take the drop arm rather than block. The slow_client
+// counter must increment by exactly the number of drops, and the fan-out
+// must complete promptly even though the slow client never drains.
+func TestSSEFanOutSlowClientDrops(t *testing.T) {
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{},
+		statusByTx:  map[string]*models.TransactionStatus{},
+	}
+	_, _, _, cancel := setupSSEServer(t, st)
+	defer cancel()
+
+	ctx, mgrCancel := context.WithCancel(t.Context())
+	defer mgrCancel()
+	mgr, err := newSSEManager(ctx, &fakePublisher{}, st, zap.NewNop())
+	if err != nil {
+		t.Fatalf("newSSEManager: %v", err)
+	}
+
+	slow := mgr.newClient("")
+	mgr.register(slow)
+	defer mgr.unregister(slow.id)
+
+	// Fill the slow client's buffer to capacity so subsequent fan-outs
+	// must take the default-drop arm.
+	for i := 0; i < cap(slow.ch); i++ {
+		slow.ch <- &models.TransactionStatus{TxID: "filler", Timestamp: time.Now()}
+	}
+
+	before := testutil.ToFloat64(metrics.APISSEDroppedTotal.WithLabelValues("slow_client"))
+
+	const drops = 5
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < drops; i++ {
+			mgr.fanOut(ctx, &models.TransactionStatus{
+				TxID:      "drop",
+				Status:    models.StatusMined,
+				Timestamp: time.Now(),
+			})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fanOut blocked on slow client (should have dropped)")
+	}
+
+	after := testutil.ToFloat64(metrics.APISSEDroppedTotal.WithLabelValues("slow_client"))
+	if got := after - before; got != drops {
+		t.Errorf("slow_client drops = %v, want %d", got, drops)
+	}
+}
+
+// TestSSEFanOutClientGoneDrops ensures a client whose ctx has been canceled
+// (i.e. unregister already ran) falls through the ctx.Done() arm of the
+// fan-out select rather than panicking on a closed channel. We invoke
+// fanOut directly so the race is deterministic.
+func TestSSEFanOutClientGoneDrops(t *testing.T) {
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{},
+		statusByTx:  map[string]*models.TransactionStatus{},
+	}
+	_, _, _, cancel := setupSSEServer(t, st)
+	defer cancel()
+
+	ctx, mgrCancel := context.WithCancel(t.Context())
+	defer mgrCancel()
+	mgr, err := newSSEManager(ctx, &fakePublisher{}, st, zap.NewNop())
+	if err != nil {
+		t.Fatalf("newSSEManager: %v", err)
+	}
+
+	gone := mgr.newClient("")
+	mgr.register(gone)
+	// Cancel WITHOUT removing from the map so fanOut still sees this
+	// client in its snapshot — exactly the race the bug describes.
+	gone.cancel()
+
+	before := testutil.ToFloat64(metrics.APISSEDroppedTotal.WithLabelValues("client_gone"))
+
+	// Must not panic.
+	mgr.fanOut(ctx, &models.TransactionStatus{
+		TxID:      "gone",
+		Status:    models.StatusMined,
+		Timestamp: time.Now(),
+	})
+
+	after := testutil.ToFloat64(metrics.APISSEDroppedTotal.WithLabelValues("client_gone"))
+	if got := after - before; got < 1 {
+		t.Errorf("client_gone drops = %v, want >= 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Each `sseClient` now carries its own context; fan-out selects on the channel and `ctx.Done()` so a canceled-and-closed client doesn't trigger send-on-closed-channel panics.
- `unregister` no longer closes the client channel — closing races concurrent fan-out sends, which is the F-020 root cause. Instead it cancels the per-client context; the consumer goroutine in `handleEventsSSE` exits via the request context (the same signal that drives unregister), and the unreferenced channel is reclaimed by the GC.
- Slow clients drop their message (and a new `arcade_api_sse_dropped_total{reason="slow_client"}` counter increments) instead of blocking the fan-out. Already-canceled clients drop with `reason="client_gone"`.
- New tests:
  - `TestSSEFanOutConcurrentUnregister` — 200 clients × 50 iterations of unregister-vs-fanOut; under `-race` this would have panicked on the previous code.
  - `TestSSEFanOutSlowClientDrops` — fills the buffer, asserts fan-out doesn't block and the `slow_client` counter increments by exactly the expected drop count.
  - `TestSSEFanOutClientGoneDrops` — cancels a client without removing it from the map (the exact race the bug describes) and asserts no panic + `client_gone` counter increments.

Closes #78

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./services/api_server/... ./metrics/... -count=1 -race`
- [x] `golangci-lint run ./services/api_server/... ./metrics/...` — 0 issues
- [ ] Reviewer to confirm `arcade_api_sse_dropped_total` naming and `client_gone`/`slow_client` reason labels match observability conventions
- [ ] Reviewer to confirm leaving the channel un-closed is acceptable (the alternative — close-after-cancel-with-drain — adds complexity for no real benefit since the consumer doesn't need the close signal)