### PR TITLE
feat(watchdog): cap block reprocessing to stop the reprocess storm

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -514,6 +514,15 @@ type WatchdogConfig struct {
 	// block likely isn't on the consensus chain, so retrying soon would
 	// produce the same disagreement. Default 4 h.
 	TerminalBackoffMs int `mapstructure:"terminal_backoff_ms"`
+	// MaxReprocessAttempts caps total /reprocess dispatches per block; once a
+	// block is re-driven this many times it is parked (reprocessing stops) so a
+	// permanently un-finalizable block can't flood arcade.block_processed and
+	// starve the bump-builder consumer. Default 10; <= 0 disables the cap.
+	MaxReprocessAttempts int `mapstructure:"max_reprocess_attempts"`
+	// MaxStaleAgeMs parks a block whose header_seen_at is older than this,
+	// regardless of attempt count — a restart-proof backstop (the in-memory
+	// attempt counter resets on redeploy). Default 6 h; <= 0 disables it.
+	MaxStaleAgeMs int `mapstructure:"max_stale_age_ms"`
 }
 
 // SSEConfig governs the standalone SSE (server-sent events) service.
@@ -869,6 +878,8 @@ func setDefaults() {
 	viper.SetDefault("watchdog.initial_backoff_ms", 60000)
 	viper.SetDefault("watchdog.max_backoff_ms", 1800000)
 	viper.SetDefault("watchdog.terminal_backoff_ms", 14400000)
+	viper.SetDefault("watchdog.max_reprocess_attempts", 10)
+	viper.SetDefault("watchdog.max_stale_age_ms", 21600000) // 6h
 
 	// SSE standalone service (mode=sse, or in-process under mode=all):
 	// enabled by default. Distinct port from api.port avoids the bind

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -324,6 +324,15 @@ var WatchdogBackoffDepth = promauto.NewGauge(prometheus.GaugeOpts{
 	Help: "Number of blocks currently held in the watchdog's in-memory backoff map.",
 })
 
+// WatchdogParkedTotal counts blocks the watchdog has parked (stopped
+// re-driving) because they hit the reprocess cap. A non-zero value means
+// blocks are permanently un-finalizable — inspect bump-builder for the
+// underlying reason (e.g. incomplete STUMPs / merkle-root mismatch).
+var WatchdogParkedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_watchdog_parked_total",
+	Help: "Blocks parked by the watchdog (reprocessing stopped), by reason.",
+}, []string{"reason"}) // max_attempts, max_age
+
 // ---------------------------------------------------------------------------
 // api_server
 // ---------------------------------------------------------------------------

--- a/services/watchdog/service.go
+++ b/services/watchdog/service.go
@@ -109,15 +109,20 @@ func ResolveConfig(c config.WatchdogConfig) Config {
 	if terminal <= 0 {
 		terminal = 4 * time.Hour
 	}
+	// Pass the cap knobs through directly: a value <= 0 means "disabled", so
+	// (unlike the backoff fields above) we must NOT substitute a default here —
+	// the viper SetDefault already supplies 10 / 6h when the operator is silent.
 	return Config{
-		Interval:        interval,
-		StaleThreshold:  stale,
-		RecencyDepth:    recency,
-		BatchSize:       batch,
-		MaxConcurrent:   maxConc,
-		LeaseTTL:        leaseTTL,
-		InitialBackoff:  initBackoff,
-		MaxBackoff:      maxBackoff,
-		TerminalBackoff: terminal,
+		Interval:             interval,
+		StaleThreshold:       stale,
+		RecencyDepth:         recency,
+		BatchSize:            batch,
+		MaxConcurrent:        maxConc,
+		LeaseTTL:             leaseTTL,
+		InitialBackoff:       initBackoff,
+		MaxBackoff:           maxBackoff,
+		TerminalBackoff:      terminal,
+		MaxReprocessAttempts: c.MaxReprocessAttempts,
+		MaxStaleAge:          time.Duration(c.MaxStaleAgeMs) * time.Millisecond,
 	}
 }

--- a/services/watchdog/watchdog.go
+++ b/services/watchdog/watchdog.go
@@ -70,6 +70,14 @@ type attemptState struct {
 	// Compared against time.Now in the tick loop; if it's in the future
 	// the candidate is skipped without an HTTP call.
 	nextEligibleAt time.Time
+	// total counts every /reprocess dispatch for this block regardless of
+	// outcome (success OR failure). Unlike failures it is never reset — it
+	// drives the MaxReprocessAttempts cap so an accepted-but-never-finalized
+	// block (which resets failures to 0 each stale window) still gets parked.
+	total int
+	// parked is set once when the block crosses a cap (attempts or age) so the
+	// WARN + metric fire exactly once, not every tick thereafter.
+	parked bool
 }
 
 // Config is the resolved knob bundle the run loop consumes. Construct
@@ -85,6 +93,12 @@ type Config struct {
 	InitialBackoff  time.Duration
 	MaxBackoff      time.Duration
 	TerminalBackoff time.Duration
+	// MaxReprocessAttempts caps total /reprocess dispatches per block; once a
+	// block hits this it is parked (reprocessing stops). <= 0 disables the cap.
+	MaxReprocessAttempts int
+	// MaxStaleAge parks a block whose header_seen_at is older than this,
+	// regardless of attempt count. Restart-proof backstop. <= 0 disables it.
+	MaxStaleAge time.Duration
 }
 
 // Watchdog is the background actor. Construction is via New so callers
@@ -269,12 +283,49 @@ func (w *Watchdog) filterEligible(rows []*models.BlockProcessingStatus, now time
 	out := rows[:0:cap(rows)]
 	for _, r := range rows {
 		st := w.attempts[r.BlockHash]
+		// Cap reprocessing: a block re-driven MaxReprocessAttempts times (or
+		// stale longer than MaxStaleAge) is parked — we stop issuing /reprocess
+		// so a permanently un-finalizable block can't soak the
+		// arcade.block_processed topic indefinitely (the reprocess storm that
+		// saturates the single bump-builder consumer). Parked entries age out
+		// via gc / RecencyDepth; a redeploy re-tries once more then re-parks.
+		if reason := w.parkReason(r, st, now); reason != "" {
+			if st == nil {
+				st = &attemptState{lastTriedAt: now}
+				w.attempts[r.BlockHash] = st
+			}
+			if !st.parked {
+				st.parked = true
+				metrics.WatchdogParkedTotal.WithLabelValues(reason).Inc()
+				w.logger.Warn("watchdog: parking block; stopping reprocess",
+					logfields.BlockHash(r.BlockHash),
+					logfields.BlockHeight(r.BlockHeight),
+					zap.String("reason", reason),
+					zap.Int("attempts", st.total))
+			}
+			continue
+		}
 		if st != nil && st.nextEligibleAt.After(now) {
 			continue
 		}
 		out = append(out, r)
 	}
 	return out
+}
+
+// parkReason returns a non-empty reason ("max_age" | "max_attempts") when the
+// block should be parked (reprocessing stopped), or "" to keep re-driving.
+// Each bound is disabled when its config value is <= 0. The max-age bound reads
+// only r.HeaderSeenAt, so it also caps blocks the attempts map hasn't seen yet
+// and survives redeploys (which reset the in-memory attempt counters).
+func (w *Watchdog) parkReason(r *models.BlockProcessingStatus, st *attemptState, now time.Time) string {
+	if w.cfg.MaxStaleAge > 0 && now.Sub(r.HeaderSeenAt) > w.cfg.MaxStaleAge {
+		return "max_age"
+	}
+	if w.cfg.MaxReprocessAttempts > 0 && st != nil && st.total >= w.cfg.MaxReprocessAttempts {
+		return "max_attempts"
+	}
+	return ""
 }
 
 // dispatch fires /reprocess calls in parallel, bounded by MaxConcurrent.
@@ -347,11 +398,19 @@ func (w *Watchdog) reprocessOne(ctx context.Context, row *models.BlockProcessing
 func (w *Watchdog) recordSuccess(hash string, now time.Time) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	w.attempts[hash] = &attemptState{
-		lastTriedAt:    now,
-		failures:       0,
-		nextEligibleAt: now.Add(w.cfg.StaleThreshold),
+	// Fetch-or-increment rather than replace: a 2xx ack does NOT mean the block
+	// finalized (only that merkle accepted the request). Preserving the total
+	// counter across re-drives is what lets MaxReprocessAttempts eventually park
+	// an accepted-but-never-finalized block instead of re-driving it forever.
+	st := w.attempts[hash]
+	if st == nil {
+		st = &attemptState{}
+		w.attempts[hash] = st
 	}
+	st.lastTriedAt = now
+	st.failures = 0
+	st.total++
+	st.nextEligibleAt = now.Add(w.cfg.StaleThreshold)
 	metrics.WatchdogBackoffDepth.Set(float64(len(w.attempts)))
 }
 
@@ -365,6 +424,7 @@ func (w *Watchdog) recordFailure(hash string, now time.Time, delay time.Duration
 	}
 	st.lastTriedAt = now
 	st.failures++
+	st.total++
 	st.nextEligibleAt = now.Add(w.jitter(delay))
 	metrics.WatchdogBackoffDepth.Set(float64(len(w.attempts)))
 }
@@ -379,6 +439,7 @@ func (w *Watchdog) recordTransientFailure(hash string, now time.Time) {
 	}
 	st.lastTriedAt = now
 	st.failures++
+	st.total++
 	delay := transientBackoff(w.cfg.InitialBackoff, w.cfg.MaxBackoff, st.failures)
 	st.nextEligibleAt = now.Add(w.jitter(delay))
 	metrics.WatchdogBackoffDepth.Set(float64(len(w.attempts)))

--- a/services/watchdog/watchdog_test.go
+++ b/services/watchdog/watchdog_test.go
@@ -330,6 +330,67 @@ func TestWatchdog_BacksOffHeavilyOn4xx(t *testing.T) {
 	}
 }
 
+// TestWatchdog_CapsReprocessAtMaxAttempts reproduces the reprocess-storm:
+// merkle keeps ACCEPTING /reprocess (202) but the block never finalizes
+// (processed_at stays NULL), so the row is re-listed every stale window. With
+// MaxReprocessAttempts the watchdog must stop re-driving after N dispatches
+// instead of forever (the old recordSuccess reset the counter each time).
+func TestWatchdog_CapsReprocessAtMaxAttempts(t *testing.T) {
+	srv := newReprocessServer(t) // default responder returns 202 Accepted
+	mc := merkleservice.NewClient(srv.server.URL, "auth", 5*time.Second)
+
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	st := &watchdogStore{
+		tipHeight: 1000,
+		stale: []*models.BlockProcessingStatus{
+			{BlockHash: "blk-1", BlockHeight: 1000, HeaderSeenAt: now.Add(-10 * time.Minute), Status: models.BlockStatusActive},
+		},
+	}
+	w := newTestWatchdog(t, st, alwaysLeader(), mc)
+	w.cfg.MaxReprocessAttempts = 3
+	w.cfg.MaxStaleAge = 0 // isolate the attempt cap
+
+	// Tick well past the cap, advancing > StaleThreshold each time so backoff
+	// never gates (only the cap should).
+	for i := 0; i < 6; i++ {
+		w.now = func() time.Time { return now.Add(time.Duration(i) * 3 * time.Minute) }
+		w.tick(context.Background())
+	}
+
+	if got := srv.callCount(); got != 3 {
+		t.Fatalf("reprocess not capped: calls=%d want 3 (MaxReprocessAttempts)", got)
+	}
+}
+
+// TestWatchdog_ParksBlockOlderThanMaxStaleAge verifies the restart-proof age
+// backstop: a block whose header_seen_at is older than MaxStaleAge is parked
+// without ever being dispatched, even with the attempt cap disabled and no
+// prior in-memory attempt state.
+func TestWatchdog_ParksBlockOlderThanMaxStaleAge(t *testing.T) {
+	srv := newReprocessServer(t)
+	mc := merkleservice.NewClient(srv.server.URL, "auth", 5*time.Second)
+
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	st := &watchdogStore{
+		tipHeight: 1000,
+		stale: []*models.BlockProcessingStatus{
+			// height-recent (within RecencyDepth) but stuck for 2h.
+			{BlockHash: "blk-old", BlockHeight: 1000, HeaderSeenAt: now.Add(-2 * time.Hour), Status: models.BlockStatusActive},
+		},
+	}
+	w := newTestWatchdog(t, st, alwaysLeader(), mc)
+	w.cfg.MaxReprocessAttempts = 0 // disable attempt cap; isolate the age cap
+	w.cfg.MaxStaleAge = time.Hour
+	w.now = func() time.Time { return now }
+
+	w.tick(context.Background())
+	w.tick(context.Background())
+
+	if got := srv.callCount(); got != 0 {
+		t.Fatalf("block older than MaxStaleAge should be parked, not dispatched: calls=%d want 0", got)
+	}
+}
+
 func TestWatchdog_LeaseSkipsWhenNotLeader(t *testing.T) {
 	srv := newReprocessServer(t)
 	mc := merkleservice.NewClient(srv.server.URL, "auth", 5*time.Second)


### PR DESCRIPTION
## Problem
The watchdog re-drives every stale `block_processing` row (`header_seen_at` set, `processed_at` NULL) via merkle `/reprocess` each stale window. The storm is on the **success** path: `recordSuccess` **replaced** `attemptState` with a fresh 0-failure struct, so a block that merkle *accepts* but never *finalizes* (one bump-builder can't complete) is re-driven every `StaleThreshold` **forever** — only *failed* /reprocess calls got backoff.

Observed on bsva-us-1: ~145 stuck blocks re-driven ~**1,445×/15m**, flooding `arcade.block_processed` faster than the single bump-builder consumer could drain (consumer-group lag ~**425k**, ~**23k** DLQ'd) → transactions stranded out of MINED.

## Fix
An **in-memory** cap (matches the watchdog's deliberate in-process backoff design — no store/schema/migration change):
- `attemptState.total`: monotonic dispatch counter, **never reset**. `recordSuccess` now fetch-or-increments instead of replacing the struct (the load-bearing change); the failure paths increment it too.
- `filterEligible` **parks** a block (stops issuing `/reprocess`) once `total >= MaxReprocessAttempts` (default **10**) **or** `header_seen_at` is older than `MaxStaleAge` (default **6h** — a restart-proof backstop needing no map state). One-shot `WARN` + new `arcade_watchdog_parked_total{reason}` counter (`max_attempts` | `max_age`).
- New knobs `watchdog.max_reprocess_attempts` / `watchdog.max_stale_age_ms`; `<= 0` disables that cap (backward-compatible — existing tests unchanged).

Parked entries still age out via the existing `gc` (24h idle) / `RecencyDepth`; a redeploy re-tries a parked block once more then re-parks (the accepted tradeoff already documented for the in-memory design; the max-age bound mitigates even that).

## Testing
- `go build ./...`, `go vet`, `go test ./services/watchdog/ ./config/` all pass.
- Added `TestWatchdog_CapsReprocessAtMaxAttempts` (merkle returns 202 forever, row stays NULL → dispatches cap at N) and `TestWatchdog_ParksBlockOlderThanMaxStaleAge`.

## Rollout note
This is the permanent fix for the reprocess-storm feedback loop. Pairs with a flux change raising bump-builder CPU + replicas (bsva-infra-flux#232) to drain the existing backlog.

https://claude.ai/code/session_0152bwyqKUBRhMkHcD5LMXsz