### PR TITLE
perf(store): page tracker startup load to bound memory (#86)

### DIFF
--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -69,6 +69,10 @@ func (m *mockStore) GetStatusesSince(context.Context, time.Time) ([]*models.Tran
 	return nil, nil
 }
 
+func (m *mockStore) IterateStatusesSince(context.Context, time.Time, func(*models.TransactionStatus) error) error {
+	return nil
+}
+
 func (m *mockStore) SetStatusByBlockHash(context.Context, string, models.Status) ([]string, error) {
 	return nil, nil
 }

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -85,6 +85,10 @@ func (s *fakeStore) GetStatusesSince(context.Context, time.Time) ([]*models.Tran
 	return nil, nil
 }
 
+func (s *fakeStore) IterateStatusesSince(context.Context, time.Time, func(*models.TransactionStatus) error) error {
+	return nil
+}
+
 func (s *fakeStore) SetStatusByBlockHash(context.Context, string, models.Status) ([]string, error) {
 	return nil, nil
 }

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -472,6 +472,41 @@ loop:
 	return results, nil
 }
 
+// IterateStatusesSince streams scan results to fn one record at a time. The
+// Aerospike client already produces records over a channel — we just hand
+// them off without buffering, so peak memory is O(1) plus whatever fn keeps.
+func (s *Store) IterateStatusesSince(ctx context.Context, _ time.Time, fn func(*models.TransactionStatus) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	stmt := aero.NewStatement(s.namespace, setTransactions)
+	rs, err := s.client.Query(s.queryPolicy(ctx), stmt)
+	if rs != nil {
+		defer func() { _ = rs.Close() }()
+	}
+	if err != nil {
+		return fmt.Errorf("query statuses: %w", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case rec, ok := <-rs.Results():
+			if !ok {
+				return nil
+			}
+			if rec.Err != nil {
+				return rec.Err
+			}
+			txid := getString(rec.Record, "txid")
+			if err := fn(recordToStatus(rec.Record, txid)); err != nil {
+				return err
+			}
+		}
+	}
+}
+
 func (s *Store) SetStatusByBlockHash(ctx context.Context, blockHash string, newStatus models.Status) ([]string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -489,6 +489,44 @@ func (s *Store) GetStatusesSince(ctx context.Context, since time.Time) ([]*model
 	return results, nil
 }
 
+// IterateStatusesSince walks the same updated-at index as GetStatusesSince but
+// hands each row to fn directly instead of accumulating a slice. The Pebble
+// iterator already streams keys lazily, so peak memory is bounded by whatever
+// fn retains rather than the full history depth.
+func (s *Store) IterateStatusesSince(ctx context.Context, since time.Time, fn func(*models.TransactionStatus) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	prefix := idxTxUpdatedPrefix()
+	iter, err := s.db.NewIter(&pebbledb.IterOptions{
+		LowerBound: prefix,
+		UpperBound: endOfPrefix(prefix),
+	})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = iter.Close() }()
+
+	sinceNs := since.UnixNano()
+	for iter.First(); iter.Valid(); iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		txid := lastSegment(iter.Key())
+		st, err := s.readStatus(txid)
+		if err != nil || st == nil {
+			continue
+		}
+		if !since.IsZero() && st.Timestamp.UnixNano() < sinceNs {
+			continue
+		}
+		if err := fn(st); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SetStatusByBlockHash walks idx:tx:block:<blockHash>:* and rewrites each
 // referenced row with the new status. For SEEN_ON_NETWORK transitions block
 // fields are cleared (matches Aerospike contract); for IMMUTABLE they're kept.

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -498,6 +498,37 @@ ORDER BY timestamp_at DESC`
 	return results, rows.Err()
 }
 
+// IterateStatusesSince streams the same query as GetStatusesSince through fn
+// without buffering the full result set. pgx's rows.Next() pulls rows from the
+// server one at a time, so memory stays O(row) regardless of history depth.
+func (s *Store) IterateStatusesSince(ctx context.Context, since time.Time, fn func(*models.TransactionStatus) error) error {
+	const q = `
+SELECT txid, status, status_code, block_hash, block_height, merkle_path,
+       extra_info, competing_txs, raw_tx, retry_count, next_retry_at,
+       timestamp_at, created_at
+FROM transactions WHERE timestamp_at >= $1
+ORDER BY timestamp_at DESC`
+	rows, err := s.pool.Query(ctx, q, since)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		st, err := scanStatus(rows)
+		if err != nil {
+			return err
+		}
+		if err := fn(st); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
 // SetStatusByBlockHash rewrites every row in the block. Block fields are
 // cleared on SEEN_ON_NETWORK transitions (reorg path) and kept otherwise —
 // matches the Aerospike / Pebble contract.

--- a/store/store.go
+++ b/store/store.go
@@ -84,6 +84,14 @@ type Store interface {
 	// GetStatusesSince retrieves all transactions updated since a given timestamp
 	GetStatusesSince(ctx context.Context, since time.Time) ([]*models.TransactionStatus, error)
 
+	// IterateStatusesSince streams every transaction updated since the given
+	// timestamp through fn, one row at a time. Implementations must avoid
+	// materializing the full result set in memory — this is the bounded-memory
+	// path used by TxTracker.LoadFromStore at startup, where months of history
+	// would otherwise pin a large slice during pruning. fn returning a non-nil
+	// error stops iteration and surfaces that error to the caller.
+	IterateStatusesSince(ctx context.Context, since time.Time, fn func(*models.TransactionStatus) error) error
+
 	// SetStatusByBlockHash updates all transactions with the given block hash to a new status.
 	// Returns the txids that were updated. For unmined statuses (SEEN_ON_NETWORK),
 	// block fields are cleared. For IMMUTABLE, block fields are preserved.

--- a/store/tracker.go
+++ b/store/tracker.go
@@ -13,6 +13,14 @@ import (
 const (
 	// ConfirmationsRequired is the number of blocks after mining before removing from tracker
 	ConfirmationsRequired = 100
+
+	// loadFromStoreBatchSize is the number of statuses LoadFromStore processes
+	// per batch before handing the kept rows to the tracker. Streaming through
+	// the store one row at a time is enough to bound peak memory; batching
+	// just amortizes the lock acquisition. 10k keeps the lock-held window
+	// short while still covering hundreds of thousands of rows in a handful
+	// of acquisitions.
+	loadFromStoreBatchSize = 10000
 )
 
 // TrackedTx holds the status for a tracked transaction
@@ -36,37 +44,81 @@ func NewTxTracker() *TxTracker {
 	}
 }
 
-// LoadFromStore populates the tracker from the store.
-// Loads all transactions that aren't deeply confirmed (mined for 100+ blocks).
+// statusIterator narrows the Store surface LoadFromStore actually needs so
+// tests can supply a fake without standing up every Store method. Any
+// implementation of Store satisfies this implicitly.
+type statusIterator interface {
+	IterateStatusesSince(ctx context.Context, since time.Time, fn func(*models.TransactionStatus) error) error
+}
+
+// LoadFromStore populates the tracker from the store, streaming rows in
+// fixed-size batches and dropping deeply-confirmed transactions before they
+// reach the tracker map. Peak memory is bounded by loadFromStoreBatchSize
+// rather than the full history depth, which matters at startup on systems
+// with months of accumulated transactions.
 func (t *TxTracker) LoadFromStore(ctx context.Context, store Store, currentHeight uint64) (int, error) {
-	statuses, err := store.GetStatusesSince(ctx, time.Time{})
-	if err != nil {
-		return 0, err
+	return t.loadFromStore(ctx, store, currentHeight, loadFromStoreBatchSize)
+}
+
+// loadFromStore is the batchSize-parameterized form of LoadFromStore so tests
+// can drive the batching boundary without inflating fixture sizes.
+func (t *TxTracker) loadFromStore(ctx context.Context, store statusIterator, currentHeight uint64, batchSize int) (int, error) {
+	if batchSize <= 0 {
+		batchSize = loadFromStoreBatchSize
 	}
 
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
+	type kept struct {
+		hash chainhash.Hash
+		tx   TrackedTx
+	}
+	batch := make([]kept, 0, batchSize)
 	count := 0
-	for _, status := range statuses {
-		// Skip transactions that are deeply confirmed
+
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		t.mu.Lock()
+		for _, k := range batch {
+			t.txids[k.hash] = k.tx
+		}
+		t.mu.Unlock()
+		count += len(batch)
+		batch = batch[:0]
+	}
+
+	err := store.IterateStatusesSince(ctx, time.Time{}, func(status *models.TransactionStatus) error {
+		// Skip transactions that are deeply confirmed — these would only be
+		// pruned moments later, so never let them touch the tracker map.
 		if status.Status == models.StatusMined && status.BlockHeight > 0 {
 			if currentHeight >= status.BlockHeight+ConfirmationsRequired {
-				continue
+				return nil
 			}
 		}
 
 		hash, err := chainhash.NewHashFromHex(status.TxID)
 		if err != nil {
-			continue
+			return nil //nolint:nilerr // malformed txid: skip the row, keep loading.
 		}
-		t.txids[*hash] = TrackedTx{
-			Status:      status.Status,
-			MinedHeight: status.BlockHeight,
+		batch = append(batch, kept{
+			hash: *hash,
+			tx: TrackedTx{
+				Status:      status.Status,
+				MinedHeight: status.BlockHeight,
+			},
+		})
+		if len(batch) >= batchSize {
+			flush()
 		}
-		count++
+		return nil
+	})
+	if err != nil {
+		// Surface the error but keep whatever we already merged so the
+		// tracker isn't left empty on a transient store hiccup mid-scan.
+		flush()
+		return count, err
 	}
-
+	flush()
 	return count, nil
 }
 

--- a/store/tracker_test.go
+++ b/store/tracker_test.go
@@ -1,12 +1,51 @@
 package store
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 
 	"github.com/bsv-blockchain/arcade/models"
 )
+
+// fakeIterStore is a minimal statusIterator stub that yields a fixed set of
+// rows and tracks the maximum number of rows held in memory by the tracker
+// during the scan, so tests can assert peak memory is bounded by batch size
+// rather than total history depth.
+type fakeIterStore struct {
+	rows   []*models.TransactionStatus
+	tr     *TxTracker
+	maxLen int
+	yields int
+	err    error
+}
+
+func (f *fakeIterStore) IterateStatusesSince(_ context.Context, _ time.Time, fn func(*models.TransactionStatus) error) error {
+	for _, r := range f.rows {
+		f.yields++
+		if err := fn(r); err != nil {
+			return err
+		}
+		// Snapshot the tracker map size after each yield. If LoadFromStore
+		// truly batches+flushes, the size walks up in plateaus rather than
+		// monotonically tracking f.yields.
+		if f.tr != nil {
+			if n := f.tr.Count(); n > f.maxLen {
+				f.maxLen = n
+			}
+		}
+	}
+	return f.err
+}
+
+// txidHex turns a small int into a deterministic 32-byte hex txid for tests.
+func txidHex(i int) string {
+	return fmt.Sprintf("%064x", i+1)
+}
 
 func TestTxTracker_AddAndContains(t *testing.T) {
 	tracker := NewTxTracker()
@@ -65,6 +104,151 @@ func TestTxTracker_Count(t *testing.T) {
 
 	if tracker.Count() != 2 {
 		t.Errorf("expected 2, got %d", tracker.Count())
+	}
+}
+
+func TestTxTracker_LoadFromStore_DropsDeeplyConfirmed(t *testing.T) {
+	const currentHeight = uint64(1_000_000)
+	rows := []*models.TransactionStatus{
+		// Old + deeply confirmed: should be dropped.
+		{TxID: txidHex(0), Status: models.StatusMined, BlockHeight: currentHeight - ConfirmationsRequired - 1},
+		{TxID: txidHex(1), Status: models.StatusMined, BlockHeight: currentHeight - ConfirmationsRequired - 5000},
+		// Recently mined but not deeply confirmed: keep.
+		{TxID: txidHex(2), Status: models.StatusMined, BlockHeight: currentHeight - 10},
+		// In flight (no block yet): keep.
+		{TxID: txidHex(3), Status: models.StatusSeenOnNetwork},
+	}
+
+	tracker := NewTxTracker()
+	store := &fakeIterStore{rows: rows, tr: tracker}
+
+	got, err := tracker.loadFromStore(context.Background(), store, currentHeight, 2)
+	if err != nil {
+		t.Fatalf("loadFromStore: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("expected 2 kept rows, got %d", got)
+	}
+	if tracker.Count() != 2 {
+		t.Fatalf("expected tracker to contain 2 rows, got %d", tracker.Count())
+	}
+	if tracker.Contains(txidHex(0)) || tracker.Contains(txidHex(1)) {
+		t.Fatal("deeply confirmed rows should not be in tracker")
+	}
+	if !tracker.Contains(txidHex(2)) || !tracker.Contains(txidHex(3)) {
+		t.Fatal("expected recent rows to be tracked")
+	}
+}
+
+func TestTxTracker_LoadFromStore_BoundedPeakMemory(t *testing.T) {
+	// Many old rows that will be pruned + a small tail of recent rows. If
+	// LoadFromStore materialized the full history before pruning, the
+	// tracker map would briefly hold all of them. With paged loading the
+	// peak is bounded by batchSize because deeply confirmed rows are
+	// filtered before they ever land in the map.
+	const (
+		currentHeight = uint64(1_000_000)
+		oldRows       = 1000
+		recentRows    = 5
+		batchSize     = 10
+	)
+
+	rows := make([]*models.TransactionStatus, 0, oldRows+recentRows)
+	for i := 0; i < oldRows; i++ {
+		rows = append(rows, &models.TransactionStatus{
+			TxID:        txidHex(i),
+			Status:      models.StatusMined,
+			BlockHeight: currentHeight - ConfirmationsRequired - 100,
+		})
+	}
+	for i := 0; i < recentRows; i++ {
+		rows = append(rows, &models.TransactionStatus{
+			TxID:   txidHex(oldRows + i),
+			Status: models.StatusSeenOnNetwork,
+		})
+	}
+
+	tracker := NewTxTracker()
+	store := &fakeIterStore{rows: rows, tr: tracker}
+
+	got, err := tracker.loadFromStore(context.Background(), store, currentHeight, batchSize)
+	if err != nil {
+		t.Fatalf("loadFromStore: %v", err)
+	}
+	if got != recentRows {
+		t.Fatalf("expected %d kept rows, got %d", recentRows, got)
+	}
+	if tracker.Count() != recentRows {
+		t.Fatalf("expected tracker count %d, got %d", recentRows, tracker.Count())
+	}
+	if store.yields != oldRows+recentRows {
+		t.Fatalf("expected store to stream %d rows, got %d", oldRows+recentRows, store.yields)
+	}
+	// Peak in-tracker count must never exceed what we kept — deeply
+	// confirmed rows are dropped before the map mutation.
+	if store.maxLen > recentRows {
+		t.Fatalf("peak tracker size %d exceeded kept rows %d (paged prune leaked old rows)", store.maxLen, recentRows)
+	}
+}
+
+func TestTxTracker_LoadFromStore_FlushesOnBatchBoundary(t *testing.T) {
+	// All rows are recent so every row is kept. With batchSize=4 and 10
+	// rows the tracker map should grow in batched steps (4, 8, 10) rather
+	// than per-row. fakeIterStore samples the size after each yield, so a
+	// minimum sampled size of <= batchSize-after-first-flush proves the
+	// tracker doesn't merge until a batch is full.
+	const (
+		currentHeight = uint64(500)
+		total         = 10
+		batchSize     = 4
+	)
+
+	rows := make([]*models.TransactionStatus, 0, total)
+	for i := 0; i < total; i++ {
+		rows = append(rows, &models.TransactionStatus{
+			TxID:   txidHex(i),
+			Status: models.StatusSeenOnNetwork,
+		})
+	}
+
+	tracker := NewTxTracker()
+	store := &fakeIterStore{rows: rows, tr: tracker}
+
+	got, err := tracker.loadFromStore(context.Background(), store, currentHeight, batchSize)
+	if err != nil {
+		t.Fatalf("loadFromStore: %v", err)
+	}
+	if got != total {
+		t.Fatalf("expected %d kept rows, got %d", total, got)
+	}
+	if tracker.Count() != total {
+		t.Fatalf("expected tracker count %d, got %d", total, tracker.Count())
+	}
+	// fakeIterStore samples right after each yield (before the post-iter
+	// flush), so we should see batched plateaus: the size grows by
+	// batchSize at a time, never one-by-one. With total=10 and batch=4
+	// the largest mid-scan plateau is 8 (two flushes); the trailing 2 rows
+	// land in the final flush after iteration completes.
+	if store.maxLen != 8 {
+		t.Fatalf("expected mid-scan peak of 8 (two batched flushes), got %d", store.maxLen)
+	}
+}
+
+func TestTxTracker_LoadFromStore_PropagatesIterError(t *testing.T) {
+	wantErr := errors.New("boom")
+	rows := []*models.TransactionStatus{
+		{TxID: txidHex(0), Status: models.StatusSeenOnNetwork},
+	}
+	tracker := NewTxTracker()
+	store := &fakeIterStore{rows: rows, tr: tracker, err: wantErr}
+
+	_, err := tracker.loadFromStore(context.Background(), store, 100, 4)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected wrapped error %v, got %v", wantErr, err)
+	}
+	// Even on iter error we should have flushed the rows we already saw.
+	if tracker.Count() != 1 {
+		t.Fatalf("expected partial flush of 1, got %d", tracker.Count())
 	}
 }
 


### PR DESCRIPTION
## Summary
- `TxTracker.LoadFromStore` now streams the store via a new `Store.IterateStatusesSince` callback API, processes rows in batches of 10000, and drops deeply-confirmed transactions before they ever land in the in-memory map. Peak memory is bounded by `loadFromStoreBatchSize` instead of full history depth.
- New `IterateStatusesSince` implemented for Postgres (pgx rows.Next), Pebble (pebbledb iterator), and Aerospike (scan-result channel) — each backend already had a row-at-a-time path, so the streaming contract is a thin wrapper rather than a new query.
- Test mocks in `services/webhook` and `services/api_server` get a one-line stub that returns nil so the wider build stays green.
- Three new tracker tests cover (1) deeply-confirmed rows are dropped, (2) peak in-tracker map size never exceeds the kept-row count even when 1000 old rows precede 5 recent ones, (3) flushes happen on batch boundaries instead of per-row.

Closes #86

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./store/... -race`
- [x] `golangci-lint run ./...` (0 issues)
- [ ] Reviewer to confirm batch size default (10000) is reasonable