### PR TITLE
fix(deploy): enable zero-downtime rolling deployments

### DIFF
--- a/cmd/arcade/main.go
+++ b/cmd/arcade/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -53,8 +54,9 @@ func run(cmd *cobra.Command, _ []string) error {
 	svcs := app.BuildServices(deps)
 
 	// Start health server for non-API modes (api-server serves /health on its own port)
+	var hs *services.HealthServer
 	if cfg.Mode != "api-server" {
-		hs := services.NewHealthServer(cfg.Health.Port, logger)
+		hs = services.NewHealthServer(cfg.Health.Port, logger)
 		hs.Start(ctx)
 	}
 
@@ -76,6 +78,10 @@ func run(cmd *cobra.Command, _ []string) error {
 		}(svc)
 	}
 
+	if hs != nil {
+		hs.SetReady(true)
+	}
+
 	select {
 	case sig := <-sigCh:
 		logger.Info("received signal, shutting down", zap.String("signal", sig.String()))
@@ -83,17 +89,33 @@ func run(cmd *cobra.Command, _ []string) error {
 		logger.Error("service error, shutting down", zap.Error(err))
 	}
 
+	// Fail readiness, then wait for kube-proxy to drop the endpoint before draining.
+	if hs != nil {
+		hs.SetReady(false)
+	}
+	time.Sleep(5 * time.Second)
+
 	cancel()
 
-	for _, svc := range svcs {
-		logger.Info("stopping service", zap.String("service", svc.Name()))
-		if err := svc.Stop(); err != nil {
-			logger.Error("error stopping service", zap.String("service", svc.Name()), zap.Error(err))
+	// Bound shutdown so a hung Stop() can't outlive terminationGracePeriodSeconds.
+	done := make(chan struct{})
+	go func() {
+		for _, svc := range svcs {
+			logger.Info("stopping service", zap.String("service", svc.Name()))
+			if err := svc.Stop(); err != nil {
+				logger.Error("error stopping service", zap.String("service", svc.Name()), zap.Error(err))
+			}
 		}
-	}
+		wg.Wait()
+		close(done)
+	}()
 
-	wg.Wait()
-	logger.Info("arcade stopped")
+	select {
+	case <-done:
+		logger.Info("arcade stopped")
+	case <-time.After(30 * time.Second):
+		logger.Warn("shutdown timed out after 30s, forcing exit")
+	}
 	return nil
 }
 

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -17,6 +17,11 @@ metadata:
     app.kubernetes.io/part-of: arcade
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: all
@@ -26,6 +31,7 @@ spec:
         app.kubernetes.io/name: all
         app.kubernetes.io/part-of: arcade
     spec:
+      terminationGracePeriodSeconds: 45
       containers:
         - name: arcade
           image: ghcr.io/bsv-blockchain/arcade:latest
@@ -52,16 +58,21 @@ spec:
               value: "arcade"
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: health
             initialDelaySeconds: 5
-            periodSeconds: 10
+            periodSeconds: 5
+            failureThreshold: 2
           livenessProbe:
             httpGet:
               path: /health
               port: health
-            initialDelaySeconds: 10
+            initialDelaySeconds: 15
             periodSeconds: 30
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
           resources:
             requests:
               cpu: 250m

--- a/services/api_server/server.go
+++ b/services/api_server/server.go
@@ -118,7 +118,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	go func() {
 		<-ctx.Done()
-		_ = s.Stop()
+		_ = s.Stop() //nolint:contextcheck // Stop uses context.Background() so the 15s drain outlives the parent ctx that just fired.
 		recorderWG.Wait()
 	}()
 

--- a/services/api_server/server.go
+++ b/services/api_server/server.go
@@ -233,7 +233,9 @@ func (s *Server) Stop() error {
 	}
 	if s.server != nil {
 		s.logger.Info("shutting down API server")
-		return s.server.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		return s.server.Shutdown(ctx)
 	}
 	return nil
 }

--- a/services/sse/service.go
+++ b/services/sse/service.go
@@ -84,7 +84,7 @@ func (s *Service) Start(ctx context.Context) error {
 
 	go func() {
 		<-ctx.Done()
-		_ = s.Stop()
+		_ = s.Stop() //nolint:contextcheck // Stop uses context.Background() so the 15s drain outlives the parent ctx that just fired.
 	}()
 
 	if err := s.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/services/sse/service.go
+++ b/services/sse/service.go
@@ -97,7 +97,9 @@ func (s *Service) Start(ctx context.Context) error {
 func (s *Service) Stop() error {
 	if s.server != nil {
 		s.logger.Info("shutting down SSE service")
-		return s.server.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		return s.server.Shutdown(ctx)
 	}
 	return nil
 }

--- a/store/batch.go
+++ b/store/batch.go
@@ -19,7 +19,7 @@ import (
 // validator parallelism (which defaults to runtime.NumCPU). Stored as int32
 // atomically so concurrent batch calls observe the latest value without a
 // lock on every read.
-var batchConcurrency int32 = int32(runtime.NumCPU())
+var batchConcurrency = int32(runtime.NumCPU())
 
 // SetBatchConcurrency overrides the parallel-loop helper concurrency at
 // process start. Zero or negative values restore the runtime.NumCPU default.


### PR DESCRIPTION
## What Changed

- **`services/api_server`, `services/sse`**: replace `server.Close()` with
  `server.Shutdown(ctx)` (15s timeout) so in-flight requests drain instead of
  having their connections severed.
- **`cmd/arcade/main.go`**: signal readiness via `HealthServer.SetReady(true)`
  once services are up, and `SetReady(false)` on shutdown so Kubernetes stops
  routing traffic before teardown begins.
- **`cmd/arcade/main.go`**: add a 5s post-readiness drain window and bound
  service teardown to 30s, so a hung `Stop()` cannot outlive the pod's grace
  period.
- **`deploy/all.yaml`**: `RollingUpdate` strategy (`maxUnavailable: 0`,
  `maxSurge: 1`), readiness probe switched from `/health` to `/ready`, a
  `preStop` sleep, and `terminationGracePeriodSeconds: 45`.

## Why It Was Necessary

The all-in-one deployment dropped requests on every rollout, due to three
latent defects:

- HTTP servers closed connections immediately on `Stop()` instead of draining.
- The `/ready` endpoint was effectively dead code — `SetReady(true)` was never
  called, so it always returned 503, and the manifest probed `/health` (always
  200) for readiness, giving Kubernetes no real signal.
- The shutdown path had no deadline; a stuck service could hang past
  `terminationGracePeriodSeconds` and be SIGKILLed mid-flight.

Together these meant new pods could receive traffic before they were serving,
and old pods were killed with requests still in flight.

## Testing Performed

- `go build ./...`, `go vet ./...` — clean.
- `go test ./services/api_server/... ./services/sse/... ./cmd/...` — 92 tests pass.
- `kubectl apply --dry-run=client -f deploy/all.yaml` — valid.
- Local container test (`arcade:local`, standalone mode): sent SIGTERM with a
  request in flight and observed:
  - `/ready` returned 200 after startup (previously always 503), and 503 during drain.
  - The in-flight request completed with a clean HTTP response (no connection reset).
  - A 5s drain window before teardown; process exited 0 via the graceful path
    (not the 30s timeout), well within the 45s grace period.

## Impact / Risk

- **Breaking change**: None — same image, same ports.
- **Behavior**: The readiness probe now targets `/ready`; this manifest must run
  an image that wires `SetReady` (included in this PR). Rolling updates surge one
  pod before draining the old.
- **Risk**: Low. The Kafka, propagation, and webhook shutdown paths were already
  graceful and are unchanged.
- **Note**: SSE connections are long-lived; `Shutdown` waits up to 15s then
  closes them, prompting clients to reconnect to the new pod.

## Notifications

- @mrz1836