### PR TITLE
Accept zero fee transactions if configured

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -241,8 +241,16 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *zap.Logger) (*De
 
 // validatorPolicyFromConfig builds the validator.Policy from cfg.Validator.
 // Returns nil when no operator-facing fields are set so NewValidator's
-// built-in defaults apply unchanged.
+// built-in defaults apply unchanged. When AcceptZeroFee is set, returns
+// a policy with an explicit pointer-to-zero MinFeePerKB so that
+// NewValidator preserves it (its nil-check is on the pointer, not the
+// value) and ValidateTransaction feeds Satoshis=0 to spv.Verify, which
+// accepts any non-negative fee — including fee=0.
 func validatorPolicyFromConfig(cfg *config.Config) *validator.Policy {
+	if cfg.Validator.AcceptZeroFee {
+		zero := uint64(0)
+		return &validator.Policy{MinFeePerKB: &zero}
+	}
 	if cfg.Validator.MinFeePerKB == 0 {
 		return nil
 	}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -32,6 +32,64 @@ func TestModeNeedsChaintracks(t *testing.T) {
 	}
 }
 
+func TestValidatorPolicyFromConfig(t *testing.T) {
+	cases := []struct {
+		name        string
+		acceptZero  bool
+		minFeePerKB uint64
+		wantNil     bool
+		wantFee     uint64
+	}{
+		{
+			name:    "unset config returns nil so NewValidator applies its default",
+			wantNil: true,
+		},
+		{
+			name:        "explicit min_fee_per_kb threads through",
+			minFeePerKB: 50,
+			wantFee:     50,
+		},
+		{
+			name:        "min_fee_per_kb=0 without flag still falls back to default",
+			minFeePerKB: 0,
+			wantNil:     true,
+		},
+		{
+			name:       "accept_zero_fee pins fee to zero",
+			acceptZero: true,
+			wantFee:    0,
+		},
+		{
+			name:        "accept_zero_fee wins over min_fee_per_kb",
+			acceptZero:  true,
+			minFeePerKB: 500,
+			wantFee:     0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Validator.AcceptZeroFee = tc.acceptZero
+			cfg.Validator.MinFeePerKB = tc.minFeePerKB
+
+			got := validatorPolicyFromConfig(cfg)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil policy, got %+v", got)
+				}
+				return
+			}
+			if got == nil || got.MinFeePerKB == nil {
+				t.Fatalf("expected non-nil policy with MinFeePerKB set, got %+v", got)
+			}
+			if *got.MinFeePerKB != tc.wantFee {
+				t.Errorf("MinFeePerKB = %d, want %d", *got.MinFeePerKB, tc.wantFee)
+			}
+		})
+	}
+}
+
 func TestResolveChaintracksBootstrapPeers(t *testing.T) {
 	const sharedPeer = "/dns4/shared.example/tcp/9905/p2p/12D3KooWShared"
 	const ctSpecific = "/dns4/chaintracks.example/tcp/9905/p2p/12D3KooWCT"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -114,6 +114,16 @@ p2p:
 health:
   port: 8081
 
+# Intake-time transaction validator. The default rejects txs whose
+# fee rate is below the BSV miner policy minimum of 100 sat/kB.
+# validator:
+#   min_fee_per_kb: 100
+#   # accept_zero_fee, when true, pins the floor to 0 sat/kB so any tx
+#   # (including fee=0) is accepted at intake. Intended for
+#   # teratestnet/regtest where the upstream Teranode is also configured
+#   # to accept zero-fee txs. Leave false on mainnet and testnet.
+#   # accept_zero_fee: false
+
 # SSRF guard for client-supplied callback URLs. The api-server rejects
 # X-CallbackUrl values whose host is loopback / link-local / RFC1918 /
 # cloud-metadata, and the webhook delivery client refuses to dial those

--- a/config/config.go
+++ b/config/config.go
@@ -601,8 +601,17 @@ const DefaultEventsSubscriberBuffer = 4096
 type ValidatorConfig struct {
 	// MinFeePerKB is the network's minimum acceptable fee rate in
 	// satoshis per kilobyte. Transactions below this rate are rejected
-	// at intake. Zero falls back to DefaultValidatorMinFeePerKB.
+	// at intake. Zero falls back to DefaultValidatorMinFeePerKB unless
+	// AcceptZeroFee is true (which forces a zero floor regardless).
 	MinFeePerKB uint64 `mapstructure:"min_fee_per_kb"`
+
+	// AcceptZeroFee, when true, pins the validator's fee floor to exactly
+	// 0 sat/kB, so any transaction including fee=0 is accepted at intake.
+	// Intended for testnet/regtest/teratestnet environments where the
+	// upstream Teranode is also configured to accept zero-fee txs. Leave
+	// false (default) on mainnet and any environment that should enforce
+	// the production fee floor. Takes precedence over MinFeePerKB.
+	AcceptZeroFee bool `mapstructure:"accept_zero_fee"`
 }
 
 // DefaultValidatorMinFeePerKB is the production fee floor in satoshis

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -45,6 +45,20 @@ func TestMinFeePerKB(t *testing.T) {
 	}
 }
 
+// TestNewValidator_PreservesExplicitZeroFee guards the invariant that
+// validatorPolicyFromConfig (app/app.go) relies on to implement
+// validator.accept_zero_fee: NewValidator's default substitution fires
+// only when the MinFeePerKB *pointer* is nil, so a non-nil pointer to a
+// zero value must be preserved verbatim. If this test ever fails the
+// zero-fee config flag silently regresses to the 100 sat/kB default.
+func TestNewValidator_PreservesExplicitZeroFee(t *testing.T) {
+	zero := uint64(0)
+	v := NewValidator(&Policy{MinFeePerKB: &zero})
+	if v.MinFeePerKB() != 0 {
+		t.Errorf("expected MinFeePerKB=0, got %d", v.MinFeePerKB())
+	}
+}
+
 func TestWrapPolicyError_Malformed(t *testing.T) {
 	v := NewValidator(nil)
 	err := v.wrapPolicyError(ErrNoInputsOrOutputs)


### PR DESCRIPTION
This pull request introduces support for an `accept_zero_fee` configuration option in the transaction validator, allowing the system to accept zero-fee transactions for development and test environments. It also ensures that the validator's fee policy logic correctly handles this new flag and includes comprehensive tests and documentation updates.

**Validator configuration enhancements:**

* Added an `AcceptZeroFee` field to `ValidatorConfig` in `config/config.go`, allowing the fee floor to be explicitly set to zero, overriding the default or configured minimum fee per KB. This is intended for testnet/regtest environments and takes precedence over `MinFeePerKB`.
* Updated the example configuration in `config.example.yaml` with documentation and commented-out settings for the new `accept_zero_fee` flag, clarifying its intended use and interaction with `min_fee_per_kb`.

**Validator logic and testing:**

* Modified the `validatorPolicyFromConfig` function in `app/app.go` to return a policy with an explicit pointer-to-zero `MinFeePerKB` when `AcceptZeroFee` is set, ensuring that the zero-fee policy is preserved and not overridden by defaults.
* Added a comprehensive unit test `TestValidatorPolicyFromConfig` in `app/app_test.go` to verify the correct behavior of the policy selection logic, including precedence and edge cases for both `accept_zero_fee` and `min_fee_per_kb`.
* Introduced a guard test `TestNewValidator_PreservesExplicitZeroFee` in `validator/validator_test.go` to ensure that an explicit zero value for `MinFeePerKB` is preserved by the validator and not replaced by the default, protecting against future regressions.
