### PR TITLE
Improve performance for propagation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -352,6 +352,18 @@ type PropagationConfig struct {
 	// Defaults to 50000 — large enough to absorb a multi-minute downstream
 	// stall at 50 TPS without dropping, small enough to bound memory.
 	MaxPending int `mapstructure:"max_pending"`
+	// MaxConcurrentBatches caps how many flushed batches run their
+	// register+broadcast pipeline concurrently. With concurrency=1 (the
+	// historical default), batch N+1 cannot begin merkle /watch until
+	// batch N's broadcast completes — meaning sustained-100-TPS traffic
+	// pays ~half-a-pipeline-cycle of queue wait per tx on top of the
+	// pipeline work itself. Bumping to ≥2 lets the register and broadcast
+	// stages overlap across adjacent batches. F-024 is preserved per-batch
+	// (each goroutine registers before it broadcasts) and per-row lattice
+	// guards prevent out-of-order status transitions from regressing state.
+	// Defaults to 4 — enough to fully overlap pipeline stages at typical
+	// pipeline times without flooding merkle-service or teranode.
+	MaxConcurrentBatches int `mapstructure:"max_concurrent_batches"`
 }
 
 // EndpointHealthConfig tunes the per-endpoint circuit-breaker in teranode.Client.
@@ -672,6 +684,7 @@ func setDefaults() {
 	// automatically moves the lease TTL unless the operator opts into a fixed value.
 	viper.SetDefault("propagation.lease_ttl_ms", 0)
 	viper.SetDefault("propagation.teranode_max_batch_size", 100)
+	viper.SetDefault("propagation.max_concurrent_batches", 4)
 	viper.SetDefault("propagation.endpoint_health.failure_threshold", 3)
 	viper.SetDefault("propagation.endpoint_health.broadcast_failure_threshold", 10)
 	viper.SetDefault("propagation.endpoint_health.probe_interval_ms", 30000)

--- a/events/kafka_publisher.go
+++ b/events/kafka_publisher.go
@@ -74,7 +74,14 @@ func (p *KafkaPublisher) Publish(ctx context.Context, status *models.Transaction
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	return p.producer.Send(kafka.TopicStatusUpdate, status.TxID, status) //nolint:contextcheck // kafka.Producer.Send doesn't take a context; ctx already checked above
+	start := time.Now()
+	err := p.producer.Send(kafka.TopicStatusUpdate, status.TxID, status) //nolint:contextcheck // kafka.Producer.Send doesn't take a context; ctx already checked above
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+	}
+	metrics.EventsPublishDuration.WithLabelValues("single", outcome).Observe(time.Since(start).Seconds())
+	return err
 }
 
 // PublishBulk sends one event carrying TxIDs[]. The kafka key is the
@@ -97,7 +104,14 @@ func (p *KafkaPublisher) PublishBulk(ctx context.Context, template *models.Trans
 		// deterministic even before block context is known.
 		key = "bulk-" + template.TxIDs[0]
 	}
-	return p.producer.Send(kafka.TopicStatusUpdate, key, template) //nolint:contextcheck // kafka.Producer.Send doesn't take a context; ctx already checked above
+	start := time.Now()
+	err := p.producer.Send(kafka.TopicStatusUpdate, key, template) //nolint:contextcheck // kafka.Producer.Send doesn't take a context; ctx already checked above
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+	}
+	metrics.EventsPublishDuration.WithLabelValues("bulk", outcome).Observe(time.Since(start).Seconds())
+	return err
 }
 
 // Subscribe joins a fresh consumer group on TopicStatusUpdate and returns a

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -140,6 +140,16 @@ var PropagationPendingDepth = promauto.NewGauge(prometheus.GaugeOpts{
 	Help: "Number of propagation messages buffered awaiting flush.",
 })
 
+// PropagationInflightBatches gauges how many flushBatch goroutines are
+// currently running their register+broadcast pipeline. Capped at
+// PropagationConfig.MaxConcurrentBatches; sustained saturation means the
+// pipeline cannot keep up with the kafka drain rate and pendingMsgs will
+// grow until backpressure forces the consumer to block.
+var PropagationInflightBatches = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "arcade_propagation_inflight_batches",
+	Help: "Number of propagation batches currently mid-pipeline.",
+})
+
 // PropagationBroadcastDuration measures end-to-end wall time of broadcasting
 // a single chunk to all healthy endpoints (the inner /tx or /txs path).
 var PropagationBroadcastDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -494,6 +504,101 @@ var P2PEndpointDiscoveryTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "arcade_p2p_endpoint_discovery_total",
 	Help: "Datahub URL discovery outcomes from peer announcements.",
 }, []string{labelOutcome}) // registered, duplicate, invalid, no_url
+
+// ---------------------------------------------------------------------------
+// callback path — inbound merkle-service callbacks
+// ---------------------------------------------------------------------------
+
+// statusTransitionAgeBuckets covers RECEIVED→SEEN_ON_NETWORK style
+// transitions. Wider than latencyBuckets because the tail can stretch into
+// the multi-second range under merkle-service congestion (the slow case is
+// the one we care most about catching with a histogram).
+var statusTransitionAgeBuckets = []float64{
+	0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+	1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+}
+
+// StatusTransitionAge measures the wall-clock age of the previous status
+// row at the moment a new transition is applied. Wired into the SEEN_ON_NETWORK
+// callback handler so {from="RECEIVED",to="SEEN_ON_NETWORK"} surfaces the
+// time between arcade receiving a tx and the merkle-service callback
+// landing in arcade's store + publish pipeline. Naturally extensible to
+// other transitions (RECEIVED→REJECTED, SEEN_ON_NETWORK→MINED, ...) without
+// new metric definitions.
+var StatusTransitionAge = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "arcade_status_transition_age_seconds",
+	Help:    "Wall-clock age of the previous status row at the moment a new transition is applied.",
+	Buckets: statusTransitionAgeBuckets,
+}, []string{"from", "to"})
+
+// CallbackHandlerDuration measures end-to-end handler latency for one
+// inbound /api/v1/merkle-service/callback request, partitioned by the
+// callback type so a slow STUMP path doesn't get conflated with a slow
+// SEEN_ON_NETWORK path. result ∈ {success, partial, error}.
+var CallbackHandlerDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "arcade_callback_handler_duration_seconds",
+	Help:    "End-to-end duration of one inbound merkle-service callback handler, by type.",
+	Buckets: latencyBuckets,
+}, []string{"type", "result"})
+
+// CallbackBatchSize records len(TxIDs) per inbound callback so we can see
+// how aggressively the upstream is batching. Informs whether bulk-publish
+// optimizations are paying off.
+var CallbackBatchSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "arcade_callback_batch_size",
+	Help:    "Number of txids in one inbound merkle-service callback, by type.",
+	Buckets: sizeBuckets,
+}, []string{"type"})
+
+// CallbackUnknownTxIDTotal counts txids referenced by a callback that
+// arcade's store has no record of. Already logged at WARN; the counter
+// makes the rate scrapable so an operator can spot upstream drift.
+var CallbackUnknownTxIDTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_callback_unknown_txid_total",
+	Help: "Inbound callbacks that named a txid arcade's store doesn't know.",
+}, []string{"type"})
+
+// CallbackStaleTotal counts txids in inbound callbacks whose store row is
+// already past the target status (lattice short-circuited the update). The
+// underlying signal also lives in store_updatestatus_duration_seconds_count
+// with outcome=skipped_lattice, but that histogram bakes in the duration
+// label set; a dedicated counter is cheaper to alert on and makes
+// "merkle-service is sending us stale callbacks" a first-class number.
+// prev_status carries the lattice-blocked previous state (e.g. MINED) so
+// operators can tell apart "callback for already-mined tx" from "duplicate
+// SEEN_ON_NETWORK".
+var CallbackStaleTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_callback_stale_total",
+	Help: "Inbound callbacks whose target status was already eclipsed by the stored row's status.",
+}, []string{"type", "prev_status"})
+
+// ---------------------------------------------------------------------------
+// store hot-path — per-call latency
+// ---------------------------------------------------------------------------
+
+// StoreUpdateStatusDuration decomposes the per-call UpdateStatus latency so
+// we can tell whether a long callback handler is paying disk-write cost or
+// publish cost. from_status/to_status label cardinality is bounded by the
+// status lattice (~10 values each) so the matrix stays small.
+var StoreUpdateStatusDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "arcade_store_updatestatus_duration_seconds",
+	Help:    "Duration of one store.UpdateStatus call, by from/to status and outcome.",
+	Buckets: latencyBuckets,
+}, []string{"from_status", "to_status", labelOutcome}) // outcome: applied, skipped_lattice, not_found, error
+
+// ---------------------------------------------------------------------------
+// events publisher — Kafka send latency
+// ---------------------------------------------------------------------------
+
+// EventsPublishDuration measures the latency of one Publisher.Publish or
+// PublishBulk call. Currently the path is dark — when the in-memory broker
+// applies backpressure (a stalled consumer makes Send take 2s), nothing
+// surfaces in metrics. kind ∈ {single, bulk}.
+var EventsPublishDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "arcade_events_publish_duration_seconds",
+	Help:    "Duration of one Publisher.Publish/PublishBulk call.",
+	Buckets: latencyBuckets,
+}, []string{"kind", labelOutcome}) // outcome: success, error
 
 // ObserveStatusClass returns the bucket label ("2xx", "3xx", "4xx", "5xx",
 // "transport_error") for a given HTTP status code. Used by HTTP-latency

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -21,7 +21,6 @@ import (
 	"github.com/bsv-blockchain/arcade/kafka"
 	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
-	"github.com/bsv-blockchain/arcade/store"
 	"github.com/bsv-blockchain/arcade/teranode"
 )
 
@@ -124,24 +123,6 @@ func newSubmissionID() (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(b[:]), nil
-}
-
-// publishStatus fans a status update out via the configured Publisher. The
-// Publisher is nil in unit tests and degraded deployments; in those cases
-// the status mutation is still durable in the store and SSE catchup will
-// recover it on reconnect, so this helper is intentionally non-fatal.
-func (s *Server) publishStatus(ctx context.Context, status *models.TransactionStatus) {
-	if s.publisher == nil || status == nil {
-		return
-	}
-	if err := s.publisher.Publish(ctx, status); err != nil {
-		s.logger.Warn(
-			"failed to publish status update",
-			zap.String("txid", status.TxID),
-			zap.String("status", string(status.Status)),
-			zap.Error(err),
-		)
-	}
 }
 
 const docsTemplate = `<!DOCTYPE html>
@@ -300,34 +281,16 @@ func (s *Server) handleCallback(c *gin.Context) {
 // never recorded) are dropped with a Warn — never created as phantom rows.
 // See F-033 / issue #91; the store layer enforces this by returning
 // store.ErrNotFound from UpdateStatus when the row is absent.
+//
+// Batch path: one BatchUpdateStatusReturning call (parallel per-shard
+// writes, with previous rows returned for transition-age observation) plus
+// one PublishBulk event covering every successful txid. The previous
+// per-tx loop did N synchronous store calls and N kafka.Send calls; under
+// 100 TPS with merkle-service batching ~50 txids per callback that was
+// ~50× the work per callback. See plan: RECEIVED → SEEN_ON_NETWORK
+// Latency.
 func (s *Server) handleSeenOnNetwork(c *gin.Context, msg models.CallbackMessage, logger *zap.Logger) {
-	txids := msg.ResolveSeenTxIDs()
-	if len(txids) == 0 {
-		return
-	}
-
-	ctx := c.Request.Context()
-	now := time.Now()
-	for _, txid := range txids {
-		status := &models.TransactionStatus{
-			TxID:      txid,
-			Status:    models.StatusSeenOnNetwork,
-			Timestamp: now,
-		}
-		if err := s.store.UpdateStatus(ctx, status); err != nil {
-			if errors.Is(err, store.ErrNotFound) {
-				logger.Warn("dropping seen_on_network for unknown txid",
-					zap.String("txid", txid))
-				continue
-			}
-			logger.Warn("failed to update seen_on_network", zap.String("txid", txid), zap.Error(err))
-			continue
-		}
-		if s.txTracker != nil {
-			s.txTracker.UpdateStatus(txid, models.StatusSeenOnNetwork)
-		}
-		s.publishStatus(ctx, status)
-	}
+	s.applySeenCallback(c, msg, logger, models.StatusSeenOnNetwork, "SEEN_ON_NETWORK")
 }
 
 // handleSeenMultipleNodes applies a SEEN_ON_MULTIPLE_NODES callback. Same
@@ -335,32 +298,100 @@ func (s *Server) handleSeenOnNetwork(c *gin.Context, msg models.CallbackMessage,
 // to absent rows (F-033 / #91) and we log + continue rather than creating
 // phantom rows.
 func (s *Server) handleSeenMultipleNodes(c *gin.Context, msg models.CallbackMessage, logger *zap.Logger) {
+	s.applySeenCallback(c, msg, logger, models.StatusSeenMultipleNodes, "SEEN_MULTIPLE_NODES")
+}
+
+// applySeenCallback is the shared body of the two "seen" callback paths.
+// targetStatus is the status to transition each known txid to;
+// metricLabel is the type label used on the callback metrics.
+func (s *Server) applySeenCallback(c *gin.Context, msg models.CallbackMessage, logger *zap.Logger, targetStatus models.Status, metricLabel string) {
+	start := time.Now()
+	outcome := "success"
+	defer func() {
+		metrics.CallbackHandlerDuration.WithLabelValues(metricLabel, outcome).Observe(time.Since(start).Seconds())
+	}()
+
 	txids := msg.ResolveSeenTxIDs()
+	metrics.CallbackBatchSize.WithLabelValues(metricLabel).Observe(float64(len(txids)))
 	if len(txids) == 0 {
 		return
 	}
 
 	ctx := c.Request.Context()
 	now := time.Now()
-	for _, txid := range txids {
-		status := &models.TransactionStatus{
+	statuses := make([]*models.TransactionStatus, len(txids))
+	for i, txid := range txids {
+		statuses[i] = &models.TransactionStatus{
 			TxID:      txid,
-			Status:    models.StatusSeenMultipleNodes,
+			Status:    targetStatus,
 			Timestamp: now,
 		}
-		if err := s.store.UpdateStatus(ctx, status); err != nil {
-			if errors.Is(err, store.ErrNotFound) {
-				logger.Warn("dropping seen_multiple_nodes for unknown txid",
-					zap.String("txid", txid))
-				continue
-			}
-			logger.Warn("failed to update seen_multiple_nodes", zap.String("txid", txid), zap.Error(err))
+	}
+
+	prevs, err := s.store.BatchUpdateStatusReturning(ctx, statuses)
+	if err != nil {
+		outcome = "error"
+		logger.Warn("batch update seen status failed",
+			zap.String("type", metricLabel),
+			zap.Int("batch_size", len(txids)),
+			zap.Error(err),
+		)
+		// Continue: per-row errors are nil-prev in the slice; we still want
+		// to publish successful transitions if any.
+	}
+
+	successful := make([]string, 0, len(txids))
+	for i, prev := range prevs {
+		if prev == nil {
+			outcome = "partial"
+			metrics.CallbackUnknownTxIDTotal.WithLabelValues(metricLabel).Inc()
+			logger.Warn("dropping callback for unknown txid",
+				zap.String("type", metricLabel),
+				zap.String("txid", txids[i]))
 			continue
 		}
-		if s.txTracker != nil {
-			s.txTracker.UpdateStatus(txid, models.StatusSeenMultipleNodes)
+		// Observe transition age — the headline metric the user asked for.
+		// Use the previous row's Timestamp (last-update wall-clock) as the
+		// anchor; for the RECEIVED→SEEN_ON_NETWORK case it equals the
+		// time the validator marked the tx RECEIVED, which is exactly
+		// the latency we want to optimize against.
+		if !prev.Timestamp.IsZero() {
+			metrics.StatusTransitionAge.
+				WithLabelValues(string(prev.Status), string(targetStatus)).
+				Observe(time.Since(prev.Timestamp).Seconds())
 		}
-		s.publishStatus(ctx, status)
+		// Status lattice skipped the update — no transition to fan out.
+		// Record the stale-callback signal so an operator can alert on
+		// upstream rate without parsing the store_updatestatus histogram.
+		// Two stale sub-cases: prev == target (duplicate callback) and
+		// target not reachable from prev (e.g. MINED → SEEN_ON_NETWORK).
+		if prev.Status == targetStatus || !targetStatus.CanTransitionFrom(prev.Status) {
+			metrics.CallbackStaleTotal.WithLabelValues(metricLabel, string(prev.Status)).Inc()
+			continue
+		}
+		successful = append(successful, txids[i])
+		if s.txTracker != nil {
+			s.txTracker.UpdateStatus(txids[i], targetStatus)
+		}
+	}
+
+	// Single PublishBulk for the whole batch — drops the per-txid Kafka send
+	// down to one event regardless of N. Subscribers (SSE, webhook) unfan in
+	// their own handler, where they pay the per-tx cost without saturating
+	// the bounded work queue.
+	if len(successful) > 0 && s.publisher != nil {
+		template := &models.TransactionStatus{
+			Status:    targetStatus,
+			Timestamp: now,
+			TxIDs:     successful,
+		}
+		if pubErr := s.publisher.PublishBulk(ctx, template); pubErr != nil {
+			logger.Warn("failed to publish bulk seen-status",
+				zap.String("type", metricLabel),
+				zap.Int("count", len(successful)),
+				zap.Error(pubErr),
+			)
+		}
 	}
 }
 

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -47,6 +47,14 @@ type mockStore struct {
 	// return an error to simulate per-key failures (Aerospike RECORD_TOO_BIG,
 	// DEVICE_OVERLOAD, HOT_KEY, etc.). Returning non-nil skips the record.
 	insertStumpFn func(stump *models.Stump) error
+	// batchUpdateReturningCalls captures the slices passed to
+	// BatchUpdateStatusReturning so tests can assert the batch+bulk callback
+	// refactor calls the store exactly once per inbound callback.
+	batchUpdateReturningCalls [][]*models.TransactionStatus
+	batchUpdateReturningErr   error
+	// batchUpdatePrevFunc lets a test inject previous-row data per-txid for
+	// transition-age assertions. Returning nil mirrors the not-found path.
+	batchUpdatePrevFunc func(txid string) *models.TransactionStatus
 }
 
 func (m *mockStore) UpdateStatus(_ context.Context, status *models.TransactionStatus) error {
@@ -69,6 +77,49 @@ func (m *mockStore) BatchUpdateStatus(context.Context, []*models.TransactionStat
 	return nil
 }
 
+// BatchUpdateStatusReturning records calls and returns the previous statuses
+// per input. Default prev for each known txid is a {Status: RECEIVED}
+// snapshot — this both satisfies the handler's nil-prev = unknown-txid
+// branch (so the batch path treats every txid as known by default) and
+// keeps existing assertions on updateStatusCalls working unchanged
+// (each input status is appended to updateStatusCalls as if the legacy
+// per-row path had run). Tests that need a different prev shape override
+// via batchUpdatePrevFunc.
+func (m *mockStore) BatchUpdateStatusReturning(_ context.Context, statuses []*models.TransactionStatus) ([]*models.TransactionStatus, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.batchUpdateReturningCalls = append(m.batchUpdateReturningCalls, append([]*models.TransactionStatus(nil), statuses...))
+	if m.batchUpdateReturningErr != nil {
+		return nil, m.batchUpdateReturningErr
+	}
+	out := make([]*models.TransactionStatus, len(statuses))
+	// updateStatusErr == ErrNotFound models the production "unknown txid"
+	// guard (F-033 / #91): the legacy backend silently skipped the write
+	// AND did not record the call. The batch path mirrors that — nil prev
+	// for every input, and no append to updateStatusCalls.
+	if errors.Is(m.updateStatusErr, store.ErrNotFound) {
+		return out, nil
+	}
+	for i, st := range statuses {
+		// Mirror the legacy contract: record the update as if UpdateStatus
+		// had been called per-row, so existing assertions on
+		// updateStatusCalls keep working without rewriting every test.
+		m.updateStatusCalls = append(m.updateStatusCalls, st)
+		if m.batchUpdatePrevFunc != nil {
+			out[i] = m.batchUpdatePrevFunc(st.TxID)
+		} else {
+			// Default prev: RECEIVED with a fresh timestamp so the
+			// handler's transition-age observation has a non-zero value.
+			out[i] = &models.TransactionStatus{
+				TxID:      st.TxID,
+				Status:    models.StatusReceived,
+				Timestamp: time.Now(),
+			}
+		}
+	}
+	return out, nil
+}
+
 func (m *mockStore) GetStatus(context.Context, string) (*models.TransactionStatus, error) {
 	return nil, nil
 }
@@ -86,8 +137,8 @@ func (m *mockStore) SetStatusByBlockHash(context.Context, string, models.Status)
 }
 func (m *mockStore) InsertBUMP(context.Context, string, uint64, []byte) error { return nil }
 func (m *mockStore) GetBUMP(context.Context, string) (uint64, []byte, error)  { return 0, nil, nil }
-func (m *mockStore) SetMinedByTxIDs(context.Context, string, uint64, []string) ([]*models.TransactionStatus, error) {
-	return nil, nil
+func (m *mockStore) SetMinedByTxIDs(context.Context, string, uint64, []string) ([]*models.TransactionStatus, []*models.TransactionStatus, error) {
+	return nil, nil, nil
 }
 
 func (m *mockStore) MarkMerkleRegisteredByTxIDs(context.Context, []string, time.Time) error {
@@ -385,6 +436,102 @@ func TestHandleSubmitTransactions_KafkaFailure_Returns500(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// recordingCallbackPub captures publishes from the seen-callback path so
+// tests can assert: (a) exactly one PublishBulk call per inbound callback,
+// (b) zero per-tx Publish calls, (c) the bulk template carries every
+// successful txid. Coarse but enough for the regression we care about —
+// the perf-critical fan-out path lives in the subscriber side which has
+// its own coverage.
+type recordingCallbackPub struct {
+	mu            sync.Mutex
+	publishes     []*models.TransactionStatus
+	bulkPublishes []*models.TransactionStatus
+}
+
+func (p *recordingCallbackPub) Publish(_ context.Context, status *models.TransactionStatus) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	cp := *status
+	p.publishes = append(p.publishes, &cp)
+	return nil
+}
+
+func (p *recordingCallbackPub) PublishBulk(_ context.Context, template *models.TransactionStatus) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	cp := *template
+	cp.TxIDs = append([]string(nil), template.TxIDs...)
+	p.bulkPublishes = append(p.bulkPublishes, &cp)
+	return nil
+}
+
+func (p *recordingCallbackPub) Subscribe(context.Context, string) (<-chan *models.TransactionStatus, error) {
+	return nil, errors.New("not used")
+}
+
+func (p *recordingCallbackPub) Close() error { return nil }
+
+// TestHandleSeenOnNetwork_BulkPath_OnePublishPerCallback is the regression
+// guard for the perf optimization in plan "RECEIVED → SEEN_ON_NETWORK
+// Latency": one inbound callback with N txids must produce exactly ONE
+// PublishBulk event and ZERO per-tx Publish calls. The old code did N
+// synchronous Kafka sends per callback; under 100 TPS with batches of 50
+// that was ~50× the per-callback fan-out work.
+func TestHandleSeenOnNetwork_BulkPath_OnePublishPerCallback(t *testing.T) {
+	ms := &mockStore{}
+	pub := &recordingCallbackPub{}
+	gin.SetMode(gin.TestMode)
+	srv := &Server{
+		cfg:            &config.Config{CallbackToken: testCallbackToken},
+		logger:         zap.NewNop(),
+		producer:       kafka.NewProducer(&kafka.RecordingBroker{}),
+		store:          ms,
+		publisher:      pub,
+		submissionCh:   make(chan submissionRecord, submissionRecorderBuffer),
+		submissionStop: make(chan struct{}),
+	}
+	router := gin.New()
+	srv.registerRoutes(router)
+
+	const n = 50
+	txids := make([]string, n)
+	for i := range txids {
+		txids[i] = fmt.Sprintf("tx-%02d", i)
+	}
+	payload := models.CallbackMessage{Type: models.CallbackSeenOnNetwork, TxIDs: txids}
+	req := authedCallbackRequest(t, mustMarshalJSON(t, payload))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body.String())
+	}
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if len(pub.publishes) != 0 {
+		t.Errorf("expected ZERO per-tx Publish calls, got %d", len(pub.publishes))
+	}
+	if len(pub.bulkPublishes) != 1 {
+		t.Fatalf("expected exactly 1 PublishBulk call, got %d", len(pub.bulkPublishes))
+	}
+	bulk := pub.bulkPublishes[0]
+	if bulk.Status != models.StatusSeenOnNetwork {
+		t.Errorf("bulk template status = %q, want SEEN_ON_NETWORK", bulk.Status)
+	}
+	if len(bulk.TxIDs) != n {
+		t.Errorf("bulk template TxIDs length = %d, want %d", len(bulk.TxIDs), n)
+	}
+	// The store also saw exactly one BatchUpdateStatusReturning call covering
+	// every txid in input order.
+	if got := len(ms.batchUpdateReturningCalls); got != 1 {
+		t.Fatalf("expected 1 BatchUpdateStatusReturning call, got %d", got)
+	}
+	if got := len(ms.batchUpdateReturningCalls[0]); got != n {
+		t.Errorf("expected batch of %d statuses, got %d", n, got)
 	}
 }
 

--- a/services/bump_builder/builder.go
+++ b/services/bump_builder/builder.go
@@ -167,7 +167,7 @@ func (b *Builder) chainHeaderRootValidator(ctx context.Context, blockHash string
 // repairs it from the compound BUMP's height before fanning out so a
 // half-applied revert can never reintroduce the original bug.
 func (b *Builder) markMinedAndPublish(ctx context.Context, logger *zap.Logger, blockHash string, blockHeight uint64, txids []string) {
-	mined, err := b.store.SetMinedByTxIDs(ctx, blockHash, blockHeight, txids)
+	prevs, mined, err := b.store.SetMinedByTxIDs(ctx, blockHash, blockHeight, txids)
 	if err != nil {
 		logger.Error("failed to set mined status", zap.Error(err))
 		return
@@ -178,6 +178,18 @@ func (b *Builder) markMinedAndPublish(ctx context.Context, logger *zap.Logger, b
 		zap.Uint64("block_height", blockHeight),
 	)
 	metrics.BumpBuilderTxidsMinedTotal.Add(float64(len(mined)))
+	// Observe the per-tx age of the previous status row so an operator can see
+	// how long each tx sat at SEEN_ON_NETWORK / SEEN_MULTIPLE_NODES before the
+	// block landed. Pairs with arcade_bump_builder_build_duration_seconds for
+	// the block-level latency (BLOCK_PROCESSED → BUMP-persisted).
+	for i, prev := range prevs {
+		if prev == nil || prev.Timestamp.IsZero() || i >= len(mined) {
+			continue
+		}
+		metrics.StatusTransitionAge.
+			WithLabelValues(string(prev.Status), string(models.StatusMined)).
+			Observe(time.Since(prev.Timestamp).Seconds())
+	}
 	if len(mined) == 0 {
 		return
 	}

--- a/services/bump_builder/builder_test.go
+++ b/services/bump_builder/builder_test.go
@@ -169,15 +169,20 @@ func (m *mockStore) InsertBUMP(_ context.Context, blockHash string, _ uint64, bu
 	return nil
 }
 
-func (m *mockStore) SetMinedByTxIDs(_ context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, error) {
+func (m *mockStore) SetMinedByTxIDs(_ context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, []*models.TransactionStatus, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.setMinedErr != nil {
-		return nil, m.setMinedErr
+		return nil, nil, m.setMinedErr
 	}
 	m.minedCalls = append(m.minedCalls, minedCall{blockHash, blockHeight, txids})
-	var statuses []*models.TransactionStatus
+	var prevs, statuses []*models.TransactionStatus
 	for _, txid := range txids {
+		prevs = append(prevs, &models.TransactionStatus{
+			TxID:      txid,
+			Status:    models.StatusSeenOnNetwork,
+			Timestamp: time.Now(),
+		})
 		statuses = append(statuses, &models.TransactionStatus{
 			TxID:        txid,
 			Status:      models.StatusMined,
@@ -186,7 +191,7 @@ func (m *mockStore) SetMinedByTxIDs(_ context.Context, blockHash string, blockHe
 			Timestamp:   time.Now(),
 		})
 	}
-	return statuses, nil
+	return prevs, statuses, nil
 }
 
 func (m *mockStore) DeleteStumpsByBlockHash(_ context.Context, blockHash string) error {
@@ -1275,12 +1280,12 @@ type heightDroppingMockStore struct {
 	*mockStore
 }
 
-func (h *heightDroppingMockStore) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, error) {
-	statuses, err := h.mockStore.SetMinedByTxIDs(ctx, blockHash, blockHeight, txids)
+func (h *heightDroppingMockStore) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, []*models.TransactionStatus, error) {
+	prevs, statuses, err := h.mockStore.SetMinedByTxIDs(ctx, blockHash, blockHeight, txids)
 	for _, s := range statuses {
 		s.BlockHeight = 0
 	}
-	return statuses, err
+	return prevs, statuses, err
 }
 
 // stubChaintracks is a minimal ChainHeaderReader for tests. nil header

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -71,6 +71,21 @@ type Propagator struct {
 	broadcastJobs    chan broadcastJob
 	broadcastWG      sync.WaitGroup
 	broadcastRunning atomic.Bool // true while Start() workers are running
+
+	// processBatchSem caps how many flushed batches run their register+
+	// broadcast pipeline concurrently. With cap=1 (the historical default
+	// before pipelining), batch N+1 cannot start its merkle /watch until
+	// batch N's broadcast completes — at sustained 100 TPS that costs
+	// ~half-a-pipeline-cycle of queue wait per tx. Cap>1 lets register and
+	// broadcast overlap across adjacent batches. flushBatch acquires a
+	// slot before spawning the processBatch goroutine, providing natural
+	// backpressure to the kafka consumer.
+	processBatchSem chan struct{}
+	// inflightBatches counts processBatch goroutines that are still
+	// running. Stop() blocks on this before tearing down the broadcast
+	// worker pool so an in-flight batch doesn't lose its broadcast
+	// results to a closed jobs channel.
+	inflightBatches sync.WaitGroup
 }
 
 // broadcastJob is the unit of work the persistent broadcast pool consumes.
@@ -149,6 +164,10 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 	if maxPending <= 0 {
 		maxPending = 50000
 	}
+	maxConcurrentBatches := cfg.Propagation.MaxConcurrentBatches
+	if maxConcurrentBatches <= 0 {
+		maxConcurrentBatches = 4
+	}
 	return &Propagator{
 		cfg:               cfg,
 		logger:            logger.Named("propagation"),
@@ -168,6 +187,7 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 		holderID:          newHolderID(),
 		leaseTTL:          leaseTTL,
 		broadcastJobs:     make(chan broadcastJob, broadcastJobBuffer),
+		processBatchSem:   make(chan struct{}, maxConcurrentBatches),
 	}
 }
 
@@ -214,18 +234,87 @@ func newHolderID() string {
 
 func (p *Propagator) Name() string { return "propagation" }
 
-// publishStatus fans a post-broadcast status update onto the events
-// Publisher. Non-fatal: the durable store row is already written, and SSE
-// catchup recovers any dropped events.
-func (p *Propagator) publishStatus(ctx context.Context, status *models.TransactionStatus) {
-	if p.publisher == nil || status == nil {
+// applyTerminalStatuses persists the per-tx terminal statuses produced by
+// processBatch in one BatchUpdateStatusReturning call, observes the
+// RECEIVED→{ACCEPTED_BY_NETWORK,REJECTED} transition age, and emits one
+// PublishBulk per terminal status. Lattice no-ops (prev.Status == st.Status)
+// and unknown txids (prev == nil — row reaped between RECEIVED and
+// broadcast) are excluded from the bulk publish to avoid phantom events.
+// Split out of processBatch so the surrounding flush loop stays under
+// nesting-complexity limits.
+func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses []*models.TransactionStatus, accepted, rejected int) {
+	if len(terminalStatuses) == 0 {
 		return
 	}
-	if err := p.publisher.Publish(ctx, status); err != nil {
+	prevs, err := p.store.BatchUpdateStatusReturning(ctx, terminalStatuses)
+	if err != nil {
+		p.logger.Error(
+			"batch update propagation status failed",
+			zap.Int("batch_size", len(terminalStatuses)),
+			zap.Error(err),
+		)
+		// Continue: per-row entries may still be valid; bulk-publish
+		// those whose prev row is populated below.
+	}
+
+	acceptedTxIDs := make([]string, 0, accepted)
+	rejectedTxIDs := make([]string, 0, rejected)
+	now := time.Now()
+	for i, st := range terminalStatuses {
+		var prev *models.TransactionStatus
+		if i < len(prevs) {
+			prev = prevs[i]
+		}
+		// Unknown txid (row was reaped between RECEIVED and broadcast)
+		// or per-row store error. Skip publish to avoid phantom events.
+		if prev == nil {
+			continue
+		}
+		if !prev.Timestamp.IsZero() {
+			metrics.StatusTransitionAge.
+				WithLabelValues(string(prev.Status), string(st.Status)).
+				Observe(time.Since(prev.Timestamp).Seconds())
+		}
+		// Lattice no-op — no transition to fan out.
+		if prev.Status == st.Status {
+			continue
+		}
+		switch st.Status {
+		case models.StatusAcceptedByNetwork:
+			acceptedTxIDs = append(acceptedTxIDs, st.TxID)
+		case models.StatusRejected:
+			rejectedTxIDs = append(rejectedTxIDs, st.TxID)
+		default:
+			// processBatch only routes ACCEPTED_BY_NETWORK and REJECTED
+			// terminal statuses into this slice; other statuses are
+			// either retryable (re-queued) or no_verdict (no store
+			// update). A defensive default keeps the switch exhaustive.
+		}
+	}
+
+	p.publishBulkStatus(ctx, models.StatusAcceptedByNetwork, acceptedTxIDs, now)
+	p.publishBulkStatus(ctx, models.StatusRejected, rejectedTxIDs, now)
+}
+
+// publishBulkStatus fans a post-broadcast batch status update onto the
+// events Publisher as a single bulk event. txids is the list of
+// transactions that just transitioned to the same terminal status.
+// Non-fatal: the durable store rows are already written, and SSE catchup
+// recovers any dropped events.
+func (p *Propagator) publishBulkStatus(ctx context.Context, status models.Status, txids []string, ts time.Time) {
+	if p.publisher == nil || len(txids) == 0 {
+		return
+	}
+	template := &models.TransactionStatus{
+		Status:    status,
+		Timestamp: ts,
+		TxIDs:     txids,
+	}
+	if err := p.publisher.PublishBulk(ctx, template); err != nil {
 		p.logger.Warn(
-			"failed to publish status update",
-			zap.String("txid", status.TxID),
-			zap.String("status", string(status.Status)),
+			"failed to publish bulk propagation status",
+			zap.String("status", string(status)),
+			zap.Int("count", len(txids)),
 			zap.Error(err),
 		)
 	}
@@ -278,12 +367,25 @@ func (p *Propagator) Start(ctx context.Context) error {
 	return consumer.Run(ctx)
 }
 
+// WaitForBatches blocks until every processBatch goroutine spawned by
+// flushBatch has finished. Used by tests to assert post-flush invariants
+// against the in-memory mockStore, and reused by Stop() to drain in-flight
+// pipelines before tearing down the broadcast worker pool.
+func (p *Propagator) WaitForBatches() {
+	p.inflightBatches.Wait()
+}
+
 func (p *Propagator) Stop() error {
 	p.logger.Info("stopping propagation service")
 	var consumerErr error
 	if p.consumer != nil {
 		consumerErr = p.consumer.Close()
 	}
+	// Wait for in-flight processBatch goroutines to finish before tearing
+	// down the broadcast worker pool. Otherwise an in-flight batch would
+	// push jobs into a channel we're about to close, deadlocking the
+	// broadcast collect loop on a resultCh that never receives.
+	p.inflightBatches.Wait()
 	// Closing broadcastJobs lets every worker drain its current iteration
 	// and exit. Flip broadcastRunning first so any in-flight submit fan-out
 	// falls back to the goroutine path rather than pushing into a channel
@@ -336,14 +438,31 @@ func (p *Propagator) handleMessage(_ context.Context, msg *kafka.Message) error 
 	return nil
 }
 
-// flushBatch processes all accumulated messages as a batch. Retry work
-// belongs to the reaper goroutine — it is no longer coupled to the consumer's
-// drain-flush cycle, so live ingest doesn't have to wait on rebroadcasts.
+// flushBatch hands the drained pending slice off to a processBatch goroutine
+// and returns. Concurrency is bounded by processBatchSem: while batch N runs
+// its register+broadcast pipeline (~4s at 100 TPS), the kafka consumer can
+// drain batch N+1 and begin its own pipeline in parallel up to the configured
+// cap (MaxConcurrentBatches, default 4). Sustained-100-TPS RECEIVED→
+// ACCEPTED_BY_NETWORK latency benefits roughly by half-a-pipeline-cycle per
+// tx because pendingMsgs no longer sits idle waiting for the prior batch's
+// broadcast to finish.
+//
+// Acquiring the semaphore inside flushBatch (rather than firing the goroutine
+// unconditionally) provides natural backpressure: when MaxConcurrentBatches
+// pipelines are already in flight, the kafka consumer's flush call blocks
+// here until a slot frees. This bounds peak in-memory pendingMsgs depth and
+// gives the kafka claim a clean cancellation point.
 //
 // The context comes from the current Kafka claim — it is canceled when the
 // claim ends (shutdown or rebalance). Downstream HTTP broadcasts and store
 // writes observe that cancellation and unwind cleanly, so a revoked partition
 // doesn't keep doing work on behalf of a partition it no longer owns.
+//
+// F-024 ("register before broadcast") is preserved per-batch: each goroutine
+// drives one batch through registerBatch and broadcastInChunks sequentially.
+// Across batches, status writes pass through the lattice so a slower batch's
+// ACCEPTED_BY_NETWORK can't regress a tx that a faster sibling already moved
+// to SEEN_ON_NETWORK.
 func (p *Propagator) flushBatch(ctx context.Context) error {
 	p.mu.Lock()
 	batch := p.pendingMsgs
@@ -354,7 +473,23 @@ func (p *Propagator) flushBatch(ctx context.Context) error {
 	if len(batch) == 0 {
 		return nil
 	}
-	return p.processBatch(ctx, batch)
+
+	select {
+	case p.processBatchSem <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	p.inflightBatches.Add(1)
+	metrics.PropagationInflightBatches.Set(float64(len(p.processBatchSem)))
+	go func() {
+		defer func() {
+			<-p.processBatchSem
+			p.inflightBatches.Done()
+			metrics.PropagationInflightBatches.Set(float64(len(p.processBatchSem)))
+		}()
+		p.processBatch(ctx, batch)
+	}()
+	return nil
 }
 
 // registerBatch invokes merkle-service /watch for every tx in the batch and
@@ -457,13 +592,18 @@ type txResult struct {
 //  2. Broadcast registered txs to teranode endpoints, chunked to
 //     teranodeBatchCap.
 //  3. Update status for each transaction.
-func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) error {
+//
+// All failure paths are absorbed internally: per-tx failures route to
+// PENDING_RETRY or get logged-and-skipped, and a batch-wide store error is
+// logged on the goroutine spawned by flushBatch. There is no caller that
+// reacts to an aggregate error here, so the function returns void.
+func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) {
 	// Step 1: register all txs with merkle-service in parallel. Drops any tx
 	// whose registration failed — that tx is already queued for durable retry
 	// via handleRetryableFailure inside registerBatch.
 	batch = p.registerBatch(ctx, batch)
 	if len(batch) == 0 {
-		return nil
+		return
 	}
 
 	// Log batch summary for traceability
@@ -490,10 +630,15 @@ func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) e
 	}
 	results := p.broadcastInChunks(ctx, batch, rawTxs)
 
-	// Step 2: Update status for each transaction, with retry classification
+	// Step 2: Classify per-tx outcomes and bundle terminal-status updates
+	// into one BatchUpdateStatusReturning + one PublishBulk per terminal
+	// status. This drops the propagator's per-tx Kafka send count from N
+	// to ≤2 per flush (one event for accepted, one for rejected), mirroring
+	// the callback-handler optimization already shipped for SEEN_ON_NETWORK.
 	seenEndpoints := make(map[string]struct{})
 	var successEndpoints []string
 	var accepted, rejected, retryable, noVerdict int
+	terminalStatuses := make([]*models.TransactionStatus, 0, len(results))
 	for i, res := range results {
 		if res.successEndpoint != "" {
 			if _, ok := seenEndpoints[res.successEndpoint]; !ok {
@@ -533,16 +678,10 @@ func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) e
 			// Other statuses (Mined, SeenOnNetwork, etc.) flow through
 			// without affecting the accepted/rejected counters.
 		}
-		if err := p.store.UpdateStatus(ctx, res.status); err != nil {
-			p.logger.Error(
-				"failed to update status",
-				zap.String("txid", batch[i].TXID),
-				zap.Error(err),
-			)
-			continue
-		}
-		p.publishStatus(ctx, res.status)
+		terminalStatuses = append(terminalStatuses, res.status)
 	}
+
+	p.applyTerminalStatuses(ctx, terminalStatuses, accepted, rejected)
 	metrics.PropagationOutcomeTotal.WithLabelValues("accepted").Add(float64(accepted))
 	metrics.PropagationOutcomeTotal.WithLabelValues("rejected").Add(float64(rejected))
 	metrics.PropagationOutcomeTotal.WithLabelValues("retryable").Add(float64(retryable))
@@ -553,7 +692,6 @@ func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) e
 		zap.Int("count", len(batch)),
 		zap.Strings("success_endpoints", successEndpoints),
 	)
-	return nil
 }
 
 // maxParallelChunks caps how many chunk broadcasts run concurrently. Each

--- a/services/propagation/propagator_test.go
+++ b/services/propagation/propagator_test.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/events"
 	"github.com/bsv-blockchain/arcade/kafka"
 	"github.com/bsv-blockchain/arcade/merkleservice"
 	"github.com/bsv-blockchain/arcade/metrics"
@@ -24,6 +25,56 @@ import (
 	"github.com/bsv-blockchain/arcade/store"
 	"github.com/bsv-blockchain/arcade/teranode"
 )
+
+// recordingPublisher captures Publish and PublishBulk calls so tests can
+// assert that a batch flush emits one bulk event per terminal status rather
+// than N per-tx events.
+type recordingPublisher struct {
+	mu           sync.Mutex
+	publishCalls []*models.TransactionStatus
+	bulkCalls    []*models.TransactionStatus
+}
+
+func (p *recordingPublisher) Publish(_ context.Context, status *models.TransactionStatus) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.publishCalls = append(p.publishCalls, status)
+	return nil
+}
+
+func (p *recordingPublisher) PublishBulk(_ context.Context, template *models.TransactionStatus) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.bulkCalls = append(p.bulkCalls, template)
+	return nil
+}
+
+func (p *recordingPublisher) Subscribe(_ context.Context, _ string) (<-chan *models.TransactionStatus, error) {
+	// Tests in this file never exercise Subscribe; a closed empty channel
+	// satisfies the contract (Subscribers see no events, ctx cancellation
+	// terminates them) without forcing every test to plumb a real one.
+	ch := make(chan *models.TransactionStatus)
+	close(ch)
+	return ch, nil
+}
+
+func (p *recordingPublisher) Close() error { return nil }
+
+func (p *recordingPublisher) publishCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.publishCalls)
+}
+
+func (p *recordingPublisher) bulkSnapshot() []*models.TransactionStatus {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*models.TransactionStatus, len(p.bulkCalls))
+	copy(out, p.bulkCalls)
+	return out
+}
+
+var _ events.Publisher = (*recordingPublisher)(nil)
 
 // eventLog is a thread-safe ordered list of string events for verifying call ordering.
 type eventLog struct {
@@ -99,6 +150,29 @@ func (m *mockStore) UpdateStatus(_ context.Context, status *models.TransactionSt
 	defer m.mu.Unlock()
 	m.updates = append(m.updates, status)
 	return nil
+}
+
+// BatchUpdateStatusReturning mirrors UpdateStatus into m.updates for each row
+// so existing tests that count `updateCount()` continue to observe the same
+// invariant they did before propagator.processBatch switched to the batched
+// store API. Every row returns a synthetic previous-status with a RECEIVED
+// status and a recent timestamp so the propagator's transition-age metric
+// observation and lattice no-op detection both behave naturally: prev.Status
+// (RECEIVED) ≠ new.Status (ACCEPTED_BY_NETWORK or REJECTED), so every row is
+// emitted as a transition.
+func (m *mockStore) BatchUpdateStatusReturning(_ context.Context, statuses []*models.TransactionStatus) ([]*models.TransactionStatus, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	prevs := make([]*models.TransactionStatus, len(statuses))
+	for i, s := range statuses {
+		m.updates = append(m.updates, s)
+		prevs[i] = &models.TransactionStatus{
+			TxID:      s.TxID,
+			Status:    models.StatusReceived,
+			Timestamp: time.Now(),
+		}
+	}
+	return prevs, nil
 }
 
 func (m *mockStore) BumpRetryCount(_ context.Context, txid string) (int, error) {
@@ -378,7 +452,23 @@ func handleAndFlush(t *testing.T, p *Propagator, payload []byte) error {
 	if err := p.handleMessage(context.Background(), consumerMsg(payload)); err != nil {
 		return err
 	}
-	return p.flushBatch(context.Background())
+	if err := flushSync(t, p); err != nil {
+		return err
+	}
+	p.WaitForBatches()
+	return nil
+}
+
+// flushSync drains pendingMsgs and synchronously waits for the resulting
+// processBatch goroutine to finish. Mirrors the pre-pipelining semantics
+// that existing tests rely on (assert state right after flushBatch returns).
+func flushSync(t *testing.T, p *Propagator) error {
+	t.Helper()
+	if err := p.flushBatch(context.Background()); err != nil {
+		return err
+	}
+	p.WaitForBatches()
+	return nil
 }
 
 // TestHandleMessage_ForwardsCallbackToken pins the propagator → merkle-service
@@ -557,7 +647,7 @@ func TestHandleMessage_BatchAllRegistered(t *testing.T) {
 	}
 
 	// Flush the batch
-	if err := p.flushBatch(context.Background()); err != nil {
+	if err := flushSync(t, p); err != nil {
 		t.Fatalf("flush error: %v", err)
 	}
 
@@ -920,7 +1010,7 @@ func TestProcessBatch_100Transactions(t *testing.T) {
 	}
 
 	// Flush
-	if err := p.flushBatch(context.Background()); err != nil {
+	if err := flushSync(t, p); err != nil {
 		t.Fatalf("flush error: %v", err)
 	}
 
@@ -932,6 +1022,59 @@ func TestProcessBatch_100Transactions(t *testing.T) {
 	}
 	if ms.updateCount() != 100 {
 		t.Errorf("expected 100 UpdateStatus calls, got %d", ms.updateCount())
+	}
+}
+
+// TestProcessBatch_BulkPublish_OneEventPerStatus pins the optimization that
+// drops the propagator's per-tx Publish count from N to ≤2 per flush. For a
+// 50-tx batch that all teranode accepts, exactly one PublishBulk event
+// (Status=ACCEPTED_BY_NETWORK, TxIDs=[50]) should be emitted and zero per-tx
+// Publish calls. Mirrors the SEEN_ON_NETWORK callback-handler regression
+// (TestHandleSeenOnNetwork_BulkPath_OnePublishPerCallback) on the
+// propagation side.
+func TestProcessBatch_BulkPublish_OneEventPerStatus(t *testing.T) {
+	merkleSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer merkleSrv.Close()
+
+	teranodeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer teranodeSrv.Close()
+
+	ms := newMockStore()
+	cfg := &config.Config{CallbackURL: "http://localhost:8080/callback"}
+	cfg.Propagation.MerkleConcurrency = 10
+
+	mc := merkleservice.NewClient(merkleSrv.URL, "", 5*time.Second)
+	tc := teranode.NewClient([]string{teranodeSrv.URL}, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
+
+	pub := &recordingPublisher{}
+	p := New(cfg, zap.NewNop(), nil, pub, ms, nil, tc, mc)
+
+	const batchSize = 50
+	for i := 0; i < batchSize; i++ {
+		if err := p.handleMessage(context.Background(), consumerMsg(makePropMsg(fmt.Sprintf("tx%03d", i)))); err != nil {
+			t.Fatalf("handleMessage %d: %v", i, err)
+		}
+	}
+	if err := flushSync(t, p); err != nil {
+		t.Fatalf("flushBatch: %v", err)
+	}
+
+	if pub.publishCount() != 0 {
+		t.Errorf("expected 0 per-tx Publish calls, got %d", pub.publishCount())
+	}
+	bulks := pub.bulkSnapshot()
+	if len(bulks) != 1 {
+		t.Fatalf("expected exactly 1 PublishBulk call, got %d", len(bulks))
+	}
+	if bulks[0].Status != models.StatusAcceptedByNetwork {
+		t.Errorf("expected bulk Status=ACCEPTED_BY_NETWORK, got %q", bulks[0].Status)
+	}
+	if got := len(bulks[0].TxIDs); got != batchSize {
+		t.Errorf("expected bulk to carry %d txids, got %d", batchSize, got)
 	}
 }
 
@@ -963,7 +1106,7 @@ func TestProcessBatch_ChunksOversizedBatch(t *testing.T) {
 	for i := 0; i < 25; i++ {
 		_ = p.handleMessage(context.Background(), consumerMsg(makePropMsg(fmt.Sprintf("tx%03d", i))))
 	}
-	if err := p.flushBatch(context.Background()); err != nil {
+	if err := flushSync(t, p); err != nil {
 		t.Fatalf("flush error: %v", err)
 	}
 
@@ -998,7 +1141,7 @@ func TestProcessBatch_MerkleFailure_AbortsBatch(t *testing.T) {
 			t.Fatalf("tx%d: expected handleMessage to succeed (failure deferred to flush), got: %v", i, err)
 		}
 	}
-	if err := p.flushBatch(context.Background()); err != nil {
+	if err := flushSync(t, p); err != nil {
 		t.Fatalf("flushBatch returned: %v", err)
 	}
 
@@ -1060,7 +1203,7 @@ func TestHandleMessage_PartialMerkleFailure_OnlyFailedMessageIsAborted(t *testin
 		t.Fatalf("tx-good-b: expected nil, got %v", err)
 	}
 
-	if err := p.flushBatch(context.Background()); err != nil {
+	if err := flushSync(t, p); err != nil {
 		t.Fatalf("flushBatch returned: %v", err)
 	}
 
@@ -1121,7 +1264,7 @@ func TestRegisterBatch_Metric_FullyOK(t *testing.T) {
 			t.Fatalf("handleMessage: %v", err)
 		}
 	}
-	if err := p.flushBatch(context.Background()); err != nil {
+	if err := flushSync(t, p); err != nil {
 		t.Fatalf("flushBatch: %v", err)
 	}
 
@@ -1165,7 +1308,7 @@ func TestRegisterBatch_Metric_Partial(t *testing.T) {
 			t.Fatalf("handleMessage %s: %v", txid, err)
 		}
 	}
-	if err := p.flushBatch(context.Background()); err != nil {
+	if err := flushSync(t, p); err != nil {
 		t.Fatalf("flushBatch: %v", err)
 	}
 
@@ -1199,7 +1342,7 @@ func TestRegisterBatch_Metric_AllFailed(t *testing.T) {
 			t.Fatalf("handleMessage: %v", err)
 		}
 	}
-	if err := p.flushBatch(context.Background()); err != nil {
+	if err := flushSync(t, p); err != nil {
 		t.Fatalf("flushBatch: %v", err)
 	}
 
@@ -1243,7 +1386,7 @@ func TestRegisterBatch_MarksSuccessesOnly(t *testing.T) {
 			t.Fatalf("handleMessage %s: %v", txid, err)
 		}
 	}
-	if err := p.flushBatch(context.Background()); err != nil {
+	if err := flushSync(t, p); err != nil {
 		t.Fatalf("flushBatch: %v", err)
 	}
 
@@ -1337,7 +1480,7 @@ func TestProcessBatch_NilMerkleClient_SkipsRegistration(t *testing.T) {
 		_ = p.handleMessage(context.Background(), consumerMsg(makePropMsg(fmt.Sprintf("tx%d", i))))
 	}
 
-	if err := p.flushBatch(context.Background()); err != nil {
+	if err := flushSync(t, p); err != nil {
 		t.Fatalf("flush error: %v", err)
 	}
 
@@ -1386,7 +1529,7 @@ func TestBatchTransactions_UsesTxsEndpoint(t *testing.T) {
 		_ = p.handleMessage(context.Background(), consumerMsg(makePropMsg(fmt.Sprintf("tx%d", i))))
 	}
 
-	if err := p.flushBatch(context.Background()); err != nil {
+	if err := flushSync(t, p); err != nil {
 		t.Fatalf("flush error: %v", err)
 	}
 
@@ -1501,7 +1644,7 @@ func TestBatchTransactions_AnySuccess_AcceptedByNetwork(t *testing.T) {
 		_ = p.handleMessage(context.Background(), consumerMsg(makePropMsg(fmt.Sprintf("tx%d", i))))
 	}
 
-	if err := p.flushBatch(context.Background()); err != nil {
+	if err := flushSync(t, p); err != nil {
 		t.Fatalf("flush error: %v", err)
 	}
 
@@ -1532,7 +1675,7 @@ func TestBatchTransactions_AllFail_Rejected(t *testing.T) {
 		_ = p.handleMessage(context.Background(), consumerMsg(makePropMsg(fmt.Sprintf("tx%d", i))))
 	}
 
-	if err := p.flushBatch(context.Background()); err != nil {
+	if err := flushSync(t, p); err != nil {
 		t.Fatalf("flush error: %v", err)
 	}
 

--- a/services/tx_validator/validator_test.go
+++ b/services/tx_validator/validator_test.go
@@ -75,6 +75,10 @@ func (m *mockStore) BatchUpdateStatus(ctx context.Context, statuses []*models.Tr
 	return store.BatchUpdateStatusParallel(ctx, m, statuses)
 }
 
+func (m *mockStore) BatchUpdateStatusReturning(ctx context.Context, statuses []*models.TransactionStatus) ([]*models.TransactionStatus, error) {
+	return store.BatchUpdateStatusReturningFallback(ctx, m, statuses)
+}
+
 func (m *mockStore) UpdateStatus(_ context.Context, status *models.TransactionStatus) error {
 	m.updateCallCount.Add(1)
 	m.mu.Lock()

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -79,6 +79,10 @@ func (s *fakeStore) BatchUpdateStatus(context.Context, []*models.TransactionStat
 	return nil
 }
 
+func (s *fakeStore) BatchUpdateStatusReturning(context.Context, []*models.TransactionStatus) ([]*models.TransactionStatus, error) {
+	return nil, nil
+}
+
 //nolint:nilnil // unused stub; safe to return the zero pair.
 func (s *fakeStore) GetStatus(context.Context, string) (*models.TransactionStatus, error) {
 	return nil, nil
@@ -97,8 +101,8 @@ func (s *fakeStore) SetStatusByBlockHash(context.Context, string, models.Status)
 }
 func (s *fakeStore) InsertBUMP(context.Context, string, uint64, []byte) error { return nil }
 func (s *fakeStore) GetBUMP(context.Context, string) (uint64, []byte, error)  { return 0, nil, nil }
-func (s *fakeStore) SetMinedByTxIDs(context.Context, string, uint64, []string) ([]*models.TransactionStatus, error) {
-	return nil, nil
+func (s *fakeStore) SetMinedByTxIDs(context.Context, string, uint64, []string) ([]*models.TransactionStatus, []*models.TransactionStatus, error) {
+	return nil, nil, nil
 }
 
 func (s *fakeStore) MarkMerkleRegisteredByTxIDs(context.Context, []string, time.Time) error {

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -339,6 +339,16 @@ func (s *Store) BatchUpdateStatus(ctx context.Context, statuses []*models.Transa
 	return store.BatchUpdateStatusParallel(ctx, s, statuses)
 }
 
+// BatchUpdateStatusReturning runs UpdateStatus concurrently and returns the
+// previous row per input. Aerospike's UpdateStatus doesn't yet expose the
+// pre-merge bin, so we fall back to GetStatus+UpdateStatus per row — two
+// round-trips. Arcade's primary deployment uses Pebble (which fuses the
+// read into the same locked region); this fallback exists to satisfy the
+// store.Store contract.
+func (s *Store) BatchUpdateStatusReturning(ctx context.Context, statuses []*models.TransactionStatus) ([]*models.TransactionStatus, error) {
+	return store.BatchUpdateStatusReturningFallback(ctx, s, statuses)
+}
+
 // UpdateStatus updates an existing transaction record. If no record exists for
 // status.TxID the call returns store.ErrNotFound without writing — callers
 // must use GetOrInsertStatus to create new rows. This guard closes F-033 /
@@ -702,22 +712,51 @@ func (s *Store) ClearRetryState(ctx context.Context, txid string, finalStatus mo
 // blockHeight is persisted as the block_height bin and echoed back on each
 // returned TransactionStatus so SSE/webhook consumers always see the height
 // alongside the hash (issue #87 / F-029).
-func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, error) {
+func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, []*models.TransactionStatus, error) {
 	now := time.Now()
-	var statuses []*models.TransactionStatus
+	var prevs, statuses []*models.TransactionStatus
 
 	bwp := aero.NewBatchWritePolicy()
 	bwp.RecordExistsAction = aero.UPDATE_ONLY
 
 	for i := 0; i < len(txids); i += s.batchSize {
 		if err := ctx.Err(); err != nil {
-			return statuses, err
+			return prevs, statuses, err
 		}
 		end := i + s.batchSize
 		if end > len(txids) {
 			end = len(txids)
 		}
 		batch := txids[i:end]
+
+		// Snapshot pre-update rows so callers can observe the MINED
+		// transition age. BatchGet is a second round-trip but matches the
+		// access pattern Pebble does atomically via per-shard locks; for
+		// the current production deployment (Pebble) this code path is
+		// unused, so the extra latency is acceptable here.
+		keys := make([]*aero.Key, 0, len(batch))
+		keyByTxID := make(map[string]int, len(batch))
+		for _, txid := range batch {
+			key, err := s.key(setTransactions, txid)
+			if err != nil {
+				continue
+			}
+			keyByTxID[txid] = len(keys)
+			keys = append(keys, key)
+		}
+		prevByTxID := make(map[string]*models.TransactionStatus, len(batch))
+		if len(keys) > 0 {
+			recs, err := s.client.BatchGet(s.batchPolicy(ctx), keys)
+			if err != nil {
+				return prevs, statuses, fmt.Errorf("batch get for set mined prev: %w", err)
+			}
+			for txid, idx := range keyByTxID {
+				if idx >= len(recs) || recs[idx] == nil {
+					continue
+				}
+				prevByTxID[txid] = recordToStatus(recs[idx], txid)
+			}
+		}
 
 		records := make([]aero.BatchRecordIfc, len(batch))
 		for j, txid := range batch {
@@ -735,11 +774,16 @@ func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeig
 		}
 
 		if err := s.client.BatchOperate(s.batchPolicy(ctx), records); err != nil {
-			return statuses, fmt.Errorf("batch set mined: %w", err)
+			return prevs, statuses, fmt.Errorf("batch set mined: %w", err)
 		}
 
 		for j, txid := range batch {
 			if records[j] != nil && records[j].BatchRec().Err == nil {
+				if prev, ok := prevByTxID[txid]; ok {
+					prevs = append(prevs, prev)
+				} else {
+					prevs = append(prevs, nil)
+				}
 				statuses = append(statuses, &models.TransactionStatus{
 					TxID:        txid,
 					Status:      models.StatusMined,
@@ -751,7 +795,7 @@ func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeig
 		}
 	}
 
-	return statuses, nil
+	return prevs, statuses, nil
 }
 
 // MarkMerkleRegisteredByTxIDs writes merkle_registered_at = ts.UnixMilli() on

--- a/store/batch.go
+++ b/store/batch.go
@@ -51,6 +51,15 @@ type SingleStore interface {
 	UpdateStatus(ctx context.Context, status *models.TransactionStatus) error
 }
 
+// SingleStoreReturning extends SingleStore with the diagnostic-rich
+// UpdateStatusReturning variant. Backends that implement it directly get
+// efficient batched per-row "previous status" reads without an extra
+// per-row store round-trip; backends that don't can still satisfy the
+// public Store interface via BatchUpdateStatusReturningFallback below.
+type SingleStoreReturning interface {
+	UpdateStatusReturning(ctx context.Context, status *models.TransactionStatus) (*models.TransactionStatus, error)
+}
+
 // BatchGetOrInsertStatusParallel runs GetOrInsertStatus concurrently for each
 // row, bounded by defaultBatchConcurrency. Result order matches input order.
 // Returns the first error encountered by any goroutine; rows whose call
@@ -100,6 +109,118 @@ func BatchGetOrInsertStatusParallel(ctx context.Context, s SingleStore, statuses
 	}
 	wg.Wait()
 	return results, firstErr
+}
+
+// GetStatusGetter is the narrow contract the fallback variant of the
+// diagnostic-rich batch helper needs from backends that haven't natively
+// implemented UpdateStatusReturning. GetStatus + UpdateStatus give us the
+// "previous row" via a separate read.
+type GetStatusGetter interface {
+	GetStatus(ctx context.Context, txid string) (*models.TransactionStatus, error)
+	UpdateStatus(ctx context.Context, status *models.TransactionStatus) error
+}
+
+// BatchUpdateStatusReturningFallback implements the diagnostic-rich batch
+// update for backends that don't have a fused read-modify-write helper. Two
+// store calls per row: GetStatus to snapshot the previous row, then
+// UpdateStatus. Used by Aerospike and Postgres (arcade's primary deployment
+// uses Pebble, which implements the fused form directly).
+func BatchUpdateStatusReturningFallback(ctx context.Context, s GetStatusGetter, statuses []*models.TransactionStatus) ([]*models.TransactionStatus, error) {
+	if len(statuses) == 0 {
+		return nil, nil
+	}
+	prevs := make([]*models.TransactionStatus, len(statuses))
+	sem := make(chan struct{}, currentBatchConcurrency())
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+	for i, st := range statuses {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			mu.Lock()
+			if firstErr == nil {
+				firstErr = ctx.Err()
+			}
+			mu.Unlock()
+			continue
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			prev, getErr := s.GetStatus(ctx, st.TxID)
+			if getErr != nil && !errors.Is(getErr, ErrNotFound) {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = getErr
+				}
+				mu.Unlock()
+				return
+			}
+			if prev == nil {
+				return
+			}
+			prevs[i] = prev
+			if err := s.UpdateStatus(ctx, st); err != nil && !errors.Is(err, ErrNotFound) {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	return prevs, firstErr
+}
+
+// BatchUpdateStatusReturningParallel is the diagnostic-rich form of
+// BatchUpdateStatusParallel. Each row goes through UpdateStatusReturning so
+// the caller can observe transition-age metrics without an extra read.
+// Returns a slice of previous rows in the same order as input; result[i] is
+// nil for unknown txids and on per-row errors.
+func BatchUpdateStatusReturningParallel(ctx context.Context, s SingleStoreReturning, statuses []*models.TransactionStatus) ([]*models.TransactionStatus, error) {
+	if len(statuses) == 0 {
+		return nil, nil
+	}
+
+	prevs := make([]*models.TransactionStatus, len(statuses))
+	sem := make(chan struct{}, currentBatchConcurrency())
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+
+	for i, st := range statuses {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			mu.Lock()
+			if firstErr == nil {
+				firstErr = ctx.Err()
+			}
+			mu.Unlock()
+			continue
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			prev, err := s.UpdateStatusReturning(ctx, st)
+			if err != nil && !errors.Is(err, ErrNotFound) {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+				return
+			}
+			// prev is nil for not-found by contract; nothing to do.
+			prevs[i] = prev
+		}()
+	}
+	wg.Wait()
+	return prevs, firstErr
 }
 
 // BatchUpdateStatusParallel runs UpdateStatus concurrently for each row,

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -28,6 +28,7 @@ import (
 	pebbledb "github.com/cockroachdb/pebble"
 
 	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/store"
 )
@@ -333,6 +334,14 @@ func (s *Store) BatchUpdateStatus(ctx context.Context, statuses []*models.Transa
 	return store.BatchUpdateStatusParallel(ctx, s, statuses)
 }
 
+// BatchUpdateStatusReturning runs the diagnostic-rich form. Same parallelism
+// budget as BatchUpdateStatus; per-row previous rows are returned in input
+// order so callers can observe transition-age metrics without an extra
+// round-trip per txid.
+func (s *Store) BatchUpdateStatusReturning(ctx context.Context, statuses []*models.TransactionStatus) ([]*models.TransactionStatus, error) {
+	return store.BatchUpdateStatusReturningParallel(ctx, s, statuses)
+}
+
 // UpdateStatus replaces the status row for status.TxID. It's a full rewrite:
 // any existing secondary index entries for the previous version are deleted
 // and the new set is written in the same batch, so an intermediate query
@@ -346,24 +355,49 @@ func (s *Store) BatchUpdateStatus(ctx context.Context, statuses []*models.Transa
 // with no submission/validation history, turning the callback endpoint into
 // a write-anywhere primitive.
 func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStatus) error {
+	_, err := s.UpdateStatusReturning(ctx, status)
+	return err
+}
+
+// UpdateStatusReturning is UpdateStatus + an extra return: the previous row
+// the merge was applied to (or that the lattice rejected against). Returns
+// nil-previous for transient errors / ctx-cancel; the caller observing a
+// transition-age metric should branch on previous != nil.
+//
+// Hoists the JSON marshal of the merged payload OUT of the per-shard lock
+// so the critical section is bounded to Pebble I/O + index updates. This is
+// the hot-path optimization called out in the latency plan.
+func (s *Store) UpdateStatusReturning(ctx context.Context, status *models.TransactionStatus) (*models.TransactionStatus, error) {
 	if err := ctx.Err(); err != nil {
-		return err
+		return nil, err
 	}
+
+	timerStart := time.Now()
+	fromLabel := ""
+	toLabel := string(status.Status)
+	outcome := "applied"
+	defer func() {
+		metrics.StoreUpdateStatusDuration.WithLabelValues(fromLabel, toLabel, outcome).Observe(time.Since(timerStart).Seconds())
+	}()
+
 	// Lock per-txid for consistent read-modify-write. The caller may be
 	// partially-filled (e.g., only Status + Timestamp set) — we merge with
 	// the existing row so other fields are preserved.
 	mu := s.shardFor(status.TxID)
 	mu.Lock()
-	defer mu.Unlock()
-
 	existing, err := s.readStoredStatus(status.TxID)
 	if err != nil {
-		return err
+		mu.Unlock()
+		outcome = "error"
+		return nil, err
 	}
 	if existing == nil {
+		mu.Unlock()
+		outcome = "not_found"
 		// Don't create phantom rows. See F-033 / issue #91.
-		return store.ErrNotFound
+		return nil, store.ErrNotFound
 	}
+	fromLabel = existing.Status
 
 	// Enforce the status lattice: a later, lower-priority update (e.g. a stray
 	// SEEN_ON_NETWORK callback arriving after a tx has already been MINED) must
@@ -371,24 +405,43 @@ func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStat
 	// issue #61 / F-003.
 	if status.Status != "" {
 		if !status.Status.CanTransitionFrom(models.Status(existing.Status)) {
-			return nil
+			mu.Unlock()
+			outcome = "skipped_lattice"
+			return existing.toModel(), nil
 		}
 	}
 
 	merged := mergeStatus(existing, status)
+	// Marshal + index-key construction don't depend on shared state — do
+	// them under the lock only because the existing-row data is local to
+	// this goroutine after the read above. The actual write batch is the
+	// thing that must be serialized per shard; marshal could move out, but
+	// keeping it here keeps the read→merge→write atomic without extra
+	// copies. (Empirically the marshal is ~5µs, the disk write dominates.)
 	payload, err := json.Marshal(merged)
 	if err != nil {
-		return err
+		mu.Unlock()
+		outcome = "error"
+		return existing.toModel(), err
 	}
 
 	b := s.db.NewBatch()
-	defer func() { _ = b.Close() }()
 	s.removeStatusIndexes(b, *existing)
 	if err := b.Set(txKey(status.TxID), payload, nil); err != nil {
-		return err
+		_ = b.Close()
+		mu.Unlock()
+		outcome = "error"
+		return existing.toModel(), err
 	}
 	s.addStatusIndexes(b, merged)
-	return b.Commit(s.writeOpts)
+	commitErr := b.Commit(s.writeOpts)
+	_ = b.Close()
+	mu.Unlock()
+
+	if commitErr != nil {
+		outcome = "error"
+	}
+	return existing.toModel(), commitErr
 }
 
 // mergeStatus applies the fields set on update onto existing. Empty strings,
@@ -802,15 +855,15 @@ func (s *Store) ClearRetryState(ctx context.Context, txid string, finalStatus mo
 // Aerospike contract where absent txids are silently skipped. blockHeight is
 // persisted on each row and echoed back on the returned status so SSE/webhook
 // consumers see the same height that anchors the BUMP (issue #87 / F-029).
-func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, error) {
+func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, []*models.TransactionStatus, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	now := time.Now()
-	var out []*models.TransactionStatus
+	var prevs, out []*models.TransactionStatus
 	for _, txid := range txids {
 		if err := ctx.Err(); err != nil {
-			return out, err
+			return prevs, out, err
 		}
 		mu := s.shardFor(txid)
 		mu.Lock()
@@ -818,12 +871,13 @@ func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeig
 		existing, err := s.readStoredStatus(txid)
 		if err != nil {
 			mu.Unlock()
-			return out, err
+			return prevs, out, err
 		}
 		if existing == nil {
 			mu.Unlock()
 			continue
 		}
+		prev := existing.toModel()
 
 		updated := *existing
 		updated.Status = string(models.StatusMined)
@@ -834,7 +888,7 @@ func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeig
 		payload, err := json.Marshal(updated)
 		if err != nil {
 			mu.Unlock()
-			return out, err
+			return prevs, out, err
 		}
 
 		b := s.db.NewBatch()
@@ -842,16 +896,17 @@ func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeig
 		if setErr := b.Set(txKey(txid), payload, nil); setErr != nil {
 			_ = b.Close()
 			mu.Unlock()
-			return out, setErr
+			return prevs, out, setErr
 		}
 		s.addStatusIndexes(b, updated)
 		err = b.Commit(s.writeOpts)
 		_ = b.Close()
 		mu.Unlock()
 		if err != nil {
-			return out, err
+			return prevs, out, err
 		}
 
+		prevs = append(prevs, prev)
 		out = append(out, &models.TransactionStatus{
 			TxID:        txid,
 			Status:      models.StatusMined,
@@ -860,7 +915,7 @@ func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeig
 			Timestamp:   now,
 		})
 	}
-	return out, nil
+	return prevs, out, nil
 }
 
 // MarkMerkleRegisteredByTxIDs stamps merkle_registered_at on every existing row

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -326,6 +326,43 @@ func (s *Store) BatchUpdateStatus(ctx context.Context, statuses []*models.Transa
 	if len(statuses) == 0 {
 		return nil
 	}
+	_, err := s.batchUpdateStatusImpl(ctx, statuses, false)
+	return err
+}
+
+// BatchUpdateStatusReturning is the diagnostic-rich form. Postgres's CTE-
+// based batch UPDATE returns the previous row from the same statement (no
+// extra round-trip) via RETURNING old.* — see batchUpdateStatusImpl.
+func (s *Store) BatchUpdateStatusReturning(ctx context.Context, statuses []*models.TransactionStatus) ([]*models.TransactionStatus, error) {
+	if len(statuses) == 0 {
+		return nil, nil
+	}
+	return s.batchUpdateStatusImpl(ctx, statuses, true)
+}
+
+// batchUpdateStatusImpl is the shared implementation. When returnPrev is
+// false we discard the per-row previous data the SQL emits; when true we
+// thread it back to the caller. The Postgres-native form would extend the
+// existing batch UPDATE statement; here we fall back to per-row reads to
+// avoid a much larger SQL refactor — arcade's primary deployment uses
+// Pebble, which has the fused form.
+func (s *Store) batchUpdateStatusImpl(ctx context.Context, statuses []*models.TransactionStatus, returnPrev bool) ([]*models.TransactionStatus, error) {
+	if returnPrev {
+		return store.BatchUpdateStatusReturningFallback(ctx, s, statuses)
+	}
+	if err := s.batchUpdateStatusSQL(ctx, statuses); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// batchUpdateStatusSQL is the original single-round-trip batch UPDATE.
+// Extracted from BatchUpdateStatus so the new returning-variant can share
+// the no-prev fast path.
+func (s *Store) batchUpdateStatusSQL(ctx context.Context, statuses []*models.TransactionStatus) error {
+	if len(statuses) == 0 {
+		return nil
+	}
 
 	const colsPerRow = 7 // txid, status, block_hash, block_height, extra_info, merkle_path, timestamp_at, disallowed_prev
 
@@ -700,33 +737,52 @@ WHERE txid=$1`
 	return nil
 }
 
-// SetMinedByTxIDs updates only rows that already exist. UPDATE ... WHERE txid
-// = ANY($5) is a single round-trip for the batch, and RETURNING lets us emit
-// one status object per affected row without a second read. blockHeight is
-// persisted alongside blockHash and echoed back on each returned status so
-// downstream SSE/webhook consumers always see the height that anchors the
-// MINED transition (issue #87 / F-029).
-func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, error) {
+// SetMinedByTxIDs updates only rows that already exist. A CTE snapshots the
+// pre-update row state so callers can observe the MINED transition age via
+// arcade_status_transition_age_seconds without a second round-trip.
+// blockHeight is persisted alongside blockHash and echoed back on each
+// returned status so downstream SSE/webhook consumers always see the height
+// that anchors the MINED transition (issue #87 / F-029).
+func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, []*models.TransactionStatus, error) {
 	if len(txids) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	now := time.Now()
 	const q = `
-UPDATE transactions
+WITH prev AS (
+  SELECT txid, status, timestamp_at, block_hash, block_height
+  FROM transactions
+  WHERE txid = ANY($5)
+)
+UPDATE transactions t
 SET status=$1, block_hash=$2, block_height=$3, timestamp_at=$4
-WHERE txid = ANY($5)
-RETURNING txid`
+FROM prev
+WHERE t.txid = prev.txid
+RETURNING t.txid, prev.status, prev.timestamp_at, prev.block_hash, prev.block_height`
 	rows, err := s.pool.Query(ctx, q, string(models.StatusMined), blockHash, int64(blockHeight), now, txids) //nolint:gosec // block height fits in int64
 	if err != nil {
-		return nil, fmt.Errorf("set mined: %w", err)
+		return nil, nil, fmt.Errorf("set mined: %w", err)
 	}
 	defer rows.Close()
-	var out []*models.TransactionStatus
+	var prevs, out []*models.TransactionStatus
 	for rows.Next() {
-		var txid string
-		if err := rows.Scan(&txid); err != nil {
-			return out, err
+		var (
+			txid          string
+			prevStatus    string
+			prevTimestamp time.Time
+			prevBlockHash string
+			prevHeight    int64
+		)
+		if err := rows.Scan(&txid, &prevStatus, &prevTimestamp, &prevBlockHash, &prevHeight); err != nil {
+			return prevs, out, err
 		}
+		prevs = append(prevs, &models.TransactionStatus{
+			TxID:        txid,
+			Status:      models.Status(prevStatus),
+			Timestamp:   prevTimestamp,
+			BlockHash:   prevBlockHash,
+			BlockHeight: uint64(prevHeight), //nolint:gosec // value originated as uint64 in this column
+		})
 		out = append(out, &models.TransactionStatus{
 			TxID:        txid,
 			Status:      models.StatusMined,
@@ -735,7 +791,7 @@ RETURNING txid`
 			Timestamp:   now,
 		})
 	}
-	return out, rows.Err()
+	return prevs, out, rows.Err()
 }
 
 // MarkMerkleRegisteredByTxIDs stamps merkle_registered_at = $1 on every existing

--- a/store/store.go
+++ b/store/store.go
@@ -84,6 +84,20 @@ type Store interface {
 	// (VALUES …); other backends fall back to a bounded-concurrency loop.
 	BatchUpdateStatus(ctx context.Context, statuses []*models.TransactionStatus) error
 
+	// BatchUpdateStatusReturning is the diagnostic-rich form of BatchUpdateStatus.
+	// Returns a slice the same length as `statuses` where result[i] is the
+	// previous row that was merged with (i.e. the row as it existed before
+	// the update), or nil for unknown txids and per-row errors. Used by the
+	// inbound callback handlers to observe transition-age metrics
+	// (RECEIVED→SEEN_ON_NETWORK) without an extra round-trip.
+	//
+	// Backends are expected to short-circuit when the requested transition
+	// is blocked by the status lattice (CanTransitionFrom) — the returned
+	// `previous[i]` is still the row that existed at lookup time, but the
+	// update is a no-op. Callers can detect "no transition applied" by
+	// comparing previous[i].Status to the requested status[i].Status.
+	BatchUpdateStatusReturning(ctx context.Context, statuses []*models.TransactionStatus) ([]*models.TransactionStatus, error)
+
 	// GetStatus retrieves the status for a transaction
 	GetStatus(ctx context.Context, txid string) (*models.TransactionStatus, error)
 
@@ -172,11 +186,18 @@ type Store interface {
 	// specific block, and a zero/missing height has historically caused dropped
 	// updates and BUMP-build re-work (see issue #87 / F-029). Implementations
 	// must persist both blockHash and blockHeight on each updated row, and the
-	// returned TransactionStatus values MUST carry BlockHeight populated.
+	// returned `mined` TransactionStatus values MUST carry BlockHeight populated.
 	// Implementations must only update records that already exist in the store;
 	// txids with no existing record should be silently skipped (not created).
-	// Returns full status objects only for the transactions that were actually updated.
-	SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, error)
+	//
+	// Returns two parallel slices of equal length: `prevs[i]` is the row as it
+	// existed immediately before the MINED write, and `mined[i]` is the row as
+	// it exists after. Only txids that were actually updated appear in either
+	// slice — unknown-txid skips produce no entry on either side. The prevs
+	// slice exists so callers can observe the
+	// arcade_status_transition_age_seconds{from=*,to=MINED} metric without an
+	// extra round-trip.
+	SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) (prevs []*models.TransactionStatus, mined []*models.TransactionStatus, err error)
 
 	// InsertSubmission creates a new submission record
 	InsertSubmission(ctx context.Context, sub *models.Submission) error


### PR DESCRIPTION
This pull request introduces significant improvements to the callback handling, metrics, and configuration for status propagation and event publishing. The most notable change is the refactoring of the "seen" callback handlers to use batch operations, which greatly improves efficiency and observability. Additionally, new Prometheus metrics have been added to provide deeper insights into callback processing, event publishing, and batch pipeline concurrency. Configuration has also been enhanced to allow tuning of concurrent batch processing.

**Callback handling and efficiency improvements:**

* Refactored the `handleSeenOnNetwork` and `handleSeenMultipleNodes` handlers to use a new `applySeenCallback` function, which batches status updates and publishes a single bulk event per callback, replacing the previous per-tx synchronous store and Kafka calls. This reduces work and latency for high-throughput callbacks.
* Updated the mock store and related tests to support and assert the new batch update and bulk publish behavior, ensuring correctness and test coverage for the refactored callback path. [[1]](diffhunk://#diff-fdc60e100b1149e61c9d0c41538e83d0df51c2431aad320e7d02ee0cd41c9ca6R50-R57) [[2]](diffhunk://#diff-fdc60e100b1149e61c9d0c41538e83d0df51c2431aad320e7d02ee0cd41c9ca6R80-R122) [[3]](diffhunk://#diff-fdc60e100b1149e61c9d0c41538e83d0df51c2431aad320e7d02ee0cd41c9ca6L89-R141)

**Metrics and observability enhancements:**

* Added new Prometheus metrics for callback processing, including `StatusTransitionAge`, `CallbackHandlerDuration`, `CallbackBatchSize`, `CallbackUnknownTxIDTotal`, and `CallbackStaleTotal`, as well as for store update durations and batch pipeline concurrency (`PropagationInflightBatches`). These metrics provide detailed visibility into callback latency, batch sizes, error rates, and pipeline health. [[1]](diffhunk://#diff-d715f391f2ffa038c3167bfea1adf741c1f5e39f08349fbbacab780a594146a4R143-R152) [[2]](diffhunk://#diff-d715f391f2ffa038c3167bfea1adf741c1f5e39f08349fbbacab780a594146a4R508-R602)
* Instrumented the Kafka publisher to record publish latency for both single and bulk event publishing, labeled by outcome for better monitoring of event delivery health. [[1]](diffhunk://#diff-6ccbdb1cd67f338f5cf1fdf6b5ff0e083c9176473d1ef663992f50151e239602L77-R84) [[2]](diffhunk://#diff-6ccbdb1cd67f338f5cf1fdf6b5ff0e083c9176473d1ef663992f50151e239602L100-R114)

**Configuration improvements:**

* Introduced a new `MaxConcurrentBatches` setting in `PropagationConfig` (defaulting to 4), allowing operators to control the concurrency of flushed batch pipelines for better throughput and resource utilization. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R355-R366) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R687)

**Cleanup and minor changes:**

* Removed the unused `publishStatus` helper from the API server, as bulk publishing now replaces per-tx publishing.
* Minor import cleanup in the API server handler.