### PR TITLE
[bump] Derive corrected subtree-0 root from coinbase BUMP, not over-climbed STUMP

### DIFF
--- a/bump/bump.go
+++ b/bump/bump.go
@@ -273,29 +273,6 @@ func applyCoinbaseToSTUMP(stumpPath *transaction.MerklePath, coinbaseTxID *chain
 	}
 }
 
-// computeCorrectedSubtreeRoot parses a subtree 0 STUMP, replaces the placeholder
-// with the real coinbase txid, and returns the corrected subtree root by climbing
-// from the coinbase leaf via the BRC-74 ComputeRoot algorithm.
-//
-// The prior implementation built only the STUMP's level 0 and called
-// computeMissingHashes, then returned mp.Path[height-1][0].Hash — but that
-// element is the LEFT child of the subtree root, not the root itself
-// (the root is H(mp.Path[height-1][0], mp.Path[height-1][1])). For any
-// pow2-sized subtree ≥2 leaves, the returned value was a mid-level hash, and
-// subtreeHashes[0] was silently corrupted. The compound BUMP merge uses
-// first-seen-wins by (level, offset), so the bug only surfaced when subtree 0
-// was not the first stump processed — i.e., it depended on the Aerospike read
-// order and went undetected until a production block with 6 subtrees was
-// delivered in order [2,4,5,3,0,1].
-func computeCorrectedSubtreeRoot(stumpData []byte, coinbaseTxID *chainhash.Hash) (*chainhash.Hash, error) {
-	stumpPath, err := transaction.NewMerklePathFromBinary(stumpData)
-	if err != nil {
-		return nil, err
-	}
-	applyCoinbaseToSTUMP(stumpPath, coinbaseTxID, nil)
-	return stumpPath.ComputeRoot(coinbaseTxID)
-}
-
 // subtree0RootFromCoinbaseBUMP derives the real subtree-0 root by walking the
 // coinbase BUMP (which is a full block-level path for the coinbase tx) from
 // level 0 up through the subtree-internal levels.
@@ -461,32 +438,33 @@ func ValidateCompoundRoot(compound *transaction.MerklePath, expected *chainhash.
 	return nil
 }
 
-// correctedSubtree0Root returns the corrected root for subtree 0 derived from the
-// real coinbase txid. Prefers the subtree-0 STUMP when present; otherwise falls
-// back to deriving the root from the coinbase BUMP using the height of any
-// available STUMP. Returns nil if no correction is possible.
-func correctedSubtree0Root(stumps []*models.Stump, coinbaseTxID *chainhash.Hash, coinbaseBUMP []byte) *chainhash.Hash {
-	for _, stump := range stumps {
-		if stump.SubtreeIndex != 0 {
-			continue
-		}
-		if root, err := computeCorrectedSubtreeRoot(stump.StumpData, coinbaseTxID); err == nil {
-			return root
-		}
+// correctedSubtree0Root returns the corrected root for subtree 0, derived
+// SOLELY from the coinbase BUMP. The datahub-supplied subtreeHashes[0] is
+// computed against the coinbase placeholder (zero hash), not the real coinbase
+// txid, so it must be recomputed from the real coinbase path.
+//
+// The coinbase BUMP is a full-block-height path: the coinbase txid climbs the
+// block's left spine to the block-header merkle root. Its first internalHeight
+// levels are exactly subtree 0, where internalHeight = (coinbase BUMP height) −
+// (subtree-root layer). We never trust a STUMP's height here: merkle-service
+// sometimes delivers subtree 0's STUMP at full block height, and climbing every
+// level of such a STUMP overshoots the subtree-0 root and lands on the BLOCK
+// root (the 2026-05-30 block-951360 incident). Deriving internalHeight from the
+// coinbase BUMP and folding only that many levels is immune to over-tall STUMPs.
+//
+// Returns nil if there is no coinbase BUMP, it is malformed, or the derived
+// internal height is non-positive.
+func correctedSubtree0Root(coinbaseBUMP []byte, numSubtrees int) *chainhash.Hash {
+	cbPath, err := transaction.NewMerklePathFromBinary(coinbaseBUMP)
+	if err != nil || len(cbPath.Path) == 0 {
 		return nil
 	}
-	// No subtree-0 STUMP delivered (merkle-service didn't track any txid in
-	// subtree 0). Derive the corrected root directly from the coinbase BUMP.
-	// Any STUMP carries a parsable BRC-74 path so internalHeight is the same
-	// across all stumps for the block.
-	if len(stumps) == 0 {
+	subtreeRootLayer := int(math.Ceil(math.Log2(float64(numSubtrees))))
+	internalHeight := len(cbPath.Path) - subtreeRootLayer
+	if internalHeight <= 0 {
 		return nil
 	}
-	mp, err := transaction.NewMerklePathFromBinary(stumps[0].StumpData)
-	if err != nil || len(mp.Path) == 0 {
-		return nil
-	}
-	return subtree0RootFromCoinbaseBUMP(coinbaseBUMP, len(mp.Path))
+	return subtree0RootFromCoinbaseBUMP(coinbaseBUMP, internalHeight)
 }
 
 // BuildCompoundBUMP merges multiple per-subtree BUMPs into a single compound
@@ -526,7 +504,7 @@ func BuildCompoundBUMP(stumps []*models.Stump, subtreeHashes []chainhash.Hash, c
 	// merkle path that climbs through the subtree-root layer's offset-0
 	// sibling (which is most of them) produces the wrong root.
 	if coinbaseTxID != nil && len(subtreeHashes) > 0 {
-		if root := correctedSubtree0Root(stumps, coinbaseTxID, coinbaseBUMP); root != nil {
+		if root := correctedSubtree0Root(coinbaseBUMP, len(subtreeHashes)); root != nil {
 			subtreeHashes[0] = *root
 		}
 	}
@@ -548,18 +526,26 @@ func BuildCompoundBUMP(stumps []*models.Stump, subtreeHashes []chainhash.Hash, c
 		return full, txids, nil
 	}
 
-	// Determine the per-subtree internal height from the first STUMP. All
-	// STUMPs in a block share the same height because Teranode subtrees are
-	// fixed-size within a block; mismatches indicate corrupt input and are
-	// rejected per STUMP below.
 	firstPath, err := transaction.NewMerklePathFromBinary(stumps[0].StumpData)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse first STUMP: %w", err)
 	}
-	internalHeight := len(firstPath.Path)
 	blockHeight := firstPath.BlockHeight
 
 	subtreeRootLayer := int(math.Ceil(math.Log2(float64(numSubtrees))))
+
+	// Determine the per-subtree internal height. The coinbase BUMP is a
+	// full-block-height path, so internalHeight = (coinbase BUMP height) −
+	// (subtree-root layer); this is authoritative and immune to STUMPs that
+	// merkle-service delivers over-tall (the block-951360 incident). Fall back
+	// to the first STUMP's height only when no coinbase BUMP is available.
+	internalHeight := len(firstPath.Path)
+	if cbPath, cbErr := transaction.NewMerklePathFromBinary(coinbaseBUMP); cbErr == nil {
+		if h := len(cbPath.Path) - subtreeRootLayer; h > 0 {
+			internalHeight = h
+		}
+	}
+
 	totalHeight := internalHeight + subtreeRootLayer
 
 	compound := &transaction.MerklePath{
@@ -584,8 +570,13 @@ func BuildCompoundBUMP(stumps []*models.Stump, subtreeHashes []chainhash.Hash, c
 		if err != nil {
 			return nil, nil, fmt.Errorf("parse STUMP for subtree %d: %w", stump.SubtreeIndex, err)
 		}
-		if len(path.Path) != internalHeight {
-			return nil, nil, fmt.Errorf("subtree %d STUMP has internal height %d, expected %d (mixed subtree heights are not supported)", stump.SubtreeIndex, len(path.Path), internalHeight)
+		// A STUMP taller than internalHeight is tolerated: merkle-service
+		// sometimes delivers a STUMP at full block height, and only its first
+		// internalHeight levels are the subtree-internal path — the placement
+		// loop below reads exactly those. A STUMP SHORTER than internalHeight
+		// cannot cover its subtree and is rejected.
+		if len(path.Path) < internalHeight {
+			return nil, nil, fmt.Errorf("subtree %d STUMP has internal height %d, expected at least %d", stump.SubtreeIndex, len(path.Path), internalHeight)
 		}
 		if stump.SubtreeIndex == 0 && coinbaseTxID != nil {
 			applyCoinbaseToSTUMP(path, coinbaseTxID, coinbaseBUMP)

--- a/bump/bump_test.go
+++ b/bump/bump_test.go
@@ -119,12 +119,54 @@ func computeBlockMerkleRoot(subtreeLeaves [][]chainhash.Hash) chainhash.Hash {
 	return computeMerkleRootFromLeaves(subtreeRoots)
 }
 
-// buildCoinbaseBUMP constructs a coinbase BUMP for the coinbase transaction in subtree 0.
-func buildCoinbaseBUMP(subtree0Leaves []chainhash.Hash, coinbaseTxID chainhash.Hash, blockHeight uint32) []byte {
+// buildCoinbaseBUMP constructs a coinbase BUMP for the coinbase transaction in
+// subtree 0. In production the coinbase BUMP is a FULL-BLOCK-height path: the
+// coinbase txid climbs the block's left spine (offset 0 at every level) all the
+// way to the block-header merkle root. We mirror that here by building the
+// subtree-internal path over the real-coinbase leaves and then appending the
+// block-level climb. subtreeRoots are the block's subtree-root-layer leaves
+// (subtree 0 at offset 0); pass nil or a length-≤1 slice for single-subtree
+// blocks, where the subtree root already is the block root.
+func buildCoinbaseBUMP(subtree0Leaves []chainhash.Hash, coinbaseTxID chainhash.Hash, blockHeight uint32, subtreeRoots []chainhash.Hash) []byte {
 	trueLeaves := make([]chainhash.Hash, len(subtree0Leaves))
 	copy(trueLeaves, subtree0Leaves)
 	trueLeaves[0] = coinbaseTxID
-	return buildSTUMP(trueLeaves, 0, blockHeight)
+	base := buildSTUMP(trueLeaves, 0, blockHeight)
+	return appendBlockClimb(base, subtreeRoots)
+}
+
+// appendBlockClimb extends a subtree-internal merkle path (rooted at the
+// subtree-0 root, climbing from offset 0) with the block-level climb up to the
+// block root, producing a full-block-height path. This is the production shape
+// for both the coinbase BUMP and an over-tall subtree-0 STUMP. The appended
+// siblings are taken from the subtree-root merkle tree along the left spine
+// (offset 0 → sibling at offset 1 each level), with Bitcoin-canonical
+// duplicate-on-odd padding. Returns baseBytes unchanged for ≤1 subtree.
+func appendBlockClimb(baseBytes []byte, subtreeRoots []chainhash.Hash) []byte {
+	if len(subtreeRoots) <= 1 {
+		return baseBytes
+	}
+	mp, err := transaction.NewMerklePathFromBinary(baseBytes)
+	if err != nil {
+		panic(err)
+	}
+	tree := buildMerkleTree(subtreeRoots)
+	offset := uint64(0)
+	for level := 0; level < len(tree)-1; level++ {
+		sibOffset := offset ^ 1
+		levelHashes := tree[level]
+		if len(levelHashes)%2 == 1 {
+			levelHashes = append(levelHashes, levelHashes[len(levelHashes)-1])
+		}
+		var elems []*transaction.PathElement
+		if sibOffset < uint64(len(levelHashes)) {
+			h := levelHashes[sibOffset]
+			elems = append(elems, &transaction.PathElement{Offset: sibOffset, Hash: &h})
+		}
+		mp.Path = append(mp.Path, elems)
+		offset = offset >> 1
+	}
+	return mp.Bytes()
 }
 
 // buildFullSTUMP constructs a STUMP containing ALL level-0 hashes for a subtree.
@@ -168,6 +210,18 @@ func buildFullSTUMP(leaves []chainhash.Hash, txOffset uint64, blockHeight uint32
 	}
 
 	return mp.Bytes()
+}
+
+// buildFullBlockSubtree0STUMP constructs a subtree-0 STUMP that merkle-service
+// delivered at FULL BLOCK HEIGHT — the defect shape behind the block-951360
+// incident. The first levels are byte-identical to the normal subtree-internal
+// full STUMP; the block-level climb (subtree-root layer + log2(N) levels) is
+// then appended so the encoded treeHeight = internalHeight + ceil(log2(N)).
+// Climbing every level of such a STUMP overshoots the subtree-0 root and lands
+// on the block root.
+func buildFullBlockSubtree0STUMP(leaves []chainhash.Hash, txOffset uint64, blockHeight uint32, subtreeRoots []chainhash.Hash) []byte {
+	base := buildFullSTUMP(leaves, txOffset, blockHeight)
+	return appendBlockClimb(base, subtreeRoots)
 }
 
 // multiSubtreeTestSetup creates a block with numSubtrees subtrees of subtreeSize txs each.
@@ -511,7 +565,7 @@ func TestAssembleBUMP_Subtree0_CoinbaseReplacement(t *testing.T) {
 
 	trueBlockRoot := computeBlockMerkleRoot([][]chainhash.Hash{trueSubtree0Leaves, subtree1Leaves})
 
-	cbBUMP := buildCoinbaseBUMP(subtree0Leaves, coinbaseTxID, 950000)
+	cbBUMP := buildCoinbaseBUMP(subtree0Leaves, coinbaseTxID, 950000, subtreeHashes)
 	result, _, err := AssembleBUMP(stump, 0, subtreeHashes, cbBUMP)
 	if err != nil {
 		t.Fatalf("AssembleBUMP failed: %v", err)
@@ -555,7 +609,7 @@ func TestAssembleBUMP_Subtree0_CoinbaseReplacement_Offset3(t *testing.T) {
 
 	trueBlockRoot := computeBlockMerkleRoot([][]chainhash.Hash{trueSubtree0Leaves, subtree1Leaves})
 
-	cbBUMP := buildCoinbaseBUMP(subtree0Leaves, coinbaseTxID, 950001)
+	cbBUMP := buildCoinbaseBUMP(subtree0Leaves, coinbaseTxID, 950001, subtreeHashes)
 	result, _, err := AssembleBUMP(stump, 0, subtreeHashes, cbBUMP)
 	if err != nil {
 		t.Fatalf("AssembleBUMP failed: %v", err)
@@ -652,7 +706,7 @@ func TestAssembleBUMP_4Subtrees_Subtree0_CoinbaseReplacement(t *testing.T) {
 
 	trueBlockRoot := computeBlockMerkleRoot(trueAllLeaves)
 
-	cbBUMP := buildCoinbaseBUMP(allLeaves[0], coinbaseTxID, 950003)
+	cbBUMP := buildCoinbaseBUMP(allLeaves[0], coinbaseTxID, 950003, subtreeHashes)
 	result, _, err := AssembleBUMP(stump, 0, subtreeHashes, cbBUMP)
 	if err != nil {
 		t.Fatalf("AssembleBUMP failed: %v", err)
@@ -850,7 +904,7 @@ func TestBuildCompoundBUMP_CoinbaseReplacement(t *testing.T) {
 		{BlockHash: "block1", SubtreeIndex: 1, StumpData: stump1},
 	}
 
-	cbBUMP := buildCoinbaseBUMP(allLeaves[0], coinbaseTxID, 1000000)
+	cbBUMP := buildCoinbaseBUMP(allLeaves[0], coinbaseTxID, 1000000, subtreeHashes)
 
 	compound, txids, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP)
 	if err != nil {
@@ -919,7 +973,7 @@ func TestBuildCompoundBUMP_CoinbaseReplacement_SingleSubtree(t *testing.T) {
 		{BlockHash: "block2", SubtreeIndex: 0, StumpData: stump0},
 	}
 
-	cbBUMP := buildCoinbaseBUMP(allLeaves[0], coinbaseTxID, 1000001)
+	cbBUMP := buildCoinbaseBUMP(allLeaves[0], coinbaseTxID, 1000001, subtreeHashes)
 
 	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP)
 	if err != nil {
@@ -1431,7 +1485,7 @@ func TestBuildCompoundBUMP_NonPow2_WithCoinbase(t *testing.T) {
 		subtreeSize = 4
 	)
 	allLeaves, trueAllLeaves, subtreeHashes, coinbaseTxID, trueBlockRoot := setupCoinbaseBlock(numSubtrees, subtreeSize)
-	cbBUMP := buildCoinbaseBUMP(trueAllLeaves[0], coinbaseTxID, 700000)
+	cbBUMP := buildCoinbaseBUMP(trueAllLeaves[0], coinbaseTxID, 700000, subtreeHashes)
 
 	stumps := make([]*models.Stump, numSubtrees)
 	for s := 0; s < numSubtrees; s++ {
@@ -1532,7 +1586,7 @@ func TestBuildCompoundBUMP_CoinbaseReplacement_OrderIndependence(t *testing.T) {
 		subtreeSize = 8 // pow2 ≥2 is sufficient to reproduce; larger only adds runtime
 	)
 	allLeaves, trueAllLeaves, subtreeHashes, coinbaseTxID, trueBlockRoot := setupCoinbaseBlock(numSubtrees, subtreeSize)
-	cbBUMP := buildCoinbaseBUMP(trueAllLeaves[0], coinbaseTxID, 700000)
+	cbBUMP := buildCoinbaseBUMP(trueAllLeaves[0], coinbaseTxID, 700000, subtreeHashes)
 
 	orderings := [][]int{
 		{0, 1, 2, 3, 4, 5}, // baseline — this was the only order the old code happened to handle
@@ -1592,22 +1646,105 @@ func TestBuildCompoundBUMP_CoinbaseReplacement_OrderIndependence(t *testing.T) {
 // coinbase), the returned hash must equal the merkle root of the same leaves
 // with offset 0 replaced by the real coinbase txid — NOT the left child of
 // that root. Covers multiple subtree heights so no pow2 case regresses.
-func TestComputeCorrectedSubtreeRoot_ReturnsRealRoot(t *testing.T) {
+func TestSubtree0RootFromCoinbaseBUMP_ReturnsRealRoot(t *testing.T) {
 	sizes := []int{2, 4, 8, 16, 32, 1024}
 	for _, size := range sizes {
 		t.Run(fmt.Sprintf("subtreeSize_%d", size), func(t *testing.T) {
 			allLeaves, trueAllLeaves, _, coinbaseTxID, _ := setupCoinbaseBlock(1, size)
-			stumpData := buildFullSTUMP(allLeaves[0], 0, 700000)
+			internalHeight := int(math.Ceil(math.Log2(float64(size))))
+			cbBUMP := buildCoinbaseBUMP(allLeaves[0], coinbaseTxID, 700000, nil)
 
-			got, err := computeCorrectedSubtreeRoot(stumpData, &coinbaseTxID)
-			if err != nil {
-				t.Fatalf("computeCorrectedSubtreeRoot failed: %v", err)
+			got := subtree0RootFromCoinbaseBUMP(cbBUMP, internalHeight)
+			if got == nil {
+				t.Fatalf("size=%d: subtree0RootFromCoinbaseBUMP returned nil", size)
 			}
 			want := computeMerkleRootFromLeaves(trueAllLeaves[0])
 			if *got != want {
 				t.Fatalf("size=%d: got %s, want %s (actual subtree root)", size, got, want)
 			}
 		})
+	}
+}
+
+// TestCorrectedSubtree0Root_Block951360_FromCoinbaseBUMP pins the over-climb fix
+// at the incident shape: a 3-subtree block whose coinbase BUMP spans full block
+// height. correctedSubtree0Root must fold only the subtree-internal levels and
+// return the REAL subtree-0 root — never the block root (the value the old
+// unbounded climb produced and which poisoned subtreeHashes[0]).
+func TestCorrectedSubtree0Root_Block951360_FromCoinbaseBUMP(t *testing.T) {
+	const (
+		numSubtrees = 3
+		subtreeSize = 8
+	)
+	_, trueAllLeaves, subtreeHashes, coinbaseTxID, trueBlockRoot := setupCoinbaseBlock(numSubtrees, subtreeSize)
+	cbBUMP := buildCoinbaseBUMP(trueAllLeaves[0], coinbaseTxID, 951360, subtreeHashes)
+
+	got := correctedSubtree0Root(cbBUMP, numSubtrees)
+	if got == nil {
+		t.Fatal("correctedSubtree0Root returned nil")
+	}
+	want := computeMerkleRootFromLeaves(trueAllLeaves[0])
+	if *got != want {
+		t.Fatalf("corrected subtree-0 root = %s, want real subtree root %s", got, want)
+	}
+	if *got == trueBlockRoot {
+		t.Fatal("corrected subtree-0 root equals the BLOCK root — over-climb regression")
+	}
+}
+
+// TestBuildCompoundBUMP_FullBlockSubtree0STUMP_Block951360 reproduces the
+// 2026-05-30 mainnet block-951360 incident: merkle-service delivered subtree
+// 0's STUMP at FULL BLOCK HEIGHT (treeHeight 17 on-chain; internalHeight +
+// ceil(log2(N)) here) rather than the subtree-internal height. The old
+// correction climbed every level of that STUMP, overshooting the subtree-0
+// root and landing on the BLOCK root, which it then wrote into
+// subtreeHashes[0]; the placement step also keyed internal height off the raw
+// STUMP height. Either way the compound BUMP's root diverged from the block
+// header merkle root and ValidateCompoundRoot rejected it, so the tx was never
+// marked MINED.
+//
+// Pre-fix this fails (placement rejects the height mismatch / the over-climbed
+// root poisons the tree). Post-fix the corrected subtree-0 root is derived from
+// the coinbase BUMP and the placement height is taken from it, so the over-tall
+// STUMP is truncated to its true subtree-internal levels and the compound
+// validates.
+func TestBuildCompoundBUMP_FullBlockSubtree0STUMP_Block951360(t *testing.T) {
+	const (
+		numSubtrees = 3 // matches block 951360's subtreeCount
+		subtreeSize = 8
+	)
+	allLeaves, trueAllLeaves, subtreeHashes, coinbaseTxID, trueBlockRoot := setupCoinbaseBlock(numSubtrees, subtreeSize)
+	cbBUMP := buildCoinbaseBUMP(trueAllLeaves[0], coinbaseTxID, 951360, subtreeHashes)
+
+	// Subtree 0's STUMP arrives at full block height (the defect); subtrees 1
+	// and 2 at the normal subtree-internal height.
+	stumps := []*models.Stump{
+		{BlockHash: "blk951360", SubtreeIndex: 0, StumpData: buildFullBlockSubtree0STUMP(allLeaves[0], 0, 951360, subtreeHashes)},
+		{BlockHash: "blk951360", SubtreeIndex: 1, StumpData: buildFullSTUMP(allLeaves[1], 0, 951360)},
+		{BlockHash: "blk951360", SubtreeIndex: 2, StumpData: buildFullSTUMP(allLeaves[2], 0, 951360)},
+	}
+
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP)
+	if err != nil {
+		t.Fatalf("BuildCompoundBUMP failed: %v", err)
+	}
+	if vErr := ValidateCompoundRoot(compound, &trueBlockRoot); vErr != nil {
+		t.Fatalf("compound BUMP did not validate against block header merkle root: %v", vErr)
+	}
+
+	// Every true leaf (including the coinbase at subtree 0, offset 0) must climb
+	// cleanly to the block root.
+	for s := 0; s < numSubtrees; s++ {
+		for i := 0; i < subtreeSize; i++ {
+			leaf := trueAllLeaves[s][i]
+			root, rErr := compound.ComputeRoot(&leaf)
+			if rErr != nil {
+				t.Fatalf("subtree %d tx %d: ComputeRoot: %v", s, i, rErr)
+			}
+			if *root != trueBlockRoot {
+				t.Fatalf("subtree %d tx %d: root mismatch: got %s, want %s", s, i, root, trueBlockRoot)
+			}
+		}
 	}
 }
 
@@ -1641,7 +1778,7 @@ func TestBuildCompoundBUMP_NoSubtree0Stump_NonPow2(t *testing.T) {
 		{BlockHash: "blkNonPow2", SubtreeIndex: trackedSubtree, StumpData: stump7},
 	}
 
-	cbBUMP := buildCoinbaseBUMP(allLeaves[0], coinbaseTxID, 1234567)
+	cbBUMP := buildCoinbaseBUMP(allLeaves[0], coinbaseTxID, 1234567, subtreeHashes)
 
 	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP)
 	if err != nil {

--- a/bump/bump_test.go
+++ b/bump/bump_test.go
@@ -963,6 +963,45 @@ func TestBuildCompoundBUMP_CoinbaseReplacement(t *testing.T) {
 	}
 }
 
+// TestBuildCompoundBUMP_NoCoinbaseBUMP_MultiSubtree_FailsSafe documents the
+// coinbase-BUMP-absent fallback for multi-subtree blocks. Ingestion does not
+// guarantee a coinbase BUMP (bump/datahub.go treats a zero-length coinbase-BUMP
+// field as "absent" and coinbaseBUMPReconciles passes on an empty one), so a
+// multi-subtree block can reach BuildCompoundBUMP with coinbaseBUMP == nil.
+// Without it, subtree 0's root cannot be corrected — the datahub computes it
+// against the coinbase placeholder, and there is no real coinbase txid to fold
+// nor a full-block path to bound the climb — so the compound root cannot match
+// the header root. This must fail loud: BuildCompoundBUMP still produces a
+// compound, but ValidateCompoundRoot rejects it against the true block root, so
+// the builder refuses to persist and the tx stays non-MINED. It must NEVER
+// silently validate against the placeholder-derived root (which would forge an
+// accepted proof).
+func TestBuildCompoundBUMP_NoCoinbaseBUMP_MultiSubtree_FailsSafe(t *testing.T) {
+	allLeaves, _, subtreeHashes, _, trueBlockRoot := setupCoinbaseBlock(3, 4)
+
+	stump0 := buildFullSTUMP(allLeaves[0], 1, 1000002)
+	stump1 := buildFullSTUMP(allLeaves[1], 0, 1000002)
+	stump2 := buildFullSTUMP(allLeaves[2], 0, 1000002)
+
+	stumps := []*models.Stump{
+		{BlockHash: "block3", SubtreeIndex: 0, StumpData: stump0},
+		{BlockHash: "block3", SubtreeIndex: 1, StumpData: stump1},
+		{BlockHash: "block3", SubtreeIndex: 2, StumpData: stump2},
+	}
+
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil)
+	if err != nil {
+		t.Fatalf("BuildCompoundBUMP failed: %v", err)
+	}
+	if compound == nil {
+		t.Fatal("expected a compound BUMP, got nil")
+	}
+
+	if err := ValidateCompoundRoot(compound, &trueBlockRoot); err == nil {
+		t.Fatal("expected ValidateCompoundRoot to REJECT the compound when no coinbase BUMP is supplied for a multi-subtree block (subtree-0 root uncorrected) — got nil error, which would mean a placeholder-derived root was accepted")
+	}
+}
+
 func TestBuildCompoundBUMP_CoinbaseReplacement_SingleSubtree(t *testing.T) {
 	allLeaves, trueAllLeaves, subtreeHashes, coinbaseTxID, trueBlockRoot := setupCoinbaseBlock(1, 4)
 	placeholder := allLeaves[0][0]


### PR DESCRIPTION
## What Changed

- Delete `computeCorrectedSubtreeRoot`, whose `stumpPath.ComputeRoot(coinbaseTxID)` climbed every level of the subtree-0 STUMP with no height bound.
- Rewrite `correctedSubtree0Root(coinbaseBUMP []byte, numSubtrees int)` to derive the corrected subtree-0 root solely from the coinbase BUMP: `internalHeight = len(cbPath.Path) − ceil(log2(numSubtrees))`, then fold the coinbase exactly `internalHeight` levels via the existing bounded primitive `subtree0RootFromCoinbaseBUMP`.
- In `BuildCompoundBUMP`, derive the placement `internalHeight` from the coinbase BUMP when present (same formula), falling back to the first STUMP's height only when no coinbase BUMP is available.
- Relax the placement height guard from `!=` to `<` so an over-tall STUMP is tolerated (only its first `internalHeight` levels are read); a STUMP shorter than `internalHeight` is still rejected.
- Add reproduction tests at the block-951360 shape and re-point the surviving unit test at `subtree0RootFromCoinbaseBUMP`.

## Why It Was Necessary

merkle-service sometimes delivers subtree 0's STUMP at full block height instead of the subtree-internal height. The old unbounded climb then overshoots the subtree-0 root and lands on the block merkle root, poisoning `subtreeHashes[0]`; the compound's top tree is built over `[block_root, s1, s2, …]` and `ValidateCompoundRoot` rejects it. The transaction is never marked `MINED`, so it remains stuck and gets rebroadcast. Observed on mainnet block 951360 (tx `85598b7b2d994153487198f9b69b482471d496c50e694f17bb92dd611edadc97`, `subtreeCount = 3`): block root `5ed5a7a9…ecbc`, wrong computed root `49c8fd3a…4f23`, STUMP `treeHeight = 17` vs. true `internalHeight = 15`. The fix derives `internalHeight` from the coinbase BUMP (authoritatively full block height), making the correction immune to over-tall STUMPs.

Closes #183

## Testing Performed

- `go test ./bump/...` — 89 tests pass, including two new reproductions: `TestBuildCompoundBUMP_FullBlockSubtree0STUMP_Block951360` (over-tall subtree-0 STUMP + normal siblings; validates against the block root) and `TestCorrectedSubtree0Root_Block951360_FromCoinbaseBUMP` (corrected root equals the real subtree root, not the block root).
- TDD: both reproductions fail on the unmodified tree (placement height-mismatch / over-climb poison) and pass after the fix.
- `go vet ./bump/...` and `gofmt -l bump/` are clean.

## Impact / Risk

- **Breaking change:** None — public signatures of `BuildCompoundBUMP` / `AssembleBUMP` are unchanged.
- **Behavioral risk:** Low. For well-formed inputs the derived `internalHeight` equals the previous STUMP-derived value, so existing behavior is preserved; the change only affects over-tall STUMPs that previously failed.
- **Caveat:** The correction relies on a coinbase BUMP being present for multi-subtree blocks. With no coinbase BUMP, both the correction and the placement-height derivation fall back to the STUMP height (today's behavior), so a `coinbaseBUMP == nil` path with an over-tall STUMP would still hit the guard.

## Notifications

- @mrz1836