### PR TITLE
Redesign API docs landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,4 @@ config.yaml
 bin/
 
 .mage-cache/
-docs-preview
+/docs-preview

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ config.yaml
 bin/
 
 .mage-cache/
+docs-preview

--- a/cmd/docs-preview/main.go
+++ b/cmd/docs-preview/main.go
@@ -1,0 +1,42 @@
+// Command docs-preview serves the rendered Arcade API docs landing page
+// at http://localhost:8080/ so it can be inspected in a browser without
+// standing up the full API server (Kafka, store, validator, ...).
+//
+// Usage:
+//
+//	go run ./cmd/docs-preview
+//	PORT=9000 go run ./cmd/docs-preview
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/bsv-blockchain/arcade/services/api_server"
+)
+
+func main() {
+	addr := ":8080"
+	if p := os.Getenv("PORT"); p != "" {
+		addr = ":" + p
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := api_server.RenderDocs(w); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+
+	log.Printf("arcade docs preview listening on http://localhost%s/", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/docs-preview/main.go
+++ b/cmd/docs-preview/main.go
@@ -12,15 +12,22 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/bsv-blockchain/arcade/services/api_server"
 )
 
 func main() {
-	addr := ":8080"
+	port := 8080
 	if p := os.Getenv("PORT"); p != "" {
-		addr = ":" + p
+		parsed, err := strconv.Atoi(p)
+		if err != nil || parsed < 1 || parsed > 65535 {
+			log.Fatal("invalid PORT: must be an integer between 1 and 65535")
+		}
+		port = parsed
 	}
+	addr := ":" + strconv.Itoa(port)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -35,8 +42,17 @@ func main() {
 		}
 	})
 
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+
 	log.Printf("arcade docs preview listening on http://localhost%s/", addr)
-	if err := http.ListenAndServe(addr, mux); err != nil {
+	if err := srv.ListenAndServe(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/services/api_server/docs.html
+++ b/services/api_server/docs.html
@@ -496,7 +496,7 @@
     <div class="hero-inner">
       <span class="badge"><span class="dot"></span>Arcade · BSV Transaction Broadcaster</span>
       <h1>The world's most scalable transaction broadcast manager</h1>
-      <p class="tagline">A high-throughput, callback-driven gateway for submitting Bitcoin SV transactions, tracking their lifecycle, and streaming status updates to subscribers in real time.</p>
+      <p class="tagline">A high-throughput, callback-driven gateway for submitting BSV transactions, tracking their lifecycle, and streaming status updates to subscribers in real time.</p>
     </div>
   </header>
 

--- a/services/api_server/docs.html
+++ b/services/api_server/docs.html
@@ -1,0 +1,639 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Arcade — The world's most scalable transaction broadcast manager</title>
+<style>
+  :root {
+    --bg: #ffffff;
+    --bg-elev: #f6f8fa;
+    --bg-code: #f6f8fa;
+    --border: #d0d7de;
+    --border-strong: #afb8c1;
+    --text: #1f2328;
+    --text-muted: #57606a;
+    --text-faint: #818b98;
+    --accent: #0969da;
+    --accent-soft: rgba(9, 105, 218, 0.08);
+    --get: #1a7f37;
+    --get-soft: rgba(26, 127, 55, 0.10);
+    --post: #0969da;
+    --post-soft: rgba(9, 105, 218, 0.10);
+    --shadow: 0 1px 0 rgba(31, 35, 40, 0.04), 0 8px 24px rgba(31, 35, 40, 0.06);
+    --radius: 12px;
+    --radius-sm: 6px;
+    --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+    --font-mono: "JetBrains Mono", "SF Mono", ui-monospace, "Cascadia Code", Menlo, monospace;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1117;
+      --bg-elev: #161b22;
+      --bg-code: #0b1018;
+      --border: #30363d;
+      --border-strong: #484f58;
+      --text: #e6edf3;
+      --text-muted: #8d96a0;
+      --text-faint: #6e7681;
+      --accent: #58a6ff;
+      --accent-soft: rgba(88, 166, 255, 0.12);
+      --get: #3fb950;
+      --get-soft: rgba(63, 185, 80, 0.14);
+      --post: #58a6ff;
+      --post-soft: rgba(88, 166, 255, 0.14);
+      --shadow: 0 1px 0 rgba(0, 0, 0, 0.4), 0 12px 32px rgba(0, 0, 0, 0.45);
+    }
+  }
+
+  html[data-theme="light"] {
+    --bg: #ffffff;
+    --bg-elev: #f6f8fa;
+    --bg-code: #f6f8fa;
+    --border: #d0d7de;
+    --border-strong: #afb8c1;
+    --text: #1f2328;
+    --text-muted: #57606a;
+    --text-faint: #818b98;
+    --accent: #0969da;
+    --accent-soft: rgba(9, 105, 218, 0.08);
+    --get: #1a7f37;
+    --get-soft: rgba(26, 127, 55, 0.10);
+    --post: #0969da;
+    --post-soft: rgba(9, 105, 218, 0.10);
+    --shadow: 0 1px 0 rgba(31, 35, 40, 0.04), 0 8px 24px rgba(31, 35, 40, 0.06);
+  }
+
+  html[data-theme="dark"] {
+    --bg: #0d1117;
+    --bg-elev: #161b22;
+    --bg-code: #0b1018;
+    --border: #30363d;
+    --border-strong: #484f58;
+    --text: #e6edf3;
+    --text-muted: #8d96a0;
+    --text-faint: #6e7681;
+    --accent: #58a6ff;
+    --accent-soft: rgba(88, 166, 255, 0.12);
+    --get: #3fb950;
+    --get-soft: rgba(63, 185, 80, 0.14);
+    --post: #58a6ff;
+    --post-soft: rgba(88, 166, 255, 0.14);
+    --shadow: 0 1px 0 rgba(0, 0, 0, 0.4), 0 12px 32px rgba(0, 0, 0, 0.45);
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: var(--font-sans);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  code, pre, .mono { font-family: var(--font-mono); }
+
+  .hero {
+    position: relative;
+    padding: 96px 24px 72px;
+    text-align: center;
+    background:
+      radial-gradient(ellipse at 50% 0%, var(--accent-soft), transparent 60%),
+      linear-gradient(180deg, var(--bg) 0%, var(--bg) 100%);
+    border-bottom: 1px solid var(--border);
+    overflow: hidden;
+  }
+
+  .hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image:
+      linear-gradient(var(--border) 1px, transparent 1px),
+      linear-gradient(90deg, var(--border) 1px, transparent 1px);
+    background-size: 48px 48px;
+    background-position: -1px -1px;
+    mask-image: radial-gradient(ellipse at 50% 0%, rgba(0, 0, 0, 0.6) 0%, transparent 70%);
+    -webkit-mask-image: radial-gradient(ellipse at 50% 0%, rgba(0, 0, 0, 0.6) 0%, transparent 70%);
+    opacity: 0.35;
+    pointer-events: none;
+  }
+
+  .hero-inner { position: relative; max-width: 880px; margin: 0 auto; }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 14px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-elev);
+    color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .badge .dot {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: var(--get); box-shadow: 0 0 8px var(--get);
+  }
+
+  .hero h1 {
+    margin: 24px 0 16px;
+    font-size: clamp(36px, 6vw, 64px);
+    line-height: 1.05;
+    font-weight: 700;
+    letter-spacing: -0.025em;
+    background: linear-gradient(180deg, var(--text) 0%, var(--text-muted) 140%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+
+  .hero .tagline {
+    margin: 0 auto;
+    max-width: 640px;
+    font-size: 17px;
+    color: var(--text-muted);
+  }
+
+  .theme-toggle {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    width: 40px;
+    height: 40px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--bg-elev);
+    color: var(--text);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+  }
+  .theme-toggle:hover { border-color: var(--border-strong); }
+  .theme-toggle svg { width: 18px; height: 18px; }
+  .theme-toggle .icon-sun { display: none; }
+  html[data-theme="dark"] .theme-toggle .icon-sun { display: block; }
+  html[data-theme="dark"] .theme-toggle .icon-moon { display: none; }
+  @media (prefers-color-scheme: dark) {
+    html:not([data-theme="light"]) .theme-toggle .icon-sun { display: block; }
+    html:not([data-theme="light"]) .theme-toggle .icon-moon { display: none; }
+  }
+
+  main {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 56px 24px 96px;
+  }
+
+  .intro { margin-bottom: 40px; }
+  .intro h2 {
+    margin: 0 0 8px;
+    font-size: 24px;
+    letter-spacing: -0.01em;
+  }
+  .intro p { margin: 0; color: var(--text-muted); }
+
+  .meta-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 12px;
+    margin: 24px 0 8px;
+  }
+  .meta-card {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 14px 16px;
+    background: var(--bg-elev);
+  }
+  .meta-card .label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-faint);
+    font-weight: 600;
+  }
+  .meta-card .value {
+    margin-top: 4px;
+    font-size: 14px;
+    color: var(--text);
+    font-family: var(--font-mono);
+  }
+
+  .routes { display: flex; flex-direction: column; gap: 14px; }
+
+  .route {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-elev);
+    box-shadow: var(--shadow);
+    overflow: hidden;
+    transition: border-color 0.15s ease;
+  }
+  .route:hover { border-color: var(--border-strong); }
+  .route.open { border-color: var(--accent); }
+
+  .route-header {
+    display: grid;
+    grid-template-columns: 80px auto 1fr auto;
+    gap: 16px;
+    align-items: center;
+    padding: 16px 20px;
+    cursor: pointer;
+    user-select: none;
+    background: transparent;
+    border: 0;
+    width: 100%;
+    text-align: left;
+    color: var(--text);
+    font: inherit;
+  }
+  .route-header:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+  }
+
+  .method {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    height: 28px;
+    padding: 0 10px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    font-family: var(--font-mono);
+  }
+  .method-get { color: var(--get); background: var(--get-soft); }
+  .method-post { color: var(--post); background: var(--post-soft); }
+
+  .route-header .path {
+    font-family: var(--font-mono);
+    font-size: 14px;
+    color: var(--text);
+    background: var(--bg-code);
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+  }
+
+  .route-header .summary {
+    color: var(--text-muted);
+    font-size: 14px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .chevron {
+    width: 18px;
+    height: 18px;
+    color: var(--text-faint);
+    transition: transform 0.2s ease;
+  }
+  .route.open .chevron { transform: rotate(180deg); color: var(--accent); }
+
+  .route-body {
+    display: none;
+    padding: 4px 20px 24px;
+    border-top: 1px solid var(--border);
+  }
+  .route.open .route-body { display: block; }
+
+  .route-body .description {
+    margin: 16px 0 0;
+    color: var(--text);
+    font-size: 14.5px;
+    line-height: 1.6;
+  }
+
+  .section { margin-top: 24px; }
+  .section h3 {
+    margin: 0 0 12px;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    font-weight: 600;
+  }
+
+  .headers-table {
+    width: 100%;
+    border-collapse: collapse;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    font-size: 13.5px;
+  }
+  .headers-table th, .headers-table td {
+    text-align: left;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  .headers-table thead th {
+    background: var(--bg-code);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .headers-table tbody tr:last-child td { border-bottom: 0; }
+  .headers-table .hdr-name { font-family: var(--font-mono); color: var(--text); white-space: nowrap; }
+  .headers-table .hdr-desc { color: var(--text-muted); }
+
+  .pill {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    background: var(--bg);
+  }
+  .pill-required { color: #b62324; border-color: rgba(182, 35, 36, 0.35); background: rgba(182, 35, 36, 0.08); }
+  .pill-recommended { color: #9a6700; border-color: rgba(154, 103, 0, 0.35); background: rgba(154, 103, 0, 0.10); }
+  .pill-optional { color: var(--text-muted); }
+
+  @media (prefers-color-scheme: dark) {
+    .pill-required { color: #ff7b72; border-color: rgba(255, 123, 114, 0.35); background: rgba(255, 123, 114, 0.10); }
+    .pill-recommended { color: #d29922; border-color: rgba(210, 153, 34, 0.35); background: rgba(210, 153, 34, 0.10); }
+  }
+  html[data-theme="dark"] .pill-required { color: #ff7b72; border-color: rgba(255, 123, 114, 0.35); background: rgba(255, 123, 114, 0.10); }
+  html[data-theme="dark"] .pill-recommended { color: #d29922; border-color: rgba(210, 153, 34, 0.35); background: rgba(210, 153, 34, 0.10); }
+  html[data-theme="light"] .pill-required { color: #b62324; border-color: rgba(182, 35, 36, 0.35); background: rgba(182, 35, 36, 0.08); }
+  html[data-theme="light"] .pill-recommended { color: #9a6700; border-color: rgba(154, 103, 0, 0.35); background: rgba(154, 103, 0, 0.10); }
+
+  .tabs {
+    display: flex;
+    gap: 4px;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+  }
+  .tab {
+    background: transparent;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    padding: 8px 12px;
+    margin-bottom: -1px;
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-radius: 0;
+  }
+  .tab:hover { color: var(--text); }
+  .tab.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+
+  .tab-panel { display: none; }
+  .tab-panel.active { display: block; }
+  .tab-panel .hint {
+    margin: 0 0 8px;
+    color: var(--text-muted);
+    font-size: 13.5px;
+  }
+
+  pre {
+    margin: 0;
+    padding: 14px 16px;
+    background: var(--bg-code);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    overflow-x: auto;
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--text);
+  }
+  pre code { font-family: var(--font-mono); }
+
+  .response-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0 0 10px;
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+  .response-status .code {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    color: var(--text);
+    padding: 2px 8px;
+    background: var(--bg-code);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
+
+  .note {
+    margin-top: 20px;
+    padding: 12px 14px;
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    border-radius: var(--radius-sm);
+    background: var(--accent-soft);
+    color: var(--text);
+    font-size: 13.5px;
+  }
+  .note strong { color: var(--accent); }
+
+  footer {
+    border-top: 1px solid var(--border);
+    padding: 32px 24px;
+    text-align: center;
+    color: var(--text-faint);
+    font-size: 13px;
+  }
+
+  @media (max-width: 720px) {
+    .hero { padding: 64px 20px 48px; }
+    main { padding: 40px 16px 64px; }
+    .route-header {
+      grid-template-columns: auto 1fr auto;
+      grid-template-areas:
+        "method path chev"
+        "summary summary summary";
+      row-gap: 8px;
+    }
+    .route-header .method { grid-area: method; }
+    .route-header .path { grid-area: path; }
+    .route-header .chevron { grid-area: chev; }
+    .route-header .summary { grid-area: summary; white-space: normal; }
+  }
+</style>
+</head>
+<body>
+  <header class="hero">
+    <button class="theme-toggle" type="button" aria-label="Toggle color theme" onclick="toggleTheme()">
+      <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+    </button>
+    <div class="hero-inner">
+      <span class="badge"><span class="dot"></span>Arcade · BSV Transaction Broadcaster</span>
+      <h1>The world's most scalable transaction broadcast manager</h1>
+      <p class="tagline">A high-throughput, callback-driven gateway for submitting Bitcoin SV transactions, tracking their lifecycle, and streaming status updates to subscribers in real time.</p>
+    </div>
+  </header>
+
+  <main>
+    <section class="intro">
+      <h2>API Reference</h2>
+      <p>Click any endpoint to expand its full request / response contract, headers, and examples. The defaults below cover the everyday submit-and-track flow.</p>
+      <div class="meta-grid">
+        <div class="meta-card">
+          <div class="label">Base URL</div>
+          <div class="value" id="base-url">—</div>
+        </div>
+        <div class="meta-card">
+          <div class="label">Content Encoding</div>
+          <div class="value">UTF-8</div>
+        </div>
+        <div class="meta-card">
+          <div class="label">Status Codes</div>
+          <div class="value">2xx · 4xx · 5xx</div>
+        </div>
+      </div>
+    </section>
+
+    <div class="routes">
+      {{range $i, $r := .Routes}}
+      <article class="route" data-method="{{$r.Method}}">
+        <button class="route-header" type="button" onclick="toggleRoute(this)" aria-expanded="false">
+          <span class="method method-{{$r.Method | lower}}">{{$r.Method}}</span>
+          <code class="path">{{$r.Path}}</code>
+          <span class="summary">{{$r.Summary}}</span>
+          <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+        </button>
+        <div class="route-body">
+          {{if $r.Description}}<p class="description">{{$r.Description}}</p>{{end}}
+
+          {{if $r.Headers}}
+          <section class="section">
+            <h3>Headers</h3>
+            <table class="headers-table">
+              <thead>
+                <tr><th>Header</th><th>Requirement</th><th>Description</th></tr>
+              </thead>
+              <tbody>
+                {{range $r.Headers}}
+                <tr>
+                  <td class="hdr-name">{{.Name}}</td>
+                  <td><span class="pill pill-{{.Requirement | lower}}">{{.Requirement}}</span></td>
+                  <td class="hdr-desc">{{.Description}}</td>
+                </tr>
+                {{end}}
+              </tbody>
+            </table>
+          </section>
+          {{end}}
+
+          {{if $r.RequestBodies}}
+          <section class="section">
+            <h3>Request Body</h3>
+            {{if gt (len $r.RequestBodies) 1}}
+            <div class="tabs" role="tablist" data-tab-group="route-{{$i}}">
+              {{range $j, $b := $r.RequestBodies}}
+              <button type="button" class="tab {{if eq $j 0}}active{{end}}" role="tab" data-tab-target="route-{{$i}}-panel-{{$j}}" onclick="switchTab(this)">{{$b.ContentType}}</button>
+              {{end}}
+            </div>
+            {{end}}
+            {{range $j, $b := $r.RequestBodies}}
+            <div class="tab-panel {{if eq $j 0}}active{{end}}" data-tab-panel="route-{{$i}}-panel-{{$j}}">
+              {{if $b.Description}}<p class="hint">{{$b.Description}}</p>{{end}}
+              {{if $b.Example}}<pre><code>{{$b.Example}}</code></pre>{{end}}
+            </div>
+            {{end}}
+          </section>
+          {{end}}
+
+          <section class="section">
+            <h3>Response</h3>
+            {{if $r.ResponseStatus}}
+            <div class="response-status"><span class="code">{{$r.ResponseStatus}}</span></div>
+            {{end}}
+            {{if $r.ResponseBody}}<pre><code>{{$r.ResponseBody}}</code></pre>{{end}}
+          </section>
+
+          {{if $r.Notes}}
+          <aside class="note"><strong>Note:</strong> {{$r.Notes}}</aside>
+          {{end}}
+        </div>
+      </article>
+      {{end}}
+    </div>
+  </main>
+
+  <footer>
+    Built for scale · Arcade powers BSV transaction broadcasts on the world's most performant ledger.
+  </footer>
+
+  <script>
+    (function () {
+      try {
+        var stored = localStorage.getItem("arcade-theme");
+        if (stored === "light" || stored === "dark") {
+          document.documentElement.setAttribute("data-theme", stored);
+        }
+      } catch (e) { /* localStorage unavailable; fall back to prefers-color-scheme */ }
+      var baseEl = document.getElementById("base-url");
+      if (baseEl) baseEl.textContent = window.location.origin;
+    })();
+
+    function toggleTheme() {
+      var current = document.documentElement.getAttribute("data-theme");
+      if (!current) {
+        var prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+        current = prefersDark ? "dark" : "light";
+      }
+      var next = current === "dark" ? "light" : "dark";
+      document.documentElement.setAttribute("data-theme", next);
+      try { localStorage.setItem("arcade-theme", next); } catch (e) { /* ignore */ }
+    }
+
+    function toggleRoute(btn) {
+      var route = btn.closest(".route");
+      if (!route) return;
+      var willOpen = !route.classList.contains("open");
+      route.classList.toggle("open", willOpen);
+      btn.setAttribute("aria-expanded", willOpen ? "true" : "false");
+    }
+
+    function switchTab(btn) {
+      var group = btn.closest(".tabs");
+      if (!group) return;
+      var target = btn.getAttribute("data-tab-target");
+      group.querySelectorAll(".tab").forEach(function (t) { t.classList.remove("active"); });
+      btn.classList.add("active");
+      var container = group.parentElement;
+      container.querySelectorAll(".tab-panel").forEach(function (p) {
+        p.classList.toggle("active", p.getAttribute("data-tab-panel") === target);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -154,9 +154,17 @@ var docsTmpl = template.Must(template.New("docs").Funcs(template.FuncMap{
 func (s *Server) handleDocs(c *gin.Context) {
 	c.Header("Content-Type", "text/html; charset=utf-8")
 	c.Status(http.StatusOK)
-	if err := docsTmpl.Execute(c.Writer, docsPage{Routes: routeDocs}); err != nil {
+	if err := RenderDocs(c.Writer); err != nil {
 		s.logger.Error("failed to render docs", zap.Error(err))
 	}
+}
+
+// RenderDocs writes the rendered API docs HTML to w. Exported so the
+// docs-preview dev command (cmd/docs-preview) can spin up the same page
+// without standing up the full API server with its Kafka / store / etc
+// dependencies.
+func RenderDocs(w io.Writer) error {
+	return docsTmpl.Execute(w, docsPage{Routes: routeDocs})
 }
 
 // healthResponse is the schema of GET /health. The top-level "status":"ok"

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/subtle"
+	_ "embed"
 	"encoding/hex"
 	"errors"
 	"html/template"
@@ -143,38 +144,8 @@ func newSubmissionID() (string, error) {
 	return hex.EncodeToString(b[:]), nil
 }
 
-const docsTemplate = `<!DOCTYPE html>
-<html>
-<head>
-<meta charset="utf-8">
-<title>Arcade API</title>
-<style>
-  body { font-family: system-ui, sans-serif; max-width: 900px; margin: 40px auto; padding: 0 20px; color: #333; }
-  h1 { border-bottom: 2px solid #eee; padding-bottom: 10px; }
-  table { width: 100%; border-collapse: collapse; margin-top: 20px; }
-  th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid #eee; }
-  th { background: #f8f8f8; font-weight: 600; }
-  code { background: #f4f4f4; padding: 2px 6px; border-radius: 3px; font-size: 0.9em; }
-  .method { font-weight: bold; }
-  .get { color: #2e7d32; }
-  .post { color: #1565c0; }
-</style>
-</head>
-<body>
-<h1>Arcade API</h1>
-<p>Available routes:</p>
-<table>
-  <tr><th>Method</th><th>Path</th><th>Description</th><th>Request</th><th>Response</th></tr>
-  {{range .}}<tr>
-    <td class="method {{.Method | lower}}">{{.Method}}</td>
-    <td><code>{{.Path}}</code></td>
-    <td>{{.Description}}</td>
-    <td>{{.RequestFormat}}</td>
-    <td><code>{{.ResponseFormat}}</code></td>
-  </tr>{{end}}
-</table>
-</body>
-</html>`
+//go:embed docs.html
+var docsTemplate string
 
 var docsTmpl = template.Must(template.New("docs").Funcs(template.FuncMap{
 	"lower": strings.ToLower,
@@ -183,7 +154,7 @@ var docsTmpl = template.Must(template.New("docs").Funcs(template.FuncMap{
 func (s *Server) handleDocs(c *gin.Context) {
 	c.Header("Content-Type", "text/html; charset=utf-8")
 	c.Status(http.StatusOK)
-	if err := docsTmpl.Execute(c.Writer, routeDocs); err != nil {
+	if err := docsTmpl.Execute(c.Writer, docsPage{Routes: routeDocs}); err != nil {
 		s.logger.Error("failed to render docs", zap.Error(err))
 	}
 }

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -351,7 +351,8 @@ func (s *Server) applySeenCallback(c *gin.Context, msg models.CallbackMessage, l
 	prevs, err := s.store.BatchUpdateStatusReturning(ctx, statuses)
 	if err != nil {
 		outcome = "error"
-		logger.Warn("batch update seen status failed",
+		logger.Warn(
+			"batch update seen status failed",
 			zap.String("type", metricLabel),
 			zap.Int("batch_size", len(txids)),
 			zap.Error(err),
@@ -406,7 +407,8 @@ func (s *Server) applySeenCallback(c *gin.Context, msg models.CallbackMessage, l
 			TxIDs:     successful,
 		}
 		if pubErr := s.publisher.PublishBulk(ctx, template); pubErr != nil {
-			logger.Warn("failed to publish bulk seen-status",
+			logger.Warn(
+				"failed to publish bulk seen-status",
 				zap.String("type", metricLabel),
 				zap.Int("count", len(successful)),
 				zap.Error(pubErr),

--- a/services/api_server/routes.go
+++ b/services/api_server/routes.go
@@ -58,7 +58,7 @@ var callbackSubscriptionHeaders = []RouteHeader{
 	{
 		Name:        "X-FullStatusUpdates",
 		Requirement: "Optional",
-		Description: "Set to \"true\" to receive every status transition (RECEIVED, SEEN_ON_NETWORK, SEEN_ON_MULTIPLE_NODES, MINED, IMMUTABLE). Default behaviour delivers only terminal/notable transitions.",
+		Description: "Set to \"true\" to receive every status transition (RECEIVED, SEEN_ON_NETWORK, SEEN_ON_MULTIPLE_NODES, MINED, IMMUTABLE). Default behavior delivers only terminal/notable transitions.",
 	},
 }
 
@@ -92,7 +92,7 @@ var routeDocs = []RouteDoc{
 			},
 		},
 		ResponseStatus: "200 OK",
-		ResponseBody: "{\n  \"txid\": \"<hex>\",\n  \"txStatus\": \"SEEN_ON_NETWORK\",\n  \"status\": \"SEEN_ON_NETWORK\",\n  \"timestamp\": \"2026-05-20T12:00:00Z\",\n  \"blockHash\": \"<hex|null>\",\n  \"blockHeight\": 870123,\n  \"merklePath\": \"<BUMP hex|null>\",\n  \"extraInfo\": \"\",\n  \"competingTxs\": []\n}",
+		ResponseBody:   "{\n  \"txid\": \"<hex>\",\n  \"txStatus\": \"SEEN_ON_NETWORK\",\n  \"status\": \"SEEN_ON_NETWORK\",\n  \"timestamp\": \"2026-05-20T12:00:00Z\",\n  \"blockHash\": \"<hex|null>\",\n  \"blockHeight\": 870123,\n  \"merklePath\": \"<BUMP hex|null>\",\n  \"extraInfo\": \"\",\n  \"competingTxs\": []\n}",
 		Notes:          "Returns 404 if the txid has never been submitted to this Arcade instance.",
 	},
 	{

--- a/services/api_server/routes.go
+++ b/services/api_server/routes.go
@@ -96,6 +96,44 @@ var routeDocs = []RouteDoc{
 		Notes:          "Returns 404 if the txid has never been submitted to this Arcade instance.",
 	},
 	{
+		Method:      "GET",
+		Path:        "/events",
+		Summary:     "Stream status updates over Server-Sent Events · separate service, default port 8082",
+		Description: "Long-lived Server-Sent Events stream that pushes lifecycle updates for every transaction submitted under the supplied callback token. Hosted by Arcade's standalone SSE service — a separate listener from the main API (default port 8082, fronted by its own Kubernetes Service in production). CORS is permissive on this endpoint so browsers can connect directly with the EventSource API.",
+		Headers: []RouteHeader{
+			{
+				Name:        "Accept",
+				Requirement: "Recommended",
+				Description: "text/event-stream",
+			},
+			{
+				Name:        "Last-Event-ID",
+				Requirement: "Optional",
+				Description: "Nanosecond timestamp returned by Arcade as the id of the last event the client received. Triggers a catchup replay of every status update that occurred strictly after this timestamp. Omit on first connect to receive the current persisted status of every txid registered under the token.",
+			},
+		},
+		RequestBodies: []RouteBody{
+			{
+				ContentType: "(query parameters)",
+				Description: "?callbackToken=<token>   the same opaque token sent as X-CallbackToken when submitting transactions. Scopes the stream to that token's transactions.",
+				Example:     "GET /events?callbackToken=my-token",
+			},
+			{
+				ContentType: "(browser, EventSource)",
+				Description: "Open a stream from JavaScript. Last-Event-ID is handled automatically by the browser on reconnect.",
+				Example:     "const es = new EventSource(\n  \"https://arcade.example.com/events?callbackToken=my-token\"\n);\nes.addEventListener(\"status\", (e) => {\n  const status = JSON.parse(e.data);\n  console.log(status.txid, status.txStatus);\n});",
+			},
+			{
+				ContentType: "(cli, curl)",
+				Description: "Tail the stream from a shell.",
+				Example:     "curl -N \"https://arcade.example.com/events?callbackToken=my-token\"",
+			},
+		},
+		ResponseStatus: "200 OK · text/event-stream",
+		ResponseBody:   "id: 1716205200123456789\nevent: status\ndata: {\"txid\":\"<hex>\",\"txStatus\":\"SEEN_ON_NETWORK\",\"timestamp\":\"2026-05-20T12:00:00Z\"}\n\nid: 1716205260987654321\nevent: status\ndata: {\"txid\":\"<hex>\",\"txStatus\":\"MINED\",\"timestamp\":\"2026-05-20T12:01:00Z\"}\n\n: keepalive\n\n",
+		Notes:          "Lines prefixed with ':' are SSE comments — Arcade sends a `: keepalive` comment every 15 seconds to hold the connection open through intermediaries. The 'id' field is the event timestamp in nanoseconds; clients reconnecting after a network blip should send it back as Last-Event-ID. The SSE service exposes its own /health and /ready endpoints on the same port. Possible txStatus values: RECEIVED, SEEN_ON_NETWORK, SEEN_ON_MULTIPLE_NODES, MINED, IMMUTABLE, REJECTED.",
+	},
+	{
 		Method:      "POST",
 		Path:        "/tx",
 		Summary:     "Submit a single transaction",

--- a/services/api_server/routes.go
+++ b/services/api_server/routes.go
@@ -5,77 +5,225 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+// RouteHeader documents a single HTTP request header for the API docs page.
+// Requirement is one of "Required", "Recommended", "Optional" — these map
+// directly onto pill styling in the rendered docs.
+type RouteHeader struct {
+	Name        string
+	Requirement string
+	Description string
+}
+
+// RouteBody documents one acceptable request body shape for a route. Routes
+// with multiple bodies (e.g. POST /tx) render a content-type selector so
+// clients only see one example at a time.
+type RouteBody struct {
+	ContentType string
+	Description string
+	Example     string
+}
+
+// RouteDoc describes a single API endpoint for the rendered docs page.
+// Summary is the short tagline shown in the collapsed card header;
+// Description is the long-form explanation revealed on expand.
 type RouteDoc struct {
 	Method         string
 	Path           string
+	Summary        string
 	Description    string
-	RequestFormat  string
-	ResponseFormat string
+	Headers        []RouteHeader
+	RequestBodies  []RouteBody
+	ResponseStatus string
+	ResponseBody   string
+	Notes          string
+}
+
+// docsPage is the template data root: the route list plus any page-level
+// fields we want to expose later (e.g. version, environment).
+type docsPage struct {
+	Routes []RouteDoc
+}
+
+var callbackSubscriptionHeaders = []RouteHeader{
+	{
+		Name:        "X-CallbackUrl",
+		Requirement: "Optional",
+		Description: "Webhook URL Arcade should POST status events to as this transaction progresses through the network. Must be a public HTTPS endpoint; private/loopback hosts are rejected unless the deployment is configured to allow them.",
+	},
+	{
+		Name:        "X-CallbackToken",
+		Requirement: "Recommended",
+		Description: "Opaque bearer token. Sent on every outbound webhook as Authorization: Bearer <token>, and used to scope Server-Sent Events streams when the client subscribes via SSE.",
+	},
+	{
+		Name:        "X-FullStatusUpdates",
+		Requirement: "Optional",
+		Description: "Set to \"true\" to receive every status transition (RECEIVED, SEEN_ON_NETWORK, SEEN_ON_MULTIPLE_NODES, MINED, IMMUTABLE). Default behaviour delivers only terminal/notable transitions.",
+	},
 }
 
 var routeDocs = []RouteDoc{
 	{
 		Method:         "GET",
 		Path:           "/health",
-		Description:    "Health check",
-		RequestFormat:  "None",
-		ResponseFormat: `{"status": "ok"}`,
+		Summary:        "Liveness probe",
+		Description:    "Reports liveness of the API server process and the upstream Datahub endpoints it depends on. Suitable as a Kubernetes liveness probe.",
+		ResponseStatus: "200 OK",
+		ResponseBody:   "{\n  \"status\": \"ok\",\n  \"datahub_urls\": [\n    { \"url\": \"https://...\", \"healthy\": true }\n  ]\n}",
 	},
 	{
 		Method:         "GET",
 		Path:           "/ready",
-		Description:    "Readiness check",
-		RequestFormat:  "None",
-		ResponseFormat: `{"status": "ready"}`,
+		Summary:        "Readiness probe",
+		Description:    "Indicates that the process has finished start-up and is ready to accept traffic. Suitable as a Kubernetes readiness probe.",
+		ResponseStatus: "200 OK",
+		ResponseBody:   "{\n  \"status\": \"ready\"\n}",
 	},
 	{
-		Method:         "GET",
-		Path:           "/tx/:txid",
-		Description:    "Get transaction status by txid",
-		RequestFormat:  "Path param: txid",
-		ResponseFormat: `{"txid", "txStatus", "status", "timestamp", "blockHash", "blockHeight", "merklePath", "extraInfo", "competingTxs"}`,
+		Method:      "GET",
+		Path:        "/tx/:txid",
+		Summary:     "Look up transaction status by txid",
+		Description: "Returns the current lifecycle state of a previously submitted transaction, including its merkle path once mined.",
+		Headers: []RouteHeader{
+			{
+				Name:        "Accept",
+				Requirement: "Optional",
+				Description: "application/json (default).",
+			},
+		},
+		ResponseStatus: "200 OK",
+		ResponseBody: "{\n  \"txid\": \"<hex>\",\n  \"txStatus\": \"SEEN_ON_NETWORK\",\n  \"status\": \"SEEN_ON_NETWORK\",\n  \"timestamp\": \"2026-05-20T12:00:00Z\",\n  \"blockHash\": \"<hex|null>\",\n  \"blockHeight\": 870123,\n  \"merklePath\": \"<BUMP hex|null>\",\n  \"extraInfo\": \"\",\n  \"competingTxs\": []\n}",
+		Notes:          "Returns 404 if the txid has never been submitted to this Arcade instance.",
 	},
 	{
-		Method:         "POST",
-		Path:           "/tx",
-		Description:    "Submit a transaction",
-		RequestFormat:  "application/octet-stream (raw), text/plain (hex), or JSON {\"rawTx\": \"<hex>\"}",
-		ResponseFormat: `{"status": "submitted"} (202 Accepted)`,
+		Method:      "POST",
+		Path:        "/tx",
+		Summary:     "Submit a single transaction",
+		Description: "Submits one Bitcoin SV transaction for validation, propagation, and lifecycle tracking. Synchronous policy validation runs before the 202 is returned; fee and script checks are delegated to the network. Pick the body encoding that matches your client — raw bytes are the most efficient.",
+		Headers: append(
+			[]RouteHeader{
+				{
+					Name:        "Content-Type",
+					Requirement: "Required",
+					Description: "One of application/octet-stream, text/plain (hex), or application/json — see the request body tabs below.",
+				},
+			},
+			callbackSubscriptionHeaders...,
+		),
+		RequestBodies: []RouteBody{
+			{
+				ContentType: "application/octet-stream",
+				Description: "Raw serialized transaction bytes. Most efficient — no encoding overhead. Supports Extended Format; the canonical txid is derived from the parsed transaction structure, not from a hash of the wire bytes.",
+				Example:     "<binary raw transaction bytes>",
+			},
+			{
+				ContentType: "text/plain",
+				Description: "Hex-encoded serialized transaction as a UTF-8 string. Whitespace is trimmed before decoding.",
+				Example:     "0100000001abc...def00000000",
+			},
+			{
+				ContentType: "application/json",
+				Description: "JSON envelope carrying the hex-encoded transaction. Useful for clients that cannot easily send a raw or text/plain body.",
+				Example:     "{\n  \"rawTx\": \"0100000001abc...def00000000\"\n}",
+			},
+		},
+		ResponseStatus: "202 Accepted",
+		ResponseBody:   "{\n  \"status\": \"submitted\"\n}\n\n// Idempotent re-submit of a txid Arcade has already seen:\n{\n  \"status\": \"already submitted\",\n  \"txid\": \"<hex>\",\n  \"state\": \"SEEN_ON_NETWORK\"\n}",
+		Notes:          "Returns 400 with a reason field on validation failure (also persisted as a terminal REJECTED row, so subscribers see the outcome). 503 with Retry-After: 1 is returned when the broker is under backpressure; the transaction was not queued and a retry is safe.",
 	},
 	{
-		Method:         "POST",
-		Path:           "/txs",
-		Description:    "Submit a batch of transactions",
-		RequestFormat:  "application/octet-stream (concatenated raw tx bytes)",
-		ResponseFormat: `{"submitted": N} (200 OK)`,
+		Method:      "POST",
+		Path:        "/txs",
+		Summary:     "Submit a batch of transactions",
+		Description: "Submits a batch of concatenated raw transactions in a single HTTP request. Each transaction is parsed, validated, dedup-CAS'd, and published as part of one fan-out. Bodies are capped at 256 MiB.",
+		Headers: append(
+			[]RouteHeader{
+				{
+					Name:        "Content-Type",
+					Requirement: "Required",
+					Description: "application/octet-stream — the only encoding accepted for batches.",
+				},
+			},
+			callbackSubscriptionHeaders...,
+		),
+		RequestBodies: []RouteBody{
+			{
+				ContentType: "application/octet-stream",
+				Description: "Concatenated raw transaction bytes. No length prefixes or separators — each transaction is parsed sequentially using the stream parser.",
+				Example:     "<binary raw tx 1><binary raw tx 2>...<binary raw tx N>",
+			},
+		},
+		ResponseStatus: "202 Accepted",
+		ResponseBody:   "{\n  \"submitted\": 42,\n  \"duplicates\": 3,\n  \"total\": 45\n}",
+		Notes:          "If any transaction in the batch fails validation the whole call returns 400 with the offending txid and reason; the failed transaction is recorded as REJECTED.",
 	},
 	{
-		Method:         "POST",
-		Path:           "/api/v1/merkle-service/callback",
-		Description:    "Receive callbacks from Merkle Service",
-		RequestFormat:  "JSON CallbackMessage with type field. Bearer token auth required (Authorization: Bearer <callback_token>).",
-		ResponseFormat: "200 OK",
+		Method:      "POST",
+		Path:        "/api/v1/merkle-service/callback",
+		Summary:     "Internal — receive callbacks from Merkle Service",
+		Description: "Internal endpoint used by the Merkle Service to deliver SEEN_ON_NETWORK, SEEN_ON_MULTIPLE_NODES, STUMP and BLOCK_PROCESSED events. Bearer authentication is mandatory; the deployment refuses to start without a configured callback token.",
+		Headers: []RouteHeader{
+			{
+				Name:        "Authorization",
+				Requirement: "Required",
+				Description: "Bearer <callback_token>. Compared in constant time against the configured token.",
+			},
+			{
+				Name:        "Content-Type",
+				Requirement: "Required",
+				Description: "application/json",
+			},
+		},
+		RequestBodies: []RouteBody{
+			{
+				ContentType: "application/json",
+				Description: "CallbackMessage envelope; the type field discriminates the variant.",
+				Example:     "{\n  \"type\": \"SEEN_ON_NETWORK\",\n  \"txid\": \"<hex>\",\n  \"txids\": [\"<hex>\", \"...\"],\n  \"blockHash\": \"<hex>\",\n  \"subtreeIndex\": 0,\n  \"stump\": \"<base64>\"\n}",
+			},
+		},
+		ResponseStatus: "200 OK",
+		ResponseBody:   "(empty body)",
+		Notes:          "Request bodies are capped (default 16 MiB) to bound memory cost of embedded STUMP blobs; oversize bodies return 413 Payload Too Large.",
 	},
 	{
-		Method:         "GET",
-		Path:           "/api/v1/blocks/processing-status",
-		Description:    "List block processing milestones (header seen, BLOCK_PROCESSED received, compound BUMP built) in descending-height order. Pages via ?limit (default 50, max 200) and ?before-height (cursor = lowest height from previous page).",
-		RequestFormat:  "Optional query: limit, before-height",
-		ResponseFormat: `{"blocks": [{"blockHash", "blockHeight", "headerSeenAt", "processedAt", "bumpBuiltAt", "status", "orphanedAt", "hasBlockProcessed", "hasCompoundBUMP"}], "nextCursor"}`,
+		Method:      "GET",
+		Path:        "/api/v1/blocks/processing-status",
+		Summary:     "List block processing milestones",
+		Description: "Lists block processing milestones (header seen, BLOCK_PROCESSED received, compound BUMP built) in descending-height order. Paginates via a height-cursor; pass the lowest height returned from the previous page as before-height to fetch the next page.",
+		Headers: []RouteHeader{
+			{
+				Name:        "Accept",
+				Requirement: "Optional",
+				Description: "application/json (default).",
+			},
+		},
+		RequestBodies: []RouteBody{
+			{
+				ContentType: "(query parameters)",
+				Description: "?limit=<int>   default 50, max 200.\n?before-height=<int>   cursor — pass the lowest height from the previous page.",
+				Example:     "GET /api/v1/blocks/processing-status?limit=50&before-height=870000",
+			},
+		},
+		ResponseStatus: "200 OK",
+		ResponseBody:   "{\n  \"blocks\": [\n    {\n      \"blockHash\": \"<hex>\",\n      \"blockHeight\": 870123,\n      \"headerSeenAt\": \"2026-05-20T12:00:00Z\",\n      \"processedAt\": \"2026-05-20T12:00:30Z\",\n      \"bumpBuiltAt\": \"2026-05-20T12:00:45Z\",\n      \"status\": \"compound-bump-built\",\n      \"orphanedAt\": null,\n      \"hasBlockProcessed\": true,\n      \"hasCompoundBUMP\": true\n    }\n  ],\n  \"nextCursor\": 870000\n}",
 	},
 	{
 		Method:         "GET",
 		Path:           "/api/v1/blocks/processing-status/:blockHash",
-		Description:    "Get block processing milestones for a single block by hash.",
-		RequestFormat:  "Path param: blockHash",
-		ResponseFormat: `{"blockHash", "blockHeight", "headerSeenAt", "processedAt", "bumpBuiltAt", "status", "orphanedAt", "hasBlockProcessed", "hasCompoundBUMP"}`,
+		Summary:        "Get processing status for a single block",
+		Description:    "Returns the block processing milestones for one block, looked up by block hash.",
+		ResponseStatus: "200 OK",
+		ResponseBody:   "{\n  \"blockHash\": \"<hex>\",\n  \"blockHeight\": 870123,\n  \"headerSeenAt\": \"2026-05-20T12:00:00Z\",\n  \"processedAt\": \"2026-05-20T12:00:30Z\",\n  \"bumpBuiltAt\": \"2026-05-20T12:00:45Z\",\n  \"status\": \"compound-bump-built\",\n  \"orphanedAt\": null,\n  \"hasBlockProcessed\": true,\n  \"hasCompoundBUMP\": true\n}",
+		Notes:          "Returns 404 if Arcade has no record of the block hash.",
 	},
 	{
 		Method:         "POST",
 		Path:           "/api/v1/blocks/:blockHash/reprocess",
-		Description:    "Ask merkle-service to re-emit STUMP + BLOCK_PROCESSED callbacks for the given block hash. Returns 503 if merkle-service is not configured for this deployment.",
-		RequestFormat:  "Path param: blockHash. No body.",
-		ResponseFormat: `{"status": "accepted", "blockHash"} (202 Accepted)`,
+		Summary:        "Ask Merkle Service to re-emit STUMP + BLOCK_PROCESSED",
+		Description:    "Requests that the upstream Merkle Service re-emit STUMP and BLOCK_PROCESSED callbacks for the given block hash. Useful for healing a deployment whose callback stream missed a block.",
+		ResponseStatus: "202 Accepted",
+		ResponseBody:   "{\n  \"status\": \"accepted\",\n  \"blockHash\": \"<hex>\"\n}",
+		Notes:          "Returns 503 if Merkle Service is not configured for this deployment.",
 	},
 }
 

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -825,7 +825,8 @@ func (s *Store) MarkMerkleRegisteredByTxIDs(ctx context.Context, txids []string,
 			if err != nil {
 				continue
 			}
-			records[j] = aero.NewBatchWrite(bwp, key,
+			records[j] = aero.NewBatchWrite(
+				bwp, key,
 				aero.PutOp(aero.NewBin("merkle_registered_at", ts.UnixMilli())),
 			)
 		}


### PR DESCRIPTION
## Summary
- Rebuild the GET / docs page that today renders as a cramped 5-column table at https://arcade-v2-us-1.bsvblockchain.tech/. The text wraps inside cells, all three content-type bodies for `POST /tx` sit side-by-side, and there's no callback-header documentation.
- New hero with the tagline **The world's most scalable transaction broadcast manager**, auto dark/light theme via `prefers-color-scheme` plus a manual toggle (persisted in `localStorage`), and one collapsible card per route — request and response bodies stay hidden until you expand the route.
- `POST /tx` now exposes a content-type tab selector (octet-stream / text/plain / JSON) so only one example is visible at a time.
- Enriched `RouteDoc` with `Headers`, `RequestBodies`, `ResponseStatus`, `ResponseBody`, `Notes`. Documents `X-CallbackUrl`, `X-CallbackToken`, `X-FullStatusUpdates` with Required / Recommended / Optional pills, plus the `Authorization` bearer on the merkle-service callback.
- Template moved out of the Go string literal and into `services/api_server/docs.html`, pulled in via `go:embed`.

## Test plan
- [x] `go build ./services/api_server/...`
- [x] `go test ./services/api_server/... -count=1`
- [x] `go vet ./services/api_server/...`
- [ ] Smoke the rendered page in light + dark system theme on a desktop browser
- [ ] Smoke the rendered page on mobile width (route header collapses to two rows)
- [ ] Verify each route card expands / collapses and that the `POST /tx` tab selector switches between the three body examples