### PR TITLE
[Sync] Update project files from source repository (f7546e4)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,8 +21,7 @@ vendor/
 
 # Binaries for programs and plugins
 dist/
-!dist/linux-amd64/
-!dist/linux-arm64/
+!dist/linux/
 gin-bin
 *.exe
 *.exe~

--- a/.github/env/10-mage-x.env
+++ b/.github/env/10-mage-x.env
@@ -36,7 +36,7 @@
 # ================================================================================================
 
 # MAGE-X version
-MAGE_X_VERSION=v1.20.16
+MAGE_X_VERSION=v1.21.0
 
 # For mage-x development, set to 'true' to use local version instead of downloading from releases
 MAGE_X_USE_LOCAL=false
@@ -71,7 +71,7 @@ MAGE_X_NANCY_VERSION=v1.2.0
 MAGE_X_STATICCHECK_VERSION=2026.1
 MAGE_X_SWAG_VERSION=v1.16.6
 MAGE_X_YAMLFMT_VERSION=v0.21.0
-MAGE_X_BENCHSTAT_VERSION=v0.0.0-20260409210113-8e83ce0f7b1c
+MAGE_X_BENCHSTAT_VERSION=v0.0.0-20260512194132-3cf34090a3db
 MAGE_X_MAGE_VERSION=v1.17.2
 
 # ================================================================================================

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
     </td>
     <td align="left">
        <a href="https://github.com/bsv-blockchain/arcade/graphs/contributors"><img src="https://img.shields.io/github/contributors/bsv-blockchain/arcade?style=flat-square&color=orange" alt="Contributors"></a>
-       <a href="https://github.com/sponsors/bsv-blockchain"><img src="https://img.shields.io/badge/sponsor-BSV-181717.svg?logo=github&style=flat-square" alt="Sponsor"></a>
+       <a href="https://deepwiki.com/bsv-blockchain/arcade"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
     </td>
   </tr>
 </table>

--- a/store/store.go
+++ b/store/store.go
@@ -197,7 +197,7 @@ type Store interface {
 	// slice exists so callers can observe the
 	// arcade_status_transition_age_seconds{from=*,to=MINED} metric without an
 	// extra round-trip.
-	SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) (prevs []*models.TransactionStatus, mined []*models.TransactionStatus, err error)
+	SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) (prevs, mined []*models.TransactionStatus, err error)
 
 	// InsertSubmission creates a new submission record
 	InsertSubmission(ctx context.Context, sub *models.Submission) error


### PR DESCRIPTION
## What Changed

* Updated `.dockerignore` to use `!dist/linux/` instead of separate `!dist/linux-amd64/` and `!dist/linux-arm64/` entries
* Bumped `MAGE_X_VERSION` from `v1.20.16` to `v1.21.0` in `.github/env/10-mage-x.env`
* Updated `MAGE_X_BENCHSTAT_VERSION` from `v0.0.0-20260409210113-8e83ce0f7b1c` to `v0.0.0-20260512194132-3cf34090a3db`

## Why It Was Necessary

* Simplifies the Docker build configuration by consolidating Linux architecture directories under a single pattern
* Updates to the latest mage-x tooling version for improved build capabilities and bug fixes
* Incorporates a newer benchstat version with recent upstream improvements

## Testing Performed

* Verify Docker builds complete successfully with the updated `.dockerignore` pattern
* Confirm CI pipelines execute properly with mage-x v1.21.0
* Validate that the updated benchstat version functions correctly in benchmark workflows

## Impact / Risk

* **Low Risk**: Docker ignore pattern change is more permissive and consolidates existing architecture-specific paths
* **Build Tooling**: mage-x version update may introduce new features or behavior changes in build scripts
* **No Breaking Changes**: These are infrastructure and tooling updates that should not affect runtime behavior

<!-- go-broadcast-metadata
group:
  id: bsv-blockchain-services
  name: bsv-blockchain-services
diff_info:
  staged_repo_available: true
  changed_files_count: 2
  files_with_original_content: 2
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: f7546e444b2dc08837d959e78725f740fd19d613
  target_repo: bsv-blockchain/arcade
  sync_commit: fb0067ffd6da70bdddf9006945fbdee6e7c8231e
  sync_time: 2026-05-14T19:29:06-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 546
  - src: .github/actions
    dest: .github/actions
    files_synced: 0
    files_examined: 18
    files_excluded: 0
    processing_time_ms: 1459
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 278
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 1
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 1071
  - src: .github/scripts
    dest: .github/scripts
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 530
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1489
  - src: .github/workflows
    dest: .github/workflows
    files_synced: 0
    files_examined: 26
    files_excluded: 0
    processing_time_ms: 1247
  - src: .vscode
    dest: .vscode
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 384
performance:
  total_files: 100
-->
