### PR TITLE
fix(ci): point Dependabot at main branch (#95)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@
 # Security Hardened Defaults:
 #   • Weekly cadence (Monday 09:00 America/New_York) – align with CVE dump cycle.
 #   • Direct dependencies only – prevents unsolicited transitive churn.
-#   • PRs labeled, assigned, and target the protected "master" branch.
+#   • PRs labeled, assigned, and target the protected "main" branch.
 #   • PR titles prefixed with chore(scope): – conventional commits.
 #   • Force‑push and delete‑branch disabled via branch‑protection rules.
 #   • PR limit = 10 to avoid queue flooding.
@@ -29,7 +29,7 @@ updates:
   # ──────────────────────────────────────────────────────────────
   - package-ecosystem: "gomod"
     directory: "/"
-    target-branch: "master"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -58,7 +58,7 @@ updates:
   # ──────────────────────────────────────────────────────────────
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "master"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -81,7 +81,7 @@ updates:
   # ──────────────────────────────────────────────────────────────
   - package-ecosystem: "devcontainers"
     directory: "/"
-    target-branch: "master"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -104,7 +104,7 @@ updates:
   # ──────────────────────────────────────────────────────────────
   - package-ecosystem: "docker"
     directory: "/"
-    target-branch: "master"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary
- Updated `.github/dependabot.yml` `target-branch:` from `master` to `main` so Dependabot PRs target the repo's actual default branch.
- Also updated the matching comment in the file header for consistency.
- The `dependabot.yml` syntax is validated by GitHub on push (no local syntax check needed).

Closes #95

## Test plan
- [x] `git remote show origin` confirms default branch is `main`
- [ ] After merge, verify the next Dependabot run targets main