### PR TITLE
Better support regtest environment

### DIFF
--- a/.github/env/10-security.env
+++ b/.github/env/10-security.env
@@ -53,8 +53,12 @@ NANCY_EXCLUDES=CVE-9999-12345,CVE-9999-43210
 # Format: comma-separated CVE IDs (e.g., CVE-9999-12345,CVE-9999-43210)
 # Used by: magex deps:audit (govulncheck)
 # Can also be passed via: magex deps:audit exclude=CVE-9999-12345
-# These are example/fake CVEs - replace with real ones as needed
-MAGE_X_CVE_EXCLUDES=CVE-9999-12345,CVE-9999-43210
+#
+# CVE-2023-26248 (GO-2024-3218 / GHSA-mqr9-hjr8-2m9w): Kademlia DHT content
+# censorship in github.com/libp2p/go-libp2p-kad-dht. Affects all versions;
+# no upstream fix — protocol-level issue in Kademlia. Reaches arcade
+# transitively via services/p2p_client -> go-p2p-message-bus -> kad-dht.
+MAGE_X_CVE_EXCLUDES=CVE-2023-26248
 
 # ================================================================================================
 # 🛠️ SECURITY TOOL VERSIONS

--- a/config/config.go
+++ b/config/config.go
@@ -79,18 +79,17 @@ func ResolveP2PNetwork(network string) (topicNetwork string, bootstrapPeers []st
 
 // ResolveChaintracksNetwork maps a canonical arcade network name to the value
 // go-chaintracks accepts at config.P2P.Network. Its chainmanager.getGenesisHeader
-// only knows "main"/"test"/"teratest"/"teratestnet", so we translate at the
-// boundary instead of leaking upstream naming into the arcade config surface.
-//
-// Regtest is intentionally absent: chaintracks has no regtest genesis header,
-// so validate() force-disables chaintracks_server when network=regtest and this
-// function is never reached with that value.
+// is an exact-match switch over "main"/"test"/"teratest"/"teratestnet"/"regtest",
+// so we translate at the boundary instead of leaking upstream naming into the
+// arcade config surface.
 func ResolveChaintracksNetwork(network string) string {
 	switch network {
 	case NetworkTestnet:
 		return "test"
 	case NetworkTeratestnet:
 		return NetworkTeratestnet
+	case NetworkRegtest:
+		return NetworkRegtest
 	case NetworkMainnet, "":
 		fallthrough
 	default:
@@ -841,10 +840,6 @@ func validate(cfg *Config) error {
 			cfg.Network, NetworkMainnet, NetworkTestnet, NetworkTeratestnet, NetworkRegtest)
 	}
 	if cfg.Network == NetworkRegtest {
-		// chaintracks has no regtest genesis header — initializing it would
-		// crash with ErrUnknownNetwork. Force-disable so operators only need to
-		// set network: regtest without also remembering chaintracks_server.
-		cfg.ChaintracksServer.Enabled = false
 		if cfg.P2P.DatahubDiscovery && len(cfg.P2P.BootstrapPeers) == 0 {
 			return fmt.Errorf("p2p.bootstrap_peers is required when network=regtest and p2p.datahub_discovery=true")
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -686,7 +686,7 @@ func setDefaults() {
 	// 0 keeps New()'s 3×reaper_interval default, so changing reaper_interval
 	// automatically moves the lease TTL unless the operator opts into a fixed value.
 	viper.SetDefault("propagation.lease_ttl_ms", 0)
-	viper.SetDefault("propagation.teranode_max_batch_size", 100)
+	viper.SetDefault("propagation.teranode_max_batch_size", 1024)
 	viper.SetDefault("propagation.max_concurrent_batches", 4)
 	viper.SetDefault("propagation.broadcast_workers", 256)
 	viper.SetDefault("propagation.max_parallel_chunks", 4)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -175,25 +175,25 @@ func TestValidate_RegtestRequiresBootstrapPeers(t *testing.T) {
 	})
 }
 
-// chaintracks has no regtest genesis header, so validate() force-disables the
-// embedded server when network=regtest. Otherwise api-server crashes at init
-// with ErrUnknownNetwork.
-func TestValidate_RegtestAutoDisablesChaintracksServer(t *testing.T) {
+// go-chaintracks now sources the regtest genesis header from go-chaincfg, so
+// validate() no longer force-disables chaintracks_server for regtest. The
+// operator's chaintracks_server.enabled choice must be respected.
+func TestValidate_RegtestPreservesChaintracksServerEnabled(t *testing.T) {
 	cfg := baseValidConfig()
 	cfg.Network = NetworkRegtest
 	cfg.ChaintracksServer.Enabled = true
 	if err := validate(cfg); err != nil {
 		t.Fatalf("unexpected validate error: %v", err)
 	}
-	if cfg.ChaintracksServer.Enabled {
-		t.Error("expected chaintracks_server.enabled to be flipped to false for regtest")
+	if !cfg.ChaintracksServer.Enabled {
+		t.Error("expected chaintracks_server.enabled to remain true for regtest")
 	}
 }
 
 // ResolveChaintracksNetwork translates to go-chaintracks's stricter accepted
 // set. Regressing this is the bug that crashed prod with "unknown network:
 // mainnet" — chainmanager.getGenesisHeader is an exact-match switch over
-// "main"/"test"/"teratest"/"teratestnet".
+// "main"/"test"/"teratest"/"teratestnet"/"regtest".
 func TestResolveChaintracksNetwork(t *testing.T) {
 	cases := []struct {
 		network string
@@ -202,6 +202,7 @@ func TestResolveChaintracksNetwork(t *testing.T) {
 		{NetworkMainnet, "main"},
 		{NetworkTestnet, "test"},
 		{NetworkTeratestnet, NetworkTeratestnet},
+		{NetworkRegtest, NetworkRegtest},
 		{"", "main"},
 	}
 	for _, tc := range cases {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/IBM/sarama v1.49.0
 	github.com/aerospike/aerospike-client-go/v7 v7.10.2
 	github.com/bsv-blockchain/go-bt/v2 v2.6.3
-	github.com/bsv-blockchain/go-chaintracks v1.2.6
+	github.com/bsv-blockchain/go-chaintracks v1.2.7
 	github.com/bsv-blockchain/go-p2p-message-bus v0.1.18
 	github.com/bsv-blockchain/go-sdk v1.2.23
 	github.com/bsv-blockchain/go-teranode-p2p-client v0.2.5
@@ -302,12 +302,12 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.26.0 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260428171046-76f71b9afea0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/bsv-blockchain/go-bt/v2 v2.6.3 h1:LtbJNgXQRFBsI+Iti1X6ccaCRrT43Ps66V5
 github.com/bsv-blockchain/go-bt/v2 v2.6.3/go.mod h1:AkVfArL+yEiA2luWAVdDtwadgzngPsayg45ISwbtvaU=
 github.com/bsv-blockchain/go-chaincfg v1.5.8 h1:zhmi42r71mAqPChhSVggzzxaseTvLqC+zipyL2fAN0g=
 github.com/bsv-blockchain/go-chaincfg v1.5.8/go.mod h1:n/Q8aGScTgydZ2Bsjfic7v8ulHBIpgI0WVyqE5mFMxU=
-github.com/bsv-blockchain/go-chaintracks v1.2.6 h1:2M6Ge3OE2lPcWl57V7X6bkRRrnsojKji31fzDA77Y3A=
-github.com/bsv-blockchain/go-chaintracks v1.2.6/go.mod h1:6C84jel9wRLe8CtmTg1XdMkXVSqt7TN6QfO8+rrE7G8=
+github.com/bsv-blockchain/go-chaintracks v1.2.7 h1:s+Lbs/NSMwfD1/EKaRLIDIr1cf7GJtULUxxyo3vVTyE=
+github.com/bsv-blockchain/go-chaintracks v1.2.7/go.mod h1:l0ch8FkIbRQI8D/uCilooZtVeUdg8sUz86fEu4uX3os=
 github.com/bsv-blockchain/go-lockfree-queue v1.1.3 h1:80OgLGs/oil6Uc8M8y09E9VgmLYy55wLTiX44yNA2Vg=
 github.com/bsv-blockchain/go-lockfree-queue v1.1.3/go.mod h1:1ah9XaAKnXdZwoAAlBZCX+cd3mMRDTlxKIRY6tVsiOM=
 github.com/bsv-blockchain/go-p2p-message-bus v0.1.18 h1:iNkivyy536Z54VY7P/bhNr5jf0z0ivESjUpV2v6ZlM8=
@@ -952,8 +952,8 @@ golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1124,8 +1124,8 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/telemetry v0.0.0-20260428171046-76f71b9afea0 h1:ER5jHKKGuNOscKUx6ChPob4dxC3gP5lkzWXa0JPJWRQ=
 golang.org/x/telemetry v0.0.0-20260428171046-76f71b9afea0/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -226,7 +226,7 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 	}
 	teranodeBatchCap := cfg.Propagation.TeranodeMaxBatchSize
 	if teranodeBatchCap <= 0 {
-		teranodeBatchCap = 100
+		teranodeBatchCap = 1024
 	}
 	maxPending := cfg.Propagation.MaxPending
 	if maxPending <= 0 {


### PR DESCRIPTION
This pull request updates the configuration logic to support running the embedded `chaintracks_server` on the `regtest` network, reflecting upstream improvements in `go-chaintracks`. It also updates dependencies to newer versions. The most important changes are:

**Configuration and Regtest Support:**

* The `validate()` function no longer force-disables `chaintracks_server` when `network=regtest`; the operator's configuration is now respected, since `go-chaintracks` supports the regtest genesis header.
* `ResolveChaintracksNetwork` and its tests now include support for the `regtest` network, mapping it correctly for upstream compatibility. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L82-R92) [[2]](diffhunk://#diff-373f5578b8f362a364b50b0d01919a57da64c128547ca10d49df8ae422237c82R205)

**Testing:**

* The test for regtest configuration was updated to ensure that enabling `chaintracks_server` on `regtest` is preserved and not automatically disabled.

**Dependency Updates:**

* Upgraded `github.com/bsv-blockchain/go-chaintracks` from `v1.2.6` to `v1.2.7`, which adds support for the regtest genesis header.
* Updated indirect dependencies: `golang.org/x/crypto` to `v0.52.0` and `golang.org/x/sys` to `v0.45.0`.
