### PR TITLE
fix(watchdog): guarantee one attempt before age-park; persist parks as status='parked'

### DIFF
--- a/models/block.go
+++ b/models/block.go
@@ -21,14 +21,24 @@ type Block struct {
 }
 
 // BlockProcessingStatusValue tracks whether a block tracked by chaintracks
-// is still on the active chain or has been orphaned by a reorg. Stored as a
-// short string for backend portability (Postgres TEXT, Aerospike string bin,
-// Pebble byte slice).
+// is still on the active chain, has been orphaned by a reorg, or has been
+// parked by the watchdog (reprocess caps exhausted — needs explicit triage,
+// no longer re-driven). Stored as a short string for backend portability
+// (Postgres TEXT, Aerospike string bin, Pebble byte slice).
 type BlockProcessingStatusValue string
 
 const (
 	BlockStatusActive   BlockProcessingStatusValue = "active"
 	BlockStatusOrphaned BlockProcessingStatusValue = "orphaned"
+	// BlockStatusParked marks an on-chain block the watchdog gave up
+	// re-driving (MaxReprocessAttempts / MaxStaleAge crossed). Unlike
+	// orphaned it IS on the active chain — its compound BUMP is genuinely
+	// missing. Parked rows leave the watchdog's stale scan (status='active'
+	// predicate) so they surface as an explicit triage backlog instead of
+	// silent processed_at=NULL churn; a fresh header arrival for the same
+	// hash resets status='active' (UpsertBlockHeaderSeen conflict path) and
+	// revives recovery.
+	BlockStatusParked BlockProcessingStatusValue = "parked"
 )
 
 // BlockProcessingStatus records the milestones we've reached for one block:

--- a/services/api_server/block_status_routes_test.go
+++ b/services/api_server/block_status_routes_test.go
@@ -117,6 +117,17 @@ func (s *blockProcStore) MarkBlocksOrphaned(_ context.Context, hashes []string, 
 	return nil
 }
 
+func (s *blockProcStore) MarkBlocksParked(_ context.Context, hashes []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, h := range hashes {
+		if row, ok := s.rows[h]; ok && row.Status == models.BlockStatusActive {
+			row.Status = models.BlockStatusParked
+		}
+	}
+	return nil
+}
+
 func (s *blockProcStore) GetBlockProcessingStatus(_ context.Context, hash string) (*models.BlockProcessingStatus, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -245,6 +245,7 @@ func (m *mockStore) MarkBlockBUMPBuilt(context.Context, string, uint64, time.Tim
 }
 
 func (m *mockStore) MarkBlocksOrphaned(context.Context, []string, time.Time) error { return nil }
+func (m *mockStore) MarkBlocksParked(context.Context, []string) error              { return nil }
 
 func (m *mockStore) GetBlockProcessingStatus(context.Context, string) (*models.BlockProcessingStatus, error) {
 	return nil, store.ErrNotFound

--- a/services/watchdog/watchdog.go
+++ b/services/watchdog/watchdog.go
@@ -264,7 +264,18 @@ func (w *Watchdog) runOnce(ctx context.Context) {
 		return
 	}
 
-	eligible := w.filterEligible(candidates, now)
+	eligible, newlyParked := w.filterEligible(candidates, now)
+	if len(newlyParked) > 0 {
+		// Persist the park as a terminal status so the rows leave the stale
+		// scan (status='active' predicate) and read as an explicit triage
+		// backlog instead of perpetual processed_at=NULL churn. Best-effort:
+		// the in-memory parked flag already stops reprocessing this run, and
+		// a redeploy would re-try once then re-park (rewriting the status).
+		if err := w.store.MarkBlocksParked(ctx, newlyParked); err != nil {
+			w.logger.Warn("watchdog: failed to persist parked status",
+				zap.Int("blocks", len(newlyParked)), zap.Error(err))
+		}
+	}
 	if len(eligible) == 0 {
 		w.gc(now)
 		return
@@ -275,8 +286,10 @@ func (w *Watchdog) runOnce(ctx context.Context) {
 }
 
 // filterEligible drops candidates whose in-memory backoff hasn't expired.
-// Returns the rows that should actually trigger a /reprocess this tick.
-func (w *Watchdog) filterEligible(rows []*models.BlockProcessingStatus, now time.Time) []*models.BlockProcessingStatus {
+// Returns the rows that should actually trigger a /reprocess this tick, plus
+// the block hashes that crossed a park cap on THIS pass (first time only) so
+// the caller can persist their terminal status.
+func (w *Watchdog) filterEligible(rows []*models.BlockProcessingStatus, now time.Time) (eligible []*models.BlockProcessingStatus, newlyParked []string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -284,11 +297,12 @@ func (w *Watchdog) filterEligible(rows []*models.BlockProcessingStatus, now time
 	for _, r := range rows {
 		st := w.attempts[r.BlockHash]
 		// Cap reprocessing: a block re-driven MaxReprocessAttempts times (or
-		// stale longer than MaxStaleAge) is parked — we stop issuing /reprocess
-		// so a permanently un-finalizable block can't soak the
-		// arcade.block_processed topic indefinitely (the reprocess storm that
-		// saturates the single bump-builder consumer). Parked entries age out
-		// via gc / RecencyDepth; a redeploy re-tries once more then re-parks.
+		// stale longer than MaxStaleAge, after at least one attempt) is
+		// parked — we stop issuing /reprocess so a permanently un-finalizable
+		// block can't soak the arcade.block_processed topic indefinitely (the
+		// reprocess storm that saturates the single bump-builder consumer).
+		// The park is persisted as status='parked' by the caller, so the row
+		// stops surfacing here at all; a redeploy re-tries once then re-parks.
 		if reason := w.parkReason(r, st, now); reason != "" {
 			if st == nil {
 				st = &attemptState{lastTriedAt: now}
@@ -296,6 +310,7 @@ func (w *Watchdog) filterEligible(rows []*models.BlockProcessingStatus, now time
 			}
 			if !st.parked {
 				st.parked = true
+				newlyParked = append(newlyParked, r.BlockHash)
 				metrics.WatchdogParkedTotal.WithLabelValues(reason).Inc()
 				w.logger.Warn("watchdog: parking block; stopping reprocess",
 					logfields.BlockHash(r.BlockHash),
@@ -310,19 +325,29 @@ func (w *Watchdog) filterEligible(rows []*models.BlockProcessingStatus, now time
 		}
 		out = append(out, r)
 	}
-	return out
+	return out, newlyParked
 }
 
 // parkReason returns a non-empty reason ("max_age" | "max_attempts") when the
 // block should be parked (reprocessing stopped), or "" to keep re-driving.
-// Each bound is disabled when its config value is <= 0. The max-age bound reads
-// only r.HeaderSeenAt, so it also caps blocks the attempts map hasn't seen yet
-// and survives redeploys (which reset the in-memory attempt counters).
+// Each bound is disabled when its config value is <= 0.
+//
+// The max-age bound only fires after at least one dispatch for the block: a
+// block ALREADY past MaxStaleAge when first seen (an incident backlog
+// surfacing late, or a redeploy resetting the in-memory counters) gets
+// exactly one recovery attempt instead of being abandoned with zero —
+// age-parking at attempts:0 silently strands recoverable blocks forever.
+// The next tick re-consults parkReason with total >= 1, so the park still
+// lands promptly after that single attempt.
 func (w *Watchdog) parkReason(r *models.BlockProcessingStatus, st *attemptState, now time.Time) string {
-	if w.cfg.MaxStaleAge > 0 && now.Sub(r.HeaderSeenAt) > w.cfg.MaxStaleAge {
+	attempts := 0
+	if st != nil {
+		attempts = st.total
+	}
+	if w.cfg.MaxStaleAge > 0 && attempts > 0 && now.Sub(r.HeaderSeenAt) > w.cfg.MaxStaleAge {
 		return "max_age"
 	}
-	if w.cfg.MaxReprocessAttempts > 0 && st != nil && st.total >= w.cfg.MaxReprocessAttempts {
+	if w.cfg.MaxReprocessAttempts > 0 && attempts >= w.cfg.MaxReprocessAttempts {
 		return "max_attempts"
 	}
 	return ""

--- a/services/watchdog/watchdog_test.go
+++ b/services/watchdog/watchdog_test.go
@@ -31,7 +31,8 @@ type watchdogStore struct {
 	stale     []*models.BlockProcessingStatus
 	staleErr  error
 
-	listCalls []listStaleCall
+	listCalls   []listStaleCall
+	parkedCalls [][]string
 }
 
 type listStaleCall struct {
@@ -92,6 +93,33 @@ func (s *watchdogStore) captureListCalls() []listStaleCall {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]listStaleCall(nil), s.listCalls...)
+}
+
+// MarkBlocksParked mirrors the real backends: records the call and flips
+// active rows to parked, so subsequent ListStaleBlockProcessingStatus calls
+// exclude them (the status filter above).
+func (s *watchdogStore) MarkBlocksParked(_ context.Context, hashes []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.parkedCalls = append(s.parkedCalls, append([]string(nil), hashes...))
+	for _, h := range hashes {
+		for _, r := range s.stale {
+			if r.BlockHash == h && (r.Status == "" || r.Status == models.BlockStatusActive) {
+				r.Status = models.BlockStatusParked
+			}
+		}
+	}
+	return nil
+}
+
+func (s *watchdogStore) parkedHashes() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []string
+	for _, call := range s.parkedCalls {
+		out = append(out, call...)
+	}
+	return out
 }
 
 type watchdogLeaser struct {
@@ -360,12 +388,16 @@ func TestWatchdog_CapsReprocessAtMaxAttempts(t *testing.T) {
 	if got := srv.callCount(); got != 3 {
 		t.Fatalf("reprocess not capped: calls=%d want 3 (MaxReprocessAttempts)", got)
 	}
+	if parked := st.parkedHashes(); len(parked) != 1 || parked[0] != "blk-1" {
+		t.Fatalf("attempt-cap park must be persisted via MarkBlocksParked: got %v want [blk-1]", parked)
+	}
 }
 
-// TestWatchdog_ParksBlockOlderThanMaxStaleAge verifies the restart-proof age
-// backstop: a block whose header_seen_at is older than MaxStaleAge is parked
-// without ever being dispatched, even with the attempt cap disabled and no
-// prior in-memory attempt state.
+// TestWatchdog_ParksBlockOlderThanMaxStaleAge verifies the age backstop AND
+// its one-attempt guarantee: a block already older than MaxStaleAge when
+// first seen (incident backlog, or a redeploy reset the in-memory counters)
+// gets exactly ONE recovery dispatch, then parks — and the park is persisted
+// as a terminal status so the row leaves the stale scan entirely.
 func TestWatchdog_ParksBlockOlderThanMaxStaleAge(t *testing.T) {
 	srv := newReprocessServer(t)
 	mc := merkleservice.NewClient(srv.server.URL, "auth", 5*time.Second)
@@ -381,13 +413,36 @@ func TestWatchdog_ParksBlockOlderThanMaxStaleAge(t *testing.T) {
 	w := newTestWatchdog(t, st, alwaysLeader(), mc)
 	w.cfg.MaxReprocessAttempts = 0 // disable attempt cap; isolate the age cap
 	w.cfg.MaxStaleAge = time.Hour
+
+	// Tick 1: aged block with zero attempts must be dispatched once, not
+	// silently abandoned.
 	w.now = func() time.Time { return now }
-
 	w.tick(context.Background())
-	w.tick(context.Background())
+	if got := srv.callCount(); got != 1 {
+		t.Fatalf("aged block must get one recovery attempt before parking: calls=%d want 1", got)
+	}
 
-	if got := srv.callCount(); got != 0 {
-		t.Fatalf("block older than MaxStaleAge should be parked, not dispatched: calls=%d want 0", got)
+	// Tick 2 (past the post-success nextEligibleAt gate): the block now has
+	// one attempt recorded, so the age cap parks it — no further dispatch,
+	// and the terminal status is persisted.
+	w.now = func() time.Time { return now.Add(3 * time.Minute) }
+	w.tick(context.Background())
+	if got := srv.callCount(); got != 1 {
+		t.Fatalf("block older than MaxStaleAge should park after its single attempt: calls=%d want 1", got)
+	}
+	if parked := st.parkedHashes(); len(parked) != 1 || parked[0] != "blk-old" {
+		t.Fatalf("park must be persisted via MarkBlocksParked: got %v want [blk-old]", parked)
+	}
+
+	// Tick 3: the persisted status removes the row from the stale scan — the
+	// watchdog no longer even sees it (no re-park, no dispatch).
+	w.now = func() time.Time { return now.Add(6 * time.Minute) }
+	w.tick(context.Background())
+	if got := srv.callCount(); got != 1 {
+		t.Fatalf("parked block resurfaced: calls=%d want 1", got)
+	}
+	if parked := st.parkedHashes(); len(parked) != 1 {
+		t.Fatalf("parked status should be persisted exactly once: got %v", parked)
 	}
 }
 

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -214,6 +214,7 @@ func (s *fakeStore) MarkBlockBUMPBuilt(context.Context, string, uint64, time.Tim
 	return nil
 }
 func (s *fakeStore) MarkBlocksOrphaned(context.Context, []string, time.Time) error { return nil }
+func (s *fakeStore) MarkBlocksParked(context.Context, []string) error              { return nil }
 
 //nolint:nilnil // unused stub.
 func (s *fakeStore) GetBlockProcessingStatus(context.Context, string) (*models.BlockProcessingStatus, error) {

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -1845,6 +1845,39 @@ func (s *Store) MarkBlocksOrphaned(ctx context.Context, blockHashes []string, or
 	return nil
 }
 
+func (s *Store) MarkBlocksParked(ctx context.Context, blockHashes []string) error {
+	if len(blockHashes) == 0 {
+		return nil
+	}
+	for _, h := range blockHashes {
+		key, err := s.key(setBlockProcessing, h)
+		if err != nil {
+			return err
+		}
+		rec, err := s.client.Get(s.readPolicy(ctx), key, binStatus)
+		if err != nil {
+			if isKeyNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("read block_processing %s: %w", h, err)
+		}
+		// Only 'active' rows park: missing rows are skipped, and an orphaned
+		// row is off-chain (a more specific terminal state) that must not be
+		// relabeled as a missing-BUMP backlog.
+		if rec == nil {
+			continue
+		}
+		if status, _ := rec.Bins[binStatus].(string); status != string(models.BlockStatusActive) {
+			continue
+		}
+		if _, err := s.client.Operate(s.writePolicy(ctx), key,
+			aero.PutOp(aero.NewBin(binStatus, string(models.BlockStatusParked)))); err != nil {
+			return fmt.Errorf("mark parked %s: %w", h, err)
+		}
+	}
+	return nil
+}
+
 func (s *Store) GetBlockProcessingStatus(ctx context.Context, blockHash string) (*models.BlockProcessingStatus, error) {
 	key, err := s.key(setBlockProcessing, blockHash)
 	if err != nil {

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -1253,6 +1253,36 @@ func (s *Store) MarkBlocksOrphaned(ctx context.Context, blockHashes []string, or
 	return nil
 }
 
+func (s *Store) MarkBlocksParked(ctx context.Context, blockHashes []string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	for _, h := range blockHashes {
+		mu := s.shardFor(h)
+		mu.Lock()
+		prev, err := s.readBlockProc(h)
+		if err != nil {
+			mu.Unlock()
+			return err
+		}
+		// Only 'active' rows park: missing rows are skipped, and an orphaned
+		// row is off-chain (a more specific terminal state) that must not be
+		// relabeled as a missing-BUMP backlog.
+		if prev == nil || prev.Status != string(models.BlockStatusActive) {
+			mu.Unlock()
+			continue
+		}
+		cur := *prev
+		cur.Status = string(models.BlockStatusParked)
+		if err := s.writeBlockProc(prev, &cur); err != nil {
+			mu.Unlock()
+			return err
+		}
+		mu.Unlock()
+	}
+	return nil
+}
+
 func (s *Store) GetBlockProcessingStatus(ctx context.Context, blockHash string) (*models.BlockProcessingStatus, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/store/pebble/pebble_test.go
+++ b/store/pebble/pebble_test.go
@@ -1086,3 +1086,65 @@ func hashesOf(rows []*models.BlockProcessingStatus) []string {
 	}
 	return out
 }
+
+func TestBlockProcessing_MarkParked(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	t0 := time.Now().Add(-time.Hour).UTC().Truncate(time.Millisecond)
+
+	if err := s.UpsertBlockHeaderSeen(ctx, "parkme", 500, t0); err != nil {
+		t.Fatalf("seen: %v", err)
+	}
+	if err := s.MarkBlocksParked(ctx, []string{"parkme"}); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	got, err := s.GetBlockProcessingStatus(ctx, "parkme")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != models.BlockStatusParked {
+		t.Errorf("Status=%q, want parked", got.Status)
+	}
+
+	// Parked rows leave the stale scan (status='active' predicate).
+	stale, err := s.ListStaleBlockProcessingStatus(ctx, time.Now(), 0, 10)
+	if err != nil {
+		t.Fatalf("list stale: %v", err)
+	}
+	for _, r := range stale {
+		if r.BlockHash == "parkme" {
+			t.Error("parked row must not surface in the stale scan")
+		}
+	}
+
+	// A fresh header arrival revives the row to active (recovery resumes).
+	if err := s.UpsertBlockHeaderSeen(ctx, "parkme", 500, t0.Add(time.Minute)); err != nil {
+		t.Fatalf("re-seen: %v", err)
+	}
+	got, _ = s.GetBlockProcessingStatus(ctx, "parkme")
+	if got.Status != models.BlockStatusActive {
+		t.Errorf("Status after re-seen=%q, want active", got.Status)
+	}
+}
+
+func TestBlockProcessing_MarkParked_SkipsOrphanedAndMissing(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	t0 := time.Now().Add(-time.Hour)
+
+	if err := s.UpsertBlockHeaderSeen(ctx, "reorged", 501, t0); err != nil {
+		t.Fatalf("seen: %v", err)
+	}
+	if err := s.MarkBlocksOrphaned(ctx, []string{"reorged"}, t0.Add(time.Minute)); err != nil {
+		t.Fatalf("orphan: %v", err)
+	}
+	// Parking must not relabel an orphaned (off-chain) row, and a missing
+	// row is a silent no-op.
+	if err := s.MarkBlocksParked(ctx, []string{"reorged", "never-seen"}); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	got, _ := s.GetBlockProcessingStatus(ctx, "reorged")
+	if got.Status != models.BlockStatusOrphaned {
+		t.Errorf("Status=%q, want orphaned (park must not override)", got.Status)
+	}
+}

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -970,6 +970,23 @@ WHERE block_hash = ANY($1)`
 	return nil
 }
 
+func (s *Store) MarkBlocksParked(ctx context.Context, blockHashes []string) error {
+	if len(blockHashes) == 0 {
+		return nil
+	}
+	// Only 'active' rows park: an orphaned row is off-chain (a more specific
+	// terminal state) and must not be relabeled as a missing-BUMP backlog.
+	const q = `
+UPDATE block_processing
+SET status = 'parked'
+WHERE block_hash = ANY($1) AND status = 'active'`
+	_, err := s.pool.Exec(ctx, q, blockHashes)
+	if err != nil {
+		return fmt.Errorf("mark blocks parked: %w", err)
+	}
+	return nil
+}
+
 func (s *Store) GetBlockProcessingStatus(ctx context.Context, blockHash string) (*models.BlockProcessingStatus, error) {
 	const q = `
 SELECT block_hash, block_height, header_seen_at, processed_at, bump_built_at, status, orphaned_at

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -1340,3 +1340,65 @@ func TestSetMinedByTxIDs_HandlesNullPrevBlock(t *testing.T) {
 		t.Errorf("mined snapshot mismatch: %+v", mined[0])
 	}
 }
+
+func TestBlockProcessing_MarkParked(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	t0 := time.Now().Add(-time.Hour).UTC().Truncate(time.Millisecond)
+
+	if err := s.UpsertBlockHeaderSeen(ctx, "parkme", 500, t0); err != nil {
+		t.Fatalf("seen: %v", err)
+	}
+	if err := s.MarkBlocksParked(ctx, []string{"parkme"}); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	got, err := s.GetBlockProcessingStatus(ctx, "parkme")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != models.BlockStatusParked {
+		t.Errorf("Status=%q, want parked", got.Status)
+	}
+
+	// Parked rows leave the stale scan (status='active' predicate).
+	stale, err := s.ListStaleBlockProcessingStatus(ctx, time.Now(), 0, 10)
+	if err != nil {
+		t.Fatalf("list stale: %v", err)
+	}
+	for _, r := range stale {
+		if r.BlockHash == "parkme" {
+			t.Error("parked row must not surface in the stale scan")
+		}
+	}
+
+	// A fresh header arrival revives the row to active (recovery resumes).
+	if err := s.UpsertBlockHeaderSeen(ctx, "parkme", 500, t0.Add(time.Minute)); err != nil {
+		t.Fatalf("re-seen: %v", err)
+	}
+	got, _ = s.GetBlockProcessingStatus(ctx, "parkme")
+	if got.Status != models.BlockStatusActive {
+		t.Errorf("Status after re-seen=%q, want active", got.Status)
+	}
+}
+
+func TestBlockProcessing_MarkParked_SkipsOrphanedAndMissing(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	t0 := time.Now().Add(-time.Hour)
+
+	if err := s.UpsertBlockHeaderSeen(ctx, "reorged-park", 501, t0); err != nil {
+		t.Fatalf("seen: %v", err)
+	}
+	if err := s.MarkBlocksOrphaned(ctx, []string{"reorged-park"}, t0.Add(time.Minute)); err != nil {
+		t.Fatalf("orphan: %v", err)
+	}
+	// Parking must not relabel an orphaned (off-chain) row, and a missing
+	// row is a silent no-op.
+	if err := s.MarkBlocksParked(ctx, []string{"reorged-park", "never-seen"}); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	got, _ := s.GetBlockProcessingStatus(ctx, "reorged-park")
+	if got.Status != models.BlockStatusOrphaned {
+		t.Errorf("Status=%q, want orphaned (park must not override)", got.Status)
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -157,6 +157,15 @@ type Store interface {
 	// service started recording).
 	MarkBlocksOrphaned(ctx context.Context, blockHashes []string, orphanedAt time.Time) error
 
+	// MarkBlocksParked transitions every named block from status='active' to
+	// status='parked' — the watchdog's terminal state for blocks whose
+	// reprocess caps (attempts/age) are exhausted. Rows that are missing or
+	// not 'active' (orphaned rows stay orphaned) are silently skipped. Parked
+	// rows drop out of ListStaleBlockProcessingStatus so they read as an
+	// explicit triage backlog rather than perpetual stale churn; a later
+	// UpsertBlockHeaderSeen for the same hash resets them to 'active'.
+	MarkBlocksParked(ctx context.Context, blockHashes []string) error
+
 	// GetBlockProcessingStatus returns the row keyed by blockHash. Returns
 	// ErrNotFound if no row exists.
 	GetBlockProcessingStatus(ctx context.Context, blockHash string) (*models.BlockProcessingStatus, error)


### PR DESCRIPTION
Closes #233.

## Problem

The `MaxStaleAge` cap (#230) parks any block whose `header_seen_at` is older than the bound — **including blocks the watchdog has never dispatched**. In production on bsva-us-1 this silently abandoned a **487-block incident backlog**: every block was already >6h stale by the time the capped watchdog first scanned it, so each was parked at `attempts:0` — zero recovery attempts, `processed_at=NULL` forever, visible only as perpetual rows in the stale query. (The backlog was recovered operationally by re-driving merkle `/reprocess` per block: 487/487 accepted.)

## Fix

1. **One-attempt guarantee** — `parkReason` only honors `max_age` after at least one dispatch for the block (`st.total > 0`). An aged backlog (or a redeploy that resets the in-memory counters) now gets exactly one recovery attempt each instead of zero; the next tick re-consults the cap with `total >= 1` and parks promptly. The bounded one-shot wave is dispatch-limited by `MaxConcurrent` + `RecencyDepth` exactly like any other tick.

2. **Persist parks as `status='parked'`** — new store method `MarkBlocksParked` (postgres / pebble / aerospike; `active → parked` only). Parked rows:
   - leave the stale scan (`status='active'` predicate) → `arcade_watchdog_stale_count` counts actionable rows only, and the watchdog stops re-scanning them every tick;
   - read as an **explicit triage backlog** (`SELECT ... WHERE status='parked'`) instead of silent `processed_at=NULL` churn;
   - are revived by the existing `UpsertBlockHeaderSeen` conflict path (reset to `'active'`) if the header re-arrives (reorg resurrection).
   - `orphaned` rows are never relabeled (off-chain is the more specific terminal state); missing rows are silently skipped. `status` has no CHECK constraint — no migration needed.

## Tests

- `TestWatchdog_ParksBlockOlderThanMaxStaleAge` (rewritten): aged block gets exactly **one** dispatch → parks → park persisted exactly once → row leaves the stale scan.
- `TestWatchdog_CapsReprocessAtMaxAttempts` (extended): attempt-cap park is persisted.
- `TestBlockProcessing_MarkParked` + `_SkipsOrphanedAndMissing` in **both** pebble and postgres (`-tags=postgres`, embedded) suites: park semantics, stale-scan exclusion, revive-on-re-seen, orphan precedence.

`go build ./... && go vet ./... && go test ./... -count=1` and `go test -tags=postgres ./store/postgres/ -run MarkParked` all pass.

Follow-up to #230. Root-cause context: the 487-block abandonment was found while investigating stale-block reprocess churn on bsva-us-1 (no stuck txs — all txs in the affected range were MINED; the gap is block-level compound-BUMP serving).