### PR TITLE
feat(bump-builder): detect and recover silently-dropped STUMPs

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -270,6 +270,20 @@ var BumpBuilderEmptyStumpBlocksTotal = promauto.NewCounter(prometheus.CounterOpt
 	Help: "BLOCK_PROCESSED messages handled with zero STUMPs in the store for the block.",
 })
 
+// BumpBuilderIncompleteStumpsTotal counts BLOCK_PROCESSED messages whose
+// merkle-supplied expected-STUMP set (CallbackMessage.ExpectedSubtreeIndices)
+// was NOT fully satisfied by the STUMPs arcade had stored once the grace window
+// elapsed. Such a block is deliberately left un-finalized (processed_at stays
+// NULL) so the watchdog re-drives it via merkle's /reprocess, which re-emits the
+// missing STUMPs and BLOCK_PROCESSED. This is the metric that makes the
+// previously-silent partial-STUMP drop visible: unlike the all-missing case
+// (empty_stump_blocks_total), a block missing only SOME of its STUMPs used to
+// build a valid-looking BUMP and lose the absent subtree's txs with no signal.
+var BumpBuilderIncompleteStumpsTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "arcade_bump_builder_incomplete_stumps_total",
+	Help: "BLOCK_PROCESSED messages left un-finalized because expected STUMPs were still missing after the grace window.",
+})
+
 // BumpBuilderShortCircuitTotal counts BLOCK_PROCESSED messages handled by the
 // short-circuit path — the BUMP already exists in the store and this is a
 // redelivery (typically from /reprocess re-emitting BLOCK_PROCESSED). Tracks

--- a/models/callback.go
+++ b/models/callback.go
@@ -47,6 +47,19 @@ type CallbackMessage struct {
 	// raw BRC-74 bytes, so HexBytes (a plain, non-reversing hex decode) is the
 	// correct type here.
 	CoinbaseBUMP HexBytes `json:"coinbaseBump,omitempty"`
+
+	// ExpectedSubtreeIndices is the set of subtree indices (ascending) that
+	// produced a STUMP for THIS callback URL in THIS block, as computed by
+	// merkle-service (merkle PR #162). STUMPs are sparse — only a subtree
+	// containing a tracked tx produces one — so without this set arcade cannot
+	// tell a lost STUMP from a legitimately-absent one, and a partial set would
+	// build a compound BUMP that validates while silently dropping the missing
+	// subtree's txs. bump-builder compares this against the STUMPs it actually
+	// stored and defers finalization (leaving processed_at NULL for watchdog
+	// /reprocess recovery) when any are missing. Additive + omitempty: an empty
+	// or absent set means "expect zero STUMPs" — the pre-#162 merkle case and
+	// the legitimate no-tracked-tx block both finalize exactly as before.
+	ExpectedSubtreeIndices []int `json:"expectedSubtreeIndices,omitempty"`
 }
 
 // ResolveSeenTxIDs returns the list of txids from either the batched TxIDs

--- a/services/api_server/block_status_routes_test.go
+++ b/services/api_server/block_status_routes_test.go
@@ -285,10 +285,18 @@ func TestHandleGetBlockProcessingStatus_NotFound(t *testing.T) {
 	}
 }
 
-func TestHandleBlockProcessed_RecordsStatusBeforeKafka(t *testing.T) {
+// TestHandleBlockProcessed_EnqueuesWithoutStamping pins the consuming-side
+// contract introduced for merkle PR #162: the HTTP handler must NOT stamp
+// processed_at. processed_at is the watchdog's recovery signal, and bump-builder
+// is now its sole owner — it sets it only once the block is genuinely finalized
+// (all expected STUMPs present, BUMP built). Stamping here, as the handler used
+// to, blinds the watchdog to the silent partial-STUMP loss. The handler must
+// still enqueue BLOCK_PROCESSED for bump-builder to consume.
+func TestHandleBlockProcessed_EnqueuesWithoutStamping(t *testing.T) {
 	bs := newBlockProcStore()
-	srv, router := setupServerWithStoreAndBlockProc(t, bs)
-	_ = srv
+	broker := &kafka.RecordingBroker{}
+	srv, router := setupServerWithStore(broker, &bs.mockStore)
+	srv.store = bs
 
 	body := mustMarshalJSON(t, models.CallbackMessage{
 		Type:      models.CallbackBlockProcessed,
@@ -300,16 +308,23 @@ func TestHandleBlockProcessed_RecordsStatusBeforeKafka(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
 	}
-	if len(bs.processedCalls) != 1 || bs.processedCalls[0] != "blk-1" {
-		t.Errorf("processedCalls=%v want [blk-1]", bs.processedCalls)
+	if len(bs.processedCalls) != 0 {
+		t.Errorf("handler must not stamp processed_at (bump-builder owns finalization), got processedCalls=%v", bs.processedCalls)
+	}
+	if len(broker.Sends) != 1 || broker.Sends[0].Topic != kafka.TopicBlockProcessed || broker.Sends[0].Key != "blk-1" {
+		t.Errorf("expected one BLOCK_PROCESSED enqueue keyed by block hash, got %+v", broker.Sends)
 	}
 }
 
-func TestHandleBlockProcessed_StoreErrorDoesNotFailRequest(t *testing.T) {
+// TestHandleBlockProcessed_KafkaErrorFailsRequest verifies the handler surfaces
+// an enqueue failure as a 500 so merkle-service retries — losing the
+// BLOCK_PROCESSED message would otherwise strand the block until the watchdog
+// notices.
+func TestHandleBlockProcessed_KafkaErrorFailsRequest(t *testing.T) {
 	bs := newBlockProcStore()
-	bs.markProcessedErr = errors.New("store down")
-	srv, router := setupServerWithStoreAndBlockProc(t, bs)
-	_ = srv
+	broker := &kafka.RecordingBroker{SendErr: errors.New("kafka down")}
+	srv, router := setupServerWithStore(broker, &bs.mockStore)
+	srv.store = bs
 
 	body := mustMarshalJSON(t, models.CallbackMessage{
 		Type:      models.CallbackBlockProcessed,
@@ -318,8 +333,8 @@ func TestHandleBlockProcessed_StoreErrorDoesNotFailRequest(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := authedCallbackRequest(t, body)
 	router.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Errorf("status=%d want 200 (store error must not fail request)", rec.Code)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status=%d want 500 when the BLOCK_PROCESSED enqueue fails", rec.Code)
 	}
 }
 

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -447,14 +447,25 @@ func (s *Server) handleBlockProcessed(c *gin.Context, msg models.CallbackMessage
 		c.JSON(http.StatusBadRequest, gin.H{jsonKeyError: "blockHash is required"})
 		return
 	}
-	// Record the milestone for observability before enqueueing — this is
-	// load-bearing only for the /api/v1/blocks/processing-status surface,
-	// not for BUMP construction. The callback message currently carries no
-	// block height, so 0 is passed; UpsertBlockHeaderSeen on the chaintracks
-	// path is authoritative for height and will overwrite a 0 placeholder.
-	if err := s.store.MarkBlockProcessed(c.Request.Context(), msg.BlockHash, 0, time.Now()); err != nil {
-		logger.Warn("failed to record block_processed status", zap.Error(err))
-	}
+	// Do NOT stamp processed_at here. processed_at is the watchdog's
+	// recovery signal — a block_processing row with header_seen_at set (by the
+	// chaintracks UpsertBlockHeaderSeen path, which is authoritative for height)
+	// but processed_at NULL is what ListStaleBlockProcessingStatus picks up to
+	// re-drive via /reprocess. Stamping it the instant BLOCK_PROCESSED arrives
+	// (as this handler used to) blinds the watchdog to the silent partial-STUMP
+	// loss: bump-builder may receive an incomplete STUMP set and build a BUMP
+	// that drops the missing subtree's txs, yet processed_at would already be
+	// set so the block could never be recovered. Ownership of the stamp now
+	// belongs to bump-builder, which sets it only once the block is genuinely
+	// finalized (all expected STUMPs present and the BUMP built/validated).
+	//
+	// Recovery of a deferred (incomplete) block relies on the watchdog finding a
+	// block_processing row with processed_at NULL — which requires a real-height
+	// header_seen_at row from the chaintracks UpsertBlockHeaderSeen path (the
+	// watchdog's stale query filters on both header_seen_at and block_height, so
+	// the height-0 placeholder this handler used to write was never recoverable
+	// anyway). That chaintracks dependency is pre-existing and unchanged here;
+	// see services/watchdog.
 	if err := s.producer.Send(kafka.TopicBlockProcessed, msg.BlockHash, msg); err != nil {
 		logger.Error("failed to publish block_processed", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{jsonKeyError: "failed to enqueue"})

--- a/services/bump_builder/builder.go
+++ b/services/bump_builder/builder.go
@@ -393,6 +393,29 @@ func (b *Builder) handleMessage(ctx context.Context, msg *kafka.Message) error {
 	}
 
 	metrics.BumpBuilderStumpCount.Observe(float64(len(stumps)))
+
+	// Completeness gate. merkle-service (PR #162) tells us exactly which subtree
+	// indices produced a STUMP for this block. If any are still missing once the
+	// grace window has elapsed, leave the block un-finalized: do NOT stamp
+	// processed_at, so ListStaleBlockProcessingStatus surfaces it and the
+	// watchdog re-drives it via /reprocess (which re-emits the missing STUMPs and
+	// BLOCK_PROCESSED). Returning nil — not an error — because a Kafka requeue
+	// would just replay against the same gap; only /reprocess can fill it, and
+	// the durable processed_at IS NULL is the recovery signal. An empty/absent
+	// expected set (pre-#162 merkle, or a block with no tracked txs) yields no
+	// missing indices and falls through to the existing behavior below.
+	if missing := missingStumpIndices(callback.ExpectedSubtreeIndices, stumps); len(missing) > 0 {
+		outcome = "incomplete_stumps"
+		metrics.BumpBuilderIncompleteStumpsTotal.Inc()
+		logger.Error(
+			"BLOCK_PROCESSED is missing expected STUMPs — deferring finalization so the watchdog can recover via /reprocess",
+			zap.Ints("missing_subtree_indices", missing),
+			zap.Int("expected_stumps", len(callback.ExpectedSubtreeIndices)),
+			zap.Int("received_stumps", len(stumps)),
+		)
+		return nil
+	}
+
 	if len(stumps) == 0 {
 		outcome = "no_stumps"
 		metrics.BumpBuilderEmptyStumpBlocksTotal.Inc()
@@ -402,7 +425,15 @@ func (b *Builder) handleMessage(ctx context.Context, msg *kafka.Message) error {
 		// need to see this rate in logs; a sustained stream while watched
 		// txs are in flight is the signal that merkle-service callbacks
 		// aren't landing.
+		//
+		// Reaching here means the expected set was empty (a non-empty set with
+		// zero received STUMPs would have been caught by the completeness gate
+		// above), so this block has no tracked txs and IS finalized — stamp
+		// processed_at so the watchdog doesn't keep re-driving a complete block.
+		// blockHeight is unknown on this path (no compound built); pass 0, which
+		// the upsert leaves the chaintracks-supplied height intact on conflict.
 		logger.Warn("BLOCK_PROCESSED arrived with zero STUMPs for this block — either no tracked txs in this block, or upstream STUMP callbacks were dropped (check merkle-service callback delivery)")
+		b.markBlockProcessed(ctx, logger, blockHash, 0)
 		return nil
 	}
 
@@ -484,6 +515,13 @@ func (b *Builder) handleMessage(ctx context.Context, msg *kafka.Message) error {
 	if err := b.store.MarkBlockBUMPBuilt(ctx, blockHash, blockHeight, time.Now()); err != nil {
 		logger.Warn("failed to record bump_built status", zap.Error(err))
 	}
+
+	// Finalize: the BUMP is built and validated and every expected STUMP was
+	// present, so stamp processed_at. This (not the HTTP handler) is now the
+	// sole owner of the stamp — see handleBlockProcessed. A soft failure here is
+	// self-healing: processed_at stays NULL, the watchdog re-drives the block,
+	// and tryShortCircuit re-stamps it on the redelivered BLOCK_PROCESSED.
+	b.markBlockProcessed(ctx, logger, blockHash, blockHeight)
 
 	// 6. Set tracked transactions to MINED.
 	// blockHeight is threaded through here (and asserted on the returned
@@ -667,6 +705,14 @@ func (b *Builder) tryShortCircuit(ctx context.Context, logger *zap.Logger, block
 	if len(txids) > 0 {
 		b.markMinedAndPublish(ctx, logger, blockHash, existingHeight, txids)
 	}
+	// Stamp processed_at on the redelivery too. The typical short-circuit
+	// trigger IS the watchdog re-firing BLOCK_PROCESSED for a block whose BUMP
+	// was built but whose processed_at never got stamped (e.g. a crash between
+	// InsertBUMP and the stamp, or a soft stamp failure on the original build).
+	// Without re-stamping here that block would loop in the watchdog forever,
+	// since the stale query keys on processed_at IS NULL and a built block can
+	// never be re-detected as incomplete.
+	b.markBlockProcessed(ctx, logger, blockHash, existingHeight)
 	// STUMP rows for this block should already have been pruned at the end
 	// of the original build; ensure stragglers are cleared in case a STUMP
 	// arrived after pruning ran.
@@ -674,6 +720,56 @@ func (b *Builder) tryShortCircuit(ctx context.Context, logger *zap.Logger, block
 		logger.Warn("failed to clean up STUMPs on short-circuit", zap.Error(delErr))
 	}
 	return true
+}
+
+// markBlockProcessed stamps processed_at on the block-processing row — the
+// signal that arcade considers the block fully finalized (all expected STUMPs
+// present, BUMP built and validated, or a legitimate no-tracked-tx block). It
+// is the single chokepoint that moved out of the HTTP handler so that a block
+// stays recoverable (processed_at NULL) until finalization genuinely completes.
+//
+// Failure is soft by design: leaving processed_at NULL keeps the block in the
+// watchdog's stale scan, which re-drives it via /reprocess and re-stamps on the
+// short-circuit path — so a transient store error self-heals rather than
+// wedging the block. blockHeight may be 0 on the no-STUMP finalize path; the
+// MarkBlockProcessed upsert preserves any chaintracks-supplied height on
+// conflict and only writes processed_at.
+func (b *Builder) markBlockProcessed(ctx context.Context, logger *zap.Logger, blockHash string, blockHeight uint64) {
+	if err := b.store.MarkBlockProcessed(ctx, blockHash, blockHeight, time.Now()); err != nil {
+		// Include the block identity: a sustained stream of these is the signal
+		// that finalized blocks are looping through the watchdog (processed_at
+		// never lands), which an aggregator can only group by block hash.
+		logger.Warn(
+			"failed to record block_processed status; block will re-drive via watchdog until the stamp lands",
+			zap.String("block_hash", blockHash),
+			zap.Uint64("block_height", blockHeight),
+			zap.Error(err),
+		)
+	}
+}
+
+// missingStumpIndices returns the subtree indices merkle-service expected to
+// produce a STUMP for this block (callback.ExpectedSubtreeIndices) that are NOT
+// present among the STUMPs arcade actually stored, preserving the ascending
+// order merkle promises. An empty expected set — pre-#162 merkle, or a block
+// with no tracked txs — yields no missing indices, so the caller finalizes
+// normally. Comparison is by set membership, never count: a duplicate or extra
+// STUMP must never be able to mask a genuinely missing one.
+func missingStumpIndices(expected []int, stumps []*models.Stump) []int {
+	if len(expected) == 0 {
+		return nil
+	}
+	received := make(map[int]struct{}, len(stumps))
+	for _, s := range stumps {
+		received[s.SubtreeIndex] = struct{}{}
+	}
+	var missing []int
+	for _, idx := range expected {
+		if _, ok := received[idx]; !ok {
+			missing = append(missing, idx)
+		}
+	}
+	return missing
 }
 
 // levelZeroTxidsFromBUMP parses a stored compound BUMP and returns every

--- a/services/bump_builder/builder_test.go
+++ b/services/bump_builder/builder_test.go
@@ -909,6 +909,58 @@ func TestBuilder_HandleMessage_EmptyExpectedSet_ZeroStumps_Finalizes(t *testing.
 	}
 }
 
+// TestBuilder_HandleMessage_FieldAbsentFromWire_BuildsNormally is the
+// old-merkle regression guard. It feeds a raw BLOCK_PROCESSED payload with the
+// expectedSubtreeIndices key ENTIRELY ABSENT — the exact wire format a
+// merkle-service older than PR #162 emits — rather than relying on Go's
+// omitempty marshalling. A block with tracked txs must still build its compound
+// BUMP and finalize (stamp processed_at) exactly as before: an absent field
+// decodes to a nil slice, the completeness gate is inert, and arcade neither
+// crashes nor defers. This pins the graceful-degradation contract so a future
+// change can't accidentally make the expected set load-bearing for decode.
+func TestBuilder_HandleMessage_FieldAbsentFromWire_BuildsNormally(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+	txidHex := testTxidHex
+
+	stumpData := makeMinimalSTUMP(txidHex)
+	ms.addStump(blockHash, 0, stumpData)
+	subtreeHash := mustHash(t, txidHex)
+	root := expectedCompoundRoot(t,
+		[]*models.Stump{{BlockHash: blockHash, SubtreeIndex: 0, StumpData: stumpData}},
+		[]chainhash.Hash{subtreeHash}, nil)
+	datahub := newDatahubServer(root, []chainhash.Hash{subtreeHash})
+	defer datahub.Close()
+
+	b := newTestBuilder(ms, datahub.URL)
+
+	// Hand-built wire bytes with NO expectedSubtreeIndices key — what pre-#162
+	// merkle sends. Document the decode contract: the absent key yields a nil
+	// slice, never an error.
+	rawWire := []byte(`{"type":"BLOCK_PROCESSED","blockHash":"` + blockHash + `"}`)
+	var decoded models.CallbackMessage
+	if err := json.Unmarshal(rawWire, &decoded); err != nil {
+		t.Fatalf("pre-#162 wire format must decode cleanly, got: %v", err)
+	}
+	if decoded.ExpectedSubtreeIndices != nil {
+		t.Fatalf("absent field must decode to nil, got %v", decoded.ExpectedSubtreeIndices)
+	}
+
+	msg := &kafka.Message{Topic: "arcade.block_processed", Value: rawWire}
+	if err := b.handleMessage(context.Background(), msg); err != nil {
+		t.Fatalf("old-merkle BLOCK_PROCESSED must build normally, got: %v", err)
+	}
+
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if _, ok := ms.bumps[blockHash]; !ok {
+		t.Error("expected BUMP to be built for an old-merkle (field-absent) block")
+	}
+	if len(ms.processedCalls) != 1 || ms.processedCalls[0].blockHash != blockHash {
+		t.Errorf("old-merkle block must finalize as before — expected MarkBlockProcessed(%s), got %+v", blockHash, ms.processedCalls)
+	}
+}
+
 func TestBuilder_HandleMessage_BumpBuiltStoreError_StillSucceeds(t *testing.T) {
 	ms := newMockStore()
 	ms.markBumpBuiltErr = errors.New("store down")

--- a/services/bump_builder/builder_test.go
+++ b/services/bump_builder/builder_test.go
@@ -50,12 +50,14 @@ type mockStore struct {
 	minedCalls       []minedCall
 	deletedBlocks    []string
 	bumpBuiltCalls   []bumpBuiltCall
+	processedCalls   []bumpBuiltCall
 	getStumpsErr     error
 	insertBUMPErr    error
 	insertStumpErr   error
 	setMinedErr      error
 	deleteStumpsErr  error
 	markBumpBuiltErr error
+	markProcessedErr error
 
 	// Janitor fixtures: tipHeight feeds GetActiveTipBlockHeight; blockProc
 	// feeds ListBlockProcessingStatus. Both default empty so existing tests
@@ -218,6 +220,20 @@ func (m *mockStore) MarkBlockBUMPBuilt(_ context.Context, blockHash string, bloc
 	return nil
 }
 
+// MarkBlockProcessed records the call so tests can assert that bump-builder —
+// not the HTTP handler — stamps processed_at, and only on a finalized block.
+// markProcessedErr injects a failure to verify the soft-fail (warn + continue)
+// path that the watchdog backstops.
+func (m *mockStore) MarkBlockProcessed(_ context.Context, blockHash string, blockHeight uint64, _ time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.markProcessedErr != nil {
+		return m.markProcessedErr
+	}
+	m.processedCalls = append(m.processedCalls, bumpBuiltCall{blockHash: blockHash, blockHeight: blockHeight})
+	return nil
+}
+
 func (m *mockStore) addStump(blockHash string, subtreeIndex int, stumpData []byte) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -235,6 +251,25 @@ func makeBlockProcessedMsg(blockHash string) *kafka.Message {
 	callback := models.CallbackMessage{
 		Type:      models.CallbackBlockProcessed,
 		BlockHash: blockHash,
+	}
+	data, err := json.Marshal(callback)
+	if err != nil {
+		panic(err)
+	}
+	return &kafka.Message{
+		Topic: "arcade.block_processed",
+		Value: data,
+	}
+}
+
+// makeBlockProcessedMsgWithExpected is makeBlockProcessedMsg plus the merkle
+// expected-STUMP index set (PR #162), so completeness-gate tests can pin which
+// subtrees merkle says should have produced a STUMP for this block.
+func makeBlockProcessedMsgWithExpected(blockHash string, expected []int) *kafka.Message {
+	callback := models.CallbackMessage{
+		Type:                   models.CallbackBlockProcessed,
+		BlockHash:              blockHash,
+		ExpectedSubtreeIndices: expected,
 	}
 	data, err := json.Marshal(callback)
 	if err != nil {
@@ -590,6 +625,13 @@ func TestBuilder_HandleMessage_ShortCircuit_BUMPAlreadyExists(t *testing.T) {
 	if len(got.txids) != 1 || got.txids[0] != testTxidHex {
 		t.Errorf("mined txids=%v want [%q]", got.txids, testTxidHex)
 	}
+
+	// The short-circuit must stamp processed_at: the typical trigger is the
+	// watchdog re-firing BLOCK_PROCESSED for a built-but-unstamped block, and
+	// without this stamp the block would loop in the watchdog forever.
+	if len(ms.processedCalls) != 1 || ms.processedCalls[0].blockHash != blockHash {
+		t.Errorf("short-circuit must stamp MarkBlockProcessed(%s), got %+v", blockHash, ms.processedCalls)
+	}
 }
 
 // TestBuilder_PruneOrphanStumps_DeletesAfterSuccess verifies the startup
@@ -682,6 +724,188 @@ func TestBuilder_HandleMessage_HappyPath_SingleSubtree(t *testing.T) {
 	// Verify the block-processing observability row was updated.
 	if len(ms.bumpBuiltCalls) != 1 || ms.bumpBuiltCalls[0].blockHash != blockHash {
 		t.Errorf("expected MarkBlockBUMPBuilt(%s), got %+v", blockHash, ms.bumpBuiltCalls)
+	}
+
+	// Finalization: bump-builder (not the HTTP handler) now owns the
+	// processed_at stamp, and must set it on a fully-built block.
+	if len(ms.processedCalls) != 1 || ms.processedCalls[0].blockHash != blockHash {
+		t.Errorf("expected MarkBlockProcessed(%s) on a finalized block, got %+v", blockHash, ms.processedCalls)
+	}
+}
+
+// TestBuilder_HandleMessage_ProcessedStampSoftFails_SelfHealsOnRedelivery
+// verifies the recovery contract for a transient store error while stamping
+// processed_at on a successful build: the build still completes (BUMP stored,
+// txs MINED) but processed_at stays NULL, so the block remains in the watchdog's
+// stale scan. When the watchdog re-drives BLOCK_PROCESSED, the short-circuit
+// finds the existing BUMP and re-stamps processed_at — the block self-heals
+// rather than wedging.
+func TestBuilder_HandleMessage_ProcessedStampSoftFails_SelfHealsOnRedelivery(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+	txidHex := testTxidHex
+
+	stumpData := makeMinimalSTUMP(txidHex)
+	ms.addStump(blockHash, 0, stumpData)
+	subtreeHash := mustHash(t, txidHex)
+	root := expectedCompoundRoot(t,
+		[]*models.Stump{{BlockHash: blockHash, SubtreeIndex: 0, StumpData: stumpData}},
+		[]chainhash.Hash{subtreeHash}, nil)
+	datahub := newDatahubServer(root, []chainhash.Hash{subtreeHash})
+	defer datahub.Close()
+
+	b := newTestBuilder(ms, datahub.URL)
+
+	// First delivery: the processed_at stamp fails transiently.
+	ms.markProcessedErr = errors.New("store down")
+	if err := b.handleMessage(context.Background(), makeBlockProcessedMsgWithExpected(blockHash, []int{0})); err != nil {
+		t.Fatalf("a soft processed_at failure must not fail the build, got: %v", err)
+	}
+	ms.mu.Lock()
+	if _, ok := ms.bumps[blockHash]; !ok {
+		t.Error("BUMP should be stored even though the processed_at stamp failed")
+	}
+	if len(ms.processedCalls) != 0 {
+		t.Errorf("processed_at must remain unstamped after a soft failure, got %+v", ms.processedCalls)
+	}
+	ms.mu.Unlock()
+
+	// Watchdog re-drives BLOCK_PROCESSED; the store has recovered. The
+	// short-circuit must find the existing BUMP and re-stamp processed_at.
+	ms.markProcessedErr = nil
+	if err := b.handleMessage(context.Background(), makeBlockProcessedMsgWithExpected(blockHash, []int{0})); err != nil {
+		t.Fatalf("redelivery short-circuit returned error: %v", err)
+	}
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if len(ms.processedCalls) != 1 || ms.processedCalls[0].blockHash != blockHash {
+		t.Errorf("short-circuit must re-stamp MarkBlockProcessed(%s) on redelivery, got %+v", blockHash, ms.processedCalls)
+	}
+}
+
+// TestBuilder_HandleMessage_IncompleteExpectedSet_DefersFinalization is the
+// core of the silent-loss fix: merkle says subtrees {0,1,2} should each have a
+// STUMP, but only {0,2} arrived. The block must NOT be finalized — no BUMP, no
+// processed_at stamp — so the watchdog can recover it via /reprocess. Returns
+// nil (not an error) so Kafka doesn't replay against the same gap.
+func TestBuilder_HandleMessage_IncompleteExpectedSet_DefersFinalization(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+
+	// Store STUMPs for subtrees 0 and 2 only; merkle expected 0, 1, 2.
+	ms.addStump(blockHash, 0, makeMinimalSTUMP(testTxidHex))
+	ms.addStump(blockHash, 2, makeMinimalSTUMP(testTxidHex))
+
+	// No datahub server, teranode nil: if the builder wrongly proceeds to build,
+	// it crashes on the fetch path — which would itself fail the test.
+	b := &Builder{
+		cfg:    &config.Config{},
+		logger: zap.NewNop().Named("bump-builder"),
+		store:  ms,
+	}
+
+	if err := b.handleMessage(context.Background(), makeBlockProcessedMsgWithExpected(blockHash, []int{0, 1, 2})); err != nil {
+		t.Fatalf("incomplete-set handleMessage must return nil (watchdog recovers), got: %v", err)
+	}
+
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if len(ms.bumps) != 0 {
+		t.Errorf("no BUMP should be built for an incomplete block, got %d", len(ms.bumps))
+	}
+	if len(ms.processedCalls) != 0 {
+		t.Errorf("processed_at must NOT be stamped for an incomplete block (watchdog recovery depends on it), got %+v", ms.processedCalls)
+	}
+}
+
+// TestBuilder_HandleMessage_IndexMismatchSameCount_Incomplete proves the gate
+// compares set membership, not counts: merkle expected {0,2}, but the stored
+// STUMPs are {0,3} — same count, yet subtree 2 is genuinely missing (and the
+// extra 3 must not mask it).
+func TestBuilder_HandleMessage_IndexMismatchSameCount_Incomplete(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+
+	ms.addStump(blockHash, 0, makeMinimalSTUMP(testTxidHex))
+	ms.addStump(blockHash, 3, makeMinimalSTUMP(testTxidHex))
+
+	b := &Builder{
+		cfg:    &config.Config{},
+		logger: zap.NewNop().Named("bump-builder"),
+		store:  ms,
+	}
+
+	if err := b.handleMessage(context.Background(), makeBlockProcessedMsgWithExpected(blockHash, []int{0, 2})); err != nil {
+		t.Fatalf("count-equal index-mismatch must return nil, got: %v", err)
+	}
+
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if len(ms.bumps) != 0 || len(ms.processedCalls) != 0 {
+		t.Errorf("count-equal but index-mismatched set must be treated as incomplete; bumps=%d processed=%d", len(ms.bumps), len(ms.processedCalls))
+	}
+}
+
+// TestBuilder_HandleMessage_CompleteExpectedSet_Finalizes is the happy path with
+// the expected set fully satisfied: merkle expected {0}, subtree 0's STUMP is
+// present, so the BUMP builds and processed_at is stamped.
+func TestBuilder_HandleMessage_CompleteExpectedSet_Finalizes(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+	txidHex := testTxidHex
+
+	stumpData := makeMinimalSTUMP(txidHex)
+	ms.addStump(blockHash, 0, stumpData)
+
+	subtreeHash := mustHash(t, txidHex)
+	root := expectedCompoundRoot(t,
+		[]*models.Stump{{BlockHash: blockHash, SubtreeIndex: 0, StumpData: stumpData}},
+		[]chainhash.Hash{subtreeHash}, nil)
+	datahub := newDatahubServer(root, []chainhash.Hash{subtreeHash})
+	defer datahub.Close()
+
+	b := newTestBuilder(ms, datahub.URL)
+
+	if err := b.handleMessage(context.Background(), makeBlockProcessedMsgWithExpected(blockHash, []int{0})); err != nil {
+		t.Fatalf("complete-set handleMessage returned error: %v", err)
+	}
+
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if _, ok := ms.bumps[blockHash]; !ok {
+		t.Error("expected BUMP to be stored for a complete block")
+	}
+	if len(ms.processedCalls) != 1 || ms.processedCalls[0].blockHash != blockHash {
+		t.Errorf("expected MarkBlockProcessed(%s) on a complete block, got %+v", blockHash, ms.processedCalls)
+	}
+}
+
+// TestBuilder_HandleMessage_EmptyExpectedSet_ZeroStumps_Finalizes covers the
+// pre-#162 merkle case and the legitimate no-tracked-tx block: an empty/absent
+// expected set with zero stored STUMPs must finalize (stamp processed_at) so the
+// watchdog doesn't endlessly re-drive a complete block.
+func TestBuilder_HandleMessage_EmptyExpectedSet_ZeroStumps_Finalizes(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+
+	b := &Builder{
+		cfg:    &config.Config{},
+		logger: zap.NewNop().Named("bump-builder"),
+		store:  ms,
+	}
+
+	// No expected set, no STUMPs — exactly today's behavior, plus the stamp.
+	if err := b.handleMessage(context.Background(), makeBlockProcessedMsg(blockHash)); err != nil {
+		t.Fatalf("empty-set zero-stump handleMessage returned error: %v", err)
+	}
+
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if len(ms.bumps) != 0 {
+		t.Errorf("no BUMP should be built with zero STUMPs, got %d", len(ms.bumps))
+	}
+	if len(ms.processedCalls) != 1 || ms.processedCalls[0].blockHash != blockHash {
+		t.Errorf("a no-tracked-tx block IS finalized — expected MarkBlockProcessed(%s), got %+v", blockHash, ms.processedCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

Consuming side of [merkle-service PR #162](https://github.com/bsv-blockchain/merkle-service/pull/162). merkle now attaches `expectedSubtreeIndices` (the set of subtree indices that produced a STUMP for each callback URL) to `BLOCK_PROCESSED`. This closes a **pre-existing silent-loss hole**: because STUMPs are sparse, arcade could not tell a lost STUMP from a legitimately-absent one, so a block missing only *some* of its STUMPs still built a compound BUMP that validated while the missing subtree's txs never reached `MINED` — no error, no metric, no recovery (the watchdog couldn't see it because `processed_at` was stamped the instant `BLOCK_PROCESSED` arrived). It also unblocks widening merkle's `callback` topic.

The fix makes **bump-builder the owner of block finalization**:

- **`handleBlockProcessed` no longer stamps `processed_at`** — it only enqueues `BLOCK_PROCESSED`. `processed_at` is the watchdog's recovery signal; stamping it on arrival is exactly what blinded the watchdog.
- **bump-builder runs a completeness gate** after the existing grace window: it compares the STUMPs it stored against `callback.ExpectedSubtreeIndices` by **set membership** (a duplicate/extra STUMP can't mask a missing one). On a gap it logs, increments `arcade_bump_builder_incomplete_stumps_total`, and returns **without** stamping `processed_at` — leaving the block in the watchdog's stale scan, which re-drives it via the **existing** block-level `POST /reprocess` (re-emitting the missing STUMPs and `BLOCK_PROCESSED`).
- **`processed_at` is now stamped only on a genuine finalize**: BUMP built and validated, a legitimate no-tracked-tx block, or the short-circuit redelivery of an already-built block.

### Why this shape

- **No new store methods, schema, config, or recovery loop.** The expected set rides the existing Kafka `BLOCK_PROCESSED` message and is re-supplied by `/reprocess` on every recovery attempt, so it never needs to be persisted in arcade. Recovery reuses the existing `services/watchdog` + `merkleservice.Client.Reprocess` (backoff, lease, recency-bounded) untouched.
- **Backward compatible.** An empty/absent expected set means "expect zero STUMPs", so an arcade running against pre-#162 merkle (field simply absent) behaves exactly as before. The only behavioural change is *where* `processed_at` is stamped (bump-builder, after grace+build) rather than *whether*.
- **Soft-fail self-heals.** If the `processed_at` stamp hits a transient store error, the block stays in the stale scan and the watchdog re-drives it; the short-circuit re-stamps on redelivery. Bounded by the watchdog's `StaleThreshold` cadence and `RecencyDepth`.

### Notes for reviewers / rollout

- Recovery of a *deferred* (incomplete) block depends on the chaintracks `UpsertBlockHeaderSeen` row supplying the real block height — this is a **pre-existing** watchdog requirement (its stale query already filters on `header_seen_at` and `block_height`), unchanged here. The old height-0 placeholder this handler used to write was never recoverable anyway.
- Observable change: `processed_at` (and the `/api/v1/blocks/processing-status` `HasBlockProcessed` flag) now flips ~grace-window later (default 30s) instead of instantly on callback receipt — it now means "finalized", not "callback received".
- Rollout order: merkle #162 **already emits** `expectedSubtreeIndices` unconditionally — there is no emit feature-flag (the `block.emitExpectedStumpSet` toggle named in merkle's design doc was never implemented; the PR's "No config flag" section rejected it). So: deploy this → arcade immediately consumes the field → verify an injected missing STUMP is detected and recovered → then widen the `callback` topic (separate change).

## Test plan

- [x] `go build ./...`, `go vet ./...` — clean
- [x] `golangci-lint run` — clean
- [x] Full suite: `go test ./...` — 637 passing
- [x] New bump-builder tests: incomplete set defers (no BUMP, no stamp); same-count index mismatch still incomplete (membership, not count); complete set finalizes + stamps; empty set + zero STUMPs finalizes; short-circuit stamps on redelivery; soft-fail self-heals via short-circuit re-stamp
- [x] New api-server tests: handler enqueues without stamping `processed_at`; Kafka enqueue failure surfaces as 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
