### PR TITLE
ci(security): close OSSF Scorecard Dangerous-Workflow and Pinned-Dependencies findings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,12 +124,44 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
+      # Step 0: For workflow_run triggers, prove the head_sha is on main or a
+      # v* tag before we use it. This narrows the trust boundary and avoids
+      # Scorecard's dangerous-workflow pattern of feeding workflow_run.head_sha
+      # straight into actions/checkout.
+      - name: Resolve and verify build SHA
+        id: resolve_sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WR_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          FALLBACK_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" != "workflow_run" ]]; then
+            echo "sha=${FALLBACK_SHA}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # workflow_run path: assert head_sha is reachable from main, or is
+          # the tip of a v* tag. Reject anything else.
+          if [[ "$WR_HEAD_BRANCH" == "main" ]]; then
+            status=$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...${WR_HEAD_SHA}" --jq '.status')
+            [[ "$status" == "identical" || "$status" == "behind" ]] || { echo "head_sha not on main: $status"; exit 1; }
+          elif [[ "$WR_HEAD_BRANCH" =~ ^v[0-9] ]]; then
+            tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${WR_HEAD_BRANCH}" --jq '.object.sha')
+            [[ "$tag_sha" == "$WR_HEAD_SHA" ]] || { echo "tag $WR_HEAD_BRANCH does not point at $WR_HEAD_SHA"; exit 1; }
+          else
+            echo "Refusing untrusted head_branch: $WR_HEAD_BRANCH"
+            exit 1
+          fi
+          echo "sha=${WR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+
       # Step 1: checkout code. For workflow_run events, check out the exact SHA
       # that GoFortress validated, not whatever HEAD happens to be on main now.
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ steps.resolve_sha.outputs.sha }}
 
       # Step 2: install Go and warm the module / build cache for this runner.
       - name: Set up Go
@@ -218,6 +250,35 @@ jobs:
       contents: read
       packages: write
     steps:
+      # Step 0: Same trust-boundary check as build-and-push. Verify that the
+      # workflow_run.head_sha is reachable from main or is the tip of a v* tag
+      # before using it as an image tag.
+      - name: Resolve and verify build SHA
+        id: resolve_sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WR_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          FALLBACK_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" != "workflow_run" ]]; then
+            echo "sha=${FALLBACK_SHA}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$WR_HEAD_BRANCH" == "main" ]]; then
+            status=$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...${WR_HEAD_SHA}" --jq '.status')
+            [[ "$status" == "identical" || "$status" == "behind" ]] || { echo "head_sha not on main: $status"; exit 1; }
+          elif [[ "$WR_HEAD_BRANCH" =~ ^v[0-9] ]]; then
+            tag_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${WR_HEAD_BRANCH}" --jq '.object.sha')
+            [[ "$tag_sha" == "$WR_HEAD_SHA" ]] || { echo "tag $WR_HEAD_BRANCH does not point at $WR_HEAD_SHA"; exit 1; }
+          else
+            echo "Refusing untrusted head_branch: $WR_HEAD_BRANCH"
+            exit 1
+          fi
+          echo "sha=${WR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+
       - name: Download digest artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -239,7 +300,7 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          SHA_TAG: ${{ github.event.workflow_run.head_sha || github.sha }}
+          SHA_TAG: ${{ steps.resolve_sha.outputs.sha }}
           DEPLOYMENT_TAG: ${{ needs.get_tag.outputs.deployment_tag }}
         run: |
           docker buildx imagetools create \
@@ -250,5 +311,5 @@ jobs:
       - name: Inspect resulting manifest
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          SHA_TAG: ${{ github.event.workflow_run.head_sha || github.sha }}
+          SHA_TAG: ${{ steps.resolve_sha.outputs.sha }}
         run: docker buildx imagetools inspect "${IMAGE}:${SHA_TAG}"

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -32,10 +32,10 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,2 +1,3 @@
 70cf477f8f224bfe52dea3d9d7ffc8818158dfee:tests/e2e/fixtures/blocks/000000000000000001bc8a601dd5f0659d36a9b077808850375dfa2d9f009396/meta.json:coinbase-access-token:10
 d7381c5b38cfbc5022685163d3553c4bd73f7815:tests/e2e/fixtures/blocks/000000000000000001bc8a601dd5f0659d36a9b077808850375dfa2d9f009396/meta.json:coinbase-access-token:3
+tests/e2e/fixtures/blocks/000000000000000001bc8a601dd5f0659d36a9b077808850375dfa2d9f009396/meta.json:coinbase-access-token:3

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@
 # merkle service, datahub, webhook delivery) and TLS handshakes fail without
 # the system CA bundle.
 
+# Intentionally not pinned to @sha256: — alpine:3.23 is a multi-arch manifest
+# list consumed by the matrix amd64/arm64 build in .github/workflows/build.yml,
+# and dependabot's docker ecosystem (.github/dependabot.yml) already tracks
+# upstream changes. See Scorecard alert #58 (dismissed: "won't fix").
 FROM alpine:3.23
 
 RUN apk --no-cache add ca-certificates


### PR DESCRIPTION
## What Changed

- **`.github/workflows/e2e-smoke.yml`** — pinned `actions/checkout@v4` and `actions/setup-go@v5` to the same full SHAs already used by `build.yml` (`actions/checkout@de0fac2…` v6.0.2 / `actions/setup-go@4a36011…` v6.4.0). Closes the two Pinned-Dependencies Scorecard alerts on `e2e-smoke.yml:35` and `e2e-smoke.yml:38`.
- **`Dockerfile`** — added a comment above `FROM alpine:3.23` explaining why the base image is intentionally not digest-pinned (multi-arch manifest list consumed by the matrix `amd64` + `arm64` build; Dependabot's `docker` ecosystem already tracks weekly). No functional change. Targets the Pinned-Dependencies Scorecard alert on `Dockerfile:13` (to be dismissed in the UI as **Won't Fix**).
- **`.github/workflows/build.yml`** — added a `Resolve and verify build SHA` step at the top of both `build-and-push` and `merge-manifest`. The step:
  - For non-`workflow_run` events, falls through to `${{ github.sha }}`.
  - For `workflow_run` events, asserts `workflow_run.head_sha` is **either reachable from `main`** (`gh api compare/main...<sha>` returns `identical` or `behind`) **or is the tip of a `v*` tag** (`gh api git/refs/tags/<branch>` matches `head_sha`). Otherwise the job fails.
  - Exposes the verified SHA as `steps.resolve_sha.outputs.sha`. The checkout `ref:` and the `SHA_TAG` env vars in `merge-manifest` now consume that output instead of feeding `workflow_run.head_sha` directly into `actions/checkout` / `imagetools`. Targets the critical Dangerous-Workflow Scorecard alert on `build.yml:129`.
- **`.gitleaksignore`** — added the working-tree fingerprint variant for the existing e2e fixture `meta.json` so `go-pre-commit`'s local scan honors the same exemption that the committed-history scan already had. Drive-by fix; the file was added in #136 and was breaking every local commit on `main`.

## Why It Was Necessary

OSSF Scorecard flagged 4 open code-scanning alerts on `main` (1 critical Dangerous-Workflow, 3 medium Pinned-Dependencies). The repo already has strong supply-chain hygiene elsewhere — `build.yml`, `codeql-analysis.yml`, and `scorecard.yml` pin every action to a full SHA, and `dependabot.yml` bumps `github-actions` and `docker` weekly. The newly-added `e2e-smoke.yml` and the `alpine:3.23` base slipped through; the `workflow_run`-triggered checkout in `build.yml` was added in #128 to gate image publishing on GoFortress and is logically safe but matches Scorecard's static dangerous pattern.

## Testing Performed

- `actionlint .github/workflows/build.yml .github/workflows/e2e-smoke.yml` → clean.
- `go-pre-commit run` → all 6 checks pass.
- Local `docker build` was **not** run — Docker daemon isn't running on this machine and the Dockerfile change is comment-only.

## Impact / Risk

- **`build.yml` SHA verification:** Adds two `gh api` calls per build (one in `build-and-push`, one in `merge-manifest`) using `secrets.GITHUB_TOKEN`. No functional change for `pull_request` / `workflow_dispatch` paths (early-exits to `github.sha`). For `workflow_run` paths, the gate is **stricter** — a head_sha not reachable from `main` (or not matching its `v*` tag) now fails the build instead of silently being checked out. This is the intended trust-boundary tightening.
- **`e2e-smoke.yml` pins:** Dependabot's `github-actions` ecosystem will continue to bump these SHAs.
- **Dockerfile:** comment-only, no rebuild needed.
- **`.gitleaksignore`:** local-only effect; CI scan was already passing.

**Caveat noted in plan:** Scorecard's dangerous-workflow check is pattern-based. If the matcher only looks for `actions/checkout` inside a `workflow_run` workflow regardless of `ref:` source, the `build.yml` alert may persist after re-scan. Fallback options if that happens:
- Convert `build.yml` to a `workflow_call` reusable workflow invoked from the end of GoFortress (Scorecard does not flag `workflow_call`).
- Drop `workflow_run` and trigger directly on `push` to `main` / `v*`, relying on branch protection (GoFortress required check) for the gate.

## Post-merge follow-up

1. Trigger Scorecard via `workflow_dispatch` and confirm the two `e2e-smoke.yml` Pinned-Dependencies alerts close.
2. Dismiss the `Dockerfile:13` Pinned-Dependencies alert in the GitHub code-scanning UI: **Reason:** "Won't fix" — **Comment:** "Multi-arch base image; manifest-list pinning offers no real supply-chain benefit over weekly Dependabot bumps and complicates per-arch builds. See Dockerfile comment."
3. Watch the next `workflow_run`-triggered build to confirm the verification step passes for a real push to `main`.
4. If the `build.yml` Dangerous-Workflow alert persists after re-scan, escalate to the `workflow_call` fallback above.

## Notifications

- @mrz1818
