### PR TITLE
[CI] Build multi-arch images on native runners

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,7 +21,8 @@ vendor/
 
 # Binaries for programs and plugins
 dist/
-!dist/linux/
+!dist/linux-amd64/
+!dist/linux-arm64/
 gin-bin
 *.exe
 *.exe~

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,14 @@ name: Build and Push to GHCR
 #   - workflow_dispatch: manual run; gated via `needs:` chain on local jobs that
 #     re-verify the head SHA passed GoFortress before publishing.
 # ------------------------------------------------------------------------------------
+# Multi-arch strategy
+# ------------------------------------------------------------------------------------
+# Each architecture is built on its native runner (`ubuntu-24.04` for amd64,
+# `ubuntu-24.04-arm` for arm64) — no QEMU emulation. Each matrix job pushes a
+# single-arch image to GHCR by digest only (no tag). The merge-manifest job then
+# composes those digests into a single multi-arch manifest list under the existing
+# tag scheme (`<sha>` and `latest` / `<git-tag>`).
+# ------------------------------------------------------------------------------------
 
 on:
   workflow_run:
@@ -30,6 +38,10 @@ on:
   workflow_dispatch:
 
 permissions: {}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: bsv-blockchain/arcade
 
 jobs:
   # --------------------------------------------------------------------------------
@@ -85,15 +97,26 @@ jobs:
     outputs:
       deployment_tag: ${{ steps.deployment_tag.outputs.id }}
 
+  # --------------------------------------------------------------------------------
+  # Per-arch native build. Each matrix entry runs on a native runner of its target
+  # architecture, cross-compiles the Go binary into dist/linux-<arch>/arcade, then
+  # uses buildx to assemble a single-arch image from the thin runtime Dockerfile
+  # and pushes it to GHCR by digest only. PRs build for verification but don't push.
+  # --------------------------------------------------------------------------------
   build-and-push:
-    # Gate the publishing step on:
-    #   - get_tag (computes the image tag)
-    #   - gofortress-gate (ensures lint/security/tests passed upstream)
     needs: [get_tag, gofortress-gate]
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       # Step 1: checkout code. For workflow_run events, check out the exact SHA
       # that GoFortress validated, not whatever HEAD happens to be on main now.
@@ -102,31 +125,124 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      # Step 2: Set up QEMU for multi-architecture builds
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      # Step 2: install Go and warm the module / build cache for this runner.
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
 
-      # Step 3: Set up Docker Buildx
+      # Step 3: build the binary natively into the dist layout the Dockerfile
+      # expects. GOOS/GOARCH are explicit so the path matches even if a future
+      # runner image defaults differ.
+      - name: Build arcade binary
+        env:
+          CGO_ENABLED: '0'
+          GOOS: linux
+          GOARCH: ${{ matrix.arch }}
+        run: |
+          mkdir -p dist/linux-${{ matrix.arch }}
+          go build -trimpath -ldflags="-s -w" -o dist/linux-${{ matrix.arch }}/arcade ./cmd/arcade
+
+      # Step 4: Set up Docker Buildx (no QEMU needed — single-platform build on
+      # a native runner of that platform).
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      # Step 4: login to GCHR
+      # Step 5: login to GHCR (skipped on PRs since we don't push).
       - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Step 5: Build and push the Docker image
-      # Publishing is allowed only for non-PR events; PRs build for verification.
-      - name: Build and push Docker image
+      # Step 6a: PR build verifies the Dockerfile assembles for this arch but
+      # never pushes anywhere.
+      - name: Build image (PR verification, no push)
+        if: github.event_name == 'pull_request'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
-          context: . # Build context (root directory, adjust if Dockerfile is elsewhere)
-          file: ./Dockerfile # Path to Dockerfile
-          platforms: linux/amd64 #, linux/arm64 Disable ARM for now
-          push: ${{ github.event_name != 'pull_request' }} # Only push on non-PR events
-          tags: |
-            ghcr.io/bsv-blockchain/arcade:${{ github.event.workflow_run.head_sha || github.sha }}
-            ghcr.io/bsv-blockchain/arcade:${{ needs.get_tag.outputs.deployment_tag }}
+          context: .
+          file: ./Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          push: false
+
+      # Step 6b: non-PR build pushes by digest only (no tag). The merge-manifest
+      # job stitches per-arch digests into the final multi-arch tag.
+      - name: Build and push image by digest
+        if: github.event_name != 'pull_request'
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      # Step 7: write the digest to a file named after itself so the merge job
+      # can reconstruct the per-arch image references.
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # --------------------------------------------------------------------------------
+  # Compose the per-arch digests into a single multi-arch manifest tagged
+  # :<sha> and :<deployment_tag>. Skipped on PRs (no digests produced).
+  # --------------------------------------------------------------------------------
+  merge-manifest:
+    needs: [build-and-push, get_tag]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digest artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compose and push multi-arch manifest
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          SHA_TAG: ${{ github.event.workflow_run.head_sha || github.sha }}
+          DEPLOYMENT_TAG: ${{ needs.get_tag.outputs.deployment_tag }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${SHA_TAG}" \
+            --tag "${IMAGE}:${DEPLOYMENT_TAG}" \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+      - name: Inspect resulting manifest
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          SHA_TAG: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: docker buildx imagetools inspect "${IMAGE}:${SHA_TAG}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,21 @@
-FROM golang:1.26-alpine AS builder
-
-WORKDIR /app
-COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o /arcade ./cmd/arcade
+# syntax=docker/dockerfile:1
+#
+# Runtime-only image. The arcade binary is cross-compiled in CI on a native
+# runner per architecture and copied in here, so this Dockerfile contains no
+# Go toolchain and no cross-compilation. To build locally, run `make
+# docker-build` (which produces the dist/linux-<arch>/arcade layout this
+# Dockerfile expects).
+#
+# ca-certificates is required: arcade is an outbound HTTPS client (Teranode,
+# merkle service, datahub, webhook delivery) and TLS handshakes fail without
+# the system CA bundle.
 
 FROM alpine:3.23
+
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /arcade /usr/local/bin/arcade
+
+ARG TARGETOS
+ARG TARGETARCH
+COPY dist/${TARGETOS}-${TARGETARCH}/arcade /usr/local/bin/arcade
+
 ENTRYPOINT ["arcade"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: build test lint docker-up docker-down run
+.PHONY: build test lint docker-up docker-down docker-build run
+
+GOARCH ?= $(shell go env GOARCH)
 
 build:
 	go build ./...
@@ -14,6 +16,14 @@ docker-up:
 
 docker-down:
 	podman-compose down
+
+# Build a single-arch image for local use that matches the CI layout. The
+# Dockerfile expects a binary at dist/linux-<arch>/arcade; this target produces
+# that layout for the host's architecture and tags the image arcade:local.
+docker-build:
+	mkdir -p dist/linux-$(GOARCH)
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -trimpath -ldflags="-s -w" -o dist/linux-$(GOARCH)/arcade ./cmd/arcade
+	docker build --platform=linux/$(GOARCH) -t arcade:local .
 
 run:
 	go run ./cmd/arcade


### PR DESCRIPTION
## What Changed

- Replaced the single-runner + QEMU container build with a 2-arch matrix that runs on native `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` (arm64) runners.
- Added a new `merge-manifest` job that composes the per-arch digests into the final multi-arch manifest tagged `:<sha>` and `:<latest|git-tag>` via `docker buildx imagetools create`. Published tag scheme is unchanged so `deploy/*.yaml` consumers are unaffected.
- Re-enabled `linux/arm64` publishing — both architectures now ship.
- Slimmed `Dockerfile` to a runtime-only image. The in-container Go builder stage is gone; each runner cross-compiles the binary natively into `dist/${TARGETOS}-${TARGETARCH}/arcade` and the Dockerfile just copies it in. `ca-certificates` is retained because arcade is an outbound HTTPS client (teranode, merkle, datahub, webhook delivery) and TLS handshakes need the system CA bundle.
- Added `make docker-build` target that mirrors the CI layout for one-shot local image builds, tagging `arcade:local`.
- Updated `.dockerignore` to allow `dist/linux-amd64/` and `dist/linux-arm64/` through (replacing the stale `!dist/linux/` carve-out left over from a goreleaser path that's no longer used — `.goreleaser.yml` has `skip: true`).
- Removed `docker/setup-qemu-action` — no longer needed.
- All action SHAs pinned per `tech-conventions/github-workflows.md`.

## Why It Was Necessary

`linux/arm64` was previously disabled because building the Go binary inside the container under QEMU emulation was slow and unreliable. Running each architecture on a native GitHub-hosted runner removes QEMU from the picture entirely:

- Native compile of the Go binary on real silicon
- Native `apk add ca-certificates` on real silicon
- Per-arch image is built and exercised on its target architecture before being published, catching arch-specific regressions at build time rather than at deploy time

`ubuntu-24.04-arm` runners are GA for public repositories and free, which makes this approach a clean fit for arcade specifically.

The gating chain (`gofortress-gate` → `get_tag` → build → publish) is preserved exactly as it was, so the F-041 / arcade#99 publishing-gate guarantees still apply.

## Testing Performed

- Workflow YAML parses cleanly.
- Walked through the workflow logic by inspection: GoFortress gating preserved; `get_tag` deployment-tag logic preserved; PR builds still verify (`push: false`) per arch with no login and no digest export; non-PR builds push by digest only and the merge job composes the final manifest.
- The two-phase pattern (`push by digest` per arch, then `imagetools create`) is the Docker-recommended idiom for cross-runner multi-arch builds.
- Local `make docker-build` exercised end-to-end on Apple Silicon (linux/arm64): cross-compiles into `dist/linux-arm64/arcade`, builds and tags `arcade:local`.
- The runners themselves haven't been exercised end-to-end before opening this PR — that's what this PR's CI run will do.

## Impact / Risk

- **Breaking change**: none for image consumers. Tag scheme is identical: `ghcr.io/bsv-blockchain/arcade:<sha>` and `:<latest|git-tag>`. The `deploy/*.yaml` manifests pull `:latest` and continue to work unchanged.
- **CI runtime**: comparable or faster. amd64 build is unchanged; arm64 was previously `disabled`, now it's a parallel native job.
- **Local dev**: `docker build .` in a clean checkout no longer works because the Dockerfile expects a pre-built binary in the dist tree. `make docker-build` is the new one-shot. Documented inline in the Dockerfile header comment.
- **Runner availability**: `ubuntu-24.04-arm` free-tier runners have separate concurrency limits from amd64. Under heavy CI load arm64 could backlog. Falling back to QEMU is a one-file change if this becomes an issue in practice.

> Note on branch name: my source fork enforces a `feature/`/`release/`/`hotfix/` branch-name regex, which is why this PR's head branch is `feature/native-arm64-build` rather than the `chore/` prefix that matches this repo's `tech-conventions/commit-branch-conventions.md`. Happy to rename if needed; the commit message itself uses the `ci(build):` type per upstream convention.