### PR TITLE
Add chained transaction e2e smoke test

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,47 @@
+name: smoke
+
+# ------------------------------------------------------------------------------------
+#  arcade in-process smoke tests
+# ------------------------------------------------------------------------------------
+# Fast, container-free smoke tests for arcade's hot paths. Boots arcade
+# in-process via app.Bootstrap + app.BuildServices against a memory Kafka
+# broker, Pebble store in tmpfs, and an httptest fake teranode — no
+# Docker, no service containers. Each test runs in a few seconds; the
+# whole suite runs in well under a minute.
+#
+# Distinct from .github/workflows/e2e-smoke.yml, which spins up Postgres
+# + Redpanda + merkle-service containers and takes ~10 minutes. This
+# workflow exists so the propagation-ordering smoke (and any future
+# in-process load tests) gate every PR without paying container cost.
+# ------------------------------------------------------------------------------------
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run smoke tests
+        run: go test -tags=smoke -timeout=5m -v ./tests/smoke/...

--- a/tests/smoke/chained_txs_test.go
+++ b/tests/smoke/chained_txs_test.go
@@ -146,12 +146,15 @@ func buildSubmissionBatches(chains [][]*bt.Tx, batchSize int) [][]*bt.Tx {
 }
 
 // postTxs POSTs a batch to arcade's /txs endpoint and returns nil on a
-// 2xx response. The body is concatenated raw tx bytes — same shape
-// production ARC clients use.
+// 2xx response. The body is concatenated raw tx bytes in BSV Extended
+// Format — arcade's validator (post PR #171) calls spv.Verify
+// unconditionally, which needs each input's PreviousTxScript +
+// PreviousTxSatoshis. Those bins live on the wire only in EF; sending
+// standard-format bytes is rejected with "'PreviousTx' not supplied".
 func postTxs(rt *arcadeRuntime, txs []*bt.Tx) error {
 	var body bytes.Buffer
 	for _, tx := range txs {
-		body.Write(tx.Bytes())
+		body.Write(tx.ExtendedBytes())
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/tests/smoke/chained_txs_test.go
+++ b/tests/smoke/chained_txs_test.go
@@ -1,0 +1,302 @@
+//go:build smoke
+
+package smoke
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+)
+
+// TestSmoke_ChainedTxBatchOrdering is the load-bearing smoke test for
+// arcade's propagation dispatcher's parent-child ordering guarantee.
+//
+// It builds a forest of ~10k chained txs (mixed depths 2–10), submits
+// them via concurrent POST /txs calls, then captures every batch arcade
+// sends to a fake teranode and asserts:
+//
+//  1. No batch ever contains both a parent and one of its children.
+//  2. For every parent→child edge, the parent's batch was sent BEFORE
+//     the child's batch.
+//  3. Every tx broadcasts exactly once — no losses, no duplicates.
+//  4. No batch exceeds Propagation.TeranodeMaxBatchSize.
+//  5. The whole pipeline completes within the test window.
+//
+// (1) is the production invariant teranode's /txs endpoint relies on —
+// the dispatcher holds children in heldMsgs until every parent leaves
+// inFlight via ACCEPTED_BY_NETWORK. (2)–(4) are weaker corollaries that
+// also catch interesting regressions: an ordering inversion would
+// surface in (2), a requeue bug in (3), a chunking bug in (4).
+func TestSmoke_ChainedTxBatchOrdering(t *testing.T) {
+	const (
+		totalTxs             = 10_000
+		minDepth             = 2
+		maxDepth             = 10
+		submissionBatchSize  = 100
+		concurrentSubmitters = 8
+		broadcastWaitTimeout = 60 * time.Second
+		teranodeMaxBatchSize = 1024 // matches buildSmokeConfig
+		pipelineWallBudget   = 60 * time.Second
+	)
+
+	recorder := newRecordingTeranode(t)
+	rt := startArcadeSmoke(t, smokeOptions{TeranodeURL: recorder.URL()})
+
+	chains := BuildChains(ChainOpts{
+		TotalTxs: totalTxs,
+		MinDepth: minDepth,
+		MaxDepth: maxDepth,
+		Seed:     1, // deterministic; bump to time.Now() for stochastic runs
+	})
+	t.Logf("built %d chains, %d total txs", len(chains), countTxs(chains))
+
+	// Flatten into submission batches. Each chain lives entirely
+	// inside one submission so the dispatcher's ordering guarantee
+	// holds: a single SendBatch on a single-partition Kafka topic
+	// preserves order within the batch, so parent always reaches the
+	// dispatcher before child. Concurrent submitters race the
+	// submissions themselves, but since chains don't span submissions
+	// and different chains share no edges, no cross-submission race
+	// can produce a child-before-parent on the wire.
+	submissions := buildSubmissionBatches(chains, submissionBatchSize)
+
+	start := time.Now()
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, concurrentSubmitters)
+	for i, batch := range submissions {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, batch []*bt.Tx) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if err := postTxs(rt, batch); err != nil {
+				t.Errorf("submission %d: %v", idx, err)
+			}
+		}(i, batch)
+	}
+	wg.Wait()
+	t.Logf("submitted %d batches in %s", len(submissions), time.Since(start))
+
+	if err := recorder.WaitForTxCount(countTxs(chains), broadcastWaitTimeout); err != nil {
+		t.Fatalf("waiting for broadcast: %v", err)
+	}
+	elapsed := time.Since(start)
+	t.Logf("pipeline drained in %s", elapsed)
+
+	batches := recorder.Snapshot()
+	t.Logf("recorded %d /txs batches", len(batches))
+
+	assertParentChildNeverCohabits(t, batches, chains)
+	assertParentPrecedesChild(t, batches, chains)
+	assertEveryTxBroadcastExactlyOnce(t, batches, chains)
+	assertChunkSize(t, batches, teranodeMaxBatchSize)
+
+	if elapsed > pipelineWallBudget {
+		t.Errorf("pipeline took %s for %d txs (budget %s) — likely a perf regression",
+			elapsed, countTxs(chains), pipelineWallBudget)
+	}
+}
+
+// buildSubmissionBatches groups chains into HTTP submission batches such
+// that each chain lives entirely inside one submission. This is the
+// crucial invariant for the test: a SendBatch on the single-partition
+// Kafka topic preserves order, so parent reaches the dispatcher before
+// child for txs in the same submission. Different chains share no
+// edges, so the order in which submissions arrive at Kafka doesn't
+// matter — there's no cross-submission race that can produce a
+// child-before-parent on the wire.
+//
+// Chain order across submissions is shuffled (deterministically by
+// seed) so concurrent submitters still stress the dispatcher with txs
+// arriving in random order.
+func buildSubmissionBatches(chains [][]*bt.Tx, batchSize int) [][]*bt.Tx {
+	order := make([]int, len(chains))
+	for i := range order {
+		order[i] = i
+	}
+	rng := rand.New(rand.NewSource(42)) //nolint:gosec // deterministic test fixture
+	rng.Shuffle(len(order), func(i, j int) { order[i], order[j] = order[j], order[i] })
+
+	batches := make([][]*bt.Tx, 0)
+	cur := make([]*bt.Tx, 0, batchSize)
+	for _, ci := range order {
+		chain := chains[ci]
+		// If adding the whole chain would push us past batchSize,
+		// flush the current submission first. The chain is then
+		// appended to the new (empty) submission.
+		if len(cur)+len(chain) > batchSize && len(cur) > 0 {
+			batches = append(batches, cur)
+			cur = make([]*bt.Tx, 0, batchSize)
+		}
+		cur = append(cur, chain...)
+	}
+	if len(cur) > 0 {
+		batches = append(batches, cur)
+	}
+	return batches
+}
+
+// postTxs POSTs a batch to arcade's /txs endpoint and returns nil on a
+// 2xx response. The body is concatenated raw tx bytes — same shape
+// production ARC clients use.
+func postTxs(rt *arcadeRuntime, txs []*bt.Tx) error {
+	var body bytes.Buffer
+	for _, tx := range txs {
+		body.Write(tx.Bytes())
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rt.baseURL+"/txs", &body)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("post /txs: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("/txs returned %d: %s", resp.StatusCode, respBody)
+	}
+	return nil
+}
+
+// countTxs sums total tx count across the forest.
+func countTxs(chains [][]*bt.Tx) int {
+	n := 0
+	for _, c := range chains {
+		n += len(c)
+	}
+	return n
+}
+
+// parentEdges builds a map child-txid → parent-txid from the chain
+// forest. Roots (chain[0]) are absent.
+func parentEdges(chains [][]*bt.Tx) map[string]string {
+	parentOf := make(map[string]string)
+	for _, c := range chains {
+		for i := 1; i < len(c); i++ {
+			parentOf[c[i].TxID()] = c[i-1].TxID()
+		}
+	}
+	return parentOf
+}
+
+// assertParentChildNeverCohabits is the load-bearing assertion. For every
+// recorded batch, it builds the txid set S and checks that no tx in S has
+// a parent also in S. A failure prints the offending parent + child + the
+// batch sequence number so the operator can map the regression back to a
+// dispatcher state-machine bug.
+func assertParentChildNeverCohabits(t *testing.T, batches []BatchRecord, chains [][]*bt.Tx) {
+	t.Helper()
+	parentOf := parentEdges(chains)
+	for _, b := range batches {
+		members := make(map[string]struct{}, len(b.TxIDs))
+		for _, id := range b.TxIDs {
+			members[id] = struct{}{}
+		}
+		for _, id := range b.TxIDs {
+			parent, ok := parentOf[id]
+			if !ok {
+				continue
+			}
+			if _, parentInBatch := members[parent]; parentInBatch {
+				t.Fatalf("batch seq=%d contains both parent %s and child %s — dispatcher parent-child invariant violated",
+					b.Seq, parent, id)
+			}
+		}
+	}
+}
+
+// assertParentPrecedesChild verifies that for every parent→child edge,
+// the parent's first-appearance batch precedes the child's first-
+// appearance batch. The dispatcher releases children only after the
+// parent terminalizes (ACCEPTED_BY_NETWORK), which by construction is
+// after the parent's batch has been broadcast.
+func assertParentPrecedesChild(t *testing.T, batches []BatchRecord, chains [][]*bt.Tx) {
+	t.Helper()
+	parentOf := parentEdges(chains)
+	firstBatchOf := make(map[string]int, countTxs(chains))
+	for _, b := range batches {
+		for _, id := range b.TxIDs {
+			if _, exists := firstBatchOf[id]; !exists {
+				firstBatchOf[id] = b.Seq
+			}
+		}
+	}
+	for child, parent := range parentOf {
+		ps, pok := firstBatchOf[parent]
+		cs, cok := firstBatchOf[child]
+		if !pok || !cok {
+			// Coverage gap is reported by assertEveryTxBroadcastExactlyOnce.
+			continue
+		}
+		if ps >= cs {
+			t.Errorf("child %s appeared in batch %d but parent %s appeared in batch %d (parent must precede child)",
+				child, cs, parent, ps)
+		}
+	}
+}
+
+// assertEveryTxBroadcastExactlyOnce checks that every submitted tx is in
+// exactly one batch. Missing txs reveal a loss path (e.g., dispatcher
+// dropping a held tx on release); duplicate txs reveal a requeue bug.
+func assertEveryTxBroadcastExactlyOnce(t *testing.T, batches []BatchRecord, chains [][]*bt.Tx) {
+	t.Helper()
+	count := make(map[string]int, countTxs(chains))
+	for _, b := range batches {
+		for _, id := range b.TxIDs {
+			count[id]++
+		}
+	}
+	missing, duplicated := 0, 0
+	for _, c := range chains {
+		for _, tx := range c {
+			id := tx.TxID()
+			switch count[id] {
+			case 0:
+				missing++
+				if missing <= 5 {
+					t.Errorf("tx %s never broadcast", id)
+				}
+			case 1:
+				// OK
+			default:
+				duplicated++
+				if duplicated <= 5 {
+					t.Errorf("tx %s broadcast %d times (expected 1)", id, count[id])
+				}
+			}
+		}
+	}
+	if missing > 5 {
+		t.Errorf("(plus %d more missing txs, not printed)", missing-5)
+	}
+	if duplicated > 5 {
+		t.Errorf("(plus %d more duplicated txs, not printed)", duplicated-5)
+	}
+}
+
+// assertChunkSize sanity-checks the broadcastInChunks layer: every
+// outbound batch fits the configured TeranodeMaxBatchSize. A regression
+// here would indicate the chunker is no longer slicing.
+func assertChunkSize(t *testing.T, batches []BatchRecord, maxBatchSize int) {
+	t.Helper()
+	for _, b := range batches {
+		if len(b.TxIDs) > maxBatchSize {
+			t.Errorf("batch seq=%d has %d txs, exceeds TeranodeMaxBatchSize=%d",
+				b.Seq, len(b.TxIDs), maxBatchSize)
+		}
+	}
+}

--- a/tests/smoke/chains.go
+++ b/tests/smoke/chains.go
@@ -1,0 +1,127 @@
+//go:build smoke
+
+package smoke
+
+import (
+	"encoding/hex"
+	"math/rand"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+)
+
+// ChainOpts tunes the forest BuildChains produces. Defaults aim at the
+// dispatcher's interesting regime: enough txs to chunk across multiple
+// teranode batches, mixed depths so release cascades have to interleave.
+type ChainOpts struct {
+	// TotalTxs is the approximate total tx count across all chains.
+	// Actual count may be ±MaxDepth-1 because we stop adding chains
+	// once we've crossed the threshold.
+	TotalTxs int
+	// MinDepth and MaxDepth bound per-chain depth (inclusive). Depth=1
+	// is a single tx with no children; depth=2 is parent + one child.
+	MinDepth int
+	MaxDepth int
+	// Seed feeds the RNG. Same seed → same forest; same forest → same
+	// txids, which makes test failures reproducible.
+	Seed int64
+}
+
+// BuildChains returns a forest of validator-passing transactions where
+// each chain is a parent → child → … leaf list. Children spend their
+// parent's single output (index 0) and carry that linkage on their
+// PreviousTxID — which is what handlers.collectInputTXIDs reads to
+// populate the propagation envelope's input_txids field.
+//
+// The returned slice is shaped [chain][tx-in-chain]; flatten as needed.
+func BuildChains(opts ChainOpts) [][]*bt.Tx {
+	if opts.MinDepth < 1 {
+		opts.MinDepth = 1
+	}
+	if opts.MaxDepth < opts.MinDepth {
+		opts.MaxDepth = opts.MinDepth
+	}
+	rng := rand.New(rand.NewSource(opts.Seed)) //nolint:gosec // deterministic test fixture, not crypto
+
+	chains := make([][]*bt.Tx, 0, opts.TotalTxs/((opts.MinDepth+opts.MaxDepth)/2))
+	total := 0
+	for total < opts.TotalTxs {
+		depth := opts.MinDepth + rng.Intn(opts.MaxDepth-opts.MinDepth+1)
+		chain := buildOneChain(depth, uint32(total))
+		chains = append(chains, chain)
+		total += len(chain)
+	}
+	return chains
+}
+
+// buildOneChain builds a depth-element chain. The root carries a synthetic
+// PreviousTxID (the same fake-utxo trick BuildValidatableTxs uses); every
+// subsequent tx's input points at its predecessor's output 0, so the
+// chain hangs off one parent → child edge per level.
+func buildOneChain(depth int, nonceBase uint32) []*bt.Tx {
+	chain := make([]*bt.Tx, 0, depth)
+	// Root: synthetic parent — same trick BuildValidatableTxs uses,
+	// 32 bytes of 0x01 as the previous-output. LockTime varies so each
+	// chain's root hashes differently.
+	const syntheticPrevTxIDHex = "0101010101010101010101010101010101010101010101010101010101010101"
+	syntheticPrev, _ := hex.DecodeString(syntheticPrevTxIDHex)
+	root := newValidatableTx(syntheticPrev, 0, nonceBase)
+	chain = append(chain, root)
+	prev := root
+	for i := 1; i < depth; i++ {
+		// Child spends prev's output 0. PreviousTxID must be the
+		// parent's TxID in chainhash (network) byte order, which is
+		// what TxIDChainHash returns.
+		prevHash := prev.TxIDChainHash()
+		child := newValidatableTx(prevHash[:], 0, nonceBase+uint32(i))
+		chain = append(chain, child)
+		prev = child
+	}
+	return chain
+}
+
+// newValidatableTx mints a single validator-passing tx that spends
+// (prevTxID, prevOutputIdx). LockTime is set to nonce so the txid stays
+// unique across the entire forest — without that, two chains of identical
+// shape would collide.
+func newValidatableTx(prevTxID []byte, prevOutputIdx uint32, nonce uint32) *bt.Tx {
+	tx := bt.NewTx()
+	tx.LockTime = nonce
+	input := &bt.Input{
+		SequenceNumber: 0xffffffff,
+	}
+	_ = input.PreviousTxIDAdd(asChainHash(prevTxID))
+	input.PreviousTxOutIndex = prevOutputIdx
+	input.PreviousTxScript = opTrueScript()
+	input.PreviousTxSatoshis = 1000
+	input.UnlockingScript = emptyScript()
+	tx.Inputs = append(tx.Inputs, input)
+	tx.AddOutput(&bt.Output{
+		Satoshis:      1,
+		LockingScript: opTrueScript(),
+	})
+	return tx
+}
+
+func asChainHash(b []byte) *chainhash.Hash {
+	var h chainhash.Hash
+	copy(h[:], b)
+	return &h
+}
+
+// opTrueScript is a single-byte OP_TRUE script. arcade's validator
+// classifies it as non-data so checkInputs and checkOutputs both accept
+// it without needing real signing or pushdata.
+func opTrueScript() *bscript.Script {
+	s := bscript.Script([]byte{0x51})
+	return &s
+}
+
+// emptyScript is the unlocking-script placeholder for inputs whose real
+// script content is irrelevant — arcade validates with skipScripts=true,
+// so this never gets executed.
+func emptyScript() *bscript.Script {
+	s := bscript.Script(nil)
+	return &s
+}

--- a/tests/smoke/chains.go
+++ b/tests/smoke/chains.go
@@ -34,6 +34,12 @@ type ChainOpts struct {
 // PreviousTxID — which is what handlers.collectInputTXIDs reads to
 // populate the propagation envelope's input_txids field.
 //
+// Callers MUST serialize each tx via tx.ExtendedBytes() before posting
+// to arcade — the validator's spv.Verify call reads the per-input
+// PreviousTxScript + PreviousTxSatoshis the EF wire encoding carries,
+// and rejects standard-format txs with "'PreviousTx' not supplied".
+// See validator/validator.go:ValidateTransaction and PR #171.
+//
 // The returned slice is shaped [chain][tx-in-chain]; flatten as needed.
 func BuildChains(opts ChainOpts) [][]*bt.Tx {
 	if opts.MinDepth < 1 {
@@ -94,8 +100,19 @@ func newValidatableTx(prevTxID []byte, prevOutputIdx uint32, nonce uint32) *bt.T
 	_ = input.PreviousTxIDAdd(asChainHash(prevTxID))
 	input.PreviousTxOutIndex = prevOutputIdx
 	input.PreviousTxScript = opTrueScript()
-	input.PreviousTxSatoshis = 1000
-	input.UnlockingScript = emptyScript()
+	// Generous source-satoshi budget so the fee check (now enabled by
+	// the validator's spv.Verify call) has plenty of headroom: with a
+	// 1-sat output this leaves 9999 sats of fee against a ~62-byte tx,
+	// far above any plausible MinFeePerKB. Mirror the e2e harness's
+	// BuildValidatableTxs which raised this from 1000 → 10000 when
+	// PR #171 tightened the validator.
+	input.PreviousTxSatoshis = 10000
+	// OP_0 (single byte 0x00) is the smallest push-only, non-empty
+	// unlocking script. arcade's pushDataCheck rejects empty unlocking
+	// scripts (ErrEmptyUnlockingScript / ErrUnlockingScriptNotPushOnly),
+	// and OP_0 pushes an empty byte string the OP_TRUE locking script
+	// happily ignores when it pushes 1 — script execution still succeeds.
+	input.UnlockingScript = minimalPushScript()
 	tx.Inputs = append(tx.Inputs, input)
 	tx.AddOutput(&bt.Output{
 		Satoshis:      1,
@@ -118,10 +135,15 @@ func opTrueScript() *bscript.Script {
 	return &s
 }
 
-// emptyScript is the unlocking-script placeholder for inputs whose real
-// script content is irrelevant — arcade validates with skipScripts=true,
-// so this never gets executed.
-func emptyScript() *bscript.Script {
-	s := bscript.Script(nil)
+// minimalPushScript is a single-byte OP_0 (0x00) push, the smallest
+// push-only script that's non-empty. arcade's policy pushDataCheck
+// requires the unlocking script to be push-only, and go-sdk's
+// SatoshisPerKilobyte fee model rejects inputs with an empty unlocking
+// script (ErrNoUnlockingScript) because it can't size the witness.
+// OP_0 pushes an empty byte string onto the stack, which the OP_TRUE
+// locking script ignores when it pushes 1 — script execution still
+// succeeds. Mirrors tests/e2e/harness/txbuilder.go:minimalPushScript.
+func minimalPushScript() *bscript.Script {
+	s := bscript.Script([]byte{0x00})
 	return &s
 }

--- a/tests/smoke/doc.go
+++ b/tests/smoke/doc.go
@@ -1,0 +1,15 @@
+// Package smoke holds fast, in-process integration tests that exercise
+// arcade's hot paths without spinning up Docker containers. The default
+// `go test ./...` run skips this directory; invoke with:
+//
+//	go test -tags=smoke -timeout=2m ./tests/smoke/...
+//
+// Unlike tests/e2e (which boots Postgres + Redpanda + merkle-service in
+// containers), this suite stays in-process: memory Kafka, Pebble in a
+// temp dir, no merkle-service, no libp2p, no chaintracks. Each test
+// stands up a fake teranode (recording_teranode.go) so the assertions
+// can inspect what arcade actually sent on the wire.
+
+//go:build smoke
+
+package smoke

--- a/tests/smoke/harness.go
+++ b/tests/smoke/harness.go
@@ -1,0 +1,241 @@
+//go:build smoke
+
+package smoke
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/bsv-blockchain/arcade/app"
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/services"
+)
+
+// arcadeRuntime is the in-process arcade instance the smoke tests drive.
+// Lifetime is tied to the *testing.T used to build it: t.Cleanup cancels
+// the run context and waits for every service goroutine.
+type arcadeRuntime struct {
+	cfg     *config.Config
+	deps    *app.Deps
+	logger  *zap.Logger
+	baseURL string
+
+	wg      sync.WaitGroup
+	cancel  context.CancelFunc
+	cleanup func()
+}
+
+// smokeOptions threads test-specific wiring into the in-process arcade
+// boot. The smoke suite never talks to a real teranode — TeranodeURL is
+// always a recordingTeranode's httptest URL.
+type smokeOptions struct {
+	// TeranodeURL is the single fake-teranode endpoint arcade sees via
+	// DatahubURLs. Required.
+	TeranodeURL string
+}
+
+// startArcadeSmoke boots arcade in-process via app.Bootstrap +
+// app.BuildServices with the lightest configuration that still exercises
+// the api-server → kafka → propagation → teranode path: memory broker,
+// Pebble in a temp dir, no merkle-service, no chaintracks, no real p2p.
+// t.Cleanup tears everything down deterministically.
+func startArcadeSmoke(t *testing.T, opts smokeOptions) *arcadeRuntime {
+	t.Helper()
+	if opts.TeranodeURL == "" {
+		t.Fatal("smokeOptions.TeranodeURL must be set")
+	}
+
+	port, err := pickFreeTCPPort()
+	if err != nil {
+		t.Fatalf("pick arcade port: %v", err)
+	}
+
+	cfg := buildSmokeConfig(t, port, opts)
+	logger := zaptest.NewLogger(t).Named("arcade-smoke")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	deps, cleanup, err := app.Bootstrap(ctx, cfg, logger)
+	if err != nil {
+		cancel()
+		t.Fatalf("app.Bootstrap: %v", err)
+	}
+
+	svcs := app.BuildServices(deps)
+
+	rt := &arcadeRuntime{
+		cfg:     cfg,
+		deps:    deps,
+		logger:  logger,
+		baseURL: fmt.Sprintf("http://127.0.0.1:%d", port),
+		cancel:  cancel,
+		cleanup: cleanup,
+	}
+
+	for _, svc := range svcs {
+		rt.wg.Add(1)
+		go func(s services.Service) {
+			defer rt.wg.Done()
+			if err := s.Start(ctx); err != nil {
+				logger.Warn("service exited with error",
+					zap.String("service", s.Name()), zap.Error(err))
+			}
+		}(svc)
+	}
+
+	t.Cleanup(func() {
+		rt.cancel()
+		for _, svc := range svcs {
+			_ = svc.Stop()
+		}
+		// Bound the wait: a stuck service shouldn't hang the test.
+		done := make(chan struct{})
+		go func() { rt.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(15 * time.Second):
+			t.Logf("arcade services did not stop within 15s")
+		}
+		rt.cleanup()
+	})
+
+	if err := rt.waitReady(15 * time.Second); err != nil {
+		t.Fatalf("arcade not ready: %v", err)
+	}
+	return rt
+}
+
+// buildSmokeConfig is intentionally close to tests/e2e/harness/arcade.go's
+// buildArcadeConfig: the boot path is the same code, the deltas are the
+// container-touching knobs the smoke suite avoids (merkle-service URL
+// empty, libp2p disabled, single in-process teranode URL).
+func buildSmokeConfig(t *testing.T, port int, opts smokeOptions) *config.Config {
+	t.Helper()
+	pebbleDir := t.TempDir()
+	cfg := &config.Config{
+		Mode:        "all",
+		LogLevel:    "warn",
+		Network:     config.NetworkRegtest,
+		StoragePath: t.TempDir(),
+		// CallbackURL is required by submit handlers' SSRF guard
+		// computation but never actually dialed in this suite.
+		CallbackURL:   fmt.Sprintf("http://127.0.0.1:%d/api/v1/merkle-service/callback", port),
+		CallbackToken: "smoke-callback-token",
+		APIServer: config.API{
+			Host: "127.0.0.1",
+			Port: port,
+		},
+		DatahubURLs: []string{opts.TeranodeURL},
+		MerkleService: config.MerkleServiceConfig{
+			// Empty URL disables merkle registration; propagator
+			// skips the /watch step and proceeds straight to
+			// broadcast — which is the path the test asserts on.
+			URL: "",
+		},
+		Kafka: config.Kafka{
+			Backend:       "memory",
+			ConsumerGroup: "arcade-smoke",
+			MaxRetries:    5,
+			BufferSize:    65536,
+		},
+		Store: config.Store{
+			Backend: "pebble",
+			Pebble: config.Pebble{
+				Path:                  pebbleDir,
+				MemTableSizeMB:        16,
+				L0CompactionThreshold: 4,
+				SyncWrites:            false,
+			},
+		},
+		Health: config.HealthConfig{Port: 0},
+		Webhook: config.WebhookConfig{
+			MaxRetries:              1,
+			ExpirationMinutes:       60,
+			InitialBackoffMs:        500,
+			MaxBackoffMs:            5000,
+			HTTPTimeoutMs:           5000,
+			MaxConcurrentDeliveries: 4,
+		},
+		Callback: config.CallbackConfig{
+			AllowPrivateIPs: true,
+			MaxBodyBytes:    config.DefaultCallbackMaxBodyBytes,
+		},
+		Events: config.EventsConfig{
+			SubscriberBuffer: config.DefaultEventsSubscriberBuffer,
+		},
+		ChaintracksServer: config.ChaintracksServerConfig{Enabled: false},
+		Propagation: config.PropagationConfig{
+			MerkleConcurrency: 2,
+			RetryMaxAttempts:  1,
+			RetryBackoffMs:    50,
+			ReaperIntervalMs:  60000, // effectively disabled for the test window
+			ReaperBatchSize:   100,
+			// Leave at default-ish so the test exercises chunking
+			// when total tx count > batch size.
+			TeranodeMaxBatchSize: 1024,
+			EndpointHealth: config.EndpointHealthConfig{
+				FailureThreshold:    3,
+				ProbeIntervalMs:     30000,
+				ProbeTimeoutMs:      2000,
+				MinHealthyEndpoints: 0,
+				RefreshIntervalMs:   30000,
+			},
+		},
+		BumpBuilder: config.BumpBuilderConfig{
+			GraceWindowMs:        500,
+			DataHubMaxBlockBytes: 1024 * 1024 * 16,
+		},
+		// p2p disabled at every knob: DHT off, no bootstrap peers,
+		// datahub-discovery off (we seeded DatahubURLs statically).
+		P2P: config.P2PConfig{
+			DatahubDiscovery: false,
+			ListenPort:       0,
+			DHTMode:          "off",
+			BootstrapPeers:   nil,
+			StoragePath:      t.TempDir(),
+			AllowPrivateURLs: true,
+		},
+	}
+	return cfg
+}
+
+// waitReady polls the configured api-server port until it accepts a TCP
+// connection or the deadline elapses. Same pattern the e2e harness uses;
+// avoids racing the listener bind.
+func (rt *arcadeRuntime) waitReady(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	dialer := &net.Dialer{Timeout: 250 * time.Millisecond}
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		conn, err := dialer.DialContext(ctx, "tcp", rt.baseURL[len("http://"):])
+		cancel()
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("arcade api-server not reachable within %s: %w", timeout, err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// pickFreeTCPPort asks the kernel for an available port by binding to
+// :0, then closing the listener. Same dance the e2e harness performs;
+// race-prone in principle (another process could grab the port between
+// close and bind) but reliable enough for tests.
+func pickFreeTCPPort() (int, error) {
+	var lc net.ListenConfig
+	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = l.Close() }()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}

--- a/tests/smoke/recording_teranode.go
+++ b/tests/smoke/recording_teranode.go
@@ -1,0 +1,164 @@
+//go:build smoke
+
+package smoke
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+)
+
+// BatchRecord captures one POST that arcade made to the fake teranode
+// /txs endpoint. Seq is monotonic in the order requests were received
+// (assigned under the recorder's mutex), so assertions can compare two
+// batches' relative positions deterministically. ReceivedAt is wall-clock
+// time at the moment the recorder grabbed the lock.
+type BatchRecord struct {
+	Seq        int
+	TxIDs      []string
+	ReceivedAt time.Time
+}
+
+// recordingTeranode is the httptest.Server stand-in arcade points at via
+// DatahubURLs. It accepts both POST /tx (single) and POST /txs (batch)
+// because the propagator can fall back to the single-tx path; either way
+// the body is concatenated raw transaction bytes, which we parse back
+// with the same sdkTx.NewTransactionFromStream call arcade's intake uses
+// — round-trip symmetry guarantees the txids match.
+//
+// Responses are always 200 OK with empty body, matching the existing
+// e2e datahub stub (tests/e2e/harness/datahub.go:179) and satisfying
+// teranode.Client.SubmitTransactions's "all peers returned 200 → accepted"
+// classification.
+type recordingTeranode struct {
+	server *httptest.Server
+
+	mu      sync.Mutex
+	batches []BatchRecord
+	seen    map[string]struct{}
+	cond    *sync.Cond
+}
+
+func newRecordingTeranode(t *testing.T) *recordingTeranode {
+	t.Helper()
+	r := &recordingTeranode{
+		seen: make(map[string]struct{}),
+	}
+	r.cond = sync.NewCond(&r.mu)
+	r.server = httptest.NewServer(http.HandlerFunc(r.handle))
+	t.Cleanup(r.server.Close)
+	return r
+}
+
+// URL returns the base URL the test feeds into arcade as a DatahubURL.
+func (r *recordingTeranode) URL() string {
+	return r.server.URL
+}
+
+func (r *recordingTeranode) handle(w http.ResponseWriter, req *http.Request) {
+	switch {
+	case req.Method == http.MethodPost && (req.URL.Path == "/txs" || req.URL.Path == "/tx"):
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		txids, err := parseBatchTxIDs(body)
+		if err != nil {
+			http.Error(w, "parse batch: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		r.recordBatch(txids)
+		w.WriteHeader(http.StatusOK)
+	default:
+		// Health probes and unknown paths fall through to 200 so the
+		// teranode client's connectivity check doesn't mark the
+		// endpoint unhealthy and stop routing batches at it.
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+// parseBatchTxIDs walks the concatenated-raw-bytes body in the same way
+// handleSubmitTransactions parses inbound batches. Returns the txids in
+// the order they appeared on the wire.
+func parseBatchTxIDs(body []byte) ([]string, error) {
+	var txids []string
+	offset := 0
+	for offset < len(body) {
+		tx, used, err := sdkTx.NewTransactionFromStream(body[offset:])
+		if err != nil {
+			return nil, fmt.Errorf("offset %d (%d txs parsed): %w", offset, len(txids), err)
+		}
+		if used == 0 {
+			break
+		}
+		txids = append(txids, tx.TxID().String())
+		offset += used
+	}
+	return txids, nil
+}
+
+func (r *recordingTeranode) recordBatch(txids []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.batches = append(r.batches, BatchRecord{
+		Seq:        len(r.batches),
+		TxIDs:      append([]string(nil), txids...),
+		ReceivedAt: time.Now(),
+	})
+	for _, id := range txids {
+		r.seen[id] = struct{}{}
+	}
+	r.cond.Broadcast()
+}
+
+// Snapshot returns a deep copy of every batch recorded so far. Safe to
+// call concurrently with active POSTs.
+func (r *recordingTeranode) Snapshot() []BatchRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]BatchRecord, len(r.batches))
+	for i, b := range r.batches {
+		ids := make([]string, len(b.TxIDs))
+		copy(ids, b.TxIDs)
+		out[i] = BatchRecord{Seq: b.Seq, TxIDs: ids, ReceivedAt: b.ReceivedAt}
+	}
+	return out
+}
+
+// WaitForTxCount blocks until at least n distinct txids have been
+// observed across all batches, or timeout elapses. Returns an error
+// reporting the observed count so callers can fail with a useful
+// diagnostic. Uses a sync.Cond + a deadline goroutine instead of a poll
+// loop so a fast pipeline doesn't burn CPU on tight intervals.
+func (r *recordingTeranode) WaitForTxCount(n int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Wake the waiter when the deadline arrives so it can return a
+	// timeout instead of blocking forever on Wait().
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-done:
+		case <-time.After(timeout):
+			r.mu.Lock()
+			r.cond.Broadcast()
+			r.mu.Unlock()
+		}
+	}()
+	for len(r.seen) < n {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("waited %s for %d txs, only saw %d", timeout, n, len(r.seen))
+		}
+		r.cond.Wait()
+	}
+	return nil
+}


### PR DESCRIPTION
This pull request introduces a new "smoke test" suite for the project. The smoke tests are fast, in-process integration tests that exercise arcade's core transaction propagation path without requiring Docker or external services. The suite is designed to run quickly on every PR, catching regressions in transaction ordering, batching, and propagation logic. The main changes include the addition of the smoke test workflow, the test harness and chain-building utilities, and a comprehensive chained transaction propagation test.

**New smoke test infrastructure and workflow:**

* Added `.github/workflows/smoke.yml` to define a fast, container-free smoke test workflow that runs on every PR and push to `main`. This workflow runs the new smoke tests using the `smoke` build tag.

**Smoke test harness and utilities:**

* Introduced `tests/smoke/harness.go` to provide an in-process arcade runtime for tests, including configuration, service management, and lifecycle handling. This enables the tests to start arcade with a memory Kafka broker, Pebble store, and a fake teranode.
* Added `tests/smoke/chains.go` to generate forests of chained transactions with configurable depth and count, ensuring realistic parent-child relationships for propagation tests.

**Smoke test documentation and test case:**

* Added `tests/smoke/doc.go` to document the purpose, usage, and structure of the smoke test suite.
* Implemented `tests/smoke/chained_txs_test.go`, a comprehensive test that submits ~10,000 chained transactions and asserts critical propagation invariants, including parent-child ordering, batching, and deduplication.