### PR TITLE
fix(bump): validate subtreeIndex before assembling BUMP (#64)

### DIFF
--- a/bump/bump.go
+++ b/bump/bump.go
@@ -24,6 +24,9 @@ import (
 //
 // Returns the minimal merkle path for the tracked transaction (with global offsets) and the global tx offset.
 func AssembleBUMP(stumpData []byte, subtreeIndex int, subtreeHashes []chainhash.Hash, coinbaseBUMP []byte) (*transaction.MerklePath, uint64, error) {
+	if err := validateSubtreeIndex(subtreeIndex, len(subtreeHashes)); err != nil {
+		return nil, 0, err
+	}
 	fullPath, txOffset, err := assembleFullPath(stumpData, subtreeIndex, subtreeHashes, coinbaseBUMP)
 	if err != nil {
 		return nil, 0, err
@@ -32,10 +35,25 @@ func AssembleBUMP(stumpData []byte, subtreeIndex int, subtreeHashes []chainhash.
 	return minimalPath, txOffset, nil
 }
 
+// validateSubtreeIndex rejects subtreeIndex values that are negative or that fall
+// outside the range of subtree hashes the block actually has. Without this guard
+// a negative index wraps when converted to uint64 and corrupts every offset in
+// the assembled BUMP, while an out-of-range positive index produces a path for a
+// subtree that isn't present in the block.
+func validateSubtreeIndex(subtreeIndex, numSubtrees int) error {
+	if subtreeIndex < 0 || subtreeIndex >= numSubtrees {
+		return fmt.Errorf("invalid subtree index %d for block with %d subtrees", subtreeIndex, numSubtrees)
+	}
+	return nil
+}
+
 // assembleFullPath constructs a full BUMP from a STUMP, retaining ALL level-0 hashes
 // and intermediate nodes. This is used by BuildCompoundBUMP to preserve data for all
 // tracked transactions, not just one.
 func assembleFullPath(stumpData []byte, subtreeIndex int, subtreeHashes []chainhash.Hash, coinbaseBUMP []byte) (*transaction.MerklePath, uint64, error) {
+	if err := validateSubtreeIndex(subtreeIndex, len(subtreeHashes)); err != nil {
+		return nil, 0, err
+	}
 	stumpPath, err := transaction.NewMerklePathFromBinary(stumpData)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to parse STUMP: %w", err)

--- a/bump/bump_test.go
+++ b/bump/bump_test.go
@@ -1682,3 +1682,136 @@ func TestBuildCompoundBUMP_NoSubtree0Stump_NonPow2(t *testing.T) {
 		t.Fatalf("minimal-path root mismatch: got %s, want %s", gotRoot, trueBlockRoot)
 	}
 }
+
+// --- Subtree Index Validation Tests (F-006) ---
+
+// TestAssembleBUMP_RejectsNegativeSubtreeIndex covers the F-006 case where a
+// negative subtreeIndex would wrap when converted to uint64 and corrupt every
+// shifted offset in the assembled BUMP.
+func TestAssembleBUMP_RejectsNegativeSubtreeIndex(t *testing.T) {
+	allLeaves, subtreeHashes, _ := multiSubtreeTestSetup(4, 4)
+	stump := buildSTUMP(allLeaves[0], 0, 900100)
+
+	_, _, err := AssembleBUMP(stump, -1, subtreeHashes, nil)
+	if err == nil {
+		t.Fatal("expected error for negative subtreeIndex, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid subtree index") {
+		t.Fatalf("expected 'invalid subtree index' error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "-1") {
+		t.Fatalf("expected error to mention the offending index -1, got: %v", err)
+	}
+}
+
+// TestAssembleBUMP_RejectsSubtreeIndexEqualToLen rejects an index equal to the
+// number of subtrees — the first out-of-range positive value.
+func TestAssembleBUMP_RejectsSubtreeIndexEqualToLen(t *testing.T) {
+	allLeaves, subtreeHashes, _ := multiSubtreeTestSetup(4, 4)
+	stump := buildSTUMP(allLeaves[0], 0, 900101)
+
+	_, _, err := AssembleBUMP(stump, len(subtreeHashes), subtreeHashes, nil)
+	if err == nil {
+		t.Fatal("expected error for subtreeIndex == len(subtreeHashes), got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid subtree index") {
+		t.Fatalf("expected 'invalid subtree index' error, got: %v", err)
+	}
+}
+
+// TestAssembleBUMP_RejectsSubtreeIndexBeyondLen rejects an index that is
+// strictly greater than len(subtreeHashes).
+func TestAssembleBUMP_RejectsSubtreeIndexBeyondLen(t *testing.T) {
+	allLeaves, subtreeHashes, _ := multiSubtreeTestSetup(4, 4)
+	stump := buildSTUMP(allLeaves[0], 0, 900102)
+
+	_, _, err := AssembleBUMP(stump, len(subtreeHashes)+1, subtreeHashes, nil)
+	if err == nil {
+		t.Fatal("expected error for subtreeIndex > len(subtreeHashes), got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid subtree index") {
+		t.Fatalf("expected 'invalid subtree index' error, got: %v", err)
+	}
+}
+
+// TestAssembleBUMP_AcceptsZeroSubtreeIndex is a regression test that
+// subtreeIndex=0 with valid inputs continues to succeed after the validation
+// guard is added.
+func TestAssembleBUMP_AcceptsZeroSubtreeIndex(t *testing.T) {
+	allLeaves, subtreeHashes, blockRoot := multiSubtreeTestSetup(4, 4)
+	txOffset := uint64(2)
+	stump := buildSTUMP(allLeaves[0], txOffset, 900103)
+
+	result, _, err := AssembleBUMP(stump, 0, subtreeHashes, nil)
+	if err != nil {
+		t.Fatalf("AssembleBUMP failed for valid subtreeIndex=0: %v", err)
+	}
+	root, err := result.ComputeRoot(&allLeaves[0][txOffset])
+	if err != nil {
+		t.Fatalf("ComputeRoot failed: %v", err)
+	}
+	if *root != blockRoot {
+		t.Fatalf("root mismatch: got %s, want %s", root, blockRoot)
+	}
+}
+
+// TestAssembleBUMP_AcceptsLastSubtreeIndex covers the upper boundary
+// subtreeIndex == len(subtreeHashes)-1.
+func TestAssembleBUMP_AcceptsLastSubtreeIndex(t *testing.T) {
+	allLeaves, subtreeHashes, blockRoot := multiSubtreeTestSetup(4, 4)
+	last := len(subtreeHashes) - 1
+	txOffset := uint64(1)
+	stump := buildSTUMP(allLeaves[last], txOffset, 900104)
+
+	result, _, err := AssembleBUMP(stump, last, subtreeHashes, nil)
+	if err != nil {
+		t.Fatalf("AssembleBUMP failed for valid last subtreeIndex=%d: %v", last, err)
+	}
+	root, err := result.ComputeRoot(&allLeaves[last][txOffset])
+	if err != nil {
+		t.Fatalf("ComputeRoot failed: %v", err)
+	}
+	if *root != blockRoot {
+		t.Fatalf("root mismatch: got %s, want %s", root, blockRoot)
+	}
+}
+
+// TestAssembleBUMP_SingleSubtree_RejectsOutOfRangeSubtreeIndex confirms the
+// single-subtree early-return path also enforces the bound. Previously a
+// caller passing subtreeIndex=1 with one subtree would have silently produced
+// a path under the placeholder coinbase branch (subtreeIndex==0 check would
+// skip) — now it errors at the boundary.
+func TestAssembleBUMP_SingleSubtree_RejectsOutOfRangeSubtreeIndex(t *testing.T) {
+	leaves := generateTxHashes(4)
+	subtreeHashes := []chainhash.Hash{computeMerkleRootFromLeaves(leaves)}
+	stump := buildSTUMP(leaves, 0, 900105)
+
+	_, _, err := AssembleBUMP(stump, 1, subtreeHashes, nil)
+	if err == nil {
+		t.Fatal("expected error for subtreeIndex=1 with single-subtree block, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid subtree index") {
+		t.Fatalf("expected 'invalid subtree index' error, got: %v", err)
+	}
+}
+
+// TestAssembleBUMP_SingleSubtree_Unaffected confirms the single-subtree
+// happy-path still works (subtreeIndex=0 with one subtree).
+func TestAssembleBUMP_SingleSubtree_Unaffected(t *testing.T) {
+	leaves := generateTxHashes(4)
+	expectedRoot := computeMerkleRootFromLeaves(leaves)
+	subtreeHashes := []chainhash.Hash{expectedRoot}
+	stump := buildSTUMP(leaves, 2, 900106)
+
+	result, _, err := AssembleBUMP(stump, 0, subtreeHashes, nil)
+	if err != nil {
+		t.Fatalf("AssembleBUMP failed for single-subtree happy path: %v", err)
+	}
+	root, err := result.ComputeRoot(&leaves[2])
+	if err != nil {
+		t.Fatalf("ComputeRoot failed: %v", err)
+	}
+	if *root != expectedRoot {
+		t.Fatalf("root mismatch: got %s, want %s", root, expectedRoot)
+	}
+}


### PR DESCRIPTION
## Summary
- `AssembleBUMP` (and the internal `assembleFullPath`) reject negative or out-of-range `subtreeIndex` at entry, returning `invalid subtree index <i> for block with <n> subtrees`. Previously a negative value wrapped to a huge `uint64` shift and corrupted every offset in the BUMP, and an out-of-range positive value built a path for a subtree not actually present in the block.
- Added 7 new tests in `bump/bump_test.go` covering: negative index, index == len, index > len, the boundary cases (0 and len-1) succeeding as regressions, and the single-subtree branch (rejecting out-of-range, accepting the happy path).

Closes #64

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./bump/... -race`
- [x] `golangci-lint run ./bump/...` (0 issues)
- [ ] Reviewer to confirm error wording / sentinel error preference