### PR TITLE
fix(deploy): align manifest image references with the published GHCR namespace (#56)

### DIFF
--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: arcade
-          image: ghcr.io/galt-tr/arcade-refactor:latest
+          image: ghcr.io/bsv-blockchain/arcade:latest
           args: ["--mode", "all"]
           ports:
             - containerPort: 8080

--- a/deploy/api-server.yaml
+++ b/deploy/api-server.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: arcade
-          image: ghcr.io/galt-tr/arcade-refactor:latest
+          image: ghcr.io/bsv-blockchain/arcade:latest
           args: ["--mode", "api-server"]
           ports:
             - containerPort: 8080

--- a/deploy/bump-builder.yaml
+++ b/deploy/bump-builder.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: arcade
-          image: ghcr.io/galt-tr/arcade-refactor:latest
+          image: ghcr.io/bsv-blockchain/arcade:latest
           args: ["--mode", "bump-builder"]
           ports:
             - containerPort: 8081

--- a/deploy/p2p-client.yaml
+++ b/deploy/p2p-client.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: arcade
-          image: ghcr.io/galt-tr/arcade-refactor:latest
+          image: ghcr.io/bsv-blockchain/arcade:latest
           args: ["--mode", "p2p-client"]
           ports:
             - containerPort: 8081

--- a/deploy/propagation.yaml
+++ b/deploy/propagation.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: arcade
-          image: ghcr.io/galt-tr/arcade-refactor:latest
+          image: ghcr.io/bsv-blockchain/arcade:latest
           args: ["--mode", "propagation"]
           ports:
             - containerPort: 8081

--- a/deploy/tx-validator.yaml
+++ b/deploy/tx-validator.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: arcade
-          image: ghcr.io/galt-tr/arcade-refactor:latest
+          image: ghcr.io/bsv-blockchain/arcade:latest
           args: ["--mode", "tx-validator"]
           ports:
             - containerPort: 8081


### PR DESCRIPTION
## Summary

Closes #56 (C-004).

The manifests under `deploy/` referenced `ghcr.io/galt-tr/arcade-refactor:latest`, an artifact CI no longer publishes. `.github/workflows/build.yml` (lines 70-72) pushes to `ghcr.io/bsv-blockchain/arcade`, tagged with both `${{ github.sha }}` and a deployment tag (`latest` on `main`, `vX.Y.Z` on tag pushes). This PR repoints every Deployment at the canonical image so a fresh `kubectl apply -f deploy/` pulls what CI actually built.

The `:latest` tag is preserved to match the existing convention in the manifests and what `build.yml` emits on `main` pushes. Pinning to immutable SHAs is a separate hardening conversation and is out of scope for this C-ticket.

## Image references (before -> after)

| File | Before | After |
| --- | --- | --- |
| `deploy/all.yaml` | `ghcr.io/galt-tr/arcade-refactor:latest` | `ghcr.io/bsv-blockchain/arcade:latest` |
| `deploy/api-server.yaml` | `ghcr.io/galt-tr/arcade-refactor:latest` | `ghcr.io/bsv-blockchain/arcade:latest` |
| `deploy/bump-builder.yaml` | `ghcr.io/galt-tr/arcade-refactor:latest` | `ghcr.io/bsv-blockchain/arcade:latest` |
| `deploy/p2p-client.yaml` | `ghcr.io/galt-tr/arcade-refactor:latest` | `ghcr.io/bsv-blockchain/arcade:latest` |
| `deploy/propagation.yaml` | `ghcr.io/galt-tr/arcade-refactor:latest` | `ghcr.io/bsv-blockchain/arcade:latest` |
| `deploy/tx-validator.yaml` | `ghcr.io/galt-tr/arcade-refactor:latest` | `ghcr.io/bsv-blockchain/arcade:latest` |

`deploy/aerospike.yaml` (`aerospike/aerospike-server:7.0`) and `deploy/kafka.yaml` (`bitnami/kafka:3.7`) are upstream third-party images and were not touched.

## Out of scope (tracked separately)

- **#92 - env var alignment with Viper keys**: still in Backlog. While verifying this PR I noticed the manifests set `ARCADE_AEROSPIKE_HOSTS` and `ARCADE_AEROSPIKE_NAMESPACE`, but `config/config.go` registers Viper defaults under `store.aerospike.hosts` / `store.aerospike.namespace` (see lines 469-470). With `viper.SetEnvPrefix("ARCADE")` + `AutomaticEnv()`, those env vars resolve to `aerospike.hosts` / `aerospike.namespace`, not `store.aerospike.*`, so they are silently ignored. `ARCADE_KAFKA_BROKERS` -> `kafka.brokers` does map correctly. Flagging here for #92 to address.
- **Helm/Kustomize migration** (the broader recommendation in C-004): remains a Backlog child. These plain manifests stay as the bootstrap path until that lands.

## Test plan

- [x] `yamllint deploy/*.yaml` - only pre-existing `document-start` warnings and a pre-existing `line-length` error in `deploy/kafka.yaml:2` (a comment); no new findings introduced by this change.
- [x] Grep verification: every `image:` line under `deploy/` now points at `ghcr.io/bsv-blockchain/arcade:latest` or an upstream third-party image (aerospike, kafka).
- [ ] Reviewer: confirm `:latest` is the desired tag for the bootstrap manifests (vs. pinning to a SHA / version tag).