### PR TITLE
test(e2e): exercise merkle-service /reprocess recovery path

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -60,10 +60,14 @@ The harness reaches the host from inside containers two ways:
 is started with `--no-map-gw` (the default for security), the host is
 not reachable from inside containers via either the gateway IP or
 `host.docker.internal`. Tests that require merkle-service to dial
-back into the harness (`TestLibP2PHost_MerkleServicePeersWithHost`,
-`TestSmoke_TxRegistersWithMerkleService`) will time out under this
-configuration. CI runners use Docker so this doesn't affect the
-required PR gate.
+back into the harness — `TestLibP2PHost_MerkleServicePeersWithHost`,
+`TestSmoke_TxRegistersWithMerkleService`,
+`TestSmoke_RealBlockMined_SingleSubtree`, and
+`TestSmoke_RealBlockMined_ViaReprocess` (the last one fails its
+`/reprocess` call with `no DataHub could serve the requested block`
+because merkle-service can't reach the harness datahub at the
+gateway IP) — will time out under this configuration. CI runners
+use Docker so this doesn't affect the required PR gate.
 
 To verify your setup: `podman run --rm alpine sh -c 'nc -zv -w2
 host.docker.internal 22 || echo NOT REACHABLE'`. If the host is

--- a/tests/e2e/harness/datahub.go
+++ b/tests/e2e/harness/datahub.go
@@ -61,6 +61,17 @@ func NewDatahub(t *testing.T) (*Datahub, error) {
 // runtime (in particular rootless podman) and pass the docker-network
 // gateway IP from Containers.GatewayIP via opts.AnnounceHost.
 func NewDatahubWith(t *testing.T, opts DatahubOptions) (*Datahub, error) {
+	return NewDatahubOnPort(t, opts, 0)
+}
+
+// NewDatahubOnPort spins up the datahub bound to a specific TCP port.
+// Pass port=0 to let the OS pick — equivalent to NewDatahubWith. Use
+// a pre-picked port (via pickFreeTCPPort) when the caller needs the
+// datahub URL constructible BEFORE the listener actually binds —
+// e.g., harness.WithReprocessReady() builds the URL and stuffs it into
+// merkle-service's DATAHUB_FALLBACK_URLS env var at container creation
+// time, then opens the listener after the container is up.
+func NewDatahubOnPort(t *testing.T, opts DatahubOptions, port int) (*Datahub, error) {
 	t.Helper()
 
 	announceHost := opts.AnnounceHost
@@ -74,12 +85,12 @@ func NewDatahubWith(t *testing.T, opts DatahubOptions) (*Datahub, error) {
 	}
 
 	// Bind on 0.0.0.0 so the merkle-service container can reach us via
-	// host.docker.internal:<port>. httptest.NewUnstartedServer binds on
-	// 127.0.0.1 by default which is unreachable from a container even
-	// with host-gateway, so we replace its listener with a 0.0.0.0 one.
-	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	// host.docker.internal / gateway-IP:<port>. httptest.NewUnstartedServer
+	// binds on 127.0.0.1 by default which is unreachable from a container
+	// even with host-gateway, so we replace its listener with a 0.0.0.0 one.
+	listener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
 	if err != nil {
-		return nil, fmt.Errorf("listen 0.0.0.0:0: %w", err)
+		return nil, fmt.Errorf("listen 0.0.0.0:%d: %w", port, err)
 	}
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(d.handle))
 	_ = srv.Listener.Close()

--- a/tests/e2e/harness/harness.go
+++ b/tests/e2e/harness/harness.go
@@ -4,6 +4,7 @@ package harness
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -26,6 +27,17 @@ type Harness struct {
 	// (e.g. to drive failure-injection scenarios) build it themselves
 	// via NewLibP2PHostWith and use the lower-level pieces.
 	LibP2P *LibP2PHost
+
+	// Datahub is non-nil only when New() was called with
+	// WithReprocessReady(). Pre-allocated on the network gateway IP
+	// BEFORE merkle-service starts and threaded into the container's
+	// DATAHUB_FALLBACK_URLS so /reprocess can find blocks staged here
+	// without needing a prior live block-fetch.
+	//
+	// For other scenarios (round-trip, single-tx registration, etc.)
+	// tests build their own datahub via h.NewDatahub(t) after
+	// New() returns.
+	Datahub *Datahub
 }
 
 // New brings up the full harness in the right order to dodge the
@@ -80,6 +92,24 @@ func New(t *testing.T, opts ...Option) *Harness {
 		cfg.merkleStart.BootstrapPeers = libp2p.BootstrapMultiaddr()
 	}
 
+	// Step 3a (optional): pre-allocate a Datahub port + URL so we can
+	// thread the URL into DATAHUB_FALLBACK_URLS BEFORE merkle-service
+	// starts. Required for /reprocess scenarios because that endpoint
+	// looks up datahubs in the operator-configured fallbacks (or the
+	// internal registry); it doesn't take a URL in the request body.
+	// The actual listener binds in step 5 after containers are up.
+	var datahubPort int
+	if cfg.reprocessReady {
+		datahubPort, err = pickFreeTCPPort()
+		if err != nil {
+			t.Fatalf("pre-pick datahub port: %v", err)
+		}
+		if cfg.merkleStart.ExtraEnv == nil {
+			cfg.merkleStart.ExtraEnv = make(map[string]string)
+		}
+		cfg.merkleStart.ExtraEnv["DATAHUB_FALLBACK_URLS"] = fmt.Sprintf("http://%s:%d", gateway, datahubPort)
+	}
+
 	// Step 4: Postgres + Redpanda + merkle-service on the prepared
 	// network.
 	containers, err := startContainersOnNetwork(ctx, t, cfg.merkleStart, nw, gateway)
@@ -87,7 +117,20 @@ func New(t *testing.T, opts ...Option) *Harness {
 		t.Fatalf("start containers: %v", err)
 	}
 
-	h := &Harness{Containers: containers, LibP2P: libp2p}
+	// Step 5 (optional): bind the pre-registered Datahub on the port
+	// we reserved in step 3a. Has to happen AFTER container start so
+	// t.Cleanup ordering matches teardown expectations (datahub closes
+	// before containers, so a final container request doesn't hit a
+	// dead listener).
+	var datahub *Datahub
+	if cfg.reprocessReady {
+		datahub, err = NewDatahubOnPort(t, DatahubOptions{AnnounceHost: gateway}, datahubPort)
+		if err != nil {
+			t.Fatalf("bind pre-registered datahub: %v", err)
+		}
+	}
+
+	h := &Harness{Containers: containers, LibP2P: libp2p, Datahub: datahub}
 	t.Cleanup(func() {
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer closeCancel()
@@ -121,6 +164,12 @@ type Option func(*harnessOptions)
 type harnessOptions struct {
 	startupTimeout time.Duration
 	merkleStart    MerkleStartOptions
+	// reprocessReady opts into the pre-registered datahub path: the
+	// harness reserves a port + advertises a datahub URL via merkle-
+	// service's DATAHUB_FALLBACK_URLS env var, then binds the
+	// listener after containers start. h.Datahub is non-nil only
+	// when this option was set.
+	reprocessReady bool
 }
 
 func defaultOptions() harnessOptions {
@@ -148,6 +197,28 @@ func WithMerkleImage(image string) Option {
 // report degraded health, which the wait strategy tolerates).
 func WithBootstrapPeers(peers string) Option {
 	return func(o *harnessOptions) { o.merkleStart.BootstrapPeers = peers }
+}
+
+// WithReprocessReady tells the harness to pre-allocate a Datahub
+// bound to the docker-network gateway IP BEFORE merkle-service
+// starts, and thread its URL into the container's
+// DATAHUB_FALLBACK_URLS env var so merkle-service's /reprocess
+// endpoint can find blocks staged on the harness datahub without
+// needing a prior live block-fetch to populate the internal datahub
+// registry.
+//
+// The pre-allocated datahub is exposed as h.Datahub. Tests stage
+// fixtures via h.Datahub.StageFixture(fix) and then trigger
+// /reprocess via harness.TriggerReprocess(...).
+//
+// Without this option, tests build their own datahub via
+// h.NewDatahub(t). That works for the round-trip scenarios where
+// the libp2p BlockMessage carries the DataHubURL inline (so
+// merkle-service learns about the URL on first fetch), but it
+// doesn't work for /reprocess because the endpoint doesn't accept
+// a DataHubURL in the request body.
+func WithReprocessReady() Option {
+	return func(o *harnessOptions) { o.reprocessReady = true }
 }
 
 // WithExtraMerkleEnv merges extra env vars into the merkle-service

--- a/tests/e2e/harness/poll.go
+++ b/tests/e2e/harness/poll.go
@@ -123,6 +123,51 @@ func BroadcastRawTxs(ctx context.Context, t *testing.T, rt *ArcadeRuntime, rawTx
 	return got, nil
 }
 
+// ReprocessResponse is the 202-Accepted body merkle-service returns
+// from POST /reprocess. DataHubURL echoes the candidate URL the
+// endpoint resolved to (i.e., which fallback / registered datahub
+// served the block on the probe).
+type ReprocessResponse struct {
+	Status     string `json:"status"`
+	BlockHash  string `json:"blockHash"`
+	DataHubURL string `json:"dataHubUrl"`
+}
+
+// TriggerReprocess POSTs to merkle-service's /reprocess endpoint
+// with the supplied block hash + arcade callback URL + token. It
+// expects HTTP 202 and returns the parsed response so callers can
+// assert which datahub URL got picked up. Any non-202 surfaces as
+// an error with the body included for diagnosis.
+func TriggerReprocess(ctx context.Context, merkleHostURL, blockHash, callbackURL, callbackToken string) (*ReprocessResponse, error) {
+	body, err := json.Marshal(map[string]string{
+		"blockHash":     blockHash,
+		"callbackUrl":   callbackURL,
+		"callbackToken": callbackToken,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal reprocess body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, merkleHostURL+"/reprocess", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build reprocess request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("post reprocess: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusAccepted {
+		return nil, fmt.Errorf("POST /reprocess: status %d body=%s", resp.StatusCode, respBody)
+	}
+	var out ReprocessResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode reprocess response: %w (body=%s)", err, respBody)
+	}
+	return &out, nil
+}
+
 // WaitForMerkleRegistration polls merkle-service's GET /api/lookup/<txid>
 // until the registered callback URL list is non-empty or the timeout
 // elapses. Hoisted from smoke_test.go so real-block scenarios can

--- a/tests/e2e/smoke_reprocess_test.go
+++ b/tests/e2e/smoke_reprocess_test.go
@@ -1,0 +1,122 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/arcade/tests/e2e/harness"
+)
+
+// TestSmoke_RealBlockMined_ViaReprocess proves merkle-service's
+// /reprocess endpoint is wired end-to-end: arcade registers 10
+// watched txids, the block they're in is NEVER announced over
+// libp2p (so merkle-service never processes it live, simulating
+// "arcade missed the BLOCK_PROCESSED message"), and the test
+// triggers /reprocess to recover. After the call we expect the
+// same valid compound BUMP + merklePaths as the round-trip test
+// produces.
+//
+// Distinguishing this from TestSmoke_RealBlockMined_SingleSubtree:
+//
+//   - Round-trip: harness publishes a libp2p BlockMessage carrying
+//     the harness datahub URL; merkle-service fetches the block
+//     inline, emits callbacks on the live pipeline.
+//   - Reprocess: no libp2p BlockMessage. merkle-service has no
+//     in-memory knowledge of the block. /reprocess hits the
+//     `DATAHUB_FALLBACK_URLS` env var (set by WithReprocessReady)
+//     to find a datahub serving the block, then runs the same
+//     pipeline with override callback URL/token scoped to arcade.
+//
+// Unlike the round-trip test this path doesn't require libp2p
+// mesh formation, so it passes locally on rootless podman too.
+func TestSmoke_RealBlockMined_ViaReprocess(t *testing.T) {
+	skipIfNoDocker(t)
+	const blockHash = "000000000000000001bc8a601dd5f0659d36a9b077808850375dfa2d9f009396"
+
+	fix := harness.LoadBlockFixture(t, blockHash)
+	t.Logf("loaded fixture: height=%d txCount=%d picked=%d subtrees=%d",
+		fix.Height, fix.TxCount, len(fix.PickedTxIDs), len(fix.Subtrees))
+
+	// WithReprocessReady pre-allocates the harness datahub on the
+	// network gateway IP and stuffs its URL into merkle-service's
+	// DATAHUB_FALLBACK_URLS env var at container creation time. The
+	// datahub listener binds after the container is up but on the
+	// pre-reserved port, so the URL we registered up front is the
+	// one that actually serves the block.
+	h := harness.New(t, harness.WithReprocessReady())
+	h.Datahub.StageFixture(fix)
+
+	rt := harness.StartArcade(t, harness.ArcadeOptions{
+		MerkleServiceURL: h.Containers.MerkleHostURL,
+		DatahubURL:       h.Datahub.LocalURL(), // arcade hits loopback; merkle-service hits gateway IP
+		LibP2PBootstrap:  h.LibP2P.BootstrapMultiaddr(),
+		MerkleAuthToken:  "e2e-watch-token",
+		CallbackToken:    "e2e-callback-token",
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 4*time.Minute)
+	defer cancel()
+
+	// 1. Register the 10 watched txids with merkle-service via
+	//    arcade's normal /tx → /watch flow.
+	txids, err := harness.BroadcastRawTxs(ctx, t, rt, fix.PickedRawTxs)
+	if err != nil {
+		t.Fatalf("broadcast: %v", err)
+	}
+	for _, id := range txids {
+		if err := harness.WaitForMerkleRegistration(ctx, h.Containers.MerkleHostURL, id, 60*time.Second); err != nil {
+			t.Fatalf("watch %s: %v", id, err)
+		}
+	}
+	t.Logf("registered %d txids with merkle-service", len(txids))
+
+	// 2. KEY: never publish a libp2p BlockMessage. merkle-service
+	//    therefore never processes the block live and never emits
+	//    STUMPs/BLOCK_PROCESSED for our watched txs — arcade is
+	//    blind to the mining event.
+
+	// 3. Sanity-check: wait briefly, then assert none of the txs has
+	//    been MINED yet. Without /reprocess there's no code path to
+	//    MINED; if one accidentally fired the test below would still
+	//    pass for the wrong reason.
+	time.Sleep(5 * time.Second)
+	for _, id := range txids {
+		st, _, _ := harness.GetTxStatus(ctx, rt, id)
+		if st.TxStatus == "MINED" || st.TxStatus == "IMMUTABLE" {
+			t.Fatalf("tx %s reached %s before /reprocess — scenario invalidated", id, st.TxStatus)
+		}
+	}
+	t.Log("confirmed all 10 txs are pre-MINED before /reprocess")
+
+	// 4. Trigger /reprocess. merkle-service probes its fallback
+	//    datahubs (we registered the harness URL via env), finds
+	//    the block, queues a BlockMessage with OverrideCallbackURL
+	//    + OverrideCallbackToken + BypassDedup, and the normal
+	//    block-processing pipeline runs scoped to arcade alone.
+	callbackURL := rt.HostURL + "/api/v1/merkle-service/callback"
+	resp, err := harness.TriggerReprocess(ctx, h.Containers.MerkleHostURL, blockHash, callbackURL, "e2e-callback-token")
+	if err != nil {
+		t.Fatalf("reprocess: %v", err)
+	}
+	if resp.DataHubURL == "" {
+		t.Fatalf("/reprocess returned empty dataHubUrl — DATAHUB_FALLBACK_URLS wiring failed")
+	}
+	t.Logf("merkle-service queued reprocess from datahub %s", resp.DataHubURL)
+
+	// 5. Subtree workers build STUMPs filtered to arcade's URL,
+	//    BLOCK_PROCESSED gets posted to arcade, bump-builder
+	//    constructs the compound BUMP, and SetMinedByTxIDs flips
+	//    each row to MINED with merklePath set.
+	if err := harness.WaitForMined(ctx, t, rt, txids, 90*time.Second); err != nil {
+		t.Fatalf("MINED post-reprocess: %v", err)
+	}
+	t.Logf("all %d txs reached MINED post-reprocess", len(txids))
+
+	// 6. The recovered merklePath must ComputeRoot()s to the block's
+	//    real header merkle root — same proof of correctness as the
+	//    round-trip test, just delivered via the recovery path.
+	harness.AssertMerklePathsMatchHeaderRoot(t, rt, fix.MerkleRoot, txids)
+}


### PR DESCRIPTION
merkle-service #112 shipped a POST /reprocess endpoint that re-drives a block through STUMP + BLOCK_PROCESSED delivery for a single requesting arcade — the operator-facing recovery hatch when arcade missed the original BLOCK_PROCESSED event. The new smoke scenario proves the recovery path lands a valid compound BUMP at arcade:

  1. arcade registers 10 watched txids via /watch
  2. NO libp2p BlockMessage is ever published, so merkle-service never processes the block live (simulates "arcade missed the BLOCK_PROCESSED event")
  3. test sanity-checks none of the txs reached MINED
  4. test calls POST /reprocess with the block hash + arcade's callback URL + token
  5. merkle-service probes its DATAHUB_FALLBACK_URLS, finds the harness datahub, runs the full block-processing pipeline with override callback URL/token + BypassDedup=true so subtree-worker emits STUMPs filtered to arcade and a single BLOCK_PROCESSED scoped to arcade's callback
  6. arcade's bump-builder builds the compound BUMP, marks all 10 txs MINED, and each merklePath ComputeRoot()s back to the block's real header merkle root

Harness additions:

- harness.New() learns a WithReprocessReady() option. When set, it pre-picks a free TCP port, builds the datahub URL on the network gateway IP, and threads it into the merkle-service container's DATAHUB_FALLBACK_URLS env var BEFORE the container starts. The Datahub listener binds on that pre-reserved port after the container is up. h.Datahub is the resulting pre-registered datahub.

- harness.NewDatahubOnPort(t, opts, port) — datahub constructor that accepts an explicit port. port=0 keeps the auto-pick behavior NewDatahubWith/NewDatahub already had.

- harness.TriggerReprocess(ctx, merkleHostURL, blockHash, callbackURL, callbackToken) — POSTs to merkle-service /reprocess, parses the 202 body into ReprocessResponse{Status, BlockHash, DataHubURL}. Returns the parsed response so callers can assert which datahub URL got picked up.

No new fixtures — the test reuses the existing single-subtree mainnet block fixture from the round-trip test.

Like the other end-to-end tests, this one requires container ↔ host networking that works on Docker but not on rootless podman with pasta's --no-map-gw default. The /reprocess call fails locally with "no DataHub could serve the requested block" — documented in tests/e2e/README.md. CI on GitHub Actions uses Docker so the test runs the full path there.

## What Changed
-

## Why It Was Necessary
-

## Testing Performed
-

## Impact / Risk
-

## Notifications
- @username
