### PR TITLE
[Do not merge] fix(tx_validator): actually validate fees and scripts (#80)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -131,6 +131,15 @@ tx_validator:
 # window. Validation is CPU-bound and stateless, so the sweet spot is around
 # NumCPU. Set 0 to take runtime.NumCPU() at startup.
 # parallelism: 0
+#
+# skip_fee_validation / skip_script_validation default to false. Leave them
+# false in production — the validator will then enforce the policy minimum
+# fee and run full script verification (via spv.Verify) for every submitted
+# transaction. Set either true ONLY in tests or in environments where the
+# underlying preconditions can't be satisfied (e.g. no chaintracker is wired
+# up yet); flipping them on is equivalent to "trust whatever the client sent".
+# skip_fee_validation: false
+# skip_script_validation: false
 
 bump_builder:
   # Grace window after BLOCK_PROCESSED before reading STUMPs, to allow for

--- a/config/config.go
+++ b/config/config.go
@@ -356,8 +356,19 @@ type CallbackConfig struct {
 // single flush window — bounded so a huge in-flight batch can't open more
 // goroutines than the host has cores. Zero or negative falls back to
 // runtime.NumCPU at construction time.
+//
+// SkipFeeValidation / SkipScriptValidation default to false (i.e. fees AND
+// scripts are checked). They exist as escape hatches for environments that
+// can't currently fulfil the underlying validator's prerequisites — for
+// example, deployments without a wired-up chaintracker should set
+// skip_script_validation=true rather than letting the SDK silently fall back
+// to WhatsOnChain. Operators flipping these to true accept that fee/script
+// rules will not be enforced for submitted transactions; they MUST NOT be
+// flipped on in production without a compensating control.
 type TxValidatorConfig struct {
-	Parallelism int `mapstructure:"parallelism"`
+	Parallelism          int  `mapstructure:"parallelism"`
+	SkipFeeValidation    bool `mapstructure:"skip_fee_validation"`
+	SkipScriptValidation bool `mapstructure:"skip_script_validation"`
 }
 
 func BindFlags(cmd *cobra.Command) {

--- a/services/tx_validator/validator.go
+++ b/services/tx_validator/validator.go
@@ -74,6 +74,14 @@ type Validator struct {
 	consumer    *kafka.ConsumerGroup
 
 	parallelism int
+	// skipFees / skipScripts mirror cfg.TxValidator.{SkipFeeValidation,
+	// SkipScriptValidation} and are forwarded to validator.ValidateTransaction
+	// at flush time. Defaults are false on both — i.e. validation is on.
+	// Finding F-022 / issue #80: these used to be hard-coded true (skip both)
+	// which silently disabled fee and script enforcement for every submitted
+	// transaction.
+	skipFees    bool
+	skipScripts bool
 
 	mu sync.Mutex
 	// pending holds raw tx bytes that haven't yet been through the validation
@@ -99,6 +107,8 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 		txTracker:   tracker,
 		txValidator: v,
 		parallelism: parallelism,
+		skipFees:    cfg.TxValidator.SkipFeeValidation,
+		skipScripts: cfg.TxValidator.SkipScriptValidation,
 	}
 }
 
@@ -467,6 +477,12 @@ func (v *Validator) phaseDedup(ctx context.Context, parsed []parseResult) (live,
 // validator.ValidateTransaction reads only immutable struct fields so
 // fan-out is safe. Mutates entries in-place: rejected=true and rejectReason
 // for failures, untouched for accepts.
+//
+// The skipFees / skipScripts arguments forwarded to the underlying validator
+// are the per-service config knobs (cfg.TxValidator.SkipFeeValidation /
+// SkipScriptValidation), default false. The previous implementation hard-
+// coded both to true, which meant fees AND scripts were silently skipped on
+// every submission — the bug fixed in #80 (F-022).
 func (v *Validator) phaseValidate(ctx context.Context, live []*validatedTx) {
 	if v.txValidator == nil {
 		// Tests sometimes pass a nil validator; treat all as accepts.
@@ -476,7 +492,7 @@ func (v *Validator) phaseValidate(ctx context.Context, live []*validatedTx) {
 	g.SetLimit(v.parallelism)
 	for _, vt := range live {
 		g.Go(func() error {
-			if err := v.txValidator.ValidateTransaction(gctx, vt.parsed, true, true); err != nil {
+			if err := v.txValidator.ValidateTransaction(gctx, vt.parsed, v.skipFees, v.skipScripts); err != nil {
 				vt.rejected = true
 				vt.rejectReason = err.Error()
 				v.logger.Info("transaction validation failed",

--- a/services/tx_validator/validator_test.go
+++ b/services/tx_validator/validator_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/script"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -136,8 +138,14 @@ func newTestValidator(broker *kafka.RecordingBroker, ms *mockStore) *Validator {
 }
 
 func newTestValidatorWithValidator(broker *kafka.RecordingBroker, ms *mockStore, txValidator *validator.Validator) *Validator {
+	return newTestValidatorWithConfig(broker, ms, txValidator, &config.Config{})
+}
+
+// newTestValidatorWithConfig wires the validator with a caller-supplied
+// config so tests can flip TxValidator.SkipFeeValidation /
+// SkipScriptValidation and assert the new plumbing.
+func newTestValidatorWithConfig(broker *kafka.RecordingBroker, ms *mockStore, txValidator *validator.Validator, cfg *config.Config) *Validator {
 	producer := kafka.NewProducer(broker)
-	cfg := &config.Config{}
 	tracker := store.NewTxTracker()
 	v := New(cfg, zap.NewNop(), producer, nil, ms, tracker, txValidator)
 	// Pin parallelism for deterministic tests so we don't accidentally serialize
@@ -485,5 +493,156 @@ func TestValidator_StartLogsParallelism(t *testing.T) {
 	v := New(cfg, logger, kafka.NewProducer(broker), nil, ms, store.NewTxTracker(), nil)
 	if v.parallelism != 16 {
 		t.Errorf("expected parallelism=16 from config, got %d", v.parallelism)
+	}
+}
+
+// makeFeeFailingTxBytes returns a freshly minted transaction that passes
+// validator.ValidatePolicy (one push-only input with a populated source
+// output, one non-data output, size > minTxSizeBytes) but has totalIn ==
+// totalOut, i.e. a fee of zero. The default min-fee-per-KB policy is 100
+// sat/kB, so spv.Verify fee enforcement must reject it whenever
+// skipFees=false. Per validator.ValidateTransaction's contract, a tx that
+// has a non-nil chaintracker but zero fee will trip fee validation before
+// any script work touches the wire — which is what we want for unit tests
+// (no network).
+func makeFeeFailingTxBytes(t *testing.T) []byte {
+	t.Helper()
+	tx := sdkTx.NewTransaction()
+	// Vary the lock_time so the txid is unique across calls — keeps
+	// dedup happy when this helper is reused inside a single batch.
+	tx.LockTime = 0xdeadbeef
+
+	srcID := chainhash.Hash{}
+	srcID[0] = 0x42
+
+	// Single input. UnlockingScript is a single OP_TRUE (0x51) so it
+	// satisfies pushDataCheck (push-only and non-empty) without dragging
+	// real signatures into the test fixture. The source output is set
+	// inline so TotalInputSatoshis returns successfully — required for
+	// spv.Verify's fee math to even run.
+	unlocking := script.Script([]byte{0x51})
+	in := &sdkTx.TransactionInput{
+		SourceTXID:      &srcID,
+		UnlockingScript: &unlocking,
+	}
+	in.SetSourceTxOutput(&sdkTx.TransactionOutput{
+		Satoshis:      1_000,
+		LockingScript: opTrueScript(),
+	})
+	tx.AddInput(in)
+
+	// Single output equal to input → zero fee → fee validation rejects.
+	tx.AddOutput(&sdkTx.TransactionOutput{
+		Satoshis:      1_000,
+		LockingScript: opTrueScript(),
+	})
+
+	// Pad with an extra OP_RETURN data output so the serialized tx is
+	// comfortably above the 61-byte minimum policy size.
+	dataScript := script.Script(append([]byte{0x6a, 0x20}, make([]byte, 0x20)...))
+	tx.AddOutput(&sdkTx.TransactionOutput{
+		Satoshis:      0,
+		LockingScript: &dataScript,
+	})
+
+	return tx.Bytes()
+}
+
+// opTrueScript returns a *script.Script containing a single OP_TRUE byte.
+// Treated as non-data and non-empty by the SDK heuristics, so it clears
+// validator.checkOutputs without producing a dust output.
+func opTrueScript() *script.Script {
+	s := script.Script([]byte{0x51})
+	return &s
+}
+
+// TestValidator_DefaultsRejectFeeFailures is the regression guard for
+// finding F-022 / issue #80. The previous implementation hard-coded
+// (skipFees=true, skipScripts=true) at the call site, so a tx with a zero
+// fee was accepted even though the underlying validator was perfectly
+// capable of catching it. With the fix the defaults thread through as
+// (false, false) and the same tx gets rejected.
+func TestValidator_DefaultsRejectFeeFailures(t *testing.T) {
+	broker := &kafka.RecordingBroker{}
+	ms := newMockStore()
+
+	realValidator := validator.NewValidator(nil, nil)
+	v := newTestValidatorWithValidator(broker, ms, realValidator)
+	if v.skipFees || v.skipScripts {
+		t.Fatalf("default config must keep fee/script validation on; got skipFees=%v skipScripts=%v",
+			v.skipFees, v.skipScripts)
+	}
+
+	if err := v.handleMessage(context.Background(), makeKafkaMsg(makeTxMsgFromBytes(makeFeeFailingTxBytes(t)))); err != nil {
+		t.Fatalf("handleMessage: %v", err)
+	}
+	if err := v.flushValidations(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	updates := ms.snapshotUpdates()
+	if len(updates) != 1 {
+		t.Fatalf("expected exactly 1 reject update from a zero-fee tx, got %d", len(updates))
+	}
+	if updates[0].Status != models.StatusRejected {
+		t.Errorf("expected REJECTED, got %q", updates[0].Status)
+	}
+	if updates[0].ExtraInfo == "" {
+		t.Errorf("reject reason should not be empty")
+	}
+	if broker.BatchCalls != 0 {
+		t.Errorf("rejected tx must not reach the propagation topic; got %d batch calls",
+			broker.BatchCalls)
+	}
+}
+
+// TestValidator_SkipFlagsBypassFeeFailures pins the new config knobs:
+// flipping skip_fee_validation=true makes the same zero-fee tx pass. The
+// test exists so a future refactor can't silently drop the flags; if this
+// test starts failing the flags have stopped being plumbed through.
+func TestValidator_SkipFlagsBypassFeeFailures(t *testing.T) {
+	broker := &kafka.RecordingBroker{}
+	ms := newMockStore()
+
+	cfg := &config.Config{}
+	cfg.TxValidator.SkipFeeValidation = true
+	cfg.TxValidator.SkipScriptValidation = true
+
+	realValidator := validator.NewValidator(nil, nil)
+	v := newTestValidatorWithConfig(broker, ms, realValidator, cfg)
+	if !v.skipFees || !v.skipScripts {
+		t.Fatalf("config skip flags must reach the validator; got skipFees=%v skipScripts=%v",
+			v.skipFees, v.skipScripts)
+	}
+
+	if err := v.handleMessage(context.Background(), makeKafkaMsg(makeTxMsgFromBytes(makeFeeFailingTxBytes(t)))); err != nil {
+		t.Fatalf("handleMessage: %v", err)
+	}
+	if err := v.flushValidations(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	if got := ms.updateCallCount.Load(); got != 0 {
+		t.Errorf("expected 0 reject updates with skip flags on, got %d", got)
+	}
+	if broker.BatchCalls != 1 || broker.MessageCount() != 1 {
+		t.Errorf("expected the tx to publish when skip flags are on; got batchCalls=%d messages=%d",
+			broker.BatchCalls, broker.MessageCount())
+	}
+}
+
+// TestValidator_DefaultSkipFlagsAreFalse is a tiny but high-value
+// invariant test. If somebody flips the defaults in TxValidatorConfig the
+// fee/script validators silently turn off again — this test fails loudly
+// the moment that happens.
+func TestValidator_DefaultSkipFlagsAreFalse(t *testing.T) {
+	cfg := &config.Config{}
+	v := New(cfg, zap.NewNop(), kafka.NewProducer(&kafka.RecordingBroker{}), nil,
+		newMockStore(), store.NewTxTracker(), nil)
+	if v.skipFees {
+		t.Error("default cfg must keep fee validation on (skipFees=false)")
+	}
+	if v.skipScripts {
+		t.Error("default cfg must keep script validation on (skipScripts=false)")
 	}
 }


### PR DESCRIPTION
## Summary
- The third and fourth args to `validator.ValidateTransaction` are `skipFees` and `skipScripts`. The tx_validator service was hard-coding both to `true`, which silently disabled fee and script enforcement for every submitted transaction (finding F-022).
- Plumbed two new opt-in escape hatches through `TxValidatorConfig` — `skip_fee_validation` and `skip_script_validation`, both defaulting to `false`. Production behavior is now "validate everything" by default; operators that can't currently satisfy the underlying SDK's prerequisites (e.g. no chaintracker wired up — `cmd/arcade/main.go` still constructs `validator.NewValidator(nil, nil)`) can flip the knobs explicitly rather than relying on a silently broken default.
- Added regression tests: a zero-fee tx is now rejected by default, the same tx passes when both skip flags are set, and a tiny invariant test pins the default-false config so a future refactor can't quietly turn enforcement back off.

Closes #80

## Reviewer please double-check
This change WILL cause previously-passing transactions to be rejected if production has been silently relying on the broken behavior. Two specific concerns to validate before merge:

1. **No chaintracker is currently wired up.** `cmd/arcade/main.go:133` calls `validator.NewValidator(nil, nil)`. With `skipScripts=false` the SDK's `spv.Verify` falls back to `chaintracker.NewWhatsOnChain(MainNet, "")` (see go-sdk/spv/verify.go), which means every script verification reaches out to WhatsOnChain. That is likely undesirable for arcade's deployment topology. Two reasonable mitigations the reviewer should pick from:
   - Wire arcade's existing chaintracks client into `NewValidator` here, OR
   - Default `skip_script_validation: true` in `setDefaults()` until the chaintracker is wired (and then drop the default once it is).
2. **Fee policy is the SDK default of 100 sat/kB.** Any transaction that paid <100 sat/kB before will now be rejected. Worth a sanity check against historical traffic / a staging environment before promoting to mainnet.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./services/tx_validator/... ./validator/... -count=1 -race`
- [x] `golangci-lint run ./services/tx_validator/... ./validator/...` — 0 issues
- [ ] Reviewer to verify the production behavior change is intended and won't reject anything legitimate