### PR TITLE
Log rejected transactions with reason

### DIFF
--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -679,6 +679,12 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 // the window can't be eliminated entirely without making the row
 // write synchronous — a trade-off the success path also accepts).
 func (s *Server) rejectAtIntake(ctx context.Context, txid, reason string, opts submitOptions) {
+	s.logger.Info(
+		"transaction rejected",
+		zap.String("txid", txid),
+		zap.String("reason", reason),
+		zap.String("stage", "intake"),
+	)
 	s.persistRejectedAtIntake(ctx, txid, reason)
 	s.recordSubmission(ctx, txid, opts)
 	if s.publisher == nil {

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -416,6 +416,12 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 			publishedAccepted = append(publishedAccepted, st.TxID)
 		case models.StatusRejected:
 			publishedRejected = append(publishedRejected, st.TxID)
+			p.logger.Info(
+				"transaction rejected",
+				zap.String("txid", st.TxID),
+				zap.String("reason", st.ExtraInfo),
+				zap.String("stage", "network"),
+			)
 		default:
 		}
 	}
@@ -478,6 +484,12 @@ func (p *Propagator) persistCascadeRejections(ctx context.Context, txids []strin
 			// via the dep graph if they care.
 			ExtraInfo: "parent rejected",
 		}
+		p.logger.Info(
+			"transaction rejected",
+			zap.String("txid", txid),
+			zap.String("reason", "parent rejected"),
+			zap.String("stage", "cascade"),
+		)
 	}
 	if _, err := p.store.BatchUpdateStatusReturning(ctx, statuses); err != nil {
 		p.logger.Warn(


### PR DESCRIPTION
## Summary

- Rejections are persisted to the store and published to Kafka, but never logged, so the reason is invisible in log-based tooling (e.g. CloudWatch Logs).
- Adds one structured `Info` log `"transaction rejected"` with `txid`, `reason`, `stage` at every `REJECTED` transition.

## Sites

- Intake validation: `api_server` `rejectAtIntake` (single + batch), `stage="intake"`
- Network/Teranode: `propagation` `applyTerminalStatuses`, logged only on a real transition (no re-log on replay/no-op), `stage="network"`
- Cascade: `persistCascadeRejections` (children of a rejected parent), `stage="cascade"`

## Notes

- Reason already lives on the status row (`ExtraInfo` / `transactions.extra_info`); this surfaces it in the log stream.
- No schema, config, or dependency changes.
- Level `Info`: captured at default `log_level`, out of error/warn alerting.
- Emitted JSON: `{"level":"info","msg":"transaction rejected","txid":"<id>","reason":"<reason>","stage":"intake"}`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./services/api_server/... ./services/propagation/...`
- [x] `go test ./...` (full suite green)
