### PR TITLE
fix(api_server): cap callback request body size (#77)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -114,8 +114,16 @@ health:
 # allow_private_ips: true if your deployment intentionally posts
 # callbacks to internal services (testing, k8s service DNS, intranet
 # webhooks). See finding F-017 / issue #75.
+#
+# max_body_bytes caps the size of an inbound POST
+# /api/v1/merkle-service/callback request body (JSON, with embedded STUMP
+# payload). Default 16 MiB is generous over a realistic STUMP delivery
+# while bounding worst-case memory if a peer is malicious or malfunctioning.
+# Oversize requests are rejected with 413 Payload Too Large. See finding
+# F-019 / issue #77.
 # callback:
 #   allow_private_ips: false
+#   max_body_bytes: 16777216    # 16 MiB
 
 # propagation:
 #   # Per-endpoint circuit-breaker for the datahub URL list. Endpoints that

--- a/config/config.go
+++ b/config/config.go
@@ -358,7 +358,24 @@ type CallbackConfig struct {
 	// Operators running purely against internal services (testing rigs,
 	// k8s service DNS, intranet webhooks) can set this true.
 	AllowPrivateIPs bool `mapstructure:"allow_private_ips"`
+	// MaxBodyBytes caps the size of an inbound POST
+	// /api/v1/merkle-service/callback body, in bytes. The callback receives
+	// JSON with embedded STUMP payloads (subtree merkle paths) that can be
+	// genuinely large for busy subtrees, but unbounded reads let a malicious
+	// or malfunctioning peer exhaust memory. Default 16 MiB is well over a
+	// realistic STUMP delivery (~hundreds of KiB even for the largest
+	// subtrees observed in production) while still bounding worst-case
+	// memory use per request. A value <= 0 selects DefaultCallbackMaxBodyBytes.
+	// Mitigates F-019 (callback JSON bodies and STUMP payloads are unbounded).
+	MaxBodyBytes int64 `mapstructure:"max_body_bytes"`
 }
+
+// DefaultCallbackMaxBodyBytes is the fallback value for
+// CallbackConfig.MaxBodyBytes when an operator leaves it unset (or sets a
+// non-positive value). 16 MiB is generous enough for the largest realistic
+// STUMP payload while still bounding memory against a hostile peer; see
+// F-019 for the threat model.
+const DefaultCallbackMaxBodyBytes int64 = 16 << 20
 
 // TxValidatorConfig tunes the parallel batch validation pipeline. Parallelism
 // caps how many transactions are parsed and validated concurrently inside a
@@ -503,6 +520,9 @@ func setDefaults() {
 	// into a blind SSRF primitive against internal services and cloud
 	// metadata endpoints.
 	viper.SetDefault("callback.allow_private_ips", false)
+	// Inbound callback body cap. 16 MiB headroom over realistic STUMP payloads
+	// while bounding memory against a hostile or malfunctioning peer (F-019).
+	viper.SetDefault("callback.max_body_bytes", DefaultCallbackMaxBodyBytes)
 
 	viper.SetDefault("storage_path", "~/.arcade")
 	viper.SetDefault("chaintracks_server.enabled", true)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -213,3 +213,15 @@ func TestResolveChaintracksNetwork(t *testing.T) {
 		})
 	}
 }
+
+// TestDefaultCallbackMaxBodyBytes pins the default body cap for the inbound
+// callback receiver. Set to 16 MiB — comfortably over a realistic STUMP
+// delivery while bounding worst-case memory if a peer is malicious or
+// malfunctioning. Mitigates F-019 / issue #77; bumping this value should be
+// a deliberate, reviewed change.
+func TestDefaultCallbackMaxBodyBytes(t *testing.T) {
+	const want int64 = 16 * 1024 * 1024
+	if DefaultCallbackMaxBodyBytes != want {
+		t.Errorf("DefaultCallbackMaxBodyBytes = %d, want %d", DefaultCallbackMaxBodyBytes, want)
+	}
+}

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/hex"
+	"errors"
 	"html/template"
 	"io"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/bsv-blockchain/arcade/callbackurl"
+	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/kafka"
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/teranode"
@@ -224,6 +226,17 @@ func (s *Server) handleReady(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ready"})
 }
 
+// callbackMaxBodyBytes returns the configured upper bound on the request
+// body for POST /api/v1/merkle-service/callback, falling back to the
+// package default when the operator leaves the knob unset or sets a
+// non-positive value. Centralized so the handler and tests stay in sync.
+func (s *Server) callbackMaxBodyBytes() int64 {
+	if n := s.cfg.Callback.MaxBodyBytes; n > 0 {
+		return n
+	}
+	return config.DefaultCallbackMaxBodyBytes
+}
+
 // handleCallback processes inbound callbacks from Merkle Service.
 // Uses CallbackMessage format with Type field.
 //
@@ -233,6 +246,12 @@ func (s *Server) handleReady(c *gin.Context) {
 // means a misconfigured deployment outside the supported envelope. We still
 // fail closed here as a defense-in-depth measure: an empty/missing bearer or
 // any mismatch is rejected with 401 before any callback processing runs.
+//
+// The request body is wrapped in http.MaxBytesReader before JSON-binding so
+// a malicious or malfunctioning peer can't exhaust memory by streaming an
+// unbounded JSON body (notably the embedded STUMP blob). Oversize bodies
+// produce a 413 Payload Too Large; the cap is configurable via
+// Callback.MaxBodyBytes (default 16 MiB). See F-019 / issue #77.
 func (s *Server) handleCallback(c *gin.Context) {
 	// Bearer token validation — always enforced, never skipped on empty
 	// configured token. subtle.ConstantTimeCompare removes the timing side
@@ -249,8 +268,20 @@ func (s *Server) handleCallback(c *gin.Context) {
 		return
 	}
 
+	// Cap the inbound body BEFORE JSON-binding. http.MaxBytesReader returns a
+	// *http.MaxBytesError once the limit is exceeded, which we map to 413.
+	// Other decode errors (malformed JSON, type mismatches) keep their
+	// existing 400 mapping — the contract for legitimate malformed input
+	// hasn't changed.
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, s.callbackMaxBodyBytes())
+
 	var msg models.CallbackMessage
 	if err := c.ShouldBindJSON(&msg); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "request body too large"})
+			return
+		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
 		return
 	}

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -988,5 +989,161 @@ func TestHandleCallback_RejectsUnauthenticated(t *testing.T) {
 				t.Errorf("rejected callback must not write to the store, got %d UpdateStatus calls", len(ms.updateStatusCalls))
 			}
 		})
+	}
+}
+
+// setupServerWithCallbackLimit returns a Server / router pair with the
+// callback body cap explicitly configured. Used by the F-019 body-cap tests
+// so they can run against a small, predictable limit instead of the 16 MiB
+// production default.
+func setupServerWithCallbackLimit(broker *kafka.RecordingBroker, ms *mockStore, maxBytes int64) (*Server, *gin.Engine) {
+	gin.SetMode(gin.TestMode)
+	producer := kafka.NewProducer(broker)
+	srv := &Server{
+		cfg: &config.Config{
+			CallbackToken: testCallbackToken,
+			Callback:      config.CallbackConfig{MaxBodyBytes: maxBytes},
+		},
+		logger:   zap.NewNop(),
+		producer: producer,
+		store:    ms,
+	}
+	router := gin.New()
+	srv.registerRoutes(router)
+	return srv, router
+}
+
+// TestHandleCallback_BodySizeLimit_UnderLimitSucceeds verifies that a
+// callback whose serialized JSON sits comfortably under the configured cap
+// is processed normally — guarding against an overly aggressive limit
+// rejecting legitimate STUMP deliveries. Locks down half of the F-019 fix.
+func TestHandleCallback_BodySizeLimit_UnderLimitSucceeds(t *testing.T) {
+	const limit = 64 * 1024 // 64 KiB
+	ms := &mockStore{}
+	_, router := setupServerWithCallbackLimit(&kafka.RecordingBroker{}, ms, limit)
+
+	// Build a STUMP payload sized so that the resulting JSON body — which
+	// hex-encodes the bytes via models.HexBytes — is just under the cap. Hex
+	// roughly doubles the byte count, so half the limit (less envelope
+	// overhead) leaves headroom for the JSON wrapper.
+	stumpBytes := make([]byte, limit/2-1024)
+	for i := range stumpBytes {
+		stumpBytes[i] = byte(i & 0xFF)
+	}
+	payload := models.CallbackMessage{
+		Type:      models.CallbackStump,
+		BlockHash: "0000000000000000000000000000000000000000000000000000000000000001",
+		Stump:     stumpBytes,
+	}
+	body := mustMarshalJSON(t, payload)
+	if int64(len(body)) >= limit {
+		t.Fatalf("test setup: body %d bytes is not under limit %d", len(body), limit)
+	}
+
+	req := authedCallbackRequest(t, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	ms.mu.Lock()
+	stored := len(ms.stumps)
+	ms.mu.Unlock()
+	if stored != 1 {
+		t.Errorf("expected 1 stump stored on under-limit body, got %d", stored)
+	}
+}
+
+// TestHandleCallback_BodySizeLimit_OverLimitReturns413 verifies the F-019
+// fix: an oversize callback POST is rejected with 413 Payload Too Large
+// (not 400) before any decoding allocates the full body. Locks down the
+// other half of the fix.
+func TestHandleCallback_BodySizeLimit_OverLimitReturns413(t *testing.T) {
+	const limit = 64 * 1024 // 64 KiB
+	ms := &mockStore{}
+	_, router := setupServerWithCallbackLimit(&kafka.RecordingBroker{}, ms, limit)
+
+	// Construct a body whose raw byte length exceeds the cap. We embed it in
+	// a CallbackSeenOnNetwork payload (oversize TxIDs list) so the structure
+	// is still valid JSON — what we're testing is the size check, not parse
+	// behavior on garbage input.
+	huge := strings.Repeat("a", int(limit)+1024)
+	body := mustMarshalJSON(t, models.CallbackMessage{
+		Type:  models.CallbackSeenOnNetwork,
+		TxIDs: []string{huge},
+	})
+	if int64(len(body)) <= limit {
+		t.Fatalf("test setup: body %d bytes is not over limit %d", len(body), limit)
+	}
+
+	req := authedCallbackRequest(t, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Oversize bodies must short-circuit before the dispatch path runs.
+	if len(ms.updateStatusCalls) != 0 {
+		t.Errorf("oversize callback must not write to the store, got %d UpdateStatus calls", len(ms.updateStatusCalls))
+	}
+}
+
+// TestHandleCallback_BodySizeLimit_HugeStumpRejected covers the original
+// F-019 scenario directly: a STUMP callback whose embedded payload is much
+// larger than the configured cap returns 413 instead of allocating the
+// entire body into memory.
+func TestHandleCallback_BodySizeLimit_HugeStumpRejected(t *testing.T) {
+	const limit = 32 * 1024 // 32 KiB
+	ms := &mockStore{}
+	_, router := setupServerWithCallbackLimit(&kafka.RecordingBroker{}, ms, limit)
+
+	// 4 MiB STUMP — vastly larger than the cap, mimicking the unbounded
+	// payload that motivated F-019.
+	stumpBytes := make([]byte, 4*1024*1024)
+	for i := range stumpBytes {
+		stumpBytes[i] = byte(i & 0xFF)
+	}
+	body := mustMarshalJSON(t, models.CallbackMessage{
+		Type:      models.CallbackStump,
+		BlockHash: "0000000000000000000000000000000000000000000000000000000000000002",
+		Stump:     stumpBytes,
+	})
+
+	req := authedCallbackRequest(t, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
+	}
+	ms.mu.Lock()
+	stored := len(ms.stumps)
+	ms.mu.Unlock()
+	if stored != 0 {
+		t.Errorf("oversize STUMP must not be persisted, got %d stored", stored)
+	}
+}
+
+// TestHandleCallback_BodySizeLimit_DefaultsToConfigConstant confirms that
+// leaving Callback.MaxBodyBytes unset (or zero/negative) falls back to the
+// package default, so a misconfiguration can never disable the cap entirely.
+func TestHandleCallback_BodySizeLimit_DefaultsToConfigConstant(t *testing.T) {
+	srv := &Server{cfg: &config.Config{}}
+	if got := srv.callbackMaxBodyBytes(); got != config.DefaultCallbackMaxBodyBytes {
+		t.Errorf("zero value: got %d, want %d", got, config.DefaultCallbackMaxBodyBytes)
+	}
+
+	srv.cfg.Callback.MaxBodyBytes = -1
+	if got := srv.callbackMaxBodyBytes(); got != config.DefaultCallbackMaxBodyBytes {
+		t.Errorf("negative value: got %d, want %d", got, config.DefaultCallbackMaxBodyBytes)
+	}
+
+	srv.cfg.Callback.MaxBodyBytes = 1 << 10
+	if got := srv.callbackMaxBodyBytes(); got != 1<<10 {
+		t.Errorf("explicit value: got %d, want %d", got, 1<<10)
 	}
 }

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -399,8 +399,7 @@ func TestHandleCallback_UnknownTxid_NoPhantomRow(t *testing.T) {
 			}
 			body := mustMarshalJSON(t, payload)
 
-			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/merkle-service/callback", bytes.NewReader(body))
-			req.Header.Set("Content-Type", "application/json")
+			req := authedCallbackRequest(t, body)
 			w := httptest.NewRecorder()
 
 			router.ServeHTTP(w, req)


### PR DESCRIPTION
## Summary
- `handleCallback` wraps `c.Request.Body` in `http.MaxBytesReader` before JSON-binding; oversize requests return 413 Payload Too Large instead of streaming the entire body into memory.
- New `callback.max_body_bytes` config knob (default 16 MiB via `config.DefaultCallbackMaxBodyBytes`); a missing/zero/negative value falls back to the default so a misconfiguration can never disable the cap entirely.
- `MaxBytesReader` only inflates the underlying `*http.Request.Body`, so a `*http.MaxBytesError` surfaces from `ShouldBindJSON` and is mapped to 413; legitimate decode errors still return 400. Closes F-019 / issue #77.

## Tests
- `TestHandleCallback_BodySizeLimit_UnderLimitSucceeds` — body just under the configured cap is processed normally.
- `TestHandleCallback_BodySizeLimit_OverLimitReturns413` — oversize JSON body returns 413 and never reaches the dispatch path.
- `TestHandleCallback_BodySizeLimit_HugeStumpRejected` — the F-019 scenario directly: a 4 MiB STUMP against a 32 KiB cap is rejected without being persisted.
- `TestHandleCallback_BodySizeLimit_DefaultsToConfigConstant` — zero/negative config falls back to the package default.
- `TestDefaultCallbackMaxBodyBytes` — pins the 16 MiB default so bumping it requires a deliberate change.
- All existing callback tests (auth, full block flow, partial STUMP failure, etc.) continue to pass.

Closes #77

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./services/api_server/... ./config/... -race`
- [x] `golangci-lint run ./services/api_server/... ./config/...` (0 issues)
- [ ] Reviewer to confirm the 16 MiB default is operationally reasonable