### PR TITLE
fix(kafka/memory_broker): avoid send-on-closed-channel during Close race (#70)

### DIFF
--- a/kafka/memory_broker.go
+++ b/kafka/memory_broker.go
@@ -21,7 +21,12 @@ import (
 //     carry sensible values. Partition is always 0.
 //   - MarkMessage is a no-op; at-most-once on crash is acceptable for a
 //     single-binary deployment.
-//   - Close closes all subscriber channels. Further Send calls return an error.
+//   - Close signals every subscriber's done channel and prevents further
+//     publishes. The mailbox channels themselves are deliberately NOT closed
+//     so a publisher that snapshotted a mailbox under the lock and released
+//     it before sending can't panic with "send on closed channel" when Close
+//     runs concurrently. Mirrors the SSE fan-out fix from #78 (F-020); see
+//     F-012 for the kafka memory-broker variant.
 type memoryBroker struct {
 	mu      sync.Mutex
 	closed  bool
@@ -33,8 +38,16 @@ type memoryBroker struct {
 // memoryMailbox is a per-(group, topic) delivery queue. Subscriptions joined
 // to the same group share it so either concurrent consumer wins the next
 // message (standard consumer-group semantics).
+//
+// done is closed when the mailbox is being torn down (broker Close, or its
+// last subscription unwinding). Publishers select on it so a concurrent
+// teardown turns a would-be send-on-closed-channel into a clean drop. The
+// mailbox channel itself is intentionally never closed — the forward
+// goroutine exits via done instead, and the unreferenced channel is left to
+// the GC. See F-012.
 type memoryMailbox struct {
 	ch       chan *Message
+	done     chan struct{}
 	refCount int
 }
 
@@ -87,13 +100,19 @@ func (b *memoryBroker) publish(ctx context.Context, topic, key string, value []b
 	}
 	offset := atomic.AddInt64(offsetPtr, 1) - 1
 
-	// Collect the mailboxes that currently care about this topic. Snapshot
+	// Snapshot the mailboxes that currently care about this topic. Snapshot
 	// under the lock, then release before sending so a blocked receiver
-	// doesn't stall other publishers.
-	var targets []chan *Message
+	// doesn't stall other publishers. Each mailbox's done channel rides
+	// along so a concurrent Close that tears down the mailbox between the
+	// snapshot and the send is observed as a drop rather than a panic.
+	type target struct {
+		ch   chan *Message
+		done chan struct{}
+	}
+	var targets []target
 	for _, topics := range b.groups {
 		if mb, ok := topics[topic]; ok {
-			targets = append(targets, mb.ch)
+			targets = append(targets, target{ch: mb.ch, done: mb.done})
 		}
 	}
 	b.mu.Unlock()
@@ -107,17 +126,33 @@ func (b *memoryBroker) publish(ctx context.Context, topic, key string, value []b
 		Timestamp: time.Now(),
 	}
 
-	for _, ch := range targets {
+	for _, t := range targets {
+		// Quick out for already-torn-down mailboxes: avoids the channel
+		// dance for subscribers we know are gone. The send-site re-checks
+		// done so the race between this peek and the select is safe.
+		select {
+		case <-t.done:
+			continue
+		default:
+		}
 		if async {
+			// Async semantics: drop on full buffer or torn-down mailbox.
 			select {
-			case ch <- msg:
+			case t.ch <- msg:
+			case <-t.done:
+				// Subscriber went away — drop silently.
 			default:
-				// drop silently — async semantics
+				// Buffer full — drop silently (async semantics).
 			}
 			continue
 		}
 		select {
-		case ch <- msg:
+		case t.ch <- msg:
+		case <-t.done:
+			// Subscriber went away mid-publish — drop and move on. The
+			// caller asked for "synchronous" but the destination is
+			// gone; treating this as a successful no-op matches the
+			// async drop and avoids a misleading error to the producer.
 		case <-ctx.Done():
 			return ctx.Err()
 		}
@@ -145,11 +180,14 @@ func (b *memoryBroker) Subscribe(groupID string, topics []string) (Subscription,
 	for _, t := range topics {
 		mb, ok := topicMailboxes[t]
 		if !ok {
-			mb = &memoryMailbox{ch: make(chan *Message, b.buffer)}
+			mb = &memoryMailbox{
+				ch:   make(chan *Message, b.buffer),
+				done: make(chan struct{}),
+			}
 			topicMailboxes[t] = mb
 		}
 		mb.refCount++
-		go forward(mb.ch, merged)
+		go forward(mb.ch, merged, mb.done)
 	}
 
 	return &memorySubscription{
@@ -161,10 +199,27 @@ func (b *memoryBroker) Subscribe(groupID string, topics []string) (Subscription,
 }
 
 // forward pipes messages from a per-topic mailbox into the merged per-
-// subscription channel until the mailbox is closed.
-func forward(in <-chan *Message, out chan<- *Message) {
-	for msg := range in {
-		out <- msg
+// subscription channel until the mailbox is torn down. The mailbox channel
+// is never closed (see F-012), so we exit via done instead of relying on
+// channel-close detection. Any messages still buffered in the mailbox at
+// teardown are abandoned; publishers may have already raced past Close and
+// landed values that no consumer will see — this matches the at-most-once
+// semantics documented on the broker.
+func forward(in <-chan *Message, out chan<- *Message, done <-chan struct{}) {
+	for {
+		select {
+		case <-done:
+			return
+		case msg, ok := <-in:
+			if !ok {
+				return
+			}
+			select {
+			case out <- msg:
+			case <-done:
+				return
+			}
+		}
 	}
 }
 
@@ -181,9 +236,15 @@ func (b *memoryBroker) Close() error {
 		return nil
 	}
 	b.closed = true
+	// Signal every mailbox via its done channel. We deliberately do NOT
+	// close mb.ch: a publisher may have snapshotted the channel under the
+	// lock and released the lock before sending (see publish), so closing
+	// it here would race that send and panic. Closing done is enough —
+	// publishers select on it to drop, and forward goroutines select on it
+	// to exit. The unreferenced channel is reclaimed by the GC. (F-012)
 	for _, topics := range b.groups {
 		for _, mb := range topics {
-			close(mb.ch)
+			close(mb.done)
 		}
 	}
 	b.groups = nil
@@ -213,8 +274,9 @@ func (s *memorySubscription) Close() error {
 		return nil
 	}
 	// We don't close s.out here — the broker owns the underlying mailboxes
-	// and will close them on broker Close(). Closing out would risk a send
-	// on a closed channel from a still-running publisher.
+	// and their done channels, and will signal them on broker Close().
+	// Closing out would risk a send on a closed channel from the still-
+	// running forward goroutines.
 	return nil
 }
 

--- a/kafka/memory_broker_test.go
+++ b/kafka/memory_broker_test.go
@@ -172,3 +172,176 @@ func TestMemoryBroker_ConsumerGroupDrainThenFlush(t *testing.T) {
 		t.Errorf("expected drain-then-flush to batch, but flush fired %d times (>=1 per msg)", flushes.Load())
 	}
 }
+
+// TestMemoryBroker_CloseRacePublish stresses the F-012 fix: many publishers
+// hammer a topic while Close runs concurrently. Before the fix, Publish
+// snapshotted the mailbox channels under the lock and then sent without it,
+// so a Close that ran in between would close mb.ch and the next send would
+// panic with "send on closed channel". After the fix, Close signals each
+// mailbox's done channel (without closing mb.ch) and Publish selects on
+// done so the send turns into a clean drop.
+//
+// The test also catches sender-side goroutine leaks: every spawned publisher
+// must return within the test's deadline.
+func TestMemoryBroker_CloseRacePublish(t *testing.T) {
+	for iter := 0; iter < 25; iter++ {
+		b := NewMemoryBroker(8)
+
+		// Spin up a fleet of subscribers across multiple groups so Publish
+		// has many mailboxes to fan out to.
+		const numGroups = 8
+		subs := make([]Subscription, 0, numGroups)
+		for g := 0; g < numGroups; g++ {
+			s, err := b.Subscribe(fmt.Sprintf("g-%d", g), []string{"race"})
+			if err != nil {
+				t.Fatalf("subscribe: %v", err)
+			}
+			subs = append(subs, s)
+		}
+
+		// Drain in the background so most sends succeed; the test isn't
+		// about correctness of delivery, only about not panicking.
+		drainCtx, drainCancel := context.WithCancel(context.Background())
+		var drainWG sync.WaitGroup
+		for _, s := range subs {
+			drainWG.Add(1)
+			go func(s Subscription) {
+				defer drainWG.Done()
+				_ = s.Consume(drainCtx, func(claim Claim) error {
+					for {
+						select {
+						case <-claim.Messages():
+						case <-claim.Context().Done():
+							return nil
+						}
+					}
+				})
+			}(s)
+		}
+
+		// Publishers race against Close. We catch any panic from a
+		// publisher goroutine via a deferred recover and surface it as a
+		// test failure.
+		const numPublishers = 32
+		var pubWG sync.WaitGroup
+		panicCh := make(chan any, numPublishers)
+		ctx := context.Background()
+		for p := 0; p < numPublishers; p++ {
+			pubWG.Add(1)
+			go func() {
+				defer pubWG.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						panicCh <- r
+					}
+				}()
+				for i := 0; i < 50; i++ {
+					_ = b.Send(ctx, "race", "k", []byte("v"))
+					_ = b.SendAsync(ctx, "race", "k", []byte("v"))
+				}
+			}()
+		}
+
+		// Close concurrently with the publisher fleet. A short jitter
+		// makes the Close land somewhere inside the publish loops most
+		// iterations.
+		time.Sleep(time.Duration(iter%5) * 100 * time.Microsecond)
+		if err := b.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+
+		pubWG.Wait()
+		drainCancel()
+		drainWG.Wait()
+		close(panicCh)
+
+		for r := range panicCh {
+			t.Fatalf("publisher panicked: %v", r)
+		}
+	}
+}
+
+// TestMemoryBroker_CloseAfterAllowsNewSendsToFail confirms that once Close
+// has run, subsequent publishes return a clear error rather than panicking
+// or hanging. Mirrors the "broker closed" guard at the top of publish.
+func TestMemoryBroker_CloseAfterAllowsNewSendsToFail(t *testing.T) {
+	b := NewMemoryBroker(4)
+	if err := b.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if err := b.Send(context.Background(), "t", "k", []byte("v")); err == nil {
+		t.Errorf("expected error sending to closed broker, got nil")
+	}
+	if err := b.SendAsync(context.Background(), "t", "k", []byte("v")); err == nil {
+		t.Errorf("expected error SendAsync-ing to closed broker, got nil")
+	}
+	if err := b.SendBatch(context.Background(), "t", []KeyValue{{Key: "k", Value: "v"}}); err == nil {
+		t.Errorf("expected error batch-sending to closed broker, got nil")
+	}
+	if _, err := b.Subscribe("g", []string{"t"}); err == nil {
+		t.Errorf("expected error subscribing to closed broker, got nil")
+	}
+
+	// Idempotent close: second close is a no-op, not a panic.
+	if err := b.Close(); err != nil {
+		t.Errorf("second close: %v", err)
+	}
+}
+
+// TestMemoryBroker_SlowSubscriberDoesNotBlockClose verifies that a stuck
+// subscriber (full mailbox, nobody draining) doesn't wedge Close or the
+// concurrent publisher. After the fix, the publisher's select observes
+// done firing and drops the message instead of waiting forever on a buffer
+// that will never drain.
+func TestMemoryBroker_SlowSubscriberDoesNotBlockClose(t *testing.T) {
+	b := NewMemoryBroker(2) // tiny buffer so we can fill it fast
+
+	sub, err := b.Subscribe("slow", []string{"t"})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	// Intentionally never call sub.Consume — the merged channel never
+	// drains, so after a couple of forwarded messages, mb.ch backs up.
+	_ = sub
+
+	// Pre-fill the buffer so the next send would block without the fix.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	for i := 0; i < 10; i++ {
+		_ = b.SendAsync(ctx, "t", "", []byte("v"))
+	}
+
+	// Kick a synchronous publisher that would otherwise block on the
+	// full buffer. Close should unblock it via mb.done.
+	pubDone := make(chan error, 1)
+	go func() {
+		pubDone <- b.Send(context.Background(), "t", "", []byte("v"))
+	}()
+
+	// Brief pause so the publisher reaches its select before Close runs.
+	time.Sleep(20 * time.Millisecond)
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- b.Close() }()
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("close: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close blocked behind a slow subscriber")
+	}
+
+	select {
+	case err := <-pubDone:
+		// Publisher should have observed mb.done firing and returned
+		// nil (drop), not panicked or hung.
+		if err != nil {
+			t.Fatalf("publisher returned error after Close: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("publisher blocked behind a slow subscriber even after Close")
+	}
+}


### PR DESCRIPTION
## Summary
- Each `memoryMailbox` now carries its own `done` channel; `Close` cancels it instead of closing the mailbox channel itself, so a publisher that snapshotted the channel under the lock can't race into a `send on closed channel` panic.
- `publish` selects on `t.ch <- msg`, `t.done`, and (for sync) `ctx.Done()`, turning a concurrent teardown into a clean drop. Async path drops on full buffer or torn-down mailbox identically.
- `forward` exits via `done` instead of waiting for channel-close so it doesn't leak after `Close`.
- New tests:
  - `TestMemoryBroker_CloseRacePublish`: 25-iteration stress with 32 publishers x 50 send pairs across 8 groups, racing `Close`. Recovers and fails on any publisher panic.
  - `TestMemoryBroker_CloseAfterAllowsNewSendsToFail`: post-close `Send`/`SendAsync`/`SendBatch`/`Subscribe` return errors cleanly; idempotent `Close`.
  - `TestMemoryBroker_SlowSubscriberDoesNotBlockClose`: full-buffer subscriber with no consumer; `Close` unblocks an in-flight publisher via `done`.

Closes #70

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./kafka/... -race` (3x, all pass)
- [x] `golangci-lint run ./kafka/...` (0 issues)
- [ ] Reviewer to verify no goroutine leaks under stress