### PR TITLE
fix(store): reject UpdateStatus for unknown txids (#91)

### DIFF
--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"html/template"
 	"io"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 	"github.com/bsv-blockchain/arcade/callbackurl"
 	"github.com/bsv-blockchain/arcade/kafka"
 	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
 	"github.com/bsv-blockchain/arcade/teranode"
 )
 
@@ -265,6 +267,11 @@ func (s *Server) handleCallback(c *gin.Context) {
 	}
 }
 
+// handleSeenOnNetwork applies a SEEN_ON_NETWORK callback from merkle-service
+// to every txid in the message. Unknown txids (i.e. callbacks for txs we
+// never recorded) are dropped with a Warn — never created as phantom rows.
+// See F-033 / issue #91; the store layer enforces this by returning
+// store.ErrNotFound from UpdateStatus when the row is absent.
 func (s *Server) handleSeenOnNetwork(c *gin.Context, msg models.CallbackMessage, logger *zap.Logger) {
 	txids := msg.ResolveSeenTxIDs()
 	if len(txids) == 0 {
@@ -280,6 +287,11 @@ func (s *Server) handleSeenOnNetwork(c *gin.Context, msg models.CallbackMessage,
 			Timestamp: now,
 		}
 		if err := s.store.UpdateStatus(ctx, status); err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				logger.Warn("dropping seen_on_network for unknown txid",
+					zap.String("txid", txid))
+				continue
+			}
 			logger.Warn("failed to update seen_on_network", zap.String("txid", txid), zap.Error(err))
 			continue
 		}
@@ -290,6 +302,10 @@ func (s *Server) handleSeenOnNetwork(c *gin.Context, msg models.CallbackMessage,
 	}
 }
 
+// handleSeenMultipleNodes applies a SEEN_ON_MULTIPLE_NODES callback. Same
+// unknown-txid handling as handleSeenOnNetwork — the store rejects updates
+// to absent rows (F-033 / #91) and we log + continue rather than creating
+// phantom rows.
 func (s *Server) handleSeenMultipleNodes(c *gin.Context, msg models.CallbackMessage, logger *zap.Logger) {
 	txids := msg.ResolveSeenTxIDs()
 	if len(txids) == 0 {
@@ -305,6 +321,11 @@ func (s *Server) handleSeenMultipleNodes(c *gin.Context, msg models.CallbackMess
 			Timestamp: now,
 		}
 		if err := s.store.UpdateStatus(ctx, status); err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				logger.Warn("dropping seen_multiple_nodes for unknown txid",
+					zap.String("txid", txid))
+				continue
+			}
 			logger.Warn("failed to update seen_multiple_nodes", zap.String("txid", txid), zap.Error(err))
 			continue
 		}

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -38,6 +38,10 @@ type mockStore struct {
 	stumps              map[string]*models.Stump
 	insertStumpErr      error
 	insertedSubmissions []*models.Submission
+	// updateStatusErr, if non-nil, is returned from UpdateStatus and the call
+	// is NOT recorded — this models the F-033 (#91) "no phantom row" guard
+	// where a backend that rejects the call must not have written anything.
+	updateStatusErr error
 	// insertStumpFn, if set, runs before the default record step and may
 	// return an error to simulate per-key failures (Aerospike RECORD_TOO_BIG,
 	// DEVICE_OVERLOAD, HOT_KEY, etc.). Returning non-nil skips the record.
@@ -45,6 +49,9 @@ type mockStore struct {
 }
 
 func (m *mockStore) UpdateStatus(_ context.Context, status *models.TransactionStatus) error {
+	if m.updateStatusErr != nil {
+		return m.updateStatusErr
+	}
 	m.updateStatusCalls = append(m.updateStatusCalls, status)
 	return nil
 }
@@ -342,6 +349,57 @@ func TestHandleCallback_SeenMultipleNodes_UpdatesStatus(t *testing.T) {
 	}
 	if ms.updateStatusCalls[1].TxID != "tx2" {
 		t.Errorf("expected second txid=tx2, got %s", ms.updateStatusCalls[1].TxID)
+	}
+}
+
+// TestHandleCallback_UnknownTxid_NoPhantomRow is the regression for F-033
+// (#91). When merkle-service POSTs a SEEN_ON_NETWORK / SEEN_MULTIPLE_NODES
+// callback for a txid we never recorded, the store layer rejects the update
+// with store.ErrNotFound and the handler must:
+//
+//   - log a Warn (operators want to see attempts to update unknown txids)
+//   - skip publishStatus / txTracker updates (no observers should learn
+//     about a tx that doesn't exist in our records)
+//   - still return 200 OK so merkle-service stops retrying — the txid is
+//     definitively unknown, not transiently unavailable.
+//
+// The contract here is intentionally NOT 404: merkle-service treats 4xx as a
+// permanent reject already, but a callback can carry a batch of txids and a
+// single unknown one shouldn't fail the whole batch.
+func TestHandleCallback_UnknownTxid_NoPhantomRow(t *testing.T) {
+	cases := []models.CallbackType{
+		models.CallbackSeenOnNetwork,
+		models.CallbackSeenMultipleNodes,
+	}
+	for _, cbType := range cases {
+		t.Run(string(cbType), func(t *testing.T) {
+			ms := &mockStore{updateStatusErr: store.ErrNotFound}
+			_, router := setupServerWithStore(&kafka.RecordingBroker{}, ms)
+
+			payload := models.CallbackMessage{
+				Type:  cbType,
+				TxIDs: []string{"unknown-tx-1", "unknown-tx-2"},
+			}
+			body := mustMarshalJSON(t, payload)
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/merkle-service/callback", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200 (callbacks for unknown txids are silently dropped), got %d: %s",
+					w.Code, w.Body.String())
+			}
+			// The store rejected the call — mockStore must not have recorded
+			// any UpdateStatus payload (otherwise the production backend would
+			// have written a phantom row).
+			if len(ms.updateStatusCalls) != 0 {
+				t.Fatalf("expected 0 recorded UpdateStatus calls when store returns ErrNotFound, got %d",
+					len(ms.updateStatusCalls))
+			}
+		})
 	}
 }
 

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -34,16 +34,6 @@ func isGenerationErr(err error) bool {
 	return false
 }
 
-// isKeyExistsErr is true when an Aerospike CREATE_ONLY write fails because
-// another writer raced us in and the record now exists.
-func isKeyExistsErr(err error) bool {
-	var aerr aero.Error
-	if errors.As(err, &aerr) {
-		return aerr.Matches(types.KEY_EXISTS_ERROR)
-	}
-	return false
-}
-
 const (
 	setTransactions     = "arcade_transactions"
 	setBumps            = "arcade_bumps"
@@ -348,6 +338,12 @@ func (s *Store) BatchUpdateStatus(ctx context.Context, statuses []*models.Transa
 	return store.BatchUpdateStatusParallel(ctx, s, statuses)
 }
 
+// UpdateStatus updates an existing transaction record. If no record exists for
+// status.TxID the call returns store.ErrNotFound without writing — callers
+// must use GetOrInsertStatus to create new rows. This guard closes F-033 /
+// issue #91: previously a callback referencing a never-submitted txid would
+// create a phantom row with no submission/validation history, turning the
+// callback endpoint into a write-anywhere primitive.
 func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStatus) error {
 	key, err := s.key(setTransactions, status.TxID)
 	if err != nil {
@@ -376,34 +372,39 @@ func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStat
 	// MINED). Read-then-CAS-write using the record's generation guarantees the
 	// pre-write check and the write are atomic with respect to other writers.
 	// See models.Status.CanTransitionFrom and #61 / F-003.
-	if status.Status == "" {
-		return s.client.Put(s.writePolicy(ctx), key, bins)
-	}
+	//
+	// Also: never create a record from UpdateStatus (F-033 / #91) — if the
+	// record is genuinely absent we return ErrNotFound. UPDATE_ONLY on the
+	// write enforces this even if a racing writer deleted the row between
+	// our read and our put.
 	for {
 		rec, gerr := s.client.Get(s.readPolicy(ctx), key, "status")
 		if gerr != nil && !isKeyNotFound(gerr) {
 			return fmt.Errorf("read status for lattice check %s: %w", status.TxID, gerr)
 		}
-		policy := s.writePolicy(ctx)
-		if rec != nil {
+		if rec == nil {
+			return store.ErrNotFound
+		}
+		if status.Status != "" {
 			existing := models.Status(getString(rec, "status"))
 			if !status.Status.CanTransitionFrom(existing) {
 				return nil
 			}
-			policy.GenerationPolicy = aero.EXPECT_GEN_EQUAL
-			policy.Generation = rec.Generation
-		} else {
-			// No existing row: only create if the row is genuinely absent. If
-			// another writer races us in, retry the read-modify-write so the
-			// lattice check covers the new state too.
-			policy.RecordExistsAction = aero.CREATE_ONLY
 		}
+		policy := s.writePolicy(ctx)
+		policy.GenerationPolicy = aero.EXPECT_GEN_EQUAL
+		policy.Generation = rec.Generation
+		policy.RecordExistsAction = aero.UPDATE_ONLY
 		if err := s.client.Put(policy, key, bins); err != nil {
-			// Generation mismatch / create-only conflict means another writer
-			// landed between our read and our put. Re-read and re-evaluate the
-			// lattice rather than silently clobbering their write.
-			if isGenerationErr(err) || isKeyExistsErr(err) {
+			// Generation mismatch means another writer landed between our read
+			// and our put. Re-read and re-evaluate the lattice rather than
+			// silently clobbering their write.
+			if isGenerationErr(err) {
 				continue
+			}
+			// UPDATE_ONLY on a record that was deleted between our read and put.
+			if isKeyNotFound(err) {
+				return store.ErrNotFound
 			}
 			return fmt.Errorf("update tx %s: %w", status.TxID, err)
 		}

--- a/store/aerospike/ctx_test.go
+++ b/store/aerospike/ctx_test.go
@@ -4,10 +4,13 @@ package aerospike
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
 )
 
 // These tests require a running Aerospike instance on localhost:3200
@@ -82,5 +85,69 @@ func TestGetStumpsByBlockHash_HappyPath(t *testing.T) {
 	}
 	if len(stumps) != 0 {
 		t.Fatalf("expected 0 stumps, got %d", len(stumps))
+	}
+}
+
+// TestUpdateStatus_UnknownTxidReturnsErrNotFound is the regression for F-033
+// (#91): UpdateStatus on a txid that has no existing record must return
+// store.ErrNotFound and must NOT create a phantom row. Aerospike previously
+// used CREATE_ONLY on the no-existing-row path which actively wrote a record;
+// we now require the row to exist (UPDATE_ONLY semantics).
+func TestUpdateStatus_UnknownTxidReturnsErrNotFound(t *testing.T) {
+	s := integrationStore(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	txid := "ghost-tx-f033-" + time.Now().Format("150405.000000000")
+
+	err := s.UpdateStatus(ctx, &models.TransactionStatus{
+		TxID:      txid,
+		Status:    models.StatusSeenOnNetwork,
+		Timestamp: time.Now(),
+	})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("expected store.ErrNotFound for unknown txid, got %v", err)
+	}
+
+	// And critically: no phantom row was created.
+	got, gerr := s.GetStatus(ctx, txid)
+	if gerr != nil {
+		t.Fatalf("GetStatus after rejected update: %v", gerr)
+	}
+	if got != nil {
+		t.Fatalf("expected nil status for ghost txid, got %+v", got)
+	}
+}
+
+// TestUpdateStatus_ExistingTxidStillWorks covers the F-033 happy-path: the
+// guard must not break legitimate updates against rows that were inserted
+// via GetOrInsertStatus.
+func TestUpdateStatus_ExistingTxidStillWorks(t *testing.T) {
+	s := integrationStore(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	txid := "real-tx-f033-" + time.Now().Format("150405.000000000")
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusReceived,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := s.UpdateStatus(ctx, &models.TransactionStatus{
+		TxID:      txid,
+		Status:    models.StatusSeenOnNetwork,
+		Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("UpdateStatus on existing row: %v", err)
+	}
+
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Status != models.StatusSeenOnNetwork {
+		t.Fatalf("expected SEEN_ON_NETWORK, got %+v", got)
 	}
 }

--- a/store/batch.go
+++ b/store/batch.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/bsv-blockchain/arcade/models"
@@ -75,6 +76,10 @@ func BatchGetOrInsertStatusParallel(ctx context.Context, s SingleStore, statuses
 
 // BatchUpdateStatusParallel runs UpdateStatus concurrently for each row,
 // bounded by defaultBatchConcurrency. Returns the first error encountered.
+// Per-row ErrNotFound is treated as a silent no-op so the batch contract
+// matches Postgres' WHERE-clause semantics: unknown txids are skipped, not
+// turned into a fatal batch error. (UpdateStatus itself still surfaces
+// ErrNotFound to single-row callers — see store.Store.UpdateStatus.)
 func BatchUpdateStatusParallel(ctx context.Context, s SingleStore, statuses []*models.TransactionStatus) error {
 	if len(statuses) == 0 {
 		return nil
@@ -100,7 +105,7 @@ func BatchUpdateStatusParallel(ctx context.Context, s SingleStore, statuses []*m
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			if err := s.UpdateStatus(ctx, st); err != nil {
+			if err := s.UpdateStatus(ctx, st); err != nil && !errors.Is(err, ErrNotFound) {
 				mu.Lock()
 				if firstErr == nil {
 					firstErr = err

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -313,8 +313,6 @@ func (s *Store) removeStatusIndexes(b *pebbledb.Batch, st storedStatus) {
 	}
 }
 
-// UpdateStatus replaces the status row for status.TxID. It's a full rewrite:
-// any existing secondary index entries for the previous version are deleted
 // BatchGetOrInsertStatus runs GetOrInsertStatus concurrently for each row.
 // Pebble is single-process and operations are already memory-fast; the
 // parallel-loop fallback is the simplest correct path here.
@@ -327,8 +325,18 @@ func (s *Store) BatchUpdateStatus(ctx context.Context, statuses []*models.Transa
 	return store.BatchUpdateStatusParallel(ctx, s, statuses)
 }
 
+// UpdateStatus replaces the status row for status.TxID. It's a full rewrite:
+// any existing secondary index entries for the previous version are deleted
 // and the new set is written in the same batch, so an intermediate query
 // never sees a stale index pointing at a row with a different status.
+//
+// UpdateStatus is for *existing* rows only. If no row exists for the given
+// txid the call returns store.ErrNotFound without writing anything — callers
+// (notably the merkle-service callback receiver) must use GetOrInsertStatus
+// to create new rows. This guard closes F-033 / issue #91: previously a
+// callback referencing a never-submitted txid would create a phantom row
+// with no submission/validation history, turning the callback endpoint into
+// a write-anywhere primitive.
 func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStatus) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -344,12 +352,16 @@ func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStat
 	if err != nil {
 		return err
 	}
+	if existing == nil {
+		// Don't create phantom rows. See F-033 / issue #91.
+		return store.ErrNotFound
+	}
 
 	// Enforce the status lattice: a later, lower-priority update (e.g. a stray
 	// SEEN_ON_NETWORK callback arriving after a tx has already been MINED) must
 	// not overwrite a terminal status. See models.Status.CanTransitionFrom and
 	// issue #61 / F-003.
-	if existing != nil && status.Status != "" {
+	if status.Status != "" {
 		if !status.Status.CanTransitionFrom(models.Status(existing.Status)) {
 			return nil
 		}
@@ -363,9 +375,7 @@ func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStat
 
 	b := s.db.NewBatch()
 	defer func() { _ = b.Close() }()
-	if existing != nil {
-		s.removeStatusIndexes(b, *existing)
-	}
+	s.removeStatusIndexes(b, *existing)
 	if err := b.Set(txKey(status.TxID), payload, nil); err != nil {
 		return err
 	}

--- a/store/pebble/pebble_test.go
+++ b/store/pebble/pebble_test.go
@@ -195,6 +195,73 @@ func TestUpdateStatus_TerminalNotOverwritten(t *testing.T) {
 	}
 }
 
+// TestUpdateStatus_UnknownTxidReturnsErrNotFound is the regression for F-033
+// (#91): UpdateStatus on a txid that has no existing row must return
+// store.ErrNotFound and must NOT create a phantom record. Previously,
+// callbacks pointing at unknown txids could synthesize bogus rows in the
+// store, turning the callback endpoint into a write-anywhere primitive.
+func TestUpdateStatus_UnknownTxidReturnsErrNotFound(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	txid := "ghost-tx"
+
+	err := s.UpdateStatus(ctx, &models.TransactionStatus{
+		TxID:      txid,
+		Status:    models.StatusSeenOnNetwork,
+		Timestamp: time.Now(),
+	})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("expected store.ErrNotFound for unknown txid, got %v", err)
+	}
+
+	// And critically: no phantom row was created.
+	got, gerr := s.GetStatus(ctx, txid)
+	if gerr != nil {
+		t.Fatalf("GetStatus after rejected update: %v", gerr)
+	}
+	if got != nil {
+		t.Fatalf("expected nil status for ghost txid, got %+v", got)
+	}
+
+	// The status index must also be empty — i.e. no idx:tx:status:SEEN_ON_NETWORK:ghost-tx.
+	v, closer, gErr := s.db.Get(idxTxStatusKey(string(models.StatusSeenOnNetwork), txid))
+	if gErr == nil {
+		_ = closer.Close()
+		t.Fatalf("phantom secondary index entry was written for ghost txid: %x", v)
+	}
+}
+
+// TestUpdateStatus_ExistingTxidStillWorks is the regression for the happy
+// path: the F-033 guard must not break legitimate updates against rows that
+// were created via GetOrInsertStatus.
+func TestUpdateStatus_ExistingTxidStillWorks(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	txid := "real-tx"
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusReceived,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := s.UpdateStatus(ctx, &models.TransactionStatus{
+		TxID:      txid,
+		Status:    models.StatusSeenOnNetwork,
+		Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("UpdateStatus on existing row: %v", err)
+	}
+
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Status != models.StatusSeenOnNetwork {
+		t.Fatalf("expected SEEN_ON_NETWORK, got %+v", got)
+	}
+}
+
 // TestUpdateStatus_ForwardTransitionsStillWork sanity-checks that the lattice
 // guard does not break legitimate forward transitions.
 func TestUpdateStatus_ForwardTransitionsStillWork(t *testing.T) {

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -384,6 +384,15 @@ WHERE t.txid = v.txid AND t.status <> ALL(v.disallowed_prev)`
 	return nil
 }
 
+// UpdateStatus updates an existing transaction. If no row exists for
+// status.TxID the call returns store.ErrNotFound without writing — callers
+// must use GetOrInsertStatus to create new rows. This guard closes F-033 /
+// issue #91: previously a callback referencing a never-submitted txid would
+// create a phantom row with no submission/validation history, turning the
+// callback endpoint into a write-anywhere primitive. Postgres' UPDATE …
+// WHERE txid=$1 already no-ops on missing rows; we now distinguish the
+// "row absent" case from "row present but lattice rejected" by checking
+// existence in a separate query when the UPDATE affects zero rows.
 func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStatus) error {
 	// Mirror Aerospike's BinMap semantics: empty fields are ignored, so the
 	// caller can issue partial updates without clobbering unrelated columns.
@@ -427,14 +436,45 @@ func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStat
 	// overwrite a terminal status (MINED/IMMUTABLE/REJECTED/DOUBLE_SPEND_ATTEMPTED)
 	// with a later, lower-priority update such as a stray SEEN_ON_NETWORK
 	// callback. See models.Status.DisallowedPreviousStatuses and #61 / F-003.
+	hasLatticeGuard := false
 	if disallowed := disallowedPrevAsStrings(status.Status); len(disallowed) > 0 {
 		q += fmt.Sprintf(" AND status <> ALL($%d::text[])", idx)
 		args = append(args, disallowed)
+		hasLatticeGuard = true
 	}
 
-	_, err := s.pool.Exec(ctx, q, args...)
+	tag, err := s.pool.Exec(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf("update tx %s: %w", status.TxID, err)
+	}
+	if tag.RowsAffected() > 0 {
+		return nil
+	}
+	// Zero rows: when no lattice guard was applied, the only way to reach
+	// here is "txid not in the table" — return ErrNotFound. With a lattice
+	// guard, zero rows could also mean "row present but transition refused";
+	// disambiguate with a cheap existence probe so legitimate lattice no-ops
+	// don't surface as ErrNotFound.
+	if !hasLatticeGuard {
+		return store.ErrNotFound
+	}
+	return s.probeMissingTxID(ctx, status.TxID)
+}
+
+// probeMissingTxID returns store.ErrNotFound if no row exists for txid, nil
+// otherwise. Used by UpdateStatus to distinguish "row absent" from "row
+// present but lattice rejected" when an UPDATE … WHERE … AND status<>ALL(…)
+// affects zero rows.
+func (s *Store) probeMissingTxID(ctx context.Context, txid string) error {
+	var exists bool
+	if err := s.pool.QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM transactions WHERE txid = $1)",
+		txid,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("update tx %s: existence probe: %w", txid, err)
+	}
+	if !exists {
+		return store.ErrNotFound
 	}
 	return nil
 }

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -553,6 +553,66 @@ func TestUpdateStatus_TerminalNotOverwritten(t *testing.T) {
 	}
 }
 
+// TestUpdateStatus_UnknownTxidReturnsErrNotFound is the regression for F-033
+// (#91): UpdateStatus on a txid that has no existing row must return
+// store.ErrNotFound and must NOT create a phantom row. Previously the UPDATE
+// no-opped silently and callers (notably the merkle-service callback handler)
+// could not distinguish "row missing" from "row updated".
+func TestUpdateStatus_UnknownTxidReturnsErrNotFound(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	txid := "ghost-tx"
+
+	err := s.UpdateStatus(ctx, &models.TransactionStatus{
+		TxID:      txid,
+		Status:    models.StatusSeenOnNetwork,
+		Timestamp: time.Now(),
+	})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("expected store.ErrNotFound for unknown txid, got %v", err)
+	}
+
+	// And critically: no phantom row was created.
+	got, gerr := s.GetStatus(ctx, txid)
+	if gerr != nil {
+		t.Fatalf("GetStatus after rejected update: %v", gerr)
+	}
+	if got != nil {
+		t.Fatalf("expected nil status for ghost txid, got %+v", got)
+	}
+}
+
+// TestUpdateStatus_ExistingTxidStillWorks is the F-033 happy-path regression:
+// the unknown-txid guard must not break updates against rows that were
+// legitimately inserted via GetOrInsertStatus.
+func TestUpdateStatus_ExistingTxidStillWorks(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	txid := "real-tx"
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusReceived,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := s.UpdateStatus(ctx, &models.TransactionStatus{
+		TxID:      txid,
+		Status:    models.StatusSeenOnNetwork,
+		Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("UpdateStatus on existing row: %v", err)
+	}
+
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Status != models.StatusSeenOnNetwork {
+		t.Fatalf("expected SEEN_ON_NETWORK, got %+v", got)
+	}
+}
+
 // TestBatchUpdateStatus_TerminalNotOverwritten covers the same F-003
 // regression for the batched code path.
 func TestBatchUpdateStatus_TerminalNotOverwritten(t *testing.T) {

--- a/store/store.go
+++ b/store/store.go
@@ -68,14 +68,20 @@ type Store interface {
 	// Pebble) fall back to a bounded-concurrency loop over GetOrInsertStatus.
 	BatchGetOrInsertStatus(ctx context.Context, statuses []*models.TransactionStatus) ([]BatchInsertResult, error)
 
-	// UpdateStatus updates an existing transaction status (used for P2P, blocks, etc.)
+	// UpdateStatus updates an existing transaction status (used for P2P, blocks, etc.).
+	// If no row exists for status.TxID the call returns ErrNotFound without
+	// writing — callers must use GetOrInsertStatus to create new rows. This
+	// guards the callback receiver path from creating phantom rows on behalf
+	// of unknown txids (F-033 / issue #91).
 	UpdateStatus(ctx context.Context, status *models.TransactionStatus) error
 
 	// BatchUpdateStatus is the multi-row form of UpdateStatus. Same partial-
 	// update semantics as UpdateStatus — empty fields are ignored, non-empty
-	// fields overwrite. Returns the first error encountered if any. Postgres
-	// implements this in a single round-trip via UPDATE ... FROM (VALUES …);
-	// other backends fall back to a bounded-concurrency loop.
+	// fields overwrite. Rows whose txid is unknown are silently skipped (the
+	// per-row ErrNotFound contract from UpdateStatus is collapsed to a no-op
+	// here — callers wanting per-row diagnostics use UpdateStatus directly).
+	// Postgres implements this in a single round-trip via UPDATE ... FROM
+	// (VALUES …); other backends fall back to a bounded-concurrency loop.
 	BatchUpdateStatus(ctx context.Context, statuses []*models.TransactionStatus) error
 
 	// GetStatus retrieves the status for a transaction


### PR DESCRIPTION
## Summary
- All three store backends (Pebble, Postgres, Aerospike) now return `store.ErrNotFound` from `UpdateStatus` when called with a txid that has no existing row, preventing phantom rows that previously turned the callback receiver into a write-anywhere primitive (F-033 / #91).
  - Pebble: explicit `existing == nil` check before write.
  - Postgres: detects zero-rows-affected and disambiguates lattice-rejection from row-absent via a cheap `SELECT EXISTS` probe.
  - Aerospike: replaces the old `CREATE_ONLY` no-existing-row branch with `UPDATE_ONLY` semantics — the lattice-CAS loop from #105 is preserved, but a missing record now surfaces `ErrNotFound` instead of silently creating one.
- `BatchUpdateStatusParallel` collapses per-row `ErrNotFound` to a silent skip so the batch contract matches Postgres' WHERE-clause semantics (unknown txids skipped, not turned into a fatal batch error).
- `services/api_server/handlers.go`: `handleSeenOnNetwork` and `handleSeenMultipleNodes` map `ErrNotFound` to a `Warn` log including the txid and skip `publishStatus` / `txTracker` updates. The HTTP response stays 200 OK so a callback batch carrying one unknown txid alongside known ones still succeeds end-to-end (merkle-service treats 4xx as a permanent reject already, and the unknown-txid case is precisely "permanently dropped").
- Doc comments on the `Store` interface, each backend's `UpdateStatus`, and `BatchUpdateStatusParallel` updated to reflect the new contract.

Defense-in-depth complement to #112 (auth on `/callback`): even an attacker with a valid bearer token can no longer create phantom rows by callback alone.

Closes #91 (F-033).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./store/... ./services/api_server/... -race -count=1` — all pass.
- [x] `go test -tags=postgres ./store/postgres/... -race -count=1` — all pass against embedded-postgres, including the two new F-033 tests.
- [x] `golangci-lint run ./store/... ./services/api_server/...` — clean.
- [ ] Reviewer: confirm the chosen HTTP status (200 OK with silent drop) for unknown-txid callbacks matches operator expectations. If 404 is preferred, switching is one line per handler.
- [ ] Reviewer: confirm Aerospike `UPDATE_ONLY` behaviour against a real cluster (the new integration test at `store/aerospike/ctx_test.go` covers this but only runs with `-tags=integration`).