### PR TITLE
fix(api-server): add healthy and version fields to /health (#208)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,14 +189,18 @@ jobs:
       # runner image defaults differ. CGO_ENABLED=1 because the validator links
       # gobdk (BSV BDK C++); the build is native per arch so the matching
       # prebuilt gobdk static archive links without a cross-compiler.
+      # version.Version is stamped from the deployment tag computed by the
+      # get_tag job (vX.Y.Z on tag pushes, "latest" otherwise) so GET /health
+      # reports the running build (issue #208).
       - name: Build arcade binary
         env:
           CGO_ENABLED: '1'
           GOOS: linux
           GOARCH: ${{ matrix.arch }}
+          VERSION: ${{ needs.get_tag.outputs.deployment_tag }}
         run: |
           mkdir -p dist/linux-${{ matrix.arch }}
-          go build -trimpath -ldflags="-s -w" -o dist/linux-${{ matrix.arch }}/arcade ./cmd/arcade
+          go build -trimpath -ldflags="-s -w -X github.com/bsv-blockchain/arcade/version.Version=${VERSION}" -o dist/linux-${{ matrix.arch }}/arcade ./cmd/arcade
 
       # Step 4: Set up Docker Buildx (no QEMU needed — single-platform build on
       # a native runner of that platform).

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 
 GOARCH ?= $(shell go env GOARCH)
 
+# Version stamped into the binary (exposed via GET /health, issue #208). Derived
+# from the git tag; falls back to "dev" outside a tagged checkout.
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+
 # CGO is required: the transaction validator links the BSV BDK C++ consensus
 # library (gobdk) via cgo, so a C/C++ toolchain (gcc/g++, libstdc++) must be
 # present to build and test. Builds are native per arch — gobdk ships a
@@ -32,7 +36,7 @@ docker-build:
 		exit 1; \
 	fi
 	mkdir -p dist/linux-$(GOARCH)
-	CGO_ENABLED=1 GOOS=linux GOARCH=$(GOARCH) go build -trimpath -ldflags="-s -w" -o dist/linux-$(GOARCH)/arcade ./cmd/arcade
+	CGO_ENABLED=1 GOOS=linux GOARCH=$(GOARCH) go build -trimpath -ldflags="-s -w -X github.com/bsv-blockchain/arcade/version.Version=$(VERSION)" -o dist/linux-$(GOARCH)/arcade ./cmd/arcade
 	docker build --platform=linux/$(GOARCH) -t arcade:local .
 
 run:

--- a/openapi/arcade.openapi.yaml
+++ b/openapi/arcade.openapi.yaml
@@ -94,6 +94,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/HealthResponse"
               example:
+                healthy: true
+                version: v0.8.0
                 status: ok
                 datahub_urls:
                   - url: https://datahub.example.com
@@ -1259,6 +1261,14 @@ components:
     HealthResponse:
       type: object
       properties:
+        healthy:
+          type: boolean
+          description: ARC health contract — true whenever the process is live.
+          example: true
+        version:
+          type: string
+          description: Build version of the running arcade binary (git tag).
+          example: v0.8.0
         status:
           type: string
           example: ok
@@ -1267,6 +1277,8 @@ components:
           items:
             $ref: "#/components/schemas/EndpointStatus"
       required:
+        - healthy
+        - version
         - status
 
     EndpointStatus:

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/teranode"
+	"github.com/bsv-blockchain/arcade/version"
 )
 
 // collectInputTXIDs returns the parent txids referenced by every input of
@@ -167,18 +168,30 @@ func RenderDocs(w io.Writer) error {
 	return docsTmpl.Execute(w, docsPage{Routes: routeDocs})
 }
 
-// healthResponse is the schema of GET /health. The top-level "status":"ok"
-// preserves backwards compatibility with existing health checkers that
-// only grep the response for liveness. Chaintracks moved out of api-server
-// in the microservice decomposition — its health is now reported by the
-// standalone chaintracks pod's /health endpoint.
+// healthResponse is the schema of GET /health. The leading "healthy" bool and
+// "version" string are the ARC health contract (github.com/bitcoin-sv/arc) — ARC
+// clients deserialise against it and gate transaction submission on
+// healthy == true, so a missing field makes them reject an otherwise-healthy
+// node (issue #208). The top-level "status":"ok" and "datahub_urls" are retained
+// for backwards compatibility with existing health checkers. As a liveness
+// probe, "healthy" is always true here: if the process answers, it is alive —
+// per-endpoint Datahub health stays in datahub_urls[].healthy. Chaintracks moved
+// out of api-server in the microservice decomposition — its health is now
+// reported by the standalone chaintracks pod's /health endpoint.
 type healthResponse struct {
+	Healthy     bool                      `json:"healthy"`
+	Version     string                    `json:"version"`
 	Status      string                    `json:"status"`
 	DatahubURLs []teranode.EndpointStatus `json:"datahub_urls"`
 }
 
 func (s *Server) handleHealth(c *gin.Context) {
-	resp := healthResponse{Status: "ok", DatahubURLs: []teranode.EndpointStatus{}}
+	resp := healthResponse{
+		Healthy:     true,
+		Version:     version.Version,
+		Status:      "ok",
+		DatahubURLs: []teranode.EndpointStatus{},
+	}
 	if s.teranode != nil {
 		resp.DatahubURLs = s.teranode.GetEndpointStatuses()
 	}

--- a/services/api_server/handlers_health_test.go
+++ b/services/api_server/handlers_health_test.go
@@ -11,13 +11,17 @@ import (
 
 	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/teranode"
+	"github.com/bsv-blockchain/arcade/version"
 )
 
 // healthResp mirrors the server's healthResponse shape but uses generic
 // Go types so test code does not depend on unexported fields.
 // Chaintracks moved out of api-server in the microservice decomposition,
-// so the response no longer includes a chaintracks block.
+// so the response no longer includes a chaintracks block. The healthy/version
+// fields are the ARC health contract (issue #208).
 type healthResp struct {
+	Healthy     bool                      `json:"healthy"`
+	Version     string                    `json:"version"`
 	Status      string                    `json:"status"`
 	DatahubURLs []teranode.EndpointStatus `json:"datahub_urls"`
 }
@@ -65,6 +69,13 @@ func TestHandleHealth_StructuredResponse(t *testing.T) {
 	if resp.Status != "ok" {
 		t.Fatalf("expected status=ok, got %q", resp.Status)
 	}
+	// ARC contract: clients gate submission on healthy == true and read version.
+	if !resp.Healthy {
+		t.Errorf("expected healthy=true, got %v (body=%s)", resp.Healthy, string(body))
+	}
+	if resp.Version != version.Version {
+		t.Errorf("expected version=%q, got %q", version.Version, resp.Version)
+	}
 
 	want := []teranode.EndpointStatus{
 		{URL: "https://a.example", Source: "configured", Healthy: true},
@@ -103,5 +114,10 @@ func TestHandleHealth_NilTeranode_ReturnsEmptyArray(t *testing.T) {
 	}
 	if string(raw["datahub_urls"]) != "[]" {
 		t.Errorf("expected datahub_urls to be `[]` in JSON, got %s", string(raw["datahub_urls"]))
+	}
+	// ARC clients require a literal `"healthy": true` — ensure the field is
+	// present and not dropped/renamed by marshalling (issue #208).
+	if string(raw["healthy"]) != "true" {
+		t.Errorf("expected healthy to be `true` in JSON, got %s", string(raw["healthy"]))
 	}
 }

--- a/services/api_server/routes.go
+++ b/services/api_server/routes.go
@@ -69,7 +69,7 @@ var routeDocs = []RouteDoc{
 		Summary:        "Liveness probe",
 		Description:    "Reports liveness of the API server process and the upstream Datahub endpoints it depends on. Suitable as a Kubernetes liveness probe.",
 		ResponseStatus: "200 OK",
-		ResponseBody:   "{\n  \"status\": \"ok\",\n  \"datahub_urls\": [\n    { \"url\": \"https://...\", \"healthy\": true }\n  ]\n}",
+		ResponseBody:   "{\n  \"healthy\": true,\n  \"version\": \"v0.8.0\",\n  \"status\": \"ok\",\n  \"datahub_urls\": [\n    { \"url\": \"https://...\", \"healthy\": true }\n  ]\n}",
 	},
 	{
 		Method:         "GET",

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,10 @@
+// Package version exposes the arcade build version.
+package version
+
+// Version is the arcade build version. It defaults to "dev" for local builds
+// and `go run`, and is overridden at release/CI build time via
+//
+//	-ldflags "-X github.com/bsv-blockchain/arcade/version.Version=<git tag>"
+//
+// (see .github/workflows/build.yml and the Makefile docker-build target).
+var Version = "dev"


### PR DESCRIPTION
## What Changed
- Added a top-level `healthy` (bool) and `version` (string) field to the `GET /health` response, ahead of the existing `status` / `datahub_urls` fields.
- New `version` package (`version/version.go`) exposing `var Version = "dev"`, stamped at build time from the git tag via `-ldflags -X` in CI (`.github/workflows/build.yml`, reusing the `get_tag` job output) and `make docker-build` (`git describe`).
- Updated the in-code route docs example, the OpenAPI `HealthResponse` schema + example, and the health handler tests.

## Why It Was Necessary
ARC clients deserialise `GET /health` against the ARC contract (`{"healthy": true, "version": "..."}`) and gate transaction submission on `healthy == true`. Arcade omitted both fields, so ARC clients failed on the missing required `healthy` field and treated a fully-functional node as unhealthy. See #208.

## Testing Performed
- `magex lint` — 0 issues, `go vet` clean.
- `CGO_ENABLED=1 go test ./services/api_server/ -run TestHandleHealth` — passes; tests assert `healthy:true`, `version` matches the package var, and that the raw JSON carries a literal `"healthy": true`.
- Built `./cmd/arcade` with `-ldflags "-X .../version.Version=v9.9.9-test"` and confirmed the string is embedded in the binary (validates the `-X` import path end-to-end).

## Impact / Risk
Low. Purely additive to the response body — `status` and `datahub_urls` are retained, so existing health checkers are unaffected. `healthy` is always `true` (liveness semantics, matching the existing always-`ok` status); per-endpoint Datahub health remains in `datahub_urls[].healthy`. The `/health` path is unchanged (not switched to ARC's `/v1/health`).

## Notifications
- @galt-tr

Closes #208
