### PR TITLE
Take p2p bootstrap peers as default for chaintracks

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -258,6 +258,30 @@ func modeNeedsChaintracks(mode string) bool {
 	}
 }
 
+// resolveChaintracksBootstrapPeers picks the bootstrap peer list passed
+// to chaintracks' embedded p2p client. Precedence, highest first:
+//  1. chaintracks.p2p.msgbus.bootstrappeers — explicit chaintracks-only
+//     override. The upstream msgbus.Config field has no mapstructure
+//     tag, so YAML must use the camelCase-flattened key
+//     ("bootstrappeers", not "bootstrap_peers"); viper matches case-
+//     insensitively but does not translate snake_case.
+//  2. p2p.bootstrap_peers — the well-documented arcade key, shared
+//     with services/p2p_client. Configuring it once at the p2p block
+//     lets both the p2p-client and chaintracks pick it up, which is
+//     what almost every private-network deployment wants.
+//  3. The network-derived default from ResolveP2PNetwork — mainnet/
+//     testnet/teratestnet DNS bootstrap, nil for regtest.
+func resolveChaintracksBootstrapPeers(cfg *config.Config) []string {
+	if len(cfg.Chaintracks.P2P.MsgBus.BootstrapPeers) > 0 {
+		return cfg.Chaintracks.P2P.MsgBus.BootstrapPeers
+	}
+	if len(cfg.P2P.BootstrapPeers) > 0 {
+		return cfg.P2P.BootstrapPeers
+	}
+	_, defaultBootstrap := config.ResolveP2PNetwork(cfg.Network)
+	return defaultBootstrap
+}
+
 // initChaintracks brings up the embedded go-chaintracks instance shared
 // across the process. Caller gates the enabled-ness check; this function
 // always tries to construct and returns an error on failure.
@@ -284,11 +308,8 @@ func initChaintracks(ctx context.Context, cfg *config.Config, logger *zap.Logger
 	// Thread the top-level network into chaintracks' embedded p2p config.
 	// Without this go-chaintracks falls back to "main" silently. Chaintracks
 	// needs the upstream-strict spelling ("main"/"test"/"teratestnet").
-	_, defaultBootstrap := config.ResolveP2PNetwork(cfg.Network)
 	cfg.Chaintracks.P2P.Network = config.ResolveChaintracksNetwork(cfg.Network)
-	if len(cfg.Chaintracks.P2P.MsgBus.BootstrapPeers) == 0 {
-		cfg.Chaintracks.P2P.MsgBus.BootstrapPeers = defaultBootstrap
-	}
+	cfg.Chaintracks.P2P.MsgBus.BootstrapPeers = resolveChaintracksBootstrapPeers(cfg)
 
 	ct, err := cfg.Chaintracks.Initialize(ctx, "arcade", nil)
 	if err != nil {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,6 +1,11 @@
 package app
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bsv-blockchain/arcade/config"
+)
 
 func TestModeNeedsChaintracks(t *testing.T) {
 	cases := []struct {
@@ -22,6 +27,68 @@ func TestModeNeedsChaintracks(t *testing.T) {
 		t.Run(tc.mode, func(t *testing.T) {
 			if got := modeNeedsChaintracks(tc.mode); got != tc.want {
 				t.Errorf("modeNeedsChaintracks(%q) = %v, want %v", tc.mode, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveChaintracksBootstrapPeers(t *testing.T) {
+	const sharedPeer = "/dns4/shared.example/tcp/9905/p2p/12D3KooWShared"
+	const ctSpecific = "/dns4/chaintracks.example/tcp/9905/p2p/12D3KooWCT"
+
+	cases := []struct {
+		name             string
+		network          string
+		p2pPeers         []string
+		chaintracksPeers []string
+		want             []string
+	}{
+		{
+			name:    "testnet default when nothing set",
+			network: config.NetworkTestnet,
+			want:    []string{"/dnsaddr/testnet.bootstrap.teranode.bsvb.tech"},
+		},
+		{
+			name:    "regtest default is nil when nothing set",
+			network: config.NetworkRegtest,
+			want:    nil,
+		},
+		{
+			name:     "p2p.bootstrap_peers feeds chaintracks",
+			network:  config.NetworkRegtest,
+			p2pPeers: []string{sharedPeer},
+			want:     []string{sharedPeer},
+		},
+		{
+			name:             "chaintracks-specific wins over p2p",
+			network:          config.NetworkRegtest,
+			p2pPeers:         []string{sharedPeer},
+			chaintracksPeers: []string{ctSpecific},
+			want:             []string{ctSpecific},
+		},
+		{
+			name:             "chaintracks-specific wins over network default",
+			network:          config.NetworkTestnet,
+			chaintracksPeers: []string{ctSpecific},
+			want:             []string{ctSpecific},
+		},
+		{
+			name:     "p2p list wins over network default",
+			network:  config.NetworkMainnet,
+			p2pPeers: []string{sharedPeer},
+			want:     []string{sharedPeer},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Network: tc.network}
+			cfg.P2P.BootstrapPeers = tc.p2pPeers
+			cfg.Chaintracks.P2P.MsgBus.BootstrapPeers = tc.chaintracksPeers
+
+			got := resolveChaintracksBootstrapPeers(cfg)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("resolveChaintracksBootstrapPeers() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -106,7 +106,8 @@ p2p:
   # listen_port: 9905
   # dht_mode: off              # "server", "client", or "off" (library default is "off")
   # storage_path: ""           # defaults to <top-level storage_path>/p2p; stores p2p_key.hex for stable peer ID
-  # bootstrap_peers: []        # override or extend the built-in defaults
+  # bootstrap_peers: []        # override the built-in defaults; also feeds chaintracks
+                               # (unless chaintracks.p2p.msgbus.bootstrappeers is set explicitly)
   # enable_mdns: false
   # allow_private_urls: false  # accept loopback/RFC1918/link-local URLs from peers
 
@@ -203,3 +204,15 @@ chaintracks_server:
 #   storage_path: ""       # embedded mode only; defaults to <storage_path>/chaintracks
 #   bootstrap_url: ""      # embedded mode only
 #   bootstrap_mode: api    # embedded mode only
+#   # Bootstrap peers default to the network-derived list, falling back to
+#   # p2p.bootstrap_peers when that's set — configure peers once at the p2p
+#   # block and both the p2p-client and chaintracks pick them up. Only set
+#   # the explicit override below when chaintracks needs a different peer
+#   # set than the p2p-client (rare). The upstream msgbus.Config struct has
+#   # no mapstructure tags, so the YAML key is the camelCase-flattened name
+#   # ("bootstrappeers", not "bootstrap_peers") — viper matches case-
+#   # insensitively but does not translate snake_case.
+#   p2p:
+#     msgbus:
+#       bootstrappeers:
+#         - /dns4/peer.example.cluster.local/tcp/9905/p2p/12D3Koo...


### PR DESCRIPTION
This pull request refactors how bootstrap peers are configured for the embedded Chaintracks service, making the logic clearer and more flexible. It introduces a helper function to determine the correct bootstrap peer list, ensures configuration precedence is respected, and adds comprehensive tests and documentation to clarify usage.

Configuration logic improvements:

* Added a new `resolveChaintracksBootstrapPeers` function in `app/app.go` to centralize and clarify the precedence for selecting Chaintracks' bootstrap peers: explicit Chaintracks override, then shared `p2p.bootstrap_peers`, then the network default.
* Updated `initChaintracks` in `app/app.go` to use the new helper for setting `MsgBus.BootstrapPeers`, ensuring the correct precedence is always applied.

Testing enhancements:

* Added a new test `TestResolveChaintracksBootstrapPeers` in `app/app_test.go` to verify the precedence logic for bootstrap peer selection across various configuration scenarios.
* Updated imports in `app/app_test.go` to support the new test.

Documentation updates:

* Improved comments and documentation in `config.example.yaml` to clearly explain the precedence and correct YAML keys for configuring bootstrap peers for both the shared and Chaintracks-specific cases. [[1]](diffhunk://#diff-c7f43f17867c7240c4a26f92d204f0999bba302964d8f9abbc10e9103ffb066aL109-R110) [[2]](diffhunk://#diff-c7f43f17867c7240c4a26f92d204f0999bba302964d8f9abbc10e9103ffb066aR207-R218)