### PR TITLE
store/postgres: cache parsed compound BUMPs for merkle-path enrichment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/fergusstrange/embedded-postgres v1.34.0
 	github.com/gin-gonic/gin v1.12.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/moby/moby/api v1.54.2
 	github.com/moby/moby/client v0.4.1
@@ -141,7 +142,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/boxo v0.39.0 // indirect

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/transaction"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -39,9 +40,19 @@ var (
 )
 
 // Store is the Postgres-backed implementation of the store interfaces.
+// bumpCacheSize bounds how many parsed compound BUMPs the store keeps
+// resident for merkle-path enrichment. enrichMerklePath runs on every
+// GetStatus of a mined tx and would otherwise re-fetch and re-parse the
+// whole block BUMP on each call — the dominant heap consumer under
+// sustained status-lookup load. Status lookups cluster on recently-mined
+// blocks, so a small LRU gives a
+// high hit rate while keeping the resident set bounded.
+const bumpCacheSize = 8
+
 type Store struct {
-	pool    *pgxpool.Pool
-	stopEmb func() error
+	pool      *pgxpool.Pool
+	stopEmb   func() error
+	bumpCache *lru.Cache[string, *transaction.MerklePath]
 }
 
 // New connects to Postgres (optionally starting the embedded-postgres process
@@ -78,7 +89,16 @@ func New(ctx context.Context, cfg config.Postgres) (*Store, error) {
 		return nil, fmt.Errorf("connect postgres: %w", err)
 	}
 
-	return &Store{pool: pool, stopEmb: stopEmbedded}, nil
+	bumpCache, err := lru.New[string, *transaction.MerklePath](bumpCacheSize)
+	if err != nil {
+		pool.Close()
+		if stopEmbedded != nil {
+			_ = stopEmbedded()
+		}
+		return nil, fmt.Errorf("init bump cache: %w", err)
+	}
+
+	return &Store{pool: pool, stopEmb: stopEmbedded, bumpCache: bumpCache}, nil
 }
 
 // EnsureIndexes applies the schema. Safe to call repeatedly — every CREATE
@@ -1398,18 +1418,37 @@ func (s *Store) enrichMerklePath(ctx context.Context, status *models.Transaction
 	if status.Status != models.StatusMined && status.Status != models.StatusImmutable {
 		return
 	}
-	_, bumpData, err := s.GetBUMP(ctx, status.BlockHash)
-	if err != nil || len(bumpData) == 0 {
+	compound := s.compoundBUMP(ctx, status.BlockHash)
+	if compound == nil {
 		return
 	}
-	status.MerklePath = extractMinimalPathForTx(bumpData, status.TxID)
+	status.MerklePath = extractMinimalPathForTx(compound, status.TxID)
 }
 
-func extractMinimalPathForTx(bumpData []byte, txid string) []byte {
+// compoundBUMP returns the parsed compound BUMP for a block, caching the
+// parsed form so repeated status lookups for txs in the same block reuse
+// it instead of re-fetching and re-parsing the (potentially large) BUMP.
+// The returned value is shared and must be treated as read-only.
+func (s *Store) compoundBUMP(ctx context.Context, blockHash string) *transaction.MerklePath {
+	if c, ok := s.bumpCache.Get(blockHash); ok {
+		return c
+	}
+	_, bumpData, err := s.GetBUMP(ctx, blockHash)
+	if err != nil || len(bumpData) == 0 {
+		return nil
+	}
 	compound, err := transaction.NewMerklePathFromBinary(bumpData)
 	if err != nil {
 		return nil
 	}
+	s.bumpCache.Add(blockHash, compound)
+	return compound
+}
+
+// extractMinimalPathForTx extracts a per-tx minimal merkle path from an
+// already-parsed compound BUMP. compound is shared via the store's bump
+// cache, so this only reads from it and builds a fresh MerklePath result.
+func extractMinimalPathForTx(compound *transaction.MerklePath, txid string) []byte {
 	txHash, err := chainhash.NewHashFromHex(txid)
 	if err != nil {
 		return nil

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -852,6 +852,11 @@ ON CONFLICT (block_hash) DO UPDATE SET block_height=EXCLUDED.block_height, bump_
 	if err != nil {
 		return fmt.Errorf("insert bump %s: %w", blockHash, err)
 	}
+	// ON CONFLICT DO UPDATE means a rebuild can overwrite bump_data for an
+	// existing block hash (e.g. late STUMP callbacks produce a more complete
+	// sparse compound). Drop any cached parse so the next status lookup
+	// re-fetches the current stored BUMP instead of serving a stale compound.
+	s.bumpCache.Remove(blockHash)
 	return nil
 }
 


### PR DESCRIPTION
  enrichMerklePath runs on every GetStatus of a mined/immutable tx and re-fetched + re-parsed the
  block's entire compound BUMP on each call. NewMerklePathFromBinary on a large block BUMP was the
  dominant heap consumer under sustained status-lookup load (pprof showed ~750MB live in
  NewMerklePathFromReader).

  Cache the parsed compound in a small (8-entry) LRU keyed by block hash. Status lookups cluster on
  recently-mined blocks, so the hit rate is high and the resident set is bounded instead of churning
  per call.

  What Changed

  - Added an 8-entry LRU (bumpCache, *lru.Cache[string, *transaction.MerklePath]) to the Postgres
  Store, initialized in New() and keyed by block hash.
  - Extracted a new compoundBUMP(ctx, blockHash) helper that returns the parsed compound from the
  cache, falling back to GetBUMP + NewMerklePathFromBinary on a miss and populating the cache.
  - enrichMerklePath now calls compoundBUMP instead of re-fetching/re-parsing inline.
  - extractMinimalPathForTx now takes an already-parsed *transaction.MerklePath instead of raw []byte,
  so parsing happens once per block rather than once per lookup. It only reads from the shared compound
  and builds a fresh MerklePath result.
  - Promoted github.com/hashicorp/golang-lru/v2 from an indirect to a direct dependency in go.mod (it
  was already in the module graph; no new transitive dependencies are introduced).

  Why It Was Necessary

  - A given tx's merkle path is stable, but enrichMerklePath re-parsed the block's whole compound BUMP
  from binary on every status lookup for any tx in that block. For large blocks this parse dominates
  allocations and drives heap churn under load — the path stays correct, but it's needlessly expensive.
  - Status lookups naturally cluster on recently-mined blocks, so a tiny LRU captures the overwhelming
  majority of repeat parses while keeping memory bounded. There is no correctness change: the same
  merkle path is produced, just from a parsed-once compound.

  Testing Performed

  - go build ./... and go vet ./... clean.
  - go test -tags postgres ./store/postgres/... passes (runs against embedded-postgres, exercising the
  GetStatus/enrichMerklePath path).
  - Validated on a production-scale Postgres store (~2M mined txs): GET /tx/<mined-txid> returns MINED
  with a byte-for-byte identical merkle path to the pre-change behavior, confirming the cache path
  produces the same output.

  Impact / Risk

  - Scope: Postgres store only; no other store backend or public API is touched. No schema or config
  changes.
  - Correctness: output is unchanged on the read path. The cache is keyed by block hash, and InsertBUMP
  uses ON CONFLICT DO UPDATE, so a rebuild can overwrite an existing block's bump_data (e.g. late STUMP
  callbacks yield a more complete sparse compound). InsertBUMP therefore invalidates the cache entry on
  every successful write, so the next lookup re-fetches and re-parses the current stored BUMP; a miss
  falls back to the prior fetch-and-parse behavior.
  - Concurrency: golang-lru/v2 is internally synchronized, and the cached *MerklePath is treated as
  read-only — extractMinimalPathForTx only reads from it and allocates a fresh result — so it's safe to
  share across concurrent lookups.
  - Memory: strictly bounded to 8 parsed compounds resident, replacing unbounded per-call churn.
  - Backward compatibility: none affected; a cache miss falls back to exactly the previous
  fetch-and-parse behavior.

