### PR TITLE
fix(propagation): retry batch when Merkle registration fails (#82)

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -142,13 +142,25 @@ var PropagationInlineRetryTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "Inline retry attempts on broadcastSingleToEndpoints.",
 }, []string{"outcome"}) // recovered, exhausted
 
-// PropagationMerkleRegisterDuration measures the merkle-service batch
+// PropagationMerkleRegisterDuration measures the merkle-service per-message
 // registration round-trip. Slow merkle calls are a common bottleneck.
 var PropagationMerkleRegisterDuration = promauto.NewHistogram(prometheus.HistogramOpts{
 	Name:    "arcade_propagation_merkle_register_duration_seconds",
-	Help:    "Duration of merkle-service RegisterBatch calls.",
+	Help:    "Duration of merkle-service Register calls.",
 	Buckets: latencyBuckets,
 })
+
+// PropagationMerkleRegisterFailures counts per-message merkle-service
+// registration failures by reason. Sustained values indicate the merkle
+// service is unhealthy — without this metric a registration outage was
+// previously masked by silent broadcast continuation. Reasons map to the
+// failure mode observed by handleMessage; today only "register_error" is
+// emitted, but the label is kept open so future error-class splits (e.g.
+// "timeout", "5xx", "auth") can be added without renaming the metric.
+var PropagationMerkleRegisterFailures = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_propagation_merkle_register_failures_total",
+	Help: "Per-message merkle-service Register failures, by reason.",
+}, []string{"reason"})
 
 // PropagationReaperLease is 1 when this pod holds the reaper lease, 0 otherwise.
 // In K8s, sum across pods should always equal 1 (or 0 during failover).

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -187,11 +187,22 @@ func (p *Propagator) Stop() error {
 	return nil
 }
 
-// handleMessage accumulates a single propagation message into the pending batch.
-// The consumer's drain-then-flush pattern calls flushBatch after all immediately
-// available messages have been processed, so the batch size naturally matches
-// what the client submitted — no configured threshold needed.
-func (p *Propagator) handleMessage(_ context.Context, msg *kafka.Message) error {
+// handleMessage registers a single propagation message with the merkle
+// service and, on success, accumulates it into the pending batch for the
+// next flush. The consumer's drain-then-flush pattern calls flushBatch after
+// all immediately available messages have been processed, so the batch size
+// for the broadcast step naturally matches what the client submitted — no
+// configured threshold needed.
+//
+// Registration is performed synchronously, per message, BEFORE the message
+// is added to the pending batch. This is the durable-registration invariant
+// from F-024: if the merkle service refuses (network blip, 5xx, timeout),
+// handleMessage returns an error so the Kafka consumer's processWithRetry
+// loop retries, and on exhaustion routes the message to DLQ — preserving
+// the registration promise instead of silently broadcasting a tx whose
+// callbacks will never fire. A failed message is never appended to
+// pendingMsgs, so it cannot be broadcast or status-updated downstream.
+func (p *Propagator) handleMessage(ctx context.Context, msg *kafka.Message) error {
 	var propMsg propagationMsg
 	if err := json.Unmarshal(msg.Value, &propMsg); err != nil {
 		return fmt.Errorf("unmarshaling propagation message: %w", err)
@@ -199,6 +210,21 @@ func (p *Propagator) handleMessage(_ context.Context, msg *kafka.Message) error 
 
 	if len(propMsg.RawTx) == 0 {
 		return fmt.Errorf("propagation message has empty raw_tx")
+	}
+
+	if p.merkleClient != nil && p.cfg.CallbackURL != "" {
+		mStart := time.Now()
+		if err := p.merkleClient.Register(ctx, propMsg.TXID, p.cfg.CallbackURL); err != nil {
+			metrics.PropagationMerkleRegisterDuration.Observe(time.Since(mStart).Seconds())
+			metrics.PropagationMerkleRegisterFailures.WithLabelValues("register_error").Inc()
+			// Surface the failure so the consumer's retry+DLQ machinery
+			// preserves the message instead of silently dropping it after
+			// continuing to broadcast. The tx is NOT added to pendingMsgs,
+			// so no downstream side-effects (broadcast, status update,
+			// PENDING_RETRY) occur for it.
+			return fmt.Errorf("merkle-service registration failed for %s: %w", propMsg.TXID, err)
+		}
+		metrics.PropagationMerkleRegisterDuration.Observe(time.Since(mStart).Seconds())
 	}
 
 	p.mu.Lock()
@@ -240,9 +266,15 @@ type txResult struct {
 }
 
 // processBatch handles a batch of propagation messages:
-// 1. Register all txids with merkle service concurrently
-// 2. Broadcast all raw txs to teranode endpoints, chunked to teranodeBatchCap
-// 3. Update status for each transaction
+//  1. Broadcast all raw txs to teranode endpoints, chunked to teranodeBatchCap.
+//  2. Update status for each transaction.
+//
+// Merkle-service registration is no longer performed here — that step has
+// moved into handleMessage so a registration failure surfaces as a per-
+// message handler error (the Kafka consumer retries; on exhaustion the
+// message is routed to DLQ). By the time processBatch sees a message it has
+// already been registered successfully, so the broadcast pipeline never
+// races ahead of an unregistered tx (F-024).
 func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) error {
 	// Log batch summary for traceability
 	txidSample := make([]string, 0, 5)
@@ -259,25 +291,7 @@ func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) e
 
 	metrics.PropagationBatchSize.Observe(float64(len(batch)))
 
-	// Step 1: Register all txids with merkle service (mandatory)
-	if p.merkleClient != nil && p.cfg.CallbackURL != "" {
-		regs := make([]merkleservice.Registration, len(batch))
-		for i, msg := range batch {
-			regs[i] = merkleservice.Registration{
-				TxID:        msg.TXID,
-				CallbackURL: p.cfg.CallbackURL,
-			}
-		}
-		mStart := time.Now()
-		if err := p.merkleClient.RegisterBatch(ctx, regs, p.merkleConcurrency); err != nil {
-			metrics.PropagationMerkleRegisterDuration.Observe(time.Since(mStart).Seconds())
-			return fmt.Errorf("merkle-service batch registration failed: %w", err)
-		}
-		metrics.PropagationMerkleRegisterDuration.Observe(time.Since(mStart).Seconds())
-		p.logger.Debug("batch registered with merkle-service", zap.Int("count", len(batch)))
-	}
-
-	// Step 2: Broadcast in chunks bounded by teranodeBatchCap so a single
+	// Step 1: Broadcast in chunks bounded by teranodeBatchCap so a single
 	// oversized Kafka flush doesn't blow past Teranode's /txs size limit.
 	rawTxs := make([][]byte, len(batch))
 	for i, msg := range batch {
@@ -285,7 +299,7 @@ func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) e
 	}
 	results := p.broadcastInChunks(ctx, batch, rawTxs)
 
-	// Step 3: Update status for each transaction, with retry classification
+	// Step 2: Update status for each transaction, with retry classification
 	seenEndpoints := make(map[string]struct{})
 	var successEndpoints []string
 	var accepted, rejected, retryable, noVerdict int

--- a/services/propagation/propagator_test.go
+++ b/services/propagation/propagator_test.go
@@ -362,8 +362,8 @@ func TestHandleMessage_MerkleFailure_NoBroadcast(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "merkle-service batch registration failed") {
-		t.Errorf("expected error to contain 'merkle-service batch registration failed', got: %v", err)
+	if !strings.Contains(err.Error(), "merkle-service registration failed") {
+		t.Errorf("expected error to contain 'merkle-service registration failed', got: %v", err)
 	}
 
 	if log.count("broadcast") != 0 {
@@ -596,7 +596,10 @@ func TestProcessBatch_ChunksOversizedBatch(t *testing.T) {
 	}
 }
 
-// Test 8: Merkle failure aborts entire batch — no broadcast
+// Test 8: Merkle failure aborts the affected message at handleMessage time
+// — no batching, no broadcast, no status update. F-024: registration is the
+// per-message gate, so the Kafka consumer's processWithRetry/DLQ machinery
+// preserves the message instead of silently broadcasting an unregistered tx.
 func TestProcessBatch_MerkleFailure_AbortsBatch(t *testing.T) {
 	var broadcastCount atomic.Int32
 	merkleSrv := newMerkleServer(&eventLog{}, http.StatusInternalServerError)
@@ -612,12 +615,18 @@ func TestProcessBatch_MerkleFailure_AbortsBatch(t *testing.T) {
 	p := newPropagator(merkleSrv.URL, teranodeSrv.URL, ms)
 
 	for i := 0; i < 5; i++ {
-		_ = p.handleMessage(context.Background(), consumerMsg(makePropMsg(fmt.Sprintf("tx%d", i))))
+		err := p.handleMessage(context.Background(), consumerMsg(makePropMsg(fmt.Sprintf("tx%d", i))))
+		if err == nil {
+			t.Fatalf("tx%d: expected handleMessage to return an error when merkle registration fails", i)
+		}
+		if !strings.Contains(err.Error(), "merkle-service registration failed") {
+			t.Fatalf("tx%d: expected merkle error, got: %v", i, err)
+		}
 	}
 
-	err := p.flushBatch(context.Background())
-	if err == nil {
-		t.Fatal("expected error from merkle failure")
+	// flushBatch on an empty pending list is a no-op; broadcast must not run.
+	if err := p.flushBatch(context.Background()); err != nil {
+		t.Fatalf("flushBatch on empty pending list should be a no-op, got: %v", err)
 	}
 
 	if broadcastCount.Load() != 0 {
@@ -625,6 +634,122 @@ func TestProcessBatch_MerkleFailure_AbortsBatch(t *testing.T) {
 	}
 	if ms.updateCount() != 0 {
 		t.Errorf("expected 0 UpdateStatus calls, got %d", ms.updateCount())
+	}
+}
+
+// F-024 regression: when registration fails for one message inside a batch,
+// only that message is rejected (its handleMessage returns an error). The
+// already-registered messages remain in the pending batch and are broadcast
+// + status-updated normally on flush. The failed tx is NEVER added to
+// pendingMsgs, so it is never broadcast, never status-updated, never put on
+// PENDING_RETRY — it relies entirely on the consumer's processWithRetry/DLQ
+// machinery to preserve the message until the operator can recover.
+func TestHandleMessage_PartialMerkleFailure_OnlyFailedMessageIsAborted(t *testing.T) {
+	// Merkle server returns 500 for txid "tx-bad", 200 for everything else.
+	var registerLog eventLog
+	merkleSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			TxID string `json:"txid"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		registerLog.add("register:" + req.TxID)
+		if req.TxID == "tx-bad" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer merkleSrv.Close()
+
+	var broadcastBodies []string
+	var bodyMu sync.Mutex
+	teranodeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyMu.Lock()
+		defer bodyMu.Unlock()
+		broadcastBodies = append(broadcastBodies, r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer teranodeSrv.Close()
+
+	ms := newMockStore()
+	p := newPropagator(merkleSrv.URL, teranodeSrv.URL, ms)
+
+	// Three messages: two succeed, one (tx-bad) fails registration.
+	goodA := makePropMsg("tx-good-a")
+	bad := makePropMsg("tx-bad")
+	goodB := makePropMsg("tx-good-b")
+
+	if err := p.handleMessage(context.Background(), consumerMsg(goodA)); err != nil {
+		t.Fatalf("tx-good-a: expected nil, got %v", err)
+	}
+	if err := p.handleMessage(context.Background(), consumerMsg(bad)); err == nil {
+		t.Fatalf("tx-bad: expected handleMessage error, got nil")
+	}
+	if err := p.handleMessage(context.Background(), consumerMsg(goodB)); err != nil {
+		t.Fatalf("tx-good-b: expected nil, got %v", err)
+	}
+
+	if err := p.flushBatch(context.Background()); err != nil {
+		t.Fatalf("flushBatch returned: %v", err)
+	}
+
+	// All three were attempted at the merkle layer; the failed one was the
+	// "bad" txid only.
+	if got := registerLog.count("register:"); got != 3 {
+		t.Errorf("expected 3 merkle register attempts, got %d", got)
+	}
+
+	// Only the two surviving txids made it into the broadcast batch — that
+	// is, exactly two good ones broadcast. /txs is used because batch>1.
+	bodyMu.Lock()
+	defer bodyMu.Unlock()
+	if len(broadcastBodies) != 1 {
+		t.Errorf("expected 1 broadcast call (the /txs batch of the 2 good txs), got %d: %v", len(broadcastBodies), broadcastBodies)
+	}
+	if len(broadcastBodies) > 0 && broadcastBodies[0] != "/txs" {
+		t.Errorf("expected /txs batch endpoint, got %s", broadcastBodies[0])
+	}
+
+	// Two status updates: one per surviving tx. tx-bad has no row written.
+	if ms.updateCount() != 2 {
+		t.Errorf("expected 2 status updates (only the 2 good txs), got %d", ms.updateCount())
+	}
+	if ms.lastUpdateForTxid("tx-bad") != nil {
+		t.Errorf("tx-bad must not have a status row — registration was rejected and the message is the consumer's responsibility to redeliver/DLQ")
+	}
+	if u := ms.lastUpdateForTxid("tx-good-a"); u == nil || u.Status != models.StatusAcceptedByNetwork {
+		t.Errorf("tx-good-a: expected ACCEPTED_BY_NETWORK status update, got %+v", u)
+	}
+	if u := ms.lastUpdateForTxid("tx-good-b"); u == nil || u.Status != models.StatusAcceptedByNetwork {
+		t.Errorf("tx-good-b: expected ACCEPTED_BY_NETWORK status update, got %+v", u)
+	}
+}
+
+// F-024 invariant: a registration failure must NOT cause any side-effects
+// downstream (broadcast, status, PENDING_RETRY) for the failed message —
+// it's entirely the consumer's job to preserve and recover it via DLQ.
+func TestHandleMessage_MerkleFailure_NoPendingRetryRow(t *testing.T) {
+	merkleSrv := newMerkleServer(&eventLog{}, http.StatusInternalServerError)
+	defer merkleSrv.Close()
+
+	teranodeSrv := newTeranodeServer(&eventLog{}, http.StatusOK)
+	defer teranodeSrv.Close()
+
+	ms := newMockStore()
+	p := newPropagator(merkleSrv.URL, teranodeSrv.URL, ms)
+
+	if err := p.handleMessage(context.Background(), consumerMsg(makePropMsg("tx-reg-fail"))); err == nil {
+		t.Fatal("expected merkle registration error from handleMessage")
+	}
+
+	// No PENDING_RETRY row — the durable retry track is for broadcast
+	// retryability, not registration. Registration retries belong to the
+	// Kafka consumer (processWithRetry → DLQ on exhaustion).
+	if ms.pendingRetryCount() != 0 {
+		t.Errorf("expected no pending retry rows, got %d", ms.pendingRetryCount())
+	}
+	if ms.updateCount() != 0 {
+		t.Errorf("expected no status updates, got %d", ms.updateCount())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Move Merkle-service registration from the batched flush path into per-message `handleMessage`. A 5xx / timeout / transport error now surfaces as a handler error, so the Kafka consumer's `processWithRetry` loop retries up to `MaxRetries` and on exhaustion routes the message to DLQ — instead of being logged-and-ignored while the broadcast continues.
- Failed messages are never appended to `pendingMsgs`, so no downstream side-effects (broadcast, `UpdateStatus`, `PENDING_RETRY`) ever fire for an unregistered tx. The registration promise is now durable: every tx that gets broadcast was acknowledged by the merkle service first.
- Partial-batch handling: registration is performed independently per message at the moment it is consumed. If one message fails inside a drain of N, only that message is rejected at the handler layer; the others remain in the pending batch and are broadcast normally on flush. The failed message rides the consumer's at-least-once redelivery / DLQ machinery — there is no half-broadcast / half-acked ambiguity.
- New counter `arcade_propagation_merkle_register_failures_total{reason}` so a merkle outage is visible in dashboards (today only `register_error`; label kept open for future error-class splits).
- Tests:
  - `TestHandleMessage_MerkleFailure_NoBroadcast` (existing) updated for the new error message.
  - `TestProcessBatch_MerkleFailure_AbortsBatch` (existing) rewritten to assert that `handleMessage` returns the registration error, no message reaches `pendingMsgs`, and `flushBatch` is a no-op.
  - `TestHandleMessage_PartialMerkleFailure_OnlyFailedMessageIsAborted` (new) — drain of 3, middle one fails registration; asserts the surviving 2 broadcast as a single `/txs` batch and only they get status updates; the failed tx has no row.
  - `TestHandleMessage_MerkleFailure_NoPendingRetryRow` (new) — registration failure must not write a `PENDING_RETRY` row (durable retry is for broadcast retryability, not registration).

Closes #82

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./services/propagation/... -count=1 -race`
- [x] `go test ./... -count=1 -race`
- [x] `golangci-lint run ./services/propagation/... ./metrics/...` (0 issues)
- [ ] Reviewer to confirm the per-message registration trade-off (loses `RegisterBatch` concurrent fan-out, gains correctness; per-claim throughput is still acceptable since `merkleservice.Register` is one HTTP roundtrip per tx and consumer claims run independently per partition).
- [ ] Reviewer to confirm `register_error` label naming; we keep the label open so a future split into `timeout` / `5xx` / `auth` doesn't require renaming the metric.

## Sibling note
PR #108 (issue #69) is the matching fix on the consumer side for the analogous "DLQ publish failure also loses the offset" bug. Together they form a complete F-024 / F-011 chain: registration failure → handler error → retry → DLQ → if DLQ also fails, offset stays uncommitted and Kafka redelivers. This PR is correct on top of either main or main+#108.