### PR TITLE
fix(deploy): persist Aerospike data to a PVC (#98)

### DIFF
--- a/deploy/aerospike.yaml
+++ b/deploy/aerospike.yaml
@@ -34,7 +34,11 @@ data:
     namespace arcade {
       replication-factor 1
       memory-size 1G
-      storage-engine memory
+      storage-engine device {
+        file /opt/aerospike/data/arcade.dat
+        filesize 8G
+        data-in-memory false
+      }
     }
 ---
 apiVersion: apps/v1
@@ -92,10 +96,20 @@ spec:
               mountPath: /opt/aerospike/etc/aerospike.conf
               subPath: aerospike.conf
               readOnly: true
+            - name: aerospike-data
+              mountPath: /opt/aerospike/data
       volumes:
         - name: config
           configMap:
             name: aerospike-config
+  volumeClaimTemplates:
+    - metadata:
+        name: aerospike-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
- Switch the `arcade` Aerospike namespace from `storage-engine memory` to a file-backed `storage-engine device` at `/opt/aerospike/data/arcade.dat` (filesize 8G, `data-in-memory false`) so data is no longer lost on pod restart.
- Add a `volumeClaimTemplates` entry (`aerospike-data`, 10Gi, ReadWriteOnce) to the StatefulSet and mount it at `/opt/aerospike/data` so each pod has durable per-replica storage.

## Test plan
- [ ] `yamllint deploy/aerospike.yaml` (only the pre-existing `document-start` warning remains)
- [ ] `kubectl apply --dry-run=server -f deploy/aerospike.yaml` in a cluster with a default StorageClass
- [ ] Apply, write a record, delete the pod, confirm the record survives the restart
- [ ] Confirm the PVC is created and bound (`kubectl get pvc -n arcade`)

Closes #98