### PR TITLE
Move to teranode tx validator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,12 +178,20 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # Step 2b: install the C/C++ toolchain. The transaction validator links
+      # the BSV BDK C++ library (gobdk) via cgo, so the build needs gcc/g++ and
+      # libstdc++. This runs natively on each arch's runner — no cross-compiler.
+      - name: Install C/C++ toolchain (cgo)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential
+
       # Step 3: build the binary natively into the dist layout the Dockerfile
       # expects. GOOS/GOARCH are explicit so the path matches even if a future
-      # runner image defaults differ.
+      # runner image defaults differ. CGO_ENABLED=1 because the validator links
+      # gobdk (BSV BDK C++); the build is native per arch so the matching
+      # prebuilt gobdk static archive links without a cross-compiler.
       - name: Build arcade binary
         env:
-          CGO_ENABLED: '0'
+          CGO_ENABLED: '1'
           GOOS: linux
           GOARCH: ${{ matrix.arch }}
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,29 @@
 # syntax=docker/dockerfile:1
 #
-# Runtime-only image. The arcade binary is cross-compiled in CI on a native
-# runner per architecture and copied in here, so this Dockerfile contains no
-# Go toolchain and no cross-compilation. To build locally, run `make
-# docker-build` (which produces the dist/linux-<arch>/arcade layout this
-# Dockerfile expects).
+# Runtime-only image. The arcade binary is built in CI on a native runner per
+# architecture and copied in here, so this Dockerfile contains no Go toolchain
+# and no cross-compilation. To build locally, run `make docker-build` (which
+# produces the dist/linux-<arch>/arcade layout this Dockerfile expects).
+#
+# The binary is built with CGO_ENABLED=1 — it links the BSV BDK C++ consensus
+# library used by the transaction validator (see the validator package), so it
+# is dynamically linked against glibc + libstdc++ and will NOT run on a musl
+# base such as alpine. The distroless/cc base below provides glibc, libstdc++,
+# libgcc and ca-certificates.
 #
 # ca-certificates is required: arcade is an outbound HTTPS client (Teranode,
 # merkle service, datahub, webhook delivery) and TLS handshakes fail without
-# the system CA bundle.
+# the system CA bundle. distroless/cc ships it, so no extra install step.
 
-# Intentionally not pinned to @sha256: — alpine:3.23 is a multi-arch manifest
-# list consumed by the matrix amd64/arm64 build in .github/workflows/build.yml,
-# and dependabot's docker ecosystem (.github/dependabot.yml) already tracks
-# upstream changes. See Scorecard alert #58 (dismissed: "won't fix").
-FROM alpine:3.23
-
-RUN apk --no-cache add ca-certificates
+# Intentionally not pinned to @sha256: — gcr.io/distroless/cc-debian12 is a
+# multi-arch manifest list consumed by the matrix amd64/arm64 build in
+# .github/workflows/build.yml, and dependabot's docker ecosystem
+# (.github/dependabot.yml) tracks upstream changes. See Scorecard alert #58
+# (dismissed: "won't fix").
+FROM gcr.io/distroless/cc-debian12
 
 ARG TARGETOS
 ARG TARGETARCH
 COPY dist/${TARGETOS}-${TARGETARCH}/arcade /usr/local/bin/arcade
 
-ENTRYPOINT ["arcade"]
+ENTRYPOINT ["/usr/local/bin/arcade"]

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,15 @@
 
 GOARCH ?= $(shell go env GOARCH)
 
+# CGO is required: the transaction validator links the BSV BDK C++ consensus
+# library (gobdk) via cgo, so a C/C++ toolchain (gcc/g++, libstdc++) must be
+# present to build and test. Builds are native per arch — gobdk ships a
+# prebuilt static archive per platform, so there is no cross-compilation.
 build:
-	go build ./...
+	CGO_ENABLED=1 go build ./...
 
 test:
-	go test ./...
+	CGO_ENABLED=1 go test ./...
 
 lint:
 	golangci-lint run
@@ -22,7 +26,7 @@ docker-down:
 # that layout for the host's architecture and tags the image arcade:local.
 docker-build:
 	mkdir -p dist/linux-$(GOARCH)
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -trimpath -ldflags="-s -w" -o dist/linux-$(GOARCH)/arcade ./cmd/arcade
+	CGO_ENABLED=1 GOOS=linux GOARCH=$(GOARCH) go build -trimpath -ldflags="-s -w" -o dist/linux-$(GOARCH)/arcade ./cmd/arcade
 	docker build --platform=linux/$(GOARCH) -t arcade:local .
 
 run:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,13 @@ docker-down:
 # Build a single-arch image for local use that matches the CI layout. The
 # Dockerfile expects a binary at dist/linux-<arch>/arcade; this target produces
 # that layout for the host's architecture and tags the image arcade:local.
+# Requires a Linux host: CGO + gobdk's per-platform static archive cannot
+# cross-compile to linux, so building the binary off-Linux would fail.
 docker-build:
+	@if [ "$$(go env GOOS)" != "linux" ]; then \
+		echo "docker-build requires a Linux host: CGO + gobdk cannot cross-compile a linux binary from $$(go env GOOS). Run on Linux or inside a Linux container."; \
+		exit 1; \
+	fi
 	mkdir -p dist/linux-$(GOARCH)
 	CGO_ENABLED=1 GOOS=linux GOARCH=$(GOARCH) go build -trimpath -ldflags="-s -w" -o dist/linux-$(GOARCH)/arcade ./cmd/arcade
 	docker build --platform=linux/$(GOARCH) -t arcade:local .

--- a/app/app.go
+++ b/app/app.go
@@ -156,7 +156,12 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *zap.Logger) (*De
 		merkleClient.SetLogger(logger.Named("merkle-client"))
 	}
 
-	txVal := validator.NewValidator(validatorPolicyFromConfig(cfg))
+	txVal, err := validator.NewValidatorForNetwork(cfg.Network, validatorPolicyFromConfig(cfg))
+	if err != nil {
+		_ = st.Close()
+		_ = producer.Close()
+		return nil, nil, fmt.Errorf("creating validator: %w", err)
+	}
 
 	publisher := events.NewKafkaPublisher(producer, logger, cfg.Events.SubscriberBuffer)
 

--- a/config/config.go
+++ b/config/config.go
@@ -594,10 +594,11 @@ type EventsConfig struct {
 // status-update bursts without committing significant memory upfront.
 const DefaultEventsSubscriberBuffer = 4096
 
-// ValidatorConfig controls intake-time transaction validation: the fee
-// floor enforced against EF/BEEF submissions and the policy-level
-// per-tx and per-script limits. Wired through to validator.Policy at
-// process startup.
+// ValidatorConfig controls intake-time transaction validation. It carries the
+// operator-facing fee floor enforced against EF/BEEF submissions; the consensus
+// and policy script rules come from teranode's BDK-backed validator (keyed by
+// the top-level network), not from this config. Wired through to the validator
+// at process startup.
 type ValidatorConfig struct {
 	// MinFeePerKB is the network's minimum acceptable fee rate in
 	// satoshis per kilobyte. Transactions below this rate are rejected

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/IBM/sarama v1.50.2
 	github.com/aerospike/aerospike-client-go/v7 v7.10.2
 	github.com/bsv-blockchain/go-bt/v2 v2.6.7
+	github.com/bsv-blockchain/go-chaincfg v1.5.10
 	github.com/bsv-blockchain/go-chaintracks v1.2.8
 	github.com/bsv-blockchain/go-p2p-message-bus v0.1.20
 	github.com/bsv-blockchain/go-sdk v1.2.24
@@ -57,9 +58,9 @@ require (
 	github.com/aws/smithy-go v1.27.2 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bitcoin-sv/bdk/module/gobdk v1.2.5-0.20260526081552-cdfa7814ee5d // indirect
 	github.com/bsv-blockchain/aerospike-client-go/v8 v8.7.1-bsv3 // indirect
 	github.com/bsv-blockchain/go-batcher/v2 v2.0.5 // indirect
-	github.com/bsv-blockchain/go-chaincfg v1.5.10 // indirect
 	github.com/bsv-blockchain/go-lockfree-queue v1.2.0 // indirect
 	github.com/bsv-blockchain/go-safe-conversion v1.2.0 // indirect
 	github.com/bsv-blockchain/go-subtree v1.4.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bitcoin-sv/bdk/module/gobdk v1.2.5-0.20260526081552-cdfa7814ee5d h1:bSTJ5f/DpTWPpnheayyZje7MK0bMSgB5xuWaxh/AOHY=
+github.com/bitcoin-sv/bdk/module/gobdk v1.2.5-0.20260526081552-cdfa7814ee5d/go.mod h1:XxBr/Y+e+pMw3+e2xYECvEayfZM3RX3n0jVvOGC3krE=
 github.com/bsv-blockchain/aerospike-client-go/v8 v8.7.1-bsv3 h1:gMqILIz4FPInYy/CYBxAYy/nU0seVPx2jvnfwy14K9E=
 github.com/bsv-blockchain/aerospike-client-go/v8 v8.7.1-bsv3/go.mod h1:t4MjZ6nitI84mr/KhpPGFCCeCT4+y4hq0di8qOHIIGk=
 github.com/bsv-blockchain/go-batcher/v2 v2.0.5 h1:71po3vI+K8g+UF3BrtyJe0EBEDDGWNIPvjPgSG6DbFk=

--- a/openspec/changes/replace-validator-with-bdk/design.md
+++ b/openspec/changes/replace-validator-with-bdk/design.md
@@ -1,0 +1,73 @@
+# Design
+
+## Engine seam
+
+`validator.Validator` keeps its public methods so the api-server intake call
+sites (`handlers.go` single + batch submit) and `app.go` wiring change
+minimally. Internally it holds two teranode `*TxValidator` instances — one that
+enforces the fee floor and one with `MinMiningTxFee=0` — so `ValidateTransaction`
+can honour `skipFees` without setting `SkipPolicyChecks=true` (which in teranode
+also disables script/standardness checks, turning on consensus mode).
+
+`NewValidatorForNetwork(network, *Policy)` resolves `chaincfg.GetChainParams`
+from arcade's existing `network` config (the param `.Name` values —
+`mainnet`/`testnet`/`teratestnet`/`regtest` — map 1:1 to BDK's chain names) and
+returns an error for unknown networks instead of letting the BDK adapter call
+`Fatalf`. The legacy `NewValidator(*Policy)` defaults to mainnet for tests.
+
+## Policy settings
+
+`settings.NewPolicySettings()` returns an all-zero struct (its defaults are a
+TODO), and the BDK adapter reads ~14 fields directly. Several zeros are unsafe —
+e.g. `MaxStackMemoryUsagePolicy=0` would reject any memory-using script — so the
+validator sets every field explicitly to teranode's canonical BSV values
+(`defaultPolicySettings`). `DataCarrier` is enabled because arcade accepts
+OP_RETURN data transactions. The operator-facing `MinFeePerKB` (satoshis/kB) is
+converted to BSV/kB for `SetMinMiningTxFee` (100 sat/kB → 0.000001 BSV/kB;
+teranode converts back via `*1e8/1000`). An explicit `MaxTxSizePolicy` override
+is capped at BDK's 1 GB consensus limit to avoid a construction panic.
+
+## go-sdk → extended go-bt conversion
+
+TxValidator needs a go-bt `*bt.Tx` in extended format. `toExtendedBT` serializes
+the go-sdk transaction's standard bytes, re-parses them with `bt.NewTxFromBytes`,
+then copies each input's `PreviousTxSatoshis` and `PreviousTxScript` from the
+go-sdk input's resolved source output (`SourceTxSatoshis()`/`SourceTxScript()`,
+populated from EF/BEEF at parse time). `script.Script` and `bscript.Script` are
+both `[]byte`, so the script copy is a direct conversion. A nil source output is
+returned as `errMissingSourceData` and mapped to ARC status 460 — a deliberate
+tightening, since BDK cannot compute fees or run scripts without it.
+
+## Static block height
+
+BDK gates fork activation (Genesis, Chronicle) by comparing the supplied block
+height against the per-network activation heights baked into `chaincfg.Params`.
+Arcade passes `allForksActiveHeight = 2_000_000_000`: above every network's
+activation heights (so all upgrades evaluate as active and arcade validates
+against current rules) yet below `math.MaxInt32`. `math.MaxUint32` cannot be
+used — the BDK adapter converts the height to int32 and, in policy mode,
+evaluates `blockHeight-1`, so it would overflow and reject every transaction.
+
+Per-input `utxoHeights` are unknown at intake (arcade does not track per-UTXO
+confirmation heights), so a full-length slice of a low sentinel height is passed:
+every input appears mature. This matches arcade's prior behaviour of not
+enforcing coinbase maturity / BIP68 at intake — teranode re-checks with real
+heights downstream and remains the authority.
+
+## Error mapping
+
+The BDK adapter wraps fee/script/policy failures under `ERR_TX_INVALID`, so the
+precise ARC status is recovered from teranode's deterministic message text
+(`mapTeranodeError` → `classifyByMessage`): "fee is too low"/"input satoshis is
+less than output" → 465; "coinbase"/"bad-txns-inputs-too-large" → 462; GoBDK
+script/policy failures → 461; `ERR_PROCESSING` (cgo exception) → 467;
+`ERR_INVALID_ARGUMENT` → 463. The original message is preserved as `ExtraInfo`.
+
+## Build & runtime
+
+`gobdk` links the BSV BDK C++ library via cgo, pulling in a prebuilt static
+archive per platform from the module cache (`bdkcgo/libGoBDK_linux_*.a`). The
+resulting binary is dynamically linked against glibc + libstdc++, so: builds use
+`CGO_ENABLED=1` with a C/C++ toolchain; CI builds each arch natively (the gobdk
+archive matches the runner arch — no cross-compiler); and the runtime image
+moves to a glibc base (`distroless/cc`).

--- a/openspec/changes/replace-validator-with-bdk/proposal.md
+++ b/openspec/changes/replace-validator-with-bdk/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Arcade validates transactions at intake with go-sdk's pure-Go script interpreter (`spv.Verify` in the `validator` package), while teranode/svnode admit transactions with go-bdk — the BSV C++ consensus library. Because arcade re-implements the rules in Go, its view of validity drifts from the node across protocol upgrades. The Chronicle upgrade already forced a hand-patch: arcade special-cased the push-only relaxation for version≥2 transactions (`validator/validator.go`), and deeper script-execution divergence still lives in `spv.Verify` (which hardcodes fork-activation flags and exposes no `WithAfterChronicle` passthrough). See issue #192.
+
+The fix is to stop re-implementing consensus and instead reuse the exact validator teranode uses: `github.com/bsv-blockchain/teranode/services/validator.TxValidator`. Arcade already depends on teranode, so this aligns the intake decision with node consensus by construction. The cost is that TxValidator binds the BSV BDK C++ library via cgo, so arcade can no longer build as a pure-Go static binary.
+
+## What Changes
+
+- Replace the `validator` package internals with a thin wrapper over teranode's `TxValidator`. The public surface (`NewValidator`, `ValidateTransaction(ctx, *sdkTx.Transaction, skipFees)`, `ValidatePolicy`, `MinFeePerKB`) is preserved so the api-server intake call sites are unchanged.
+- Add `NewValidatorForNetwork(network, *Policy)`, which resolves `go-chaincfg` params from arcade's `network` config and builds the validator; `app.go` wires it and propagates the error.
+- Convert the go-sdk transaction to an extended go-bt `*bt.Tx` (per-input `PreviousTxSatoshis`/`PreviousTxScript` from the EF/BEEF source data) — the form TxValidator requires. A missing source output is now a hard rejection (ARC status 460).
+- Pass a static "all-forks-active" block height (`2_000_000_000`) so BDK applies current consensus rules; arcade's intake is height-agnostic post-Genesis and does not track the chain tip.
+- Map teranode validation errors to arcade's ARC status codes, preserving the client-facing reason and the existing `StatusRejected`/`ExtraInfo` behavior.
+- Remove the hand-patched Chronicle push-only rule — BDK now enforces the version gate natively.
+- Switch the whole build to `CGO_ENABLED=1` and the runtime image to a glibc base (distroless/cc instead of alpine), since the binary dynamically links glibc + libstdc++.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `tx-validator`: the validation engine changes from arcade's pure-Go checks to teranode's BDK-backed `TxValidator`, so intake accept/reject decisions match node consensus across protocol upgrades. The service's consume/route/state-update behavior is unchanged; only the rule engine and its rejection-reason mapping change.
+
+## Impact
+
+- **Build toolchain**: `CGO_ENABLED=1` everywhere (Makefile, `build.yml`); a C/C++ toolchain (gcc/g++, libstdc++) is required at build time. Pure-Go static builds and easy cross-compilation are no longer possible; each arch builds natively (gobdk ships a prebuilt static archive per platform, so no cross-compiler is needed).
+- **Runtime image**: Dockerfile base changes from `alpine:3.23` (musl) to `gcr.io/distroless/cc-debian12` (glibc + libstdc++ + ca-certificates). A musl base will not run the cgo binary.
+- **New transitive dependency**: `github.com/bitcoin-sv/bdk/module/gobdk` (cgo, recorded `// indirect`); `github.com/bsv-blockchain/go-chaincfg` becomes a direct dependency.
+- **Behavior tightening**: transactions whose inputs lack source data are rejected at intake with status 460 (previously they passed the policy stage and failed later in `spv.Verify`). Max-tx-size policy moves from arcade's 4 GiB ceiling to teranode's canonical 10 MB mempool default (BDK also caps the policy setting at 1 GB).
+- **Hot-path cost**: each submit crosses the cgo boundary into C++ once per transaction, plus a go-sdk→go-bt serialize/re-parse. The C++ validator is built once and reused.
+- **Tests**: the `validator` package and api-server tests now require cgo + the gobdk archive (delivered by `go mod download`); they will not run under `CGO_ENABLED=0`.

--- a/openspec/changes/replace-validator-with-bdk/specs/tx-validator/spec.md
+++ b/openspec/changes/replace-validator-with-bdk/specs/tx-validator/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Validate transactions
+
+The TX validator SHALL validate transactions using teranode's BDK-backed
+`TxValidator` (`github.com/bsv-blockchain/teranode/services/validator`) — the
+same engine teranode/svnode use — so that arcade's accept/reject decision
+matches node consensus across protocol upgrades. The validator SHALL NOT
+re-implement consensus or policy script rules in Go. Valid transactions are
+routed to propagation; invalid transactions are rejected with the rejection
+reason recorded.
+
+The validator SHALL convert each submitted transaction to extended form (every
+input carrying its previous output's satoshis and locking script, drawn from the
+EF/BEEF source data) before validation, and SHALL validate against current
+consensus rules by supplying a block height at which all protocol upgrades
+(including Chronicle) are active.
+
+#### Scenario: Valid transaction
+
+- **WHEN** a transaction passes BDK validation (structure, standardness, script
+  execution, sigops, and — unless fee checks are skipped — the fee floor)
+- **THEN** the validator SHALL route it to propagation and record its initial state
+
+#### Scenario: Invalid transaction
+
+- **WHEN** a transaction fails BDK validation
+- **THEN** the validator SHALL mark it REJECTED with a reason mapped to the
+  matching ARC status code (e.g. fee too low → 465, invalid scripts → 461,
+  invalid inputs → 462) and SHALL NOT propagate it
+
+#### Scenario: Chronicle version-gated unlocking scripts
+
+- **WHEN** a version≥2 transaction carries a non-push-only (functional-opcode)
+  unlocking script that otherwise evaluates successfully
+- **THEN** the validator SHALL accept it (the Chronicle relaxation, applied by
+  the BDK engine)
+- **AND WHEN** the same unlocking script appears in a version<2 transaction
+- **THEN** the validator SHALL reject it with ARC status 461 (push-only rule)
+
+#### Scenario: Missing source data
+
+- **WHEN** a submitted transaction has an input with no resolvable source output
+  (satoshis + locking script)
+- **THEN** the validator SHALL reject it with ARC status 460 (not extended
+  format) without attempting BDK validation
+
+#### Scenario: Duplicate transaction
+
+- **WHEN** a transaction is submitted that already exists in the store
+- **THEN** the validator SHALL return the existing transaction state without
+  re-processing

--- a/openspec/changes/replace-validator-with-bdk/tasks.md
+++ b/openspec/changes/replace-validator-with-bdk/tasks.md
@@ -1,0 +1,35 @@
+## 1. Validator engine
+
+- [x] 1.1 Replace `validator/validator.go` internals with a wrapper over teranode `TxValidator`; keep `NewValidator`, `ValidateTransaction(ctx, *sdkTx.Transaction, skipFees)`, `ValidatePolicy`, `MinFeePerKB` and the `Policy` type.
+- [x] 1.2 Add `NewValidatorForNetwork(network, *Policy)` resolving `chaincfg.GetChainParams`; build fee-checked and fee-skipping `*TxValidator` instances.
+- [x] 1.3 Set all BDK-read `PolicySettings` fields to canonical BSV defaults (`defaultPolicySettings`); convert `MinFeePerKB` sat/kB → BSV/kB; cap `MaxTxSizePolicy` overrides at the 1 GB BDK limit; enable `DataCarrier`.
+- [x] 1.4 Use a static `allForksActiveHeight = 2_000_000_000` and a low-sentinel `utxoHeights` slice; document why `math.MaxUint32` is unusable.
+
+## 2. Conversion and error mapping
+
+- [x] 2.1 Add `toExtendedBT` (`validator/convert.go`): serialize → `bt.NewTxFromBytes` → copy `PreviousTxSatoshis`/`PreviousTxScript`; return `errMissingSourceData` when source data is absent.
+- [x] 2.2 Add `mapTeranodeError`/`classifyByMessage` (`validator/errmap.go`): teranode `*errors.Error` codes + message text → ARC status; preserve reason as `ExtraInfo`; `errMissingSourceData` → 460.
+
+## 3. Wiring and config
+
+- [x] 3.1 In `app/app.go`, construct via `validator.NewValidatorForNetwork(cfg.Network, validatorPolicyFromConfig(cfg))` and propagate the error (clean up store/producer).
+- [ ] 3.2 Confirm `config.go`'s `ValidatorConfig` comment no longer references removed pure-Go policy fields; no new config fields required for the first cut.
+
+## 4. Build system (cgo everywhere)
+
+- [x] 4.1 `Makefile`: `CGO_ENABLED=1` in `build`, `test`, `docker-build`.
+- [x] 4.2 `Dockerfile`: switch runtime base from `alpine` (musl) to `gcr.io/distroless/cc-debian12` (glibc + libstdc++ + ca-certs); use an absolute ENTRYPOINT path.
+- [x] 4.3 `.github/workflows/build.yml`: `CGO_ENABLED=1`; install `build-essential` before the build.
+- [ ] 4.4 Verify the `fortress-*` workflows (test/vet/lint/bench/fuzz) build with cgo — they rely on the runner's default `CGO_ENABLED=1` and an installed C toolchain; add an explicit toolchain step if any leg lacks gcc/g++.
+
+## 5. Tests
+
+- [x] 5.1 Rewrite `validator/validator_test.go` for the BDK engine: construction, sat/kB→BSV/kB, `toExtendedBT` (+ missing-source-data), `mapTeranodeError` table.
+- [x] 5.2 Chronicle regression (#192) through the real BDK engine: version≥2 non-push-only unlocking script accepted; version<2 rejected with status 461.
+- [x] 5.3 Fee path: underpaid tx → 465; same tx accepted with `skipFees`.
+- [ ] 5.4 Document in the package/test that `go test ./validator/...` requires cgo + a C toolchain.
+
+## 6. Docs
+
+- [x] 6.1 Author this OpenSpec change; run `openspec validate replace-validator-with-bdk --strict`.
+- [ ] 6.2 Note the cgo build requirement and the glibc runtime base in the repo README / build docs.

--- a/tests/e2e/harness/txbuilder.go
+++ b/tests/e2e/harness/txbuilder.go
@@ -14,11 +14,16 @@ import (
 	"github.com/bsv-blockchain/teranode/model"
 )
 
-// nonDataScript returns a single-byte OP_TRUE locking script. arcade's
-// validator considers this non-data (so checkOutputs accepts it) and
-// it's accepted by checkInputs as a non-coinbase witness.
+// nonDataScript returns an OP_DROP OP_TRUE locking script. Paired with the
+// OP_0 unlocking script (minimalPushScript), the full evaluation is
+// OP_0 OP_DROP OP_TRUE: the empty push is dropped and OP_TRUE leaves a single
+// truthy element, so the stack is clean. The BDK validator enforces the
+// post-Genesis CLEANSTACK rule (exactly one truthy element must remain after
+// execution), which a bare OP_TRUE paired with OP_0 would violate (it leaves
+// two elements). It is non-data so checkOutputs accepts it, and non-standard
+// scripts are fine because the validator runs with RequireStandard=false.
 func nonDataScript() *bscript.Script {
-	s := bscript.Script([]byte{0x51})
+	s := bscript.Script([]byte{0x75, 0x51})
 	return &s
 }
 
@@ -26,10 +31,9 @@ func nonDataScript() *bscript.Script {
 // script that's non-empty. arcade's policy pushDataCheck requires the
 // unlocking script to be push-only, and go-sdk's SatoshisPerKilobyte
 // fee model rejects inputs with an empty unlocking script
-// (ErrNoUnlockingScript) because it can't size the witness. OP_0
-// pushes an empty byte string onto the stack, which the OP_TRUE
-// locking script ignores when it pushes 1 — script execution still
-// succeeds.
+// (ErrNoUnlockingScript) because it can't size the witness. OP_0 pushes an
+// empty byte string that the OP_DROP in nonDataScript pops back off, leaving a
+// clean stack — see nonDataScript for why the drop is required.
 func minimalPushScript() *bscript.Script {
 	s := bscript.Script([]byte{0x00})
 	return &s
@@ -73,19 +77,18 @@ func BuildTxs(n int, startNonce uint32) []*bt.Tx {
 // arcade's intake validator (structural policy + script execution +
 // fee check; merkle proofs on parents are trusted). Each tx has:
 //
-//   - One input pointing at a non-zero source txid + OP_TRUE locking
-//     script + 10_000 satoshis (passes checkInputs as non-coinbase and
-//     covers the fee floor by a wide margin).
-//   - One output with OP_TRUE locking script + 1 satoshi (passes
+//   - One input pointing at a non-zero source txid + OP_DROP OP_TRUE
+//     locking script + 10_000 satoshis (passes checkInputs as
+//     non-coinbase and covers the fee floor by a wide margin).
+//   - One output with OP_DROP OP_TRUE locking script + 1 satoshi (passes
 //     checkOutputs; remaining ~9999 sats become fee).
 //   - LockTime = startNonce + i, ensuring each tx hashes differently.
 //
-// OP_TRUE (0x51) is a trivially-satisfied locking script — an empty
-// unlocking script evaluates to true against it, so script execution
-// inside spv.Verify succeeds without any signing. Callers must serialize
-// these via ExtendedBytes() so arcade's go-sdk parser sees the per-input
-// source script + satoshis (otherwise GetFee returns "PreviousTx not
-// supplied" inside the fee check).
+// The OP_0 unlocking script + OP_DROP OP_TRUE locking script evaluate to a
+// single truthy element on a clean stack, which the BDK validator's CLEANSTACK
+// rule requires (see nonDataScript). Callers must serialize these via
+// ExtendedBytes() so arcade's go-sdk parser sees the per-input source script +
+// satoshis (otherwise the fee check fails with "PreviousTx not supplied").
 func BuildValidatableTxs(n int, startNonce uint32) []*bt.Tx {
 	out := make([]*bt.Tx, n)
 	// Reused across all txs so we don't re-allocate the same constant

--- a/tests/e2e/harness/txbuilder.go
+++ b/tests/e2e/harness/txbuilder.go
@@ -20,20 +20,17 @@ import (
 // truthy element, so the stack is clean. The BDK validator enforces the
 // post-Genesis CLEANSTACK rule (exactly one truthy element must remain after
 // execution), which a bare OP_TRUE paired with OP_0 would violate (it leaves
-// two elements). It is non-data so checkOutputs accepts it, and non-standard
-// scripts are fine because the validator runs with RequireStandard=false.
+// two elements). The script is non-standard, which the BDK validator accepts
+// because it runs with RequireStandard=false.
 func nonDataScript() *bscript.Script {
 	s := bscript.Script([]byte{0x75, 0x51})
 	return &s
 }
 
-// minimalPushScript is a single-byte OP_0 push, the smallest push-only
-// script that's non-empty. arcade's policy pushDataCheck requires the
-// unlocking script to be push-only, and go-sdk's SatoshisPerKilobyte
-// fee model rejects inputs with an empty unlocking script
-// (ErrNoUnlockingScript) because it can't size the witness. OP_0 pushes an
-// empty byte string that the OP_DROP in nonDataScript pops back off, leaving a
-// clean stack — see nonDataScript for why the drop is required.
+// minimalPushScript is a single-byte OP_0 push, the smallest non-empty
+// unlocking script. OP_0 pushes an empty byte string that the OP_DROP in
+// nonDataScript pops back off, leaving a clean stack — see nonDataScript for
+// why the drop is required.
 func minimalPushScript() *bscript.Script {
 	s := bscript.Script([]byte{0x00})
 	return &s
@@ -78,10 +75,10 @@ func BuildTxs(n int, startNonce uint32) []*bt.Tx {
 // fee check; merkle proofs on parents are trusted). Each tx has:
 //
 //   - One input pointing at a non-zero source txid + OP_DROP OP_TRUE
-//     locking script + 10_000 satoshis (passes checkInputs as
-//     non-coinbase and covers the fee floor by a wide margin).
-//   - One output with OP_DROP OP_TRUE locking script + 1 satoshi (passes
-//     checkOutputs; remaining ~9999 sats become fee).
+//     locking script + 10_000 satoshis (non-coinbase, covering the fee
+//     floor by a wide margin).
+//   - One output with OP_DROP OP_TRUE locking script + 1 satoshi
+//     (remaining ~9999 sats become fee).
 //   - LockTime = startNonce + i, ensuring each tx hashes differently.
 //
 // The OP_0 unlocking script + OP_DROP OP_TRUE locking script evaluate to a

--- a/tests/e2e/harness/txbuilder_test.go
+++ b/tests/e2e/harness/txbuilder_test.go
@@ -20,9 +20,11 @@ func TestBuildValidatableTxs_PassesArcadePolicyValidator(t *testing.T) {
 	txs := BuildValidatableTxs(5, 100)
 
 	for i, tx := range txs {
-		// arcade parses txs via go-sdk, not go-bt — round-trip via
-		// raw bytes so we exercise the same path.
-		raw := tx.Bytes()
+		// arcade parses txs via go-sdk, not go-bt, and clients POST the
+		// extended (EF) serialization — round-trip via ExtendedBytes so the
+		// parsed tx carries the per-input source script + satoshis the BDK
+		// validator needs (BroadcastTx posts tx.ExtendedBytes() too).
+		raw := tx.ExtendedBytes()
 		sdkParsed, err := sdkTx.NewTransactionFromBytes(raw)
 		if err != nil {
 			t.Fatalf("tx %d: sdk parse: %v (raw=%x)", i, err, raw)

--- a/tests/smoke/chains.go
+++ b/tests/smoke/chains.go
@@ -109,9 +109,10 @@ func newValidatableTx(prevTxID []byte, prevOutputIdx, nonce uint32) *bt.Tx {
 	input.PreviousTxSatoshis = 10000
 	// OP_0 (single byte 0x00) is the smallest push-only, non-empty
 	// unlocking script. arcade's pushDataCheck rejects empty unlocking
-	// scripts (ErrEmptyUnlockingScript / ErrUnlockingScriptNotPushOnly),
-	// and OP_0 pushes an empty byte string the OP_TRUE locking script
-	// happily ignores when it pushes 1 — script execution still succeeds.
+	// scripts (ErrEmptyUnlockingScript / ErrUnlockingScriptNotPushOnly).
+	// The empty byte string OP_0 pushes is popped by the OP_DROP in
+	// opTrueScript, so OP_TRUE leaves a single truthy element on a clean
+	// stack — required by the BDK validator's CLEANSTACK rule.
 	input.UnlockingScript = minimalPushScript()
 	tx.Inputs = append(tx.Inputs, input)
 	tx.AddOutput(&bt.Output{
@@ -127,11 +128,15 @@ func asChainHash(b []byte) *chainhash.Hash {
 	return &h
 }
 
-// opTrueScript is a single-byte OP_TRUE script. arcade's validator
-// classifies it as non-data so checkInputs and checkOutputs both accept
-// it without needing real signing or pushdata.
+// opTrueScript is an OP_DROP OP_TRUE script. Paired with the OP_0 unlocking
+// script (minimalPushScript) the full evaluation is OP_0 OP_DROP OP_TRUE: the
+// empty push is dropped and OP_TRUE leaves a single truthy element on a clean
+// stack, which the BDK validator's post-Genesis CLEANSTACK rule requires (a
+// bare OP_TRUE would leave two elements and be rejected). arcade's validator
+// classifies it as non-data so checkInputs and checkOutputs both accept it, and
+// non-standard scripts are fine because the validator runs RequireStandard=false.
 func opTrueScript() *bscript.Script {
-	s := bscript.Script([]byte{0x51})
+	s := bscript.Script([]byte{0x75, 0x51})
 	return &s
 }
 
@@ -140,9 +145,9 @@ func opTrueScript() *bscript.Script {
 // requires the unlocking script to be push-only, and go-sdk's
 // SatoshisPerKilobyte fee model rejects inputs with an empty unlocking
 // script (ErrNoUnlockingScript) because it can't size the witness.
-// OP_0 pushes an empty byte string onto the stack, which the OP_TRUE
-// locking script ignores when it pushes 1 — script execution still
-// succeeds. Mirrors tests/e2e/harness/txbuilder.go:minimalPushScript.
+// OP_0 pushes an empty byte string that the OP_DROP in opTrueScript pops back
+// off, leaving a clean stack — see opTrueScript. Mirrors
+// tests/e2e/harness/txbuilder.go:minimalPushScript.
 func minimalPushScript() *bscript.Script {
 	s := bscript.Script([]byte{0x00})
 	return &s

--- a/tests/smoke/chains.go
+++ b/tests/smoke/chains.go
@@ -35,9 +35,9 @@ type ChainOpts struct {
 // populate the propagation envelope's input_txids field.
 //
 // Callers MUST serialize each tx via tx.ExtendedBytes() before posting
-// to arcade — the validator's spv.Verify call reads the per-input
-// PreviousTxScript + PreviousTxSatoshis the EF wire encoding carries,
-// and rejects standard-format txs with "'PreviousTx' not supplied".
+// to arcade — the validator reads the per-input PreviousTxScript +
+// PreviousTxSatoshis the EF wire encoding carries to build the extended
+// tx that BDK validates, and rejects standard-format txs that omit it.
 // See validator/validator.go:ValidateTransaction and PR #171.
 //
 // The returned slice is shaped [chain][tx-in-chain]; flatten as needed.
@@ -100,16 +100,13 @@ func newValidatableTx(prevTxID []byte, prevOutputIdx, nonce uint32) *bt.Tx {
 	_ = input.PreviousTxIDAdd(asChainHash(prevTxID))
 	input.PreviousTxOutIndex = prevOutputIdx
 	input.PreviousTxScript = opTrueScript()
-	// Generous source-satoshi budget so the fee check (now enabled by
-	// the validator's spv.Verify call) has plenty of headroom: with a
-	// 1-sat output this leaves 9999 sats of fee against a ~62-byte tx,
-	// far above any plausible MinFeePerKB. Mirror the e2e harness's
-	// BuildValidatableTxs which raised this from 1000 → 10000 when
-	// PR #171 tightened the validator.
+	// Generous source-satoshi budget so the validator's fee check has
+	// plenty of headroom: with a 1-sat output this leaves 9999 sats of
+	// fee against a ~62-byte tx, far above any plausible MinFeePerKB.
+	// Mirror the e2e harness's BuildValidatableTxs which raised this from
+	// 1000 → 10000 when PR #171 tightened the validator.
 	input.PreviousTxSatoshis = 10000
-	// OP_0 (single byte 0x00) is the smallest push-only, non-empty
-	// unlocking script. arcade's pushDataCheck rejects empty unlocking
-	// scripts (ErrEmptyUnlockingScript / ErrUnlockingScriptNotPushOnly).
+	// OP_0 (single byte 0x00) is the smallest non-empty unlocking script.
 	// The empty byte string OP_0 pushes is popped by the OP_DROP in
 	// opTrueScript, so OP_TRUE leaves a single truthy element on a clean
 	// stack — required by the BDK validator's CLEANSTACK rule.
@@ -132,21 +129,17 @@ func asChainHash(b []byte) *chainhash.Hash {
 // script (minimalPushScript) the full evaluation is OP_0 OP_DROP OP_TRUE: the
 // empty push is dropped and OP_TRUE leaves a single truthy element on a clean
 // stack, which the BDK validator's post-Genesis CLEANSTACK rule requires (a
-// bare OP_TRUE would leave two elements and be rejected). arcade's validator
-// classifies it as non-data so checkInputs and checkOutputs both accept it, and
-// non-standard scripts are fine because the validator runs RequireStandard=false.
+// bare OP_TRUE would leave two elements and be rejected). The script is
+// non-standard, which the BDK validator accepts because it runs with
+// RequireStandard=false.
 func opTrueScript() *bscript.Script {
 	s := bscript.Script([]byte{0x75, 0x51})
 	return &s
 }
 
-// minimalPushScript is a single-byte OP_0 (0x00) push, the smallest
-// push-only script that's non-empty. arcade's policy pushDataCheck
-// requires the unlocking script to be push-only, and go-sdk's
-// SatoshisPerKilobyte fee model rejects inputs with an empty unlocking
-// script (ErrNoUnlockingScript) because it can't size the witness.
-// OP_0 pushes an empty byte string that the OP_DROP in opTrueScript pops back
-// off, leaving a clean stack — see opTrueScript. Mirrors
+// minimalPushScript is a single-byte OP_0 (0x00) push, the smallest non-empty
+// unlocking script. OP_0 pushes an empty byte string that the OP_DROP in
+// opTrueScript pops back off, leaving a clean stack — see opTrueScript. Mirrors
 // tests/e2e/harness/txbuilder.go:minimalPushScript.
 func minimalPushScript() *bscript.Script {
 	s := bscript.Script([]byte{0x00})

--- a/validator/convert.go
+++ b/validator/convert.go
@@ -1,0 +1,46 @@
+package validator
+
+import (
+	"errors"
+	"fmt"
+
+	bt "github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+)
+
+// errMissingSourceData is returned when an input lacks the previous-output data
+// (satoshis + locking script) required to build an extended transaction. The
+// BDK validator needs this to compute fees and execute scripts; arcade obtains
+// it from the EF/BEEF carried with the submission.
+var errMissingSourceData = errors.New("transaction could not be transformed to extended format: missing input source data")
+
+// toExtendedBT converts a go-sdk transaction into an extended go-bt transaction
+// (each input carrying PreviousTxSatoshis and PreviousTxScript), which is the
+// form teranode's TxValidator requires. Source data is copied from the go-sdk
+// input's resolved source output (populated from EF/BEEF at parse time).
+func toExtendedBT(tx *sdkTx.Transaction) (*bt.Tx, error) {
+	btx, err := bt.NewTxFromBytes(tx.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("re-parse transaction into go-bt: %w", err)
+	}
+
+	if len(btx.Inputs) != len(tx.Inputs) {
+		return nil, fmt.Errorf("input count mismatch after re-parse: bt=%d sdk=%d", len(btx.Inputs), len(tx.Inputs))
+	}
+
+	for i, in := range tx.Inputs {
+		sats := in.SourceTxSatoshis()
+		lock := in.SourceTxScript()
+		if sats == nil || lock == nil {
+			return nil, fmt.Errorf("%w: input %d", errMissingSourceData, i)
+		}
+
+		btx.Inputs[i].PreviousTxSatoshis = *sats
+		// script.Script and bscript.Script are both []byte; convert directly.
+		prevScript := bscript.Script(*lock)
+		btx.Inputs[i].PreviousTxScript = &prevScript
+	}
+
+	return btx, nil
+}

--- a/validator/errmap.go
+++ b/validator/errmap.go
@@ -1,0 +1,66 @@
+package validator
+
+import (
+	"errors"
+	"strings"
+
+	tnerr "github.com/bsv-blockchain/teranode/errors"
+
+	arcerrors "github.com/bsv-blockchain/arcade/errors"
+)
+
+// mapTeranodeError translates an error from the BDK-backed TxValidator (or the
+// extended-format conversion) into an arcade ArcError carrying an ARC status
+// code. The original message is preserved as ExtraInfo so the client-facing
+// reason and the persisted StatusRejected/ExtraInfo are unchanged.
+func mapTeranodeError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, errMissingSourceData) {
+		return arcerrors.NewArcErrorWithInfo(err, arcerrors.StatusTxFormat, err.Error())
+	}
+
+	msg := err.Error()
+
+	var te *tnerr.Error
+	if errors.As(err, &te) {
+		switch te.Code() {
+		case tnerr.ERR_PROCESSING:
+			// Internal BDK/cgo failure (e.g. SCRIPT_ERR_CGO_EXCEPTION) — not
+			// attributable to the submitted transaction.
+			return arcerrors.NewArcErrorWithInfo(err, arcerrors.StatusGeneric, msg)
+		case tnerr.ERR_INVALID_ARGUMENT:
+			return arcerrors.NewArcErrorWithInfo(err, arcerrors.StatusMalformed, msg)
+		}
+	}
+
+	return classifyByMessage(err, msg)
+}
+
+// classifyByMessage picks an ARC status from teranode's deterministic error
+// messages. The BDK adapter wraps fee/script/policy failures under
+// ERR_TX_INVALID, so the precise status is recovered from the message text.
+func classifyByMessage(err error, msg string) error {
+	lower := strings.ToLower(msg)
+
+	switch {
+	case strings.Contains(lower, "fee is too low"),
+		strings.Contains(lower, "input satoshis is less than output"):
+		return arcerrors.NewArcErrorWithInfo(err, arcerrors.StatusFees, msg)
+	case strings.Contains(lower, "coinbase"),
+		strings.Contains(lower, "bad-txns-inputs-too-large"):
+		return arcerrors.NewArcErrorWithInfo(err, arcerrors.StatusInputs, msg)
+	case strings.Contains(lower, "oversize"),
+		strings.Contains(lower, "tx-size"),
+		strings.Contains(lower, "too big"):
+		return arcerrors.NewArcErrorWithInfo(err, arcerrors.StatusTxSize, msg)
+	case strings.Contains(lower, "gobdk"),
+		strings.Contains(lower, "script"):
+		// Script execution / standardness / policy failure from the engine.
+		return arcerrors.NewArcErrorWithInfo(err, arcerrors.StatusUnlockingScripts, msg)
+	default:
+		return arcerrors.NewArcErrorWithInfo(err, arcerrors.StatusGeneric, msg)
+	}
+}

--- a/validator/errmap.go
+++ b/validator/errmap.go
@@ -33,6 +33,10 @@ func mapTeranodeError(err error) error {
 			return arcerrors.NewArcErrorWithInfo(err, arcerrors.StatusGeneric, msg)
 		case tnerr.ERR_INVALID_ARGUMENT:
 			return arcerrors.NewArcErrorWithInfo(err, arcerrors.StatusMalformed, msg)
+		default:
+			// Every other teranode code (notably ERR_TX_INVALID, which wraps
+			// fee/script/policy failures) is classified from the message text.
+			return classifyByMessage(err, msg)
 		}
 	}
 

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,355 +1,230 @@
 // Package validator provides transaction validation functionality.
+//
+// Validation is delegated to teranode's BDK-backed TxValidator
+// (github.com/bsv-blockchain/teranode/services/validator), the exact validator
+// teranode/svnode use to admit transactions. This guarantees that arcade's
+// intake decision matches node consensus across protocol upgrades instead of
+// re-implementing the rules in pure Go, which previously drifted (e.g. the
+// Chronicle push-only relaxation had to be hand-patched here). See issue #192.
+//
+// Because the BDK engine is a cgo binding to the BSV C++ consensus library,
+// this package requires CGO_ENABLED=1 and the gobdk static archive (delivered
+// by `go mod download`) to build and run.
 package validator
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
-	"github.com/bsv-blockchain/go-sdk/chainhash"
-	"github.com/bsv-blockchain/go-sdk/script"
-	"github.com/bsv-blockchain/go-sdk/script/interpreter"
-	"github.com/bsv-blockchain/go-sdk/spv"
+	chaincfg "github.com/bsv-blockchain/go-chaincfg"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
-	feemodel "github.com/bsv-blockchain/go-sdk/transaction/fee_model"
-
-	arcerrors "github.com/bsv-blockchain/arcade/errors"
+	tnvalidator "github.com/bsv-blockchain/teranode/services/validator"
+	"github.com/bsv-blockchain/teranode/settings"
+	"github.com/bsv-blockchain/teranode/ulogger"
 )
 
 const (
-	maxBlockSize                       = 4 * 1024 * 1024 * 1024
-	maxSatoshis                        = 21_000_000_00_000_000
-	maxTxSigopsCountPolicyAfterGenesis = ^uint32(0)
-	minTxSizeBytes                     = 61
-	dustLimit                          = 1
+	// allForksActiveHeight is the block height arcade reports to the BDK
+	// validator at intake. It sits above every network's Genesis and Chronicle
+	// activation heights — so all protocol upgrades evaluate as active and
+	// arcade validates against current consensus rules — yet stays below
+	// math.MaxInt32. The BDK adapter converts the height to int32 and, in policy
+	// mode, evaluates blockHeight-1, so math.MaxUint32 would overflow and reject
+	// every transaction. arcade's intake is height-agnostic post-Genesis, so a
+	// static height avoids a chain-tip lookup on the hot path.
+	allForksActiveHeight uint32 = 2_000_000_000
+
+	// assumedUTXOHeight is the per-input source height arcade reports for every
+	// spent output. arcade does not track per-UTXO confirmation heights on the
+	// intake path, so it reports a height far below allForksActiveHeight; every
+	// input therefore appears mature. This matches arcade's prior behaviour of
+	// not enforcing coinbase maturity / relative locktime at intake — teranode
+	// remains the authority and re-checks with real heights downstream.
+	assumedUTXOHeight uint32 = 1
+
+	// maxTxSizePolicyConsensusLimit is the BDK consensus ceiling on the policy
+	// max-tx-size setting; the engine rejects construction above it.
+	maxTxSizePolicyConsensusLimit = 1_000_000_000
+
+	// defaultNetwork is used by NewValidator, which retains the legacy
+	// network-less constructor for tests and callers that do not select one.
+	defaultNetwork = "mainnet"
 )
 
-// DefaultMinFeePerKB defines the minimum fee per kilobyte.
+// DefaultMinFeePerKB defines the default minimum fee per kilobyte, in satoshis.
 var DefaultMinFeePerKB = uint64(100)
 
-var (
-	ErrNoInputsOrOutputs               = errors.New("transaction has no inputs or outputs")
-	ErrTxOutputInvalid                 = errors.New("transaction output is invalid")
-	ErrTxOutputSatoshisInvalid         = errors.New("output satoshis is invalid")
-	ErrTxOutputNonZeroOpReturn         = errors.New("output has non 0 value op return")
-	ErrTxOutputTotalSatoshisTooHigh    = errors.New("output total satoshis is too high")
-	ErrTxInputInvalid                  = errors.New("transaction input is invalid")
-	ErrTxInputCoinbaseInput            = errors.New("input is a coinbase input")
-	ErrTxInputSatoshisTooHigh          = errors.New("input satoshis is too high")
-	ErrTxInputTotalSatoshisTooHigh     = errors.New("input total satoshis is too high")
-	ErrUnlockingScriptHasTooManySigOps = errors.New("transaction unlocking scripts have too many sigops")
-	ErrEmptyUnlockingScript            = errors.New("transaction input unlocking script is empty")
-	ErrUnlockingScriptNotPushOnly      = errors.New("transaction input unlocking script is not push only")
-	ErrTxSizeLessThanMinSize           = fmt.Errorf("transaction size in bytes is less than %d bytes", minTxSizeBytes)
-	ErrTxSizeGreaterThanMax            = fmt.Errorf("transaction size in bytes is greater than %d bytes", maxBlockSize)
-)
-
-// Policy defines validation policy settings
+// Policy defines the operator-facing validation policy. Fields left at their
+// zero value fall back to arcade/teranode defaults.
 type Policy struct {
-	MaxTxSizePolicy         int
+	// MaxTxSizePolicy caps transaction size in bytes (0 => defaultMaxTxSizePolicy).
+	MaxTxSizePolicy int
+	// MaxTxSigopsCountsPolicy caps sigops per transaction (0 => unlimited, the
+	// BSV post-Genesis default).
 	MaxTxSigopsCountsPolicy int64
-	MinFeePerKB             *uint64
+	// MinFeePerKB is the fee floor in satoshis/kB. A nil pointer uses
+	// DefaultMinFeePerKB; an explicit pointer-to-zero accepts any fee.
+	MinFeePerKB *uint64
 }
 
-// Validator performs local transaction validation before submission.
+// Validator performs intake transaction validation by delegating to teranode's
+// BDK-backed TxValidator. It holds two validators: one that enforces the fee
+// floor and one that does not, so ValidateTransaction can honour skipFees
+// without disabling the script/standardness checks (which SkipPolicyChecks
+// would also turn off).
 type Validator struct {
-	policy *Policy
+	tv          *tnvalidator.TxValidator
+	tvNoFee     *tnvalidator.TxValidator
+	minFeePerKB uint64
 }
 
-// NewValidator creates a new transaction validator with the given policy.
-// A nil policy uses defaults.
+// NewValidator creates a validator for mainnet with the given policy. A nil
+// policy uses defaults. Retained for backward compatibility; production wiring
+// should use NewValidatorForNetwork to select the configured network.
 func NewValidator(policy *Policy) *Validator {
-	if policy == nil {
-		policy = &Policy{}
+	v, err := NewValidatorForNetwork(defaultNetwork, policy)
+	if err != nil {
+		// mainnet params always resolve; a failure here is a programming error.
+		panic(err)
 	}
-	if policy.MaxTxSizePolicy == 0 {
-		policy.MaxTxSizePolicy = maxBlockSize
-	}
-	if policy.MaxTxSigopsCountsPolicy == 0 {
-		policy.MaxTxSigopsCountsPolicy = int64(maxTxSigopsCountPolicyAfterGenesis)
-	}
-	if policy.MinFeePerKB == nil {
-		policy.MinFeePerKB = &DefaultMinFeePerKB
-	}
-	return &Validator{policy: policy}
+	return v
 }
 
-// ValidatePolicy validates a transaction against node policy rules
-func (v *Validator) ValidatePolicy(tx *sdkTx.Transaction) error {
-	txSize := tx.Size()
-
-	if len(tx.Inputs) == 0 || len(tx.Outputs) == 0 {
-		return ErrNoInputsOrOutputs
+// NewValidatorForNetwork creates a validator bound to the given network
+// (mainnet/testnet/teratestnet/regtest). It returns an error for an unknown
+// network rather than letting the BDK adapter fail fatally.
+func NewValidatorForNetwork(network string, policy *Policy) (*Validator, error) {
+	params, err := chaincfg.GetChainParams(network)
+	if err != nil {
+		return nil, fmt.Errorf("validator: resolve chain params for network %q: %w", network, err)
 	}
 
-	if txSize > v.policy.MaxTxSizePolicy {
-		return ErrTxSizeGreaterThanMax
+	minFee := DefaultMinFeePerKB
+	if policy != nil && policy.MinFeePerKB != nil {
+		minFee = *policy.MinFeePerKB
 	}
 
-	if txSize < minTxSizeBytes {
-		return ErrTxSizeLessThanMinSize
+	// 0 => keep the canonical default from defaultPolicySettings. An explicit
+	// override is capped at the BDK consensus limit so construction never panics.
+	maxTxSize := 0
+	if policy != nil && policy.MaxTxSizePolicy > 0 {
+		maxTxSize = policy.MaxTxSizePolicy
+		if maxTxSize > maxTxSizePolicyConsensusLimit {
+			maxTxSize = maxTxSizePolicyConsensusLimit
+		}
 	}
 
-	if err := v.checkInputs(tx); err != nil {
-		return err
+	var maxSigops int64 // 0 => unlimited (BSV post-Genesis)
+	if policy != nil && policy.MaxTxSigopsCountsPolicy > 0 {
+		maxSigops = policy.MaxTxSigopsCountsPolicy
 	}
 
-	if err := v.checkOutputs(tx); err != nil {
-		return err
-	}
+	logger := ulogger.New("arcade-validator")
 
-	if err := v.sigOpsCheck(tx); err != nil {
-		return err
-	}
-
-	if err := v.pushDataCheck(tx); err != nil {
-		return err
-	}
-
-	return nil
+	return &Validator{
+		tv:          tnvalidator.NewTxValidator(logger, buildSettings(params, maxTxSize, maxSigops, minFee)),
+		tvNoFee:     tnvalidator.NewTxValidator(logger, buildSettings(params, maxTxSize, maxSigops, 0)),
+		minFeePerKB: minFee,
+	}, nil
 }
 
-// MinFeePerKB returns the configured minimum fee per KB
+// MinFeePerKB returns the configured minimum fee per kB, in satoshis.
 func (v *Validator) MinFeePerKB() uint64 {
-	return *v.policy.MinFeePerKB
+	return v.minFeePerKB
 }
 
-// ValidateTransaction runs policy validation, script execution on every
-// input, and optionally fee adequacy. Merkle-proof verification on BEEF
-// parents is always skipped (GullibleHeadersClient) because arcade does
-// not own a chaintracker on the intake path — script execution against
-// the source data carried in EF/BEEF is the meaningful per-tx check at
-// submit time. spv.Verify takes a context.Context as its first argument;
-// callers that don't have a ctx can pass context.TODO().
+// ValidateTransaction validates a transaction against current node consensus
+// rules using the BDK engine. The transaction is converted to extended go-bt
+// form from the source data carried in EF/BEEF; a missing source output is a
+// hard rejection (StatusTxFormat). When skipFees is true the fee floor is not
+// enforced but all script and standardness checks still run.
 //
-//nolint:contextcheck // ctx==nil callers are explicitly supported via TODO fallback below
-func (v *Validator) ValidateTransaction(ctx context.Context, tx *sdkTx.Transaction, skipFees bool) error {
-	if err := v.ValidatePolicy(tx); err != nil {
-		return v.wrapPolicyError(err)
+// ctx is accepted for call-site compatibility; BDK validation is synchronous
+// and does not observe it.
+func (v *Validator) ValidateTransaction(_ context.Context, tx *sdkTx.Transaction, skipFees bool) error {
+	btx, err := toExtendedBT(tx)
+	if err != nil {
+		return mapTeranodeError(err)
 	}
 
-	var feeModel sdkTx.FeeModel
-	if !skipFees {
-		feeModel = &feemodel.SatoshisPerKilobyte{Satoshis: *v.policy.MinFeePerKB}
+	utxoHeights := make([]uint32, len(btx.Inputs))
+	for i := range utxoHeights {
+		utxoHeights[i] = assumedUTXOHeight
 	}
 
-	if ctx == nil {
-		ctx = context.TODO()
+	tv := v.tv
+	if skipFees {
+		tv = v.tvNoFee
 	}
 
-	if _, err := spv.Verify(ctx, tx, &spv.GullibleHeadersClient{}, feeModel); err != nil {
-		return v.wrapSPVError(err)
-	}
-
-	return nil
-}
-
-// wrapPolicyError wraps policy validation errors with ARC-compatible status codes.
-func (v *Validator) wrapPolicyError(err error) error {
-	switch {
-	case errors.Is(err, ErrNoInputsOrOutputs):
-		return arcerrors.NewArcError(err, arcerrors.StatusMalformed)
-	case errors.Is(err, ErrTxSizeGreaterThanMax), errors.Is(err, ErrTxSizeLessThanMinSize):
-		return arcerrors.NewArcError(err, arcerrors.StatusTxSize)
-	case errors.Is(err, ErrTxInputInvalid):
-		return arcerrors.NewArcError(err, arcerrors.StatusInputs)
-	case errors.Is(err, ErrTxOutputInvalid):
-		return arcerrors.NewArcError(err, arcerrors.StatusOutputs)
-	case errors.Is(err, ErrUnlockingScriptHasTooManySigOps),
-		errors.Is(err, ErrEmptyUnlockingScript),
-		errors.Is(err, ErrUnlockingScriptNotPushOnly):
-		return arcerrors.NewArcError(err, arcerrors.StatusUnlockingScripts)
-	default:
-		return arcerrors.NewArcError(err, arcerrors.StatusMalformed)
-	}
-}
-
-// wrapSPVError wraps SPV verification errors with ARC-compatible status codes.
-func (v *Validator) wrapSPVError(err error) error {
-	errStr := err.Error()
-	switch {
-	case contains(errStr, "fee"):
-		return arcerrors.NewArcErrorWithInfo(err, arcerrors.StatusFees, errStr)
-	case contains(errStr, "script"):
-		return arcerrors.NewArcError(err, arcerrors.StatusUnlockingScripts)
-	case contains(errStr, "input"), contains(errStr, "source"):
-		return arcerrors.NewArcError(err, arcerrors.StatusInputs)
-	case contains(errStr, "merkle"):
-		return arcerrors.NewArcError(err, arcerrors.StatusGeneric)
-	default:
-		return arcerrors.NewArcError(err, arcerrors.StatusGeneric)
-	}
-}
-
-func contains(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsStr(s, sub))
-}
-
-func containsStr(s, sub string) bool {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
-}
-
-func (v *Validator) checkOutputs(tx *sdkTx.Transaction) error {
-	total := uint64(0)
-	for _, output := range tx.Outputs {
-		isData := output.LockingScript.IsData()
-		switch {
-		case !isData && (output.Satoshis > maxSatoshis || output.Satoshis < dustLimit):
-			return errors.Join(ErrTxOutputInvalid, ErrTxOutputSatoshisInvalid)
-		case isData && output.Satoshis != 0:
-			return errors.Join(ErrTxOutputInvalid, ErrTxOutputNonZeroOpReturn)
-		}
-		// Overflow-safe accumulation: both total and output.Satoshis are
-		// individually <= maxSatoshis here, so maxSatoshis - output.Satoshis
-		// cannot underflow and the comparison catches any wrap before it
-		// happens.
-		if total > maxSatoshis-output.Satoshis {
-			return errors.Join(ErrTxOutputInvalid, ErrTxOutputTotalSatoshisTooHigh)
-		}
-		total += output.Satoshis
-	}
-	if total > maxSatoshis {
-		return errors.Join(ErrTxOutputInvalid, ErrTxOutputTotalSatoshisTooHigh)
+	if vErr := tv.ValidateTransaction(btx, allForksActiveHeight, utxoHeights, tnvalidator.NewDefaultOptions()); vErr != nil {
+		return mapTeranodeError(vErr)
 	}
 	return nil
 }
 
-func (v *Validator) checkInputs(tx *sdkTx.Transaction) error {
-	total := uint64(0)
-	for _, input := range tx.Inputs {
-		if *input.SourceTXID == (chainhash.Hash{}) {
-			return errors.Join(ErrTxInputInvalid, ErrTxInputCoinbaseInput)
-		}
-
-		inputSatoshis := uint64(0)
-		if input.SourceTxSatoshis() != nil {
-			inputSatoshis = *input.SourceTxSatoshis()
-		}
-
-		if inputSatoshis > maxSatoshis {
-			return errors.Join(ErrTxInputInvalid, ErrTxInputSatoshisTooHigh)
-		}
-		// Overflow-safe accumulation: both total and inputSatoshis are
-		// individually <= maxSatoshis here, so maxSatoshis - inputSatoshis
-		// cannot underflow and the comparison catches any wrap before it
-		// happens.
-		if total > maxSatoshis-inputSatoshis {
-			return errors.Join(ErrTxInputInvalid, ErrTxInputTotalSatoshisTooHigh)
-		}
-		total += inputSatoshis
-	}
-	if total > maxSatoshis {
-		return errors.Join(ErrTxInputInvalid, ErrTxInputTotalSatoshisTooHigh)
-	}
-	return nil
+// ValidatePolicy runs structural, script and standardness validation without
+// enforcing the fee floor. Retained for callers that want a fee-agnostic check.
+func (v *Validator) ValidatePolicy(tx *sdkTx.Transaction) error {
+	return v.ValidateTransaction(context.Background(), tx, true)
 }
 
-func (v *Validator) sigOpsCheck(tx *sdkTx.Transaction) error {
-	parser := interpreter.DefaultOpcodeParser{}
-	numSigOps := int64(0)
-
-	for _, input := range tx.Inputs {
-		parsedUnlockingScript, err := parser.Parse(input.UnlockingScript)
-		if err != nil {
-			return err
-		}
-		numSigOps += countSigOps(parsedUnlockingScript)
+// buildSettings assembles a teranode settings.Settings for the BDK validator:
+// canonical BSV policy defaults, with the operator-controlled tx-size, sigop
+// and fee values applied. minFeePerKB is in satoshis/kB and converted to the
+// BSV/kB units teranode's fee check expects (0 => no fee floor).
+func buildSettings(params *chaincfg.Params, maxTxSize int, maxSigops int64, minFeePerKB uint64) *settings.Settings {
+	pol := defaultPolicySettings()
+	if maxTxSize > 0 {
+		pol.MaxTxSizePolicy = maxTxSize
 	}
-
-	for _, output := range tx.Outputs {
-		parsedLockingScript, err := parser.Parse(output.LockingScript)
-		if err != nil {
-			return err
-		}
-		numSigOps += countSigOps(parsedLockingScript)
-	}
-
-	if numSigOps > v.policy.MaxTxSigopsCountsPolicy {
-		return ErrUnlockingScriptHasTooManySigOps
-	}
-	return nil
+	pol.MaxTxSigopsCountsPolicy = maxSigops
+	pol.MinMiningTxFee = satPerKBToBSVPerKB(minFeePerKB)
+	return &settings.Settings{ChainCfgParams: params, Policy: pol}
 }
 
-// countSigOps counts the signature operations contained in a parsed script.
-//
-// The accounting follows the standard Bitcoin policy used by node
-// implementations:
-//
-//   - OP_CHECKSIG and OP_CHECKSIGVERIFY each contribute 1 sigop.
-//   - OP_CHECKMULTISIG and OP_CHECKMULTISIGVERIFY contribute the value of
-//     the immediately-preceding small-int opcode (OP_1..OP_16), or
-//     MaxPubKeysPerMultiSigBeforeGenesis (20) if no small-int precedes.
-//
-// This is the cheap, static count used to enforce the policy budget
-// (MaxTxSigopsCountsPolicy). It does not recurse into P2SH redeem scripts;
-// BSV has disabled P2SH at the consensus level so that case is intentionally
-// out of scope here.
-func countSigOps(lockingScript interpreter.ParsedScript) int64 {
-	numSigOps := int64(0)
-	for i, op := range lockingScript {
-		switch op.Value() {
-		case script.OpCHECKSIG, script.OpCHECKSIGVERIFY:
-			numSigOps++
-		case script.OpCHECKMULTISIG, script.OpCHECKMULTISIGVERIFY:
-			numSigOps += multisigSigOpCount(lockingScript, i)
-		}
+// defaultPolicySettings returns teranode's canonical BSV policy values.
+// settings.NewPolicySettings() returns an all-zero struct (zeros would make the
+// C++ engine reject memory-bound scripts), so every field the BDK adapter reads
+// is set explicitly. DataCarrier is enabled because arcade accepts OP_RETURN
+// data transactions; MaxTxSizePolicy and MinMiningTxFee are overwritten by
+// buildSettings.
+func defaultPolicySettings() *settings.PolicySettings {
+	return &settings.PolicySettings{
+		ExcessiveBlockSize:              4294967296,
+		MaxTxSizePolicy:                 10485760,
+		MaxOrphanTxSize:                 1000000,
+		DataCarrierSize:                 1000000,
+		MaxScriptSizePolicy:             500000,
+		MaxOpsPerScriptPolicy:           1000000,
+		MaxScriptNumLengthPolicy:        10000,
+		MaxPubKeysPerMultisigPolicy:     0,
+		MaxTxSigopsCountsPolicy:         0,
+		MaxStackMemoryUsagePolicy:       104857600,
+		MaxStackMemoryUsageConsensus:    0,
+		LimitAncestorCount:              1000000,
+		LimitCPFPGroupMembersCount:      1000000,
+		AcceptNonStdOutputs:             true,
+		RequireStandard:                 false,
+		DataCarrier:                     true,
+		PermitBareMultisig:              true,
+		MinMiningTxFee:                  0,
+		MaxStdTxValidationDuration:      3,
+		MaxNonStdTxValidationDuration:   1000,
+		MaxTxChainValidationBudget:      50,
+		ValidationClockCPU:              false,
+		MinConsolidationFactor:          20,
+		MaxConsolidationInputScriptSize: 150,
+		MinConfConsolidationInput:       6,
+		MinConsolidationInputMaturity:   6,
+		AcceptNonStdConsolidationInput:  false,
+		MaxCoinsViewCacheSize:           0,
 	}
-	return numSigOps
 }
 
-// multisigSigOpCount returns the sigop weight of an OP_CHECKMULTISIG[VERIFY]
-// at index i in script. If the immediately-preceding opcode is OP_1..OP_16,
-// the weight is that small int (1..16); otherwise the weight defaults to
-// MaxPubKeysPerMultiSigBeforeGenesis (20), the standard upper bound applied
-// by Bitcoin-family nodes when the explicit pubkey count is not statically
-// visible.
-func multisigSigOpCount(s interpreter.ParsedScript, i int) int64 {
-	if i > 0 {
-		prev := s[i-1].Value()
-		if prev >= script.Op1 && prev <= script.Op16 {
-			return int64(prev-script.Op1) + 1
-		}
-	}
-	return int64(interpreter.MaxPubKeysPerMultiSigBeforeGenesis)
-}
-
-// pushDataCheck enforces the "data only in unlocking script" rule: an input's
-// unlocking script may contain only data-push operations, never functional
-// opcodes.
-//
-// The Chronicle upgrade (BSV mainnet block 943,816) lifted this rule for
-// transactions that opt in with a version greater than 1. Version 0/1
-// transactions retain the original push-only requirement; for version >= 2 the
-// unlocking script may carry functional opcodes. This mirrors svnode/BDK, where
-// the same relaxation is gated on the transaction version, not the block
-// height, so the gate here is purely version-based.
-// https://docs.bsvblockchain.org/network-topology/nodes/sv-node/chronicle-release
-//
-// The empty-unlocking-script rejection is independent of the push-only rule and
-// is applied to every transaction regardless of version.
-func (v *Validator) pushDataCheck(tx *sdkTx.Transaction) error {
-	enforcePushOnly := tx.Version < 2
-
-	for _, input := range tx.Inputs {
-		if input.UnlockingScript == nil {
-			return ErrEmptyUnlockingScript
-		}
-		if !enforcePushOnly {
-			continue
-		}
-		parser := interpreter.DefaultOpcodeParser{}
-		parsedUnlockingScript, err := parser.Parse(input.UnlockingScript)
-		if err != nil {
-			return err
-		}
-		if !parsedUnlockingScript.IsPushOnly() {
-			return ErrUnlockingScriptNotPushOnly
-		}
-	}
-	return nil
+// satPerKBToBSVPerKB converts a satoshis/kB fee rate to BSV/kB, the unit
+// teranode's checkFees expects (it converts back via *1e8/1000). 100 sat/kB =>
+// 0.000001 BSV/kB.
+func satPerKBToBSVPerKB(satPerKB uint64) float64 {
+	return float64(satPerKB) / 1e8
 }

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -222,10 +222,12 @@ func TestValidate_ChronicleVersionGate(t *testing.T) {
 }
 
 // TestValidate_FeeTooLow confirms an underpaid transaction is rejected with the
-// fee status. The output consumes all but 1 satoshi of a large input across a
-// padded transaction, so the fee is below the 100 sat/kB floor.
+// fee status. The validator is built with a deliberately high fee floor so the
+// 1-satoshi fee (a 100_000-sat input spent to a 99_999-sat output) is
+// unambiguously below it regardless of BDK's default fee policy.
 func TestValidate_FeeTooLow(t *testing.T) {
-	v := NewValidator(nil)
+	highFee := uint64(1_000_000) // 1M sat/kB — any realistic tx underpays.
+	v := NewValidator(&Policy{MinFeePerKB: &highFee})
 	in := spendableSource(nonPushUnlocking(), 100_000, []byte{script.OpTRUE})
 	tx := &sdkTx.Transaction{
 		Version: 2,
@@ -235,13 +237,13 @@ func TestValidate_FeeTooLow(t *testing.T) {
 
 	err := v.ValidateTransaction(context.Background(), tx, false)
 	if err == nil {
-		t.Skip("BDK accepted near-zero fee; min fee policy may differ from expectation")
+		t.Fatal("underpaid tx must be rejected with a fee error")
 	}
 	if arcErr := arcerrors.GetArcError(err); arcErr == nil || arcErr.StatusCode != arcerrors.StatusFees {
 		t.Errorf("expected StatusFees, got %v", err)
 	}
 
-	// skipFees must accept the same transaction.
+	// skipFees must accept the same transaction (tvNoFee ignores the floor).
 	if err := v.ValidateTransaction(context.Background(), tx, true); err != nil {
 		t.Errorf("skipFees should accept underpaid tx, got %v", err)
 	}

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -1,56 +1,38 @@
 package validator
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/script"
-	"github.com/bsv-blockchain/go-sdk/script/interpreter"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+	tnerr "github.com/bsv-blockchain/teranode/errors"
 
 	arcerrors "github.com/bsv-blockchain/arcade/errors"
 )
 
+// --- construction --------------------------------------------------------
+
 func TestNewValidator_Defaults(t *testing.T) {
 	v := NewValidator(nil)
-	if v.policy.MaxTxSizePolicy != maxBlockSize {
-		t.Errorf("expected maxBlockSize default, got %d", v.policy.MaxTxSizePolicy)
-	}
-	if v.policy.MinFeePerKB == nil || *v.policy.MinFeePerKB != DefaultMinFeePerKB {
-		t.Error("expected default min fee per KB")
-	}
-}
-
-func TestNewValidator_CustomPolicy(t *testing.T) {
-	minFee := uint64(50)
-	p := &Policy{
-		MaxTxSizePolicy:         1000,
-		MaxTxSigopsCountsPolicy: 500,
-		MinFeePerKB:             &minFee,
-	}
-	v := NewValidator(p)
-	if v.policy.MaxTxSizePolicy != 1000 {
-		t.Errorf("expected 1000, got %d", v.policy.MaxTxSizePolicy)
-	}
-	if *v.policy.MinFeePerKB != 50 {
-		t.Errorf("expected 50, got %d", *v.policy.MinFeePerKB)
-	}
-}
-
-func TestMinFeePerKB(t *testing.T) {
-	v := NewValidator(nil)
 	if v.MinFeePerKB() != DefaultMinFeePerKB {
-		t.Errorf("expected %d, got %d", DefaultMinFeePerKB, v.MinFeePerKB())
+		t.Errorf("expected default min fee %d, got %d", DefaultMinFeePerKB, v.MinFeePerKB())
 	}
 }
 
-// TestNewValidator_PreservesExplicitZeroFee guards the invariant that
-// validatorPolicyFromConfig (app/app.go) relies on to implement
-// validator.accept_zero_fee: NewValidator's default substitution fires
-// only when the MinFeePerKB *pointer* is nil, so a non-nil pointer to a
-// zero value must be preserved verbatim. If this test ever fails the
-// zero-fee config flag silently regresses to the 100 sat/kB default.
+func TestNewValidator_CustomMinFee(t *testing.T) {
+	minFee := uint64(50)
+	v := NewValidator(&Policy{MinFeePerKB: &minFee})
+	if v.MinFeePerKB() != 50 {
+		t.Errorf("expected 50, got %d", v.MinFeePerKB())
+	}
+}
+
+// TestNewValidator_PreservesExplicitZeroFee guards the accept_zero_fee invariant
+// that validatorPolicyFromConfig (app/app.go) relies on: a non-nil pointer to a
+// zero value must be preserved verbatim rather than substituted with the default.
 func TestNewValidator_PreservesExplicitZeroFee(t *testing.T) {
 	zero := uint64(0)
 	v := NewValidator(&Policy{MinFeePerKB: &zero})
@@ -59,502 +41,207 @@ func TestNewValidator_PreservesExplicitZeroFee(t *testing.T) {
 	}
 }
 
-func TestWrapPolicyError_Malformed(t *testing.T) {
-	v := NewValidator(nil)
-	err := v.wrapPolicyError(ErrNoInputsOrOutputs)
-
-	arcErr := arcerrors.GetArcError(err)
-	if arcErr == nil {
-		t.Fatal("expected ArcError")
-	}
-	if arcErr.StatusCode != arcerrors.StatusMalformed {
-		t.Errorf("expected StatusMalformed (463), got %d", arcErr.StatusCode)
+func TestNewValidatorForNetwork_KnownNetworks(t *testing.T) {
+	for _, n := range []string{"mainnet", "testnet", "teratestnet", "regtest"} {
+		if _, err := NewValidatorForNetwork(n, nil); err != nil {
+			t.Errorf("network %q: unexpected error %v", n, err)
+		}
 	}
 }
 
-func TestWrapPolicyError_TxSize(t *testing.T) {
-	v := NewValidator(nil)
-	err := v.wrapPolicyError(ErrTxSizeGreaterThanMax)
-
-	arcErr := arcerrors.GetArcError(err)
-	if arcErr == nil {
-		t.Fatal("expected ArcError")
-	}
-	if arcErr.StatusCode != arcerrors.StatusTxSize {
-		t.Errorf("expected StatusTxSize (474), got %d", arcErr.StatusCode)
+func TestNewValidatorForNetwork_UnknownNetwork(t *testing.T) {
+	if _, err := NewValidatorForNetwork("nope", nil); err == nil {
+		t.Fatal("expected error for unknown network, got nil")
 	}
 }
 
-func TestWrapPolicyError_Inputs(t *testing.T) {
-	v := NewValidator(nil)
-	err := v.wrapPolicyError(ErrTxInputInvalid)
-
-	arcErr := arcerrors.GetArcError(err)
-	if arcErr == nil {
-		t.Fatal("expected ArcError")
+func TestSatPerKBToBSVPerKB(t *testing.T) {
+	// 100 sat/kB == 0.000001 BSV/kB; teranode converts back via *1e8/1000.
+	if got := satPerKBToBSVPerKB(100); got != 0.000001 {
+		t.Errorf("expected 0.000001, got %v", got)
 	}
-	if arcErr.StatusCode != arcerrors.StatusInputs {
-		t.Errorf("expected StatusInputs (462), got %d", arcErr.StatusCode)
+	if got := satPerKBToBSVPerKB(0); got != 0 {
+		t.Errorf("expected 0, got %v", got)
 	}
 }
 
-func TestWrapPolicyError_Outputs(t *testing.T) {
-	v := NewValidator(nil)
-	err := v.wrapPolicyError(ErrTxOutputInvalid)
+// --- conversion ----------------------------------------------------------
 
-	arcErr := arcerrors.GetArcError(err)
-	if arcErr == nil {
-		t.Fatal("expected ArcError")
-	}
-	if arcErr.StatusCode != arcerrors.StatusOutputs {
-		t.Errorf("expected StatusOutputs (464), got %d", arcErr.StatusCode)
-	}
-}
-
-func TestWrapPolicyError_UnlockingScripts(t *testing.T) {
-	v := NewValidator(nil)
-	err := v.wrapPolicyError(ErrUnlockingScriptHasTooManySigOps)
-
-	arcErr := arcerrors.GetArcError(err)
-	if arcErr == nil {
-		t.Fatal("expected ArcError")
-	}
-	if arcErr.StatusCode != arcerrors.StatusUnlockingScripts {
-		t.Errorf("expected StatusUnlockingScripts (461), got %d", arcErr.StatusCode)
-	}
-}
-
-// nonDataLockingScript returns a minimal non-data locking script suitable for
-// exercising the output validation paths. A single OP_TRUE (0x51) is treated
-// as a non-data, non-empty locking script by the SDK's IsData heuristic.
-func nonDataLockingScript() *script.Script {
-	s := script.Script([]byte{0x51})
-	return &s
-}
-
-// nonZeroSourceTXID returns a pointer to a non-zero chainhash so an input is
-// not treated as a coinbase input by checkInputs.
 func nonZeroSourceTXID() *chainhash.Hash {
 	h := chainhash.Hash{}
 	h[0] = 0x01
 	return &h
 }
 
-// TestCheckOutputs_OverflowGuarded crafts a transaction with two non-data
-// outputs each at maxSatoshis. Each value individually passes the
-// "output.Satoshis > maxSatoshis" check, and their sum exceeds maxSatoshis;
-// the per-iteration guard must reject this before the unbounded total can
-// be relied upon.
-func TestCheckOutputs_OverflowGuarded(t *testing.T) {
-	v := NewValidator(nil)
-
-	tx := &sdkTx.Transaction{
-		Outputs: []*sdkTx.TransactionOutput{
-			{Satoshis: maxSatoshis, LockingScript: nonDataLockingScript()},
-			{Satoshis: maxSatoshis, LockingScript: nonDataLockingScript()},
-		},
-	}
-
-	err := v.checkOutputs(tx)
-	if err == nil {
-		t.Fatal("expected error for total satoshis above maxSatoshis, got nil")
-	}
-	if !errors.Is(err, ErrTxOutputTotalSatoshisTooHigh) {
-		t.Errorf("expected ErrTxOutputTotalSatoshisTooHigh, got %v", err)
-	}
-	if !errors.Is(err, ErrTxOutputInvalid) {
-		t.Errorf("expected ErrTxOutputInvalid wrap, got %v", err)
-	}
+func scriptFromBytes(b []byte) *script.Script {
+	s := script.Script(b)
+	return &s
 }
 
-// TestCheckOutputs_ManySmallOutputsCannotOverflow exercises the per-iteration
-// guard by accumulating many outputs whose total exceeds maxSatoshis. This is
-// the regression case for F-004: prior to the fix a sequence of values that
-// summed past 2^64 could wrap and slip past the post-loop check.
-func TestCheckOutputs_ManySmallOutputsCannotOverflow(t *testing.T) {
-	v := NewValidator(nil)
-
-	half := uint64(maxSatoshis / 2)
-	tx := &sdkTx.Transaction{
-		Outputs: []*sdkTx.TransactionOutput{
-			{Satoshis: half, LockingScript: nonDataLockingScript()},
-			{Satoshis: half, LockingScript: nonDataLockingScript()},
-			{Satoshis: half, LockingScript: nonDataLockingScript()},
-		},
-	}
-
-	err := v.checkOutputs(tx)
-	if err == nil {
-		t.Fatal("expected error for cumulative output satoshis above maxSatoshis, got nil")
-	}
-	if !errors.Is(err, ErrTxOutputTotalSatoshisTooHigh) {
-		t.Errorf("expected ErrTxOutputTotalSatoshisTooHigh, got %v", err)
-	}
-}
-
-// TestCheckOutputs_ValidPasses confirms a legitimate transaction is still
-// accepted by checkOutputs after the overflow guard is added.
-func TestCheckOutputs_ValidPasses(t *testing.T) {
-	v := NewValidator(nil)
+func TestToExtendedBT_PopulatesSourceData(t *testing.T) {
+	in := &sdkTx.TransactionInput{SourceTXID: nonZeroSourceTXID()}
+	in.UnlockingScript = scriptFromBytes([]byte{script.Op0})
+	in.SetSourceTxOutput(&sdkTx.TransactionOutput{Satoshis: 1234, LockingScript: scriptFromBytes([]byte{script.Op1})})
 
 	tx := &sdkTx.Transaction{
-		Outputs: []*sdkTx.TransactionOutput{
-			{Satoshis: 1_000, LockingScript: nonDataLockingScript()},
-			{Satoshis: 2_000, LockingScript: nonDataLockingScript()},
-		},
+		Version: 2,
+		Inputs:  []*sdkTx.TransactionInput{in},
+		Outputs: []*sdkTx.TransactionOutput{{Satoshis: 1000, LockingScript: scriptFromBytes([]byte{script.Op1})}},
 	}
 
-	if err := v.checkOutputs(tx); err != nil {
-		t.Fatalf("expected no error for valid outputs, got %v", err)
-	}
-}
-
-// TestCheckInputs_OverflowGuarded crafts a transaction whose input
-// SourceTxSatoshis values are each <= maxSatoshis but whose cumulative sum
-// exceeds maxSatoshis. Without the per-iteration guard a uint64 wrap could
-// allow the post-loop check to pass.
-func TestCheckInputs_OverflowGuarded(t *testing.T) {
-	v := NewValidator(nil)
-
-	makeInput := func(sats uint64) *sdkTx.TransactionInput {
-		in := &sdkTx.TransactionInput{SourceTXID: nonZeroSourceTXID()}
-		in.SetSourceTxOutput(&sdkTx.TransactionOutput{Satoshis: sats, LockingScript: nonDataLockingScript()})
-		return in
-	}
-
-	tx := &sdkTx.Transaction{
-		Inputs: []*sdkTx.TransactionInput{
-			makeInput(maxSatoshis),
-			makeInput(maxSatoshis),
-		},
-	}
-
-	err := v.checkInputs(tx)
-	if err == nil {
-		t.Fatal("expected error for total input satoshis above maxSatoshis, got nil")
-	}
-	if !errors.Is(err, ErrTxInputTotalSatoshisTooHigh) {
-		t.Errorf("expected ErrTxInputTotalSatoshisTooHigh, got %v", err)
-	}
-	if !errors.Is(err, ErrTxInputInvalid) {
-		t.Errorf("expected ErrTxInputInvalid wrap, got %v", err)
-	}
-}
-
-// TestCheckInputs_ManySmallInputsCannotOverflow exercises the per-iteration
-// guard via accumulation across multiple inputs.
-func TestCheckInputs_ManySmallInputsCannotOverflow(t *testing.T) {
-	v := NewValidator(nil)
-
-	half := uint64(maxSatoshis / 2)
-	makeInput := func(sats uint64) *sdkTx.TransactionInput {
-		in := &sdkTx.TransactionInput{SourceTXID: nonZeroSourceTXID()}
-		in.SetSourceTxOutput(&sdkTx.TransactionOutput{Satoshis: sats, LockingScript: nonDataLockingScript()})
-		return in
-	}
-
-	tx := &sdkTx.Transaction{
-		Inputs: []*sdkTx.TransactionInput{
-			makeInput(half),
-			makeInput(half),
-			makeInput(half),
-		},
-	}
-
-	err := v.checkInputs(tx)
-	if err == nil {
-		t.Fatal("expected error for cumulative input satoshis above maxSatoshis, got nil")
-	}
-	if !errors.Is(err, ErrTxInputTotalSatoshisTooHigh) {
-		t.Errorf("expected ErrTxInputTotalSatoshisTooHigh, got %v", err)
-	}
-}
-
-// parseScript is a small test helper that runs the SDK's default opcode
-// parser over the supplied raw script bytes. The parser itself is exercised
-// by the SDK's own tests, so any error here indicates a bug in the test
-// fixture rather than the code under test.
-func parseScript(t *testing.T, raw []byte) interpreter.ParsedScript {
-	t.Helper()
-	parser := interpreter.DefaultOpcodeParser{}
-	s := script.Script(raw)
-	parsed, err := parser.Parse(&s)
+	btx, err := toExtendedBT(tx)
 	if err != nil {
-		t.Fatalf("parse script %x: %v", raw, err)
+		t.Fatalf("toExtendedBT: %v", err)
 	}
-	return parsed
+	if len(btx.Inputs) != 1 {
+		t.Fatalf("expected 1 input, got %d", len(btx.Inputs))
+	}
+	if btx.Inputs[0].PreviousTxSatoshis != 1234 {
+		t.Errorf("PreviousTxSatoshis = %d, want 1234", btx.Inputs[0].PreviousTxSatoshis)
+	}
+	if btx.Inputs[0].PreviousTxScript == nil || len(*btx.Inputs[0].PreviousTxScript) != 1 {
+		t.Errorf("PreviousTxScript not populated: %v", btx.Inputs[0].PreviousTxScript)
+	}
 }
 
-// TestCountSigOps_EmptyScript ensures an empty script yields zero sigops.
-func TestCountSigOps_EmptyScript(t *testing.T) {
-	parsed := parseScript(t, []byte{})
-	if got := countSigOps(parsed); got != 0 {
-		t.Errorf("empty script: expected 0 sigops, got %d", got)
+func TestToExtendedBT_MissingSourceData(t *testing.T) {
+	in := &sdkTx.TransactionInput{SourceTXID: nonZeroSourceTXID()}
+	in.UnlockingScript = scriptFromBytes([]byte{script.Op0})
+	// No source output set.
+
+	tx := &sdkTx.Transaction{
+		Version: 2,
+		Inputs:  []*sdkTx.TransactionInput{in},
+		Outputs: []*sdkTx.TransactionOutput{{Satoshis: 1000, LockingScript: scriptFromBytes([]byte{script.Op1})}},
+	}
+
+	_, err := toExtendedBT(tx)
+	if !errors.Is(err, errMissingSourceData) {
+		t.Fatalf("expected errMissingSourceData, got %v", err)
 	}
 }
 
-// TestCountSigOps_CheckSig regresses the original behavior: a single
-// OP_CHECKSIG and a single OP_CHECKSIGVERIFY each count as one sigop.
-func TestCountSigOps_CheckSig(t *testing.T) {
+// --- error mapping -------------------------------------------------------
+
+func TestMapTeranodeError(t *testing.T) {
 	cases := []struct {
 		name string
-		raw  []byte
-		want int64
+		err  error
+		want arcerrors.StatusCode
 	}{
-		{"OP_CHECKSIG", []byte{script.OpCHECKSIG}, 1},
-		{"OP_CHECKSIGVERIFY", []byte{script.OpCHECKSIGVERIFY}, 1},
-		{"two OP_CHECKSIG", []byte{script.OpCHECKSIG, script.OpCHECKSIG}, 2},
+		{"missing source data", errMissingSourceData, arcerrors.StatusTxFormat},
+		{"fee too low", tnerr.NewTxInvalidError("transaction fee is too low: 1 < 10 required"), arcerrors.StatusFees},
+		{"input < output", tnerr.NewTxInvalidError("transaction input satoshis is less than output satoshis: 1 < 2"), arcerrors.StatusFees},
+		{"coinbase", tnerr.NewTxInvalidError("transaction input 0 is a coinbase input"), arcerrors.StatusInputs},
+		{"inputs too large", tnerr.NewTxPolicyError("bad-txns-inputs-too-large"), arcerrors.StatusInputs},
+		{"bdk script", tnerr.NewTxInvalidError("GoBDK fail to ValidateTransaction", tnerr.NewTxPolicyError("GoBDK fail to ValidateTransaction by policy settings")), arcerrors.StatusUnlockingScripts},
+		{"cgo processing", tnerr.NewProcessingError("GoBDK fail to ValidateTransaction"), arcerrors.StatusGeneric},
+		{"invalid argument", tnerr.NewInvalidArgumentError("bad height"), arcerrors.StatusMalformed},
 	}
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			parsed := parseScript(t, tc.raw)
-			if got := countSigOps(parsed); got != tc.want {
-				t.Errorf("countSigOps(%s) = %d, want %d", tc.name, got, tc.want)
+			mapped := mapTeranodeError(tc.err)
+			arcErr := arcerrors.GetArcError(mapped)
+			if arcErr == nil {
+				t.Fatalf("expected ArcError, got %v", mapped)
+			}
+			if arcErr.StatusCode != tc.want {
+				t.Errorf("status = %d, want %d (err=%v)", arcErr.StatusCode, tc.want, mapped)
+			}
+			if arcErr.ExtraInfo == "" {
+				t.Error("expected ExtraInfo to carry the reason string")
 			}
 		})
 	}
 }
 
-// TestCountSigOps_CheckMultisigWithSmallInt verifies that an OP_CHECKMULTISIG
-// preceded by OP_3 contributes 3 sigops, matching the canonical
-// "n-of-m signed by n keys" multisig accounting.
-func TestCountSigOps_CheckMultisigWithSmallInt(t *testing.T) {
-	parsed := parseScript(t, []byte{script.Op3, script.OpCHECKMULTISIG})
-	if got := countSigOps(parsed); got != 3 {
-		t.Errorf("OP_3 OP_CHECKMULTISIG: expected 3 sigops, got %d", got)
+func TestMapTeranodeError_Nil(t *testing.T) {
+	if mapTeranodeError(nil) != nil {
+		t.Error("expected nil for nil input")
 	}
 }
 
-// TestCountSigOps_CheckMultisigDefaults verifies that an OP_CHECKMULTISIG
-// with no preceding small-int contributes the standard upper bound of 20
-// sigops (MaxPubKeysPerMultiSigBeforeGenesis).
-func TestCountSigOps_CheckMultisigDefaults(t *testing.T) {
-	parsed := parseScript(t, []byte{script.OpCHECKMULTISIG})
-	if got := countSigOps(parsed); got != 20 {
-		t.Errorf("bare OP_CHECKMULTISIG: expected 20 sigops, got %d", got)
-	}
+// --- end-to-end BDK validation (#192 Chronicle regression) ---------------
+
+// spendableSource builds an input that spends a fabricated previous output with
+// the given locking script and satoshis. The prev txid is non-zero so the input
+// is not treated as a coinbase input.
+func spendableSource(unlocking []byte, prevSats uint64, prevLock []byte) *sdkTx.TransactionInput {
+	in := &sdkTx.TransactionInput{SourceTXID: nonZeroSourceTXID(), SourceTxOutIndex: 0}
+	in.UnlockingScript = scriptFromBytes(unlocking)
+	in.SetSourceTxOutput(&sdkTx.TransactionOutput{Satoshis: prevSats, LockingScript: scriptFromBytes(prevLock)})
+	return in
 }
 
-// TestCountSigOps_CheckMultisigVerifyImmediatelyPrecedingSmallInt ensures we
-// look at the immediately-preceding opcode (OP_15), not some earlier one
-// (OP_3), when assigning sigop weight to OP_CHECKMULTISIGVERIFY.
-func TestCountSigOps_CheckMultisigVerifyImmediatelyPrecedingSmallInt(t *testing.T) {
-	parsed := parseScript(t, []byte{
-		script.Op3, script.OpDROP,
-		script.Op15, script.OpCHECKMULTISIGVERIFY,
-	})
-	if got := countSigOps(parsed); got != 15 {
-		t.Errorf("OP_3 OP_DROP OP_15 OP_CHECKMULTISIGVERIFY: expected 15 sigops, got %d", got)
-	}
+// nonPushUnlocking returns an unlocking script that pushes a 50-byte blob then
+// OP_DROP — a functional (non-push-only) opcode. The leading data push also pads
+// the transaction comfortably past any minimum-size rule. After it runs the
+// stack is empty; paired with an OP_TRUE locking script the combined script
+// evaluates to true. This is the exact shape the Chronicle upgrade re-allowed
+// for version>=2 transactions (issue #192).
+func nonPushUnlocking() []byte {
+	b := []byte{0x32} // push 50 bytes
+	b = append(b, make([]byte, 50)...)
+	b = append(b, script.OpDROP)
+	return b
 }
 
-// TestCountSigOps_MixedCheckSigAndMultisig combines OP_CHECKSIG and a
-// small-int weighted OP_CHECKMULTISIG to confirm the sigops are summed.
-func TestCountSigOps_MixedCheckSigAndMultisig(t *testing.T) {
-	parsed := parseScript(t, []byte{
-		script.OpCHECKSIG,
-		script.Op2, script.OpCHECKMULTISIG,
-	})
-	if got := countSigOps(parsed); got != 3 {
-		t.Errorf("OP_CHECKSIG OP_2 OP_CHECKMULTISIG: expected 3 sigops, got %d", got)
-	}
-}
-
-// TestCountSigOps_OpZeroIsNotSmallInt confirms OP_0 does not satisfy the
-// small-int branch (it is 0x00, not 0x51..0x60), and so an
-// OP_CHECKMULTISIG preceded by OP_0 falls back to the default 20.
-func TestCountSigOps_OpZeroIsNotSmallInt(t *testing.T) {
-	parsed := parseScript(t, []byte{script.Op0, script.OpCHECKMULTISIG})
-	if got := countSigOps(parsed); got != 20 {
-		t.Errorf("OP_0 OP_CHECKMULTISIG: expected 20 sigops (no small-int), got %d", got)
-	}
-}
-
-// nonPushUnlockingScript returns the unlocking script PUSH(0x21) OP_SHA256
-// (hex 0121a8). The leading 0x01 pushes one byte (0x21); 0xa8 is OP_SHA256, a
-// functional (non-push) opcode. This is the exact shape that triggered the
-// Chronicle push-only regression report. IsPushOnly() returns false for it.
-func nonPushUnlockingScript() *script.Script {
-	s := script.Script([]byte{0x01, 0x21, script.OpSHA256})
-	return &s
-}
-
-// pushOnlyUnlockingScript returns a minimal push-only unlocking script: a
-// single OP_0 (0x00) push. IsPushOnly() returns true for it.
-func pushOnlyUnlockingScript() *script.Script {
-	s := script.Script([]byte{script.Op0})
-	return &s
-}
-
-// txWithUnlockingScript builds a transaction at the given version with a single
-// input carrying the supplied unlocking script. A nil unlockingScript leaves
-// the input's UnlockingScript nil (exercising the empty-script path).
-func txWithUnlockingScript(version uint32, unlockingScript *script.Script) *sdkTx.Transaction {
-	in := &sdkTx.TransactionInput{SourceTXID: nonZeroSourceTXID()}
-	in.UnlockingScript = unlockingScript
+func chronicleTx(version uint32) *sdkTx.Transaction {
+	// prev output: OP_TRUE (anyone-can-spend), 100_000 sats so fees are easily covered.
+	in := spendableSource(nonPushUnlocking(), 100_000, []byte{script.OpTRUE})
 	return &sdkTx.Transaction{
 		Version: version,
 		Inputs:  []*sdkTx.TransactionInput{in},
+		Outputs: []*sdkTx.TransactionOutput{{Satoshis: 90_000, LockingScript: scriptFromBytes([]byte{script.OpTRUE})}},
 	}
 }
 
-// TestPushDataCheck_ChronicleVersionGate is the core regression test for the
-// Chronicle "data only in unlocking script" relaxation. Transactions with
-// version < 2 must still reject functional opcodes in the unlocking script;
-// transactions with version >= 2 must accept them. Push-only and empty scripts
-// behave the same across all versions.
-func TestPushDataCheck_ChronicleVersionGate(t *testing.T) {
+// TestValidate_ChronicleVersionGate is the core #192 regression, driven through
+// the real BDK engine: a non-push-only unlocking script must be rejected for
+// version<2 (pre-Chronicle push-only rule) and accepted for version>=2.
+func TestValidate_ChronicleVersionGate(t *testing.T) {
 	v := NewValidator(nil)
+	ctx := context.Background()
 
-	cases := []struct {
-		name      string
-		version   uint32
-		unlocking *script.Script
-		wantErr   error // nil means accepted
-	}{
-		// version < 2 keeps the strict push-only rule
-		{"v0 non-push rejected", 0, nonPushUnlockingScript(), ErrUnlockingScriptNotPushOnly},
-		{"v1 non-push rejected", 1, nonPushUnlockingScript(), ErrUnlockingScriptNotPushOnly},
-
-		// version >= 2 opts into the Chronicle relaxation
-		{"v2 non-push accepted", 2, nonPushUnlockingScript(), nil},
-		{"v3 non-push accepted", 3, nonPushUnlockingScript(), nil},
-
-		// push-only is always valid, regardless of version
-		{"v1 push-only accepted", 1, pushOnlyUnlockingScript(), nil},
-		{"v2 push-only accepted", 2, pushOnlyUnlockingScript(), nil},
-		{"v3 push-only accepted", 3, pushOnlyUnlockingScript(), nil},
-
-		// the empty-script rejection is independent of the version gate
-		{"v1 empty rejected", 1, nil, ErrEmptyUnlockingScript},
-		{"v2 empty rejected", 2, nil, ErrEmptyUnlockingScript},
-		{"v3 empty rejected", 3, nil, ErrEmptyUnlockingScript},
+	if err := v.ValidateTransaction(ctx, chronicleTx(2), false); err != nil {
+		t.Fatalf("version 2 non-push unlocking script must be accepted, got %v", err)
+	}
+	if err := v.ValidateTransaction(ctx, chronicleTx(3), false); err != nil {
+		t.Fatalf("version 3 non-push unlocking script must be accepted, got %v", err)
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := v.pushDataCheck(txWithUnlockingScript(tc.version, tc.unlocking))
-			switch {
-			case tc.wantErr == nil && err != nil:
-				t.Fatalf("expected acceptance, got %v", err)
-			case tc.wantErr != nil && !errors.Is(err, tc.wantErr):
-				t.Fatalf("expected %v, got %v", tc.wantErr, err)
-			}
-		})
+	err := v.ValidateTransaction(ctx, chronicleTx(1), false)
+	if err == nil {
+		t.Fatal("version 1 non-push unlocking script must be rejected")
+	}
+	if arcErr := arcerrors.GetArcError(err); arcErr == nil || arcErr.StatusCode != arcerrors.StatusUnlockingScripts {
+		t.Errorf("expected StatusUnlockingScripts, got %v", err)
 	}
 }
 
-// TestPushDataCheck_MultiInputVersionGate confirms the version gate applies to
-// every input, not just the first: a version-1 transaction is rejected if any
-// input is non-push, while a version-2 transaction accepts a mix of push-only
-// and non-push inputs.
-func TestPushDataCheck_MultiInputVersionGate(t *testing.T) {
+// TestValidate_FeeTooLow confirms an underpaid transaction is rejected with the
+// fee status. The output consumes all but 1 satoshi of a large input across a
+// padded transaction, so the fee is below the 100 sat/kB floor.
+func TestValidate_FeeTooLow(t *testing.T) {
 	v := NewValidator(nil)
-
-	makeInput := func(s *script.Script) *sdkTx.TransactionInput {
-		in := &sdkTx.TransactionInput{SourceTXID: nonZeroSourceTXID()}
-		in.UnlockingScript = s
-		return in
-	}
-
-	v1 := &sdkTx.Transaction{
-		Version: 1,
-		Inputs: []*sdkTx.TransactionInput{
-			makeInput(pushOnlyUnlockingScript()),
-			makeInput(nonPushUnlockingScript()),
-		},
-	}
-	if err := v.pushDataCheck(v1); !errors.Is(err, ErrUnlockingScriptNotPushOnly) {
-		t.Fatalf("v1 mixed inputs: expected ErrUnlockingScriptNotPushOnly, got %v", err)
-	}
-
-	v2 := &sdkTx.Transaction{
+	in := spendableSource(nonPushUnlocking(), 100_000, []byte{script.OpTRUE})
+	tx := &sdkTx.Transaction{
 		Version: 2,
-		Inputs: []*sdkTx.TransactionInput{
-			makeInput(pushOnlyUnlockingScript()),
-			makeInput(nonPushUnlockingScript()),
-		},
-	}
-	if err := v.pushDataCheck(v2); err != nil {
-		t.Fatalf("v2 mixed inputs: expected acceptance, got %v", err)
-	}
-}
-
-// TestValidatePolicy_Version3NonPushAccepted exercises the full policy path
-// (not just pushDataCheck in isolation) for the reported scenario: a version-3
-// transaction whose input carries a functional opcode in the unlocking script
-// must not be rejected on push-only grounds. The transaction is padded to clear
-// the minimum-size policy and given a valid non-data output so the only
-// behavior under test is the Chronicle gate.
-func TestValidatePolicy_Version3NonPushAccepted(t *testing.T) {
-	v := NewValidator(nil)
-
-	in := &sdkTx.TransactionInput{SourceTXID: nonZeroSourceTXID()}
-	// PUSH(60 bytes) OP_SHA256: a non-push-only unlocking script large enough
-	// that the serialized tx clears minTxSizeBytes.
-	padded := append([]byte{0x3c}, make([]byte, 0x3c)...)
-	padded = append(padded, script.OpSHA256)
-	us := script.Script(padded)
-	in.UnlockingScript = &us
-
-	tx := &sdkTx.Transaction{
-		Version: 3,
 		Inputs:  []*sdkTx.TransactionInput{in},
-		Outputs: []*sdkTx.TransactionOutput{
-			{Satoshis: 1_000, LockingScript: nonDataLockingScript()},
-		},
+		Outputs: []*sdkTx.TransactionOutput{{Satoshis: 99_999, LockingScript: scriptFromBytes([]byte{script.OpTRUE})}},
 	}
 
-	if err := v.ValidatePolicy(tx); err != nil {
-		t.Fatalf("v3 non-push unlocking script must pass policy validation, got %v", err)
+	err := v.ValidateTransaction(context.Background(), tx, false)
+	if err == nil {
+		t.Skip("BDK accepted near-zero fee; min fee policy may differ from expectation")
 	}
-}
-
-// TestValidatePolicy_Version1NonPushRejected is the negative counterpart: the
-// same non-push unlocking script in a version-1 transaction must still be
-// rejected with the unlocking-scripts ARC status.
-func TestValidatePolicy_Version1NonPushRejected(t *testing.T) {
-	v := NewValidator(nil)
-
-	in := &sdkTx.TransactionInput{SourceTXID: nonZeroSourceTXID()}
-	padded := append([]byte{0x3c}, make([]byte, 0x3c)...)
-	padded = append(padded, script.OpSHA256)
-	us := script.Script(padded)
-	in.UnlockingScript = &us
-
-	tx := &sdkTx.Transaction{
-		Version: 1,
-		Inputs:  []*sdkTx.TransactionInput{in},
-		Outputs: []*sdkTx.TransactionOutput{
-			{Satoshis: 1_000, LockingScript: nonDataLockingScript()},
-		},
+	if arcErr := arcerrors.GetArcError(err); arcErr == nil || arcErr.StatusCode != arcerrors.StatusFees {
+		t.Errorf("expected StatusFees, got %v", err)
 	}
 
-	err := v.ValidatePolicy(tx)
-	if !errors.Is(err, ErrUnlockingScriptNotPushOnly) {
-		t.Fatalf("v1 non-push unlocking script must be rejected, got %v", err)
-	}
-}
-
-// TestCheckInputs_ValidPasses confirms a legitimate transaction is still
-// accepted by checkInputs after the overflow guard is added.
-func TestCheckInputs_ValidPasses(t *testing.T) {
-	v := NewValidator(nil)
-
-	makeInput := func(sats uint64) *sdkTx.TransactionInput {
-		in := &sdkTx.TransactionInput{SourceTXID: nonZeroSourceTXID()}
-		in.SetSourceTxOutput(&sdkTx.TransactionOutput{Satoshis: sats, LockingScript: nonDataLockingScript()})
-		return in
-	}
-
-	tx := &sdkTx.Transaction{
-		Inputs: []*sdkTx.TransactionInput{
-			makeInput(1_000),
-			makeInput(2_000),
-		},
-	}
-
-	if err := v.checkInputs(tx); err != nil {
-		t.Fatalf("expected no error for valid inputs, got %v", err)
+	// skipFees must accept the same transaction.
+	if err := v.ValidateTransaction(context.Background(), tx, true); err != nil {
+		t.Errorf("skipFees should accept underpaid tx, got %v", err)
 	}
 }

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -181,7 +181,8 @@ func spendableSource(unlocking []byte, prevSats uint64, prevLock []byte) *sdkTx.
 // evaluates to true. This is the exact shape the Chronicle upgrade re-allowed
 // for version>=2 transactions (issue #192).
 func nonPushUnlocking() []byte {
-	b := []byte{0x32} // push 50 bytes
+	b := make([]byte, 0, 52)
+	b = append(b, 0x32) // push 50 bytes
 	b = append(b, make([]byte, 50)...)
 	b = append(b, script.OpDROP)
 	return b


### PR DESCRIPTION
This pull request replaces arcade's pure-Go transaction validator with teranode's BDK-backed C++ consensus validator, ensuring intake validation matches node consensus and future protocol upgrades. It introduces cgo and native C/C++ toolchain requirements throughout the build and runtime, changes the Docker runtime base to glibc, and updates documentation and tests to reflect these changes.

**Validator engine replacement and behavior alignment:**
- Replaces the `validator` package internals with a wrapper around teranode's `TxValidator` (C++ BDK), preserving the public API but aligning validation decisions with node consensus. Introduces `NewValidatorForNetwork` for correct network parameterization and error handling. [[1]](diffhunk://#diff-f39de75590cd7627b0130adae7527fcb7fe79478e8031c558533d2481c1bff43R1-R73) [[2]](diffhunk://#diff-01ca7f09caf26a6867eb05146758999d772884d7bc0cd0c637b61838031559bbR1-R30) [[3]](diffhunk://#diff-e41f5203b5614916c966c6ff7965207ea16392d8ee40ad614dc0ddcbd819609bR1-R52) [[4]](diffhunk://#diff-5ca406ee1fc37aeff64f2ab4d1249b5dc1843dec22f270c1cc394439d6b6922aR1-R35) [[5]](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7L159-R164)
- Converts transactions to extended form for validation, strictly rejects those missing source data (ARC status 460), and uses a static "all-forks-active" block height to ensure all protocol upgrades are active during validation. [[1]](diffhunk://#diff-f39de75590cd7627b0130adae7527fcb7fe79478e8031c558533d2481c1bff43R1-R73) [[2]](diffhunk://#diff-e41f5203b5614916c966c6ff7965207ea16392d8ee40ad614dc0ddcbd819609bR1-R52) [[3]](diffhunk://#diff-5ca406ee1fc37aeff64f2ab4d1249b5dc1843dec22f270c1cc394439d6b6922aR1-R35)

**Build system and runtime changes:**
- Requires `CGO_ENABLED=1` for all builds and tests; updates `Makefile`, CI workflow (`build.yml`), and Dockerfile to install and use the C/C++ toolchain, and switches the runtime image from Alpine (musl) to `distroless/cc-debian12` (glibc + libstdc++). Pure-Go static builds and cross-compilation are no longer supported. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R5-R13) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L25-R29) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R181-R194) [[4]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R29) [[5]](diffhunk://#diff-01ca7f09caf26a6867eb05146758999d772884d7bc0cd0c637b61838031559bbR1-R30)

**Dependency updates:**
- Adds direct and indirect dependencies on `github.com/bitcoin-sv/bdk/module/gobdk` (for cgo BDK bindings) and `github.com/bsv-blockchain/go-chaincfg` for network parameter resolution. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R9) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R61-L62)

**Documentation and specification:**
- Updates OpenSpec design, proposal, requirements, and tasks to document the validator replacement, new build/runtime requirements, error/status mapping, and rationale for the changes. [[1]](diffhunk://#diff-f39de75590cd7627b0130adae7527fcb7fe79478e8031c558533d2481c1bff43R1-R73) [[2]](diffhunk://#diff-01ca7f09caf26a6867eb05146758999d772884d7bc0cd0c637b61838031559bbR1-R30) [[3]](diffhunk://#diff-e41f5203b5614916c966c6ff7965207ea16392d8ee40ad614dc0ddcbd819609bR1-R52) [[4]](diffhunk://#diff-5ca406ee1fc37aeff64f2ab4d1249b5dc1843dec22f270c1cc394439d6b6922aR1-R35)

**Test and e2e harness adjustments:**
- Updates e2e test harness scripts and comments to reflect BDK's stricter script execution rules (CLEANSTACK), ensuring test transactions conform to consensus.

**Config and comments:**
- Updates `ValidatorConfig` comments to clarify that consensus/policy rules now come from teranode/BDK, not from local config fields.