### PR TITLE
fix(validator): report unknown-parent height so post-Genesis pushes aren't capped at 520 bytes (#214)

### DIFF
--- a/validator/validator.go
+++ b/validator/validator.go
@@ -15,6 +15,7 @@ package validator
 import (
 	"context"
 	"fmt"
+	"math"
 
 	chaincfg "github.com/bsv-blockchain/go-chaincfg"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
@@ -34,13 +35,33 @@ const (
 	// static height avoids a chain-tip lookup on the hot path.
 	allForksActiveHeight uint32 = 2_000_000_000
 
-	// assumedUTXOHeight is the per-input source height arcade reports for every
+	// unknownParentHeight is the per-input source height arcade reports for every
 	// spent output. arcade does not track per-UTXO confirmation heights on the
-	// intake path, so it reports a height far below allForksActiveHeight; every
-	// input therefore appears mature. This matches arcade's prior behaviour of
-	// not enforcing coinbase maturity / relative locktime at intake — teranode
-	// remains the authority and re-checks with real heights downstream.
-	assumedUTXOHeight uint32 = 1
+	// intake path, so instead of fabricating a concrete height it reports the
+	// "parent height unknown" sentinel — the value of teranode's internal
+	// unconfirmedParentHeight (teranode .../services/validator/Validator.go), which
+	// teranode itself stamps for parents whose height it cannot resolve.
+	//
+	// In policy mode — arcade's only mode; NewDefaultOptions sets
+	// SkipPolicyChecks=false — teranode's BDK adapter (substituteUnconfirmedHeights
+	// in .../services/validator/ScriptVerifierGoBDK.go) resolves this sentinel to
+	// the candidate block height (allForksActiveHeight), which is post-Genesis and
+	// post-Chronicle. Every input is therefore evaluated against current consensus,
+	// matching how teranode's own mempool intake treats an unconfirmed parent.
+	//
+	// The previous value of 1 was below every network's Genesis activation height,
+	// so BDK keyed each input's protocol era to pre-Genesis and wrongly enforced the
+	// historical 520-byte MAX_SCRIPT_ELEMENT_SIZE_BEFORE_GENESIS limit on modern
+	// post-Genesis spends (issue #214). The per-input UTXO height — not the spending
+	// block height — selects that limit, so reporting a post-Genesis source height is
+	// what lifts it. arcade's path runs no coinbase-maturity or relative-locktime
+	// check, so reporting an "immature" height has no downside here; teranode remains
+	// the authority and re-checks with real heights downstream.
+	//
+	// This is correct only in policy mode: in consensus mode the adapter maps the
+	// sentinel to MEMPOOL_HEIGHT and BDK rejects every transaction as having an
+	// unconfirmed input. arcade never validates in consensus mode.
+	unknownParentHeight uint32 = math.MaxUint32
 
 	// maxTxSizePolicyConsensusLimit is the BDK consensus ceiling on the policy
 	// max-tx-size setting; the engine rejects construction above it.
@@ -149,7 +170,7 @@ func (v *Validator) ValidateTransaction(_ context.Context, tx *sdkTx.Transaction
 
 	utxoHeights := make([]uint32, len(btx.Inputs))
 	for i := range utxoHeights {
-		utxoHeights[i] = assumedUTXOHeight
+		utxoHeights[i] = unknownParentHeight
 	}
 
 	tv := v.tv

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -3,12 +3,14 @@ package validator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/script"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
 	tnerr "github.com/bsv-blockchain/teranode/errors"
+	tnvalidator "github.com/bsv-blockchain/teranode/services/validator"
 
 	arcerrors "github.com/bsv-blockchain/arcade/errors"
 )
@@ -174,18 +176,29 @@ func spendableSource(unlocking []byte, prevSats uint64, prevLock []byte) *sdkTx.
 	return in
 }
 
-// nonPushUnlocking returns an unlocking script that pushes a 50-byte blob then
-// OP_DROP — a functional (non-push-only) opcode. The leading data push also pads
-// the transaction comfortably past any minimum-size rule. After it runs the
-// stack is empty; paired with an OP_TRUE locking script the combined script
-// evaluates to true. This is the exact shape the Chronicle upgrade re-allowed
-// for version>=2 transactions (issue #192).
+// pushDropUnlocking returns an unlocking script that pushes n bytes then OP_DROP
+// — a functional (non-push-only) opcode that leaves the stack empty, so paired
+// with an OP_TRUE locking script the combined script evaluates to true. Because
+// it is non-push-only it is only accepted for version>=2 (post-Chronicle)
+// transactions (issue #192). AppendPushData emits the minimal push encoding
+// (direct, OP_PUSHDATA1 or OP_PUSHDATA2), so element sizes above the historical
+// 520-byte pre-Genesis limit are exercised faithfully (issue #214).
+func pushDropUnlocking(n int) []byte {
+	s := &script.Script{}
+	if err := s.AppendPushData(make([]byte, n)); err != nil {
+		panic(err)
+	}
+	if err := s.AppendOpcodes(script.OpDROP); err != nil {
+		panic(err)
+	}
+	return *s
+}
+
+// nonPushUnlocking pushes a 50-byte blob then OP_DROP. The leading data push also
+// pads the transaction comfortably past any minimum-size rule. This is the exact
+// shape the Chronicle upgrade re-allowed for version>=2 transactions (issue #192).
 func nonPushUnlocking() []byte {
-	b := make([]byte, 0, 52)
-	b = append(b, 0x32) // push 50 bytes
-	b = append(b, make([]byte, 50)...)
-	b = append(b, script.OpDROP)
-	return b
+	return pushDropUnlocking(50)
 }
 
 func chronicleTx(version uint32) *sdkTx.Transaction {
@@ -218,6 +231,73 @@ func TestValidate_ChronicleVersionGate(t *testing.T) {
 	}
 	if arcErr := arcerrors.GetArcError(err); arcErr == nil || arcErr.StatusCode != arcerrors.StatusUnlockingScripts {
 		t.Errorf("expected StatusUnlockingScripts, got %v", err)
+	}
+}
+
+// largePushTx builds a version-2 transaction whose single input spends an OP_TRUE
+// (anyone-can-spend) source output with a <pushSize-byte push> OP_DROP unlocking
+// script. The input is funded generously so fees can never be the reason a size is
+// rejected — the only variable under test is the pushed-element size.
+func largePushTx(pushSize int) *sdkTx.Transaction {
+	in := spendableSource(pushDropUnlocking(pushSize), 100_000, []byte{script.OpTRUE})
+	return &sdkTx.Transaction{
+		Version: 2,
+		Inputs:  []*sdkTx.TransactionInput{in},
+		Outputs: []*sdkTx.TransactionOutput{{Satoshis: 10_000, LockingScript: scriptFromBytes([]byte{script.OpTRUE})}},
+	}
+}
+
+// TestValidate_PostGenesisLargePushes is the #214 regression, driven through the
+// real BDK engine. The historical 520-byte MAX_SCRIPT_ELEMENT_SIZE_BEFORE_GENESIS
+// limit is keyed off the *source UTXO height*, not the spending block height. Arcade
+// reported height 1 (pre-Genesis) for every input, so BDK applied the limit to
+// post-Genesis spends and rejected otherwise-valid transactions that push >520-byte
+// elements (the same transactions ARC accepts and miners mine).
+//
+// The fix reports the unknown-parent sentinel instead, which teranode resolves to the
+// post-Genesis candidate block height in policy mode — so the limit no longer applies.
+// Each case proves the rejection is purely a function of the reported source height:
+// at pre-Genesis height 1 BDK rejects >520-byte pushes, at a post-Genesis height it
+// accepts them, and arcade's public intake (which now reports the sentinel) accepts.
+func TestValidate_PostGenesisLargePushes(t *testing.T) {
+	v := NewValidator(nil)
+	ctx := context.Background()
+
+	// A concrete, unambiguously post-Genesis source height (well above every
+	// network's Genesis/Chronicle activation height, at/below the spending height).
+	const postGenesisHeight = allForksActiveHeight - 1
+
+	for _, size := range []int{520, 521, 5210} {
+		t.Run(fmt.Sprintf("push_%d_bytes", size), func(t *testing.T) {
+			tx := largePushTx(size)
+			overLimit := size > 520
+
+			// Root-cause control: call the BDK validator directly, varying only the
+			// source UTXO height. Use the fee-agnostic validator so fees never
+			// interfere; NewDefaultOptions keeps it in policy mode (arcade's mode).
+			btx, err := toExtendedBT(tx)
+			if err != nil {
+				t.Fatalf("toExtendedBT: %v", err)
+			}
+			preGenesisErr := v.tvNoFee.ValidateTransaction(btx, allForksActiveHeight, []uint32{1}, tnvalidator.NewDefaultOptions())
+			postGenesisErr := v.tvNoFee.ValidateTransaction(btx, allForksActiveHeight, []uint32{postGenesisHeight}, tnvalidator.NewDefaultOptions())
+
+			if overLimit && preGenesisErr == nil {
+				t.Errorf("BDK must reject a %d-byte push at pre-Genesis source height 1 (pre-Genesis 520-byte limit)", size)
+			}
+			if !overLimit && preGenesisErr != nil {
+				t.Errorf("BDK must accept a %d-byte push even at source height 1, got %v", size, preGenesisErr)
+			}
+			if postGenesisErr != nil {
+				t.Errorf("BDK must accept a %d-byte push at a post-Genesis source height, got %v", size, postGenesisErr)
+			}
+
+			// Regression guard: arcade's public intake must accept all sizes. Before
+			// the fix this fails for 521 and 5210 with a push-value-size error.
+			if err := v.ValidateTransaction(ctx, tx, true); err != nil {
+				t.Errorf("arcade intake must accept a %d-byte post-Genesis push, got %v", size, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #214. Arcade's BDK-backed validator rejected otherwise-valid modern transactions whose unlocking scripts push elements larger than 520 bytes, with `Push value size limit exceeded` — even though the same raw transactions are accepted by ARC and mined on-chain.

**Root cause.** `ValidateTransaction` validates the spending transaction at `allForksActiveHeight = 2_000_000_000` (post-Genesis/Chronicle) but reported `assumedUTXOHeight = 1` for **every** source UTXO. BDK's per-input `CalculateFlags(utxoHeight, blockHeight, consensus)` keys each input's protocol era — and therefore the historical 520-byte `MAX_SCRIPT_ELEMENT_SIZE_BEFORE_GENESIS` limit — off the **source UTXO height**, not the spending block height. Height `1` is below every network's Genesis activation height (mainnet 620538), so each input was evaluated under pre-Genesis rules and the 520-byte limit was wrongly applied to post-Genesis spends.

## Fix

Report teranode's unknown-parent sentinel (`math.MaxUint32`, the value of teranode's internal `unconfirmedParentHeight`) instead of `1`. In **policy mode** — arcade's only mode (`NewDefaultOptions` sets `SkipPolicyChecks=false`) — teranode's BDK adapter (`substituteUnconfirmedHeights`) resolves the sentinel to the post-Genesis candidate block height, so every input is evaluated against current consensus. This mirrors how teranode's own mempool intake stamps the sentinel for parents whose height it cannot resolve (`services/validator/Validator.go`).

This is the issue author's preferred fix ("adopt Teranode/BDK's candidate/unknown-parent height policy"). It is robust to future activation-height changes (no magic threshold to maintain) and semantically honest — arcade genuinely does not know parent heights at intake. arcade's path runs **no** coinbase-maturity or relative-locktime check, so the old "appears mature" rationale for height 1 has no downside.

## Tests

`TestValidate_PostGenesisLargePushes` exercises 520-, 521-, and 5210-byte pushes through the **real BDK engine**:
- **Regression guard:** arcade's public `ValidateTransaction` must accept all three sizes. This failed for 521/5210 before the fix (`utxoHeights=1 error=Push value size limit exceeded`) and passes after.
- **Root-cause control:** calling the BDK validator directly proves the rejection is purely a function of the reported source height — at pre-Genesis height `1` BDK rejects >520-byte pushes; at a post-Genesis height it accepts them. This also guards against future BDK behavior changes.

The existing `TestValidate_ChronicleVersionGate` and `TestValidate_FeeTooLow` still pass, confirming the Chronicle version-gate keys off the spending block height (not the UTXO height) and that the change is isolated.

## Verification

```
CGO_ENABLED=1 go test ./validator/...   # all pass (incl. existing regressions)
CGO_ENABLED=1 go build ./...            # clean
go vet ./validator/ + gofmt             # clean
```