### PR TITLE
feat(bump-builder): wait for chaintracks before skipping canonical-root validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -462,6 +462,16 @@ type EndpointHealthConfig struct {
 // giving merkle-service retries time to land for any STUMPs that initially got a 5xx.
 type BumpBuilderConfig struct {
 	GraceWindowMs int `mapstructure:"grace_window_ms"`
+	// HeaderWaitMs bounds how long the DataHub-fetch canonical-root
+	// validator waits for chaintracks to learn a freshly-mined block's
+	// header before giving up and skipping the cross-check. bump-builder is
+	// driven by the BLOCK_PROCESSED Kafka message while chaintracks ingests
+	// headers over an independent teranode P2P subscription; for a block
+	// mined seconds earlier the Kafka path usually wins that race, and
+	// without a wait the validator silently skipped its only independent
+	// canonicality check. <= 0 disables the wait (single lookup, legacy
+	// behavior).
+	HeaderWaitMs int `mapstructure:"header_wait_ms"`
 	// DataHubMaxBlockBytes caps a single /block/<hash> response body fetched
 	// from a DataHub endpoint, in bytes. The DataHub serves block metadata
 	// (header + subtree-hash list + coinbase tx + coinbase BUMP), so the
@@ -858,6 +868,11 @@ func setDefaults() {
 	// can't see ARCADE_CHAINTRACKS_URL — register the key explicitly here.
 	viper.SetDefault("chaintracks.url", "")
 	viper.SetDefault("bump_builder.grace_window_ms", 30000)
+	// 10s covers the observed chaintracks P2P-ingestion lag for a
+	// freshly-mined block (typically < 2s) with margin, while bounding how
+	// long a DataHub fetch can stall when chaintracks genuinely never
+	// learns the header (e.g. it is down).
+	viper.SetDefault("bump_builder.header_wait_ms", 10000)
 	// 1 GiB — DataHub /block/<hash> responses contain block metadata
 	// (header + subtree hashes + coinbase tx + coinbase BUMP). 1 GiB is
 	// two-plus orders of magnitude of headroom over a realistic payload

--- a/services/bump_builder/builder.go
+++ b/services/bump_builder/builder.go
@@ -101,17 +101,27 @@ func combineValidators(a, b bump.BlockDataValidator) bump.BlockDataValidator {
 	}
 }
 
+// headerWaitPollInterval is the pause between chaintracks header lookups
+// while chainHeaderRootValidator waits out the ingestion race (see below).
+// 1s keeps the wait responsive without hammering the chaintracks API.
+const headerWaitPollInterval = time.Second
+
 // chainHeaderRootValidator returns a validator that compares the datahub's
 // header merkle root against the canonical merkle root from chaintracks. A
 // mismatch means the datahub returned a block representation that doesn't
 // belong to the canonical chain (pruned peer, stale cache, malicious peer),
 // so the fetch loop should fall through to the next URL.
 //
-// Soft-fails to "no validation" when chaintracks doesn't know the header
-// yet — this is a real race in mode=all where chaintracks's P2P subscription
-// is independent of the BLOCK_PROCESSED message that drives bump-builder.
-// The post-build ValidateCompoundRoot at builder.go still runs and catches
-// any compound that doesn't reconcile.
+// chaintracks not knowing the header yet is a real race: its teranode P2P
+// subscription is independent of the Kafka BLOCK_PROCESSED message that
+// drives bump-builder, and for a block mined seconds earlier the Kafka path
+// usually wins. The validator retries the lookup for up to
+// bump_builder.header_wait_ms so the race resolves into a real cross-check
+// instead of a silent skip; only when chaintracks still doesn't know the
+// header after the wait does it soft-fail to "no validation" (post-build
+// ValidateCompoundRoot still runs and catches any compound that doesn't
+// reconcile — but that check uses the datahub's own root, so it cannot
+// prove canonicality the way this one does).
 func (b *Builder) chainHeaderRootValidator(ctx context.Context, blockHash string, logger *zap.Logger) bump.BlockDataValidator {
 	if b.chainHeader == nil {
 		return nil
@@ -121,15 +131,25 @@ func (b *Builder) chainHeaderRootValidator(ctx context.Context, blockHash string
 		logger.Warn("skipping canonical-root validation: invalid block hash", zap.Error(err))
 		return nil
 	}
+	// One wall-clock budget for the whole block, shared by every per-URL
+	// invocation of the validator: the race being waited out is chaintracks
+	// ingesting THIS block, so the clock starts once. If chaintracks is
+	// genuinely down, only the first fetch attempt pays the wait — later
+	// URLs find the budget spent and degrade to a single lookup each.
+	var headerWaitDeadline time.Time
+	if wait := time.Duration(b.cfg.BumpBuilder.HeaderWaitMs) * time.Millisecond; wait > 0 {
+		headerWaitDeadline = time.Now().Add(wait)
+	}
 	return func(_ []chainhash.Hash, fetchedRoot *chainhash.Hash) error {
-		header, lookupErr := b.chainHeader.GetHeaderByHash(ctx, hashObj)
+		header, lookupErr := b.lookupHeaderWithWait(ctx, hashObj, headerWaitDeadline, logger)
 		if lookupErr != nil || header == nil {
 			// Soft-fail: log and accept the response. Post-build
 			// ValidateCompoundRoot is still the final guard.
 			if lookupErr != nil && !errors.Is(lookupErr, context.Canceled) {
-				logger.Debug(
-					"chaintracks header lookup failed; skipping canonical-root validation",
+				logger.Warn(
+					"chaintracks header still unknown after wait; skipping canonical-root validation",
 					logfields.BlockHash(blockHash),
+					zap.Int("header_wait_ms", b.cfg.BumpBuilder.HeaderWaitMs),
 					zap.Error(lookupErr),
 				)
 			}
@@ -148,6 +168,39 @@ func (b *Builder) chainHeaderRootValidator(ctx context.Context, blockHash string
 		}
 		return nil
 	}
+}
+
+// lookupHeaderWithWait fetches the block header from chaintracks, retrying
+// until deadline while chaintracks catches up on a freshly-mined block (its
+// P2P ingestion races the Kafka path that drives bump-builder). Returns the
+// last lookup outcome once the deadline passes; a zero/past deadline
+// degrades to a single lookup. Context cancellation aborts the wait
+// immediately.
+func (b *Builder) lookupHeaderWithWait(ctx context.Context, hashObj *chainhash.Hash, deadline time.Time, logger *zap.Logger) (*chaintrackslib.BlockHeader, error) {
+	header, lookupErr := b.chainHeader.GetHeaderByHash(ctx, hashObj)
+	if (lookupErr == nil && header != nil) || errors.Is(lookupErr, context.Canceled) {
+		return header, lookupErr
+	}
+	if !time.Now().Before(deadline) {
+		return header, lookupErr
+	}
+
+	logger.Debug("chaintracks header not yet known; waiting for ingestion",
+		zap.Duration("budget", time.Until(deadline)))
+	ticker := time.NewTicker(headerWaitPollInterval)
+	defer ticker.Stop()
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+		header, lookupErr = b.chainHeader.GetHeaderByHash(ctx, hashObj)
+		if (lookupErr == nil && header != nil) || errors.Is(lookupErr, context.Canceled) {
+			return header, lookupErr
+		}
+	}
+	return header, lookupErr
 }
 
 // markMinedAndPublish moves the txids to MINED and fans the resulting status

--- a/services/bump_builder/builder_test.go
+++ b/services/bump_builder/builder_test.go
@@ -1589,17 +1589,39 @@ func (h *heightDroppingMockStore) SetMinedByTxIDs(ctx context.Context, blockHash
 
 // stubChaintracks is a minimal ChainHeaderReader for tests. nil header
 // returns simulate "chaintracks doesn't know this block yet" (soft fail).
-// Non-nil headers simulate the canonical chain.
+// Non-nil headers simulate the canonical chain. setHeader allows tests to
+// inject a header mid-run (the ingestion race lookupHeaderWithWait rides
+// out), so reads and writes are mutex-guarded.
 type stubChaintracks struct {
+	mu      sync.Mutex
 	headers map[string]*chaintrackslib.BlockHeader
 	err     error
+	lookups int
 }
 
 func (s *stubChaintracks) GetHeaderByHash(_ context.Context, h *chainhash.Hash) (*chaintrackslib.BlockHeader, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lookups++
 	if s.err != nil {
 		return nil, s.err
 	}
 	return s.headers[h.String()], nil
+}
+
+func (s *stubChaintracks) setHeader(hash string, header *chaintrackslib.BlockHeader) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.headers == nil {
+		s.headers = map[string]*chaintrackslib.BlockHeader{}
+	}
+	s.headers[hash] = header
+}
+
+func (s *stubChaintracks) lookupCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lookups
 }
 
 // TestBuilder_HandleMessage_PrunedPeerFallthrough simulates the production
@@ -1757,5 +1779,122 @@ func TestBuilder_HandleMessage_ChaintracksUnknownHeader_SoftFails(t *testing.T) 
 	defer ms.mu.Unlock()
 	if _, ok := ms.bumps[blockHash]; !ok {
 		t.Error("BUMP should still be stored when chaintracks doesn't know the header (soft-fail)")
+	}
+}
+
+// TestBuilder_HandleMessage_ChaintracksLateHeader_ValidatesAfterWait covers
+// the ingestion race the header wait exists for: chaintracks doesn't know a
+// freshly-mined block at first lookup, but learns it during the
+// bump_builder.header_wait_ms budget. The validator must pick the header up
+// on a retry and run a REAL canonical-root cross-check (here: matching →
+// build succeeds) instead of silently skipping validation.
+func TestBuilder_HandleMessage_ChaintracksLateHeader_ValidatesAfterWait(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+	txidHex := testTxidHex
+
+	stumpData := makeMinimalSTUMP(txidHex)
+	ms.addStump(blockHash, 0, stumpData)
+
+	subtreeHash := mustHash(t, txidHex)
+	root := expectedCompoundRoot(t,
+		[]*models.Stump{{BlockHash: blockHash, SubtreeIndex: 0, StumpData: stumpData}},
+		[]chainhash.Hash{subtreeHash}, nil)
+
+	datahub := newDatahubServer(root, []chainhash.Hash{subtreeHash})
+	defer datahub.Close()
+
+	// Header is absent at start; arrives (matching the datahub root) while
+	// the validator waits.
+	var rootHash chainhash.Hash
+	copy(rootHash[:], root)
+	stub := &stubChaintracks{}
+	hashObj, _ := chainhash.NewHashFromHex(blockHash)
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		stub.setHeader(hashObj.String(), &chaintrackslib.BlockHeader{Header: &block.Header{MerkleRoot: rootHash}})
+	}()
+
+	cfg := &config.Config{
+		DatahubURLs: []string{datahub.URL},
+		BumpBuilder: config.BumpBuilderConfig{HeaderWaitMs: 3000},
+	}
+	tc := teranode.NewClient([]string{datahub.URL}, "", teranode.HealthConfig{})
+	b := &Builder{
+		cfg:         cfg,
+		logger:      zap.NewNop().Named("bump-builder"),
+		store:       ms,
+		teranode:    tc,
+		chainHeader: stub,
+	}
+
+	if err := b.handleMessage(context.Background(), makeBlockProcessedMsg(blockHash)); err != nil {
+		t.Fatalf("expected late header to validate cleanly, got: %v", err)
+	}
+	if got := stub.lookupCount(); got < 2 {
+		t.Errorf("expected the validator to retry the header lookup, lookups=%d want >= 2", got)
+	}
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if _, ok := ms.bumps[blockHash]; !ok {
+		t.Error("expected BUMP to be stored after late-header validation")
+	}
+}
+
+// TestBuilder_HandleMessage_ChaintracksLateHeader_MismatchRejects proves the
+// wait leads to real enforcement, not just acceptance: the header that
+// arrives during the wait DISAGREES with the datahub's root, so the fetch
+// must be rejected exactly as if chaintracks had known the header up front.
+func TestBuilder_HandleMessage_ChaintracksLateHeader_MismatchRejects(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+	txidHex := testTxidHex
+
+	stumpData := makeMinimalSTUMP(txidHex)
+	ms.addStump(blockHash, 0, stumpData)
+
+	subtreeHash := mustHash(t, txidHex)
+	datahubRoot := expectedCompoundRoot(t,
+		[]*models.Stump{{BlockHash: blockHash, SubtreeIndex: 0, StumpData: stumpData}},
+		[]chainhash.Hash{subtreeHash}, nil)
+
+	datahub := newDatahubServer(datahubRoot, []chainhash.Hash{subtreeHash})
+	defer datahub.Close()
+
+	canonicalRoot := chainhash.Hash{}
+	for i := range canonicalRoot {
+		canonicalRoot[i] = 0xFF
+	}
+	stub := &stubChaintracks{}
+	hashObj, _ := chainhash.NewHashFromHex(blockHash)
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		stub.setHeader(hashObj.String(), &chaintrackslib.BlockHeader{Header: &block.Header{MerkleRoot: canonicalRoot}})
+	}()
+
+	cfg := &config.Config{
+		DatahubURLs: []string{datahub.URL},
+		BumpBuilder: config.BumpBuilderConfig{HeaderWaitMs: 3000},
+	}
+	tc := teranode.NewClient([]string{datahub.URL}, "", teranode.HealthConfig{})
+	b := &Builder{
+		cfg:         cfg,
+		logger:      zap.NewNop().Named("bump-builder"),
+		store:       ms,
+		teranode:    tc,
+		chainHeader: stub,
+	}
+
+	err := b.handleMessage(context.Background(), makeBlockProcessedMsg(blockHash))
+	if err == nil {
+		t.Fatal("expected error when the late canonical header disagrees with the datahub root")
+	}
+	if !strings.Contains(err.Error(), "merkle_root mismatch") && !strings.Contains(err.Error(), "validator rejected") {
+		t.Errorf("expected merkle_root mismatch error, got: %v", err)
+	}
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if _, ok := ms.bumps[blockHash]; ok {
+		t.Error("BUMP must NOT be stored when the late header disagrees with the datahub")
 	}
 }


### PR DESCRIPTION
## Problem

The DataHub-fetch canonical-root validator (`chainHeaderRootValidator`) soft-fails to "no validation" when chaintracks doesn't know the block header — and that race is the **common case** for a freshly-mined block: bump-builder is driven by the Kafka `BLOCK_PROCESSED` message while chaintracks ingests headers over an independent teranode P2P subscription, and the Kafka path usually wins by seconds. Observed live on bsva-us-1 (block 957032): `chaintracks header lookup failed; skipping canonical-root validation` (404), BUMP built with the cross-check skipped.

The check being skipped is the only **independent** canonicality guard on the DataHub path — the post-build `ValidateCompoundRoot` uses the merkle root the DataHub itself supplied, so it proves internal consistency but cannot catch an internally-consistent-but-non-canonical block from a pruned/stale/malicious peer.

## Fix

Retry the chaintracks lookup for up to **`bump_builder.header_wait_ms`** (new knob, default 10s; `<= 0` disables → single lookup, legacy behavior) so the ingestion race resolves into a real cross-check instead of a silent skip.

- **One wall-clock budget per block**, computed at validator construction and shared across every per-URL invocation — if chaintracks is genuinely down, only the first DataHub-URL attempt pays the wait; later URLs degrade to a single lookup each (no N×10s stall).
- 1s poll interval; context cancellation aborts immediately.
- The final skip (header still unknown after the wait) logs at **Warn** — it's now rare and meaningful, where before it fired on nearly every fresh block at Debug.

Note: after bsv-blockchain/merkle-service#173 (BLOCK_PROCESSED carries merkleRoot/coinbase from the fetched block), bump-builder takes the callback path and this validator rarely runs at all — this is defense-in-depth for the residual DataHub-fallback builds.

## Tests

- `TestBuilder_HandleMessage_ChaintracksLateHeader_ValidatesAfterWait` — header arrives mid-wait → validator retries (`lookups >= 2`) and validates; BUMP stored.
- `TestBuilder_HandleMessage_ChaintracksLateHeader_MismatchRejects` — the late header **disagrees** with the DataHub root → fetch rejected, no BUMP stored (the wait leads to enforcement, not just acceptance).
- Pre-existing `ChaintracksRootMismatch` / `ChaintracksUnknownHeader_SoftFails` pass unchanged (zero-value config disables the wait → legacy single-lookup path locked).

`go build ./... && go vet ./... && go test ./... -count=1` all pass.