### PR TITLE
fix(bump): compose compound BUMPs correctly for blocks with a lifted final subtree

### DIFF
--- a/bump/bump.go
+++ b/bump/bump.go
@@ -491,7 +491,20 @@ func correctedSubtree0Root(coinbaseBUMP []byte, numSubtrees int) *chainhash.Hash
 // Output is structurally equivalent to the old algorithm — same merkle root,
 // same extracted minimal paths for tracked txs — and the nine existing
 // BuildCompoundBUMP tests pass unchanged.
-func BuildCompoundBUMP(stumps []*models.Stump, subtreeHashes []chainhash.Hash, coinbaseBUMP []byte) (*transaction.MerklePath, []string, error) {
+//
+// headerMerkleRoot (optional, nil to skip) enables lifted-final-subtree
+// support: teranode allows only the FINAL subtree to be incomplete and, when
+// it is shorter than the first subtree's capacity, LIFTS its root to the
+// common height (one self-hash per missing level) before composing the block
+// merkle root. The lift amount is derived here by matching candidate
+// top-tree roots against headerMerkleRoot; the final subtree's STUMP is then
+// accepted at its natural (shorter) height, the lift levels are represented
+// as duplicate-flag elements, and a no-STUMP final slot is seeded with the
+// lifted root. Without this, any block whose final subtree holds at most
+// half the first subtree's capacity builds a compound the canonical chain
+// rejects (issue #234; sibling of merkle-service#179). Passing nil preserves
+// the legacy uniform-height behavior.
+func BuildCompoundBUMP(stumps []*models.Stump, subtreeHashes []chainhash.Hash, coinbaseBUMP []byte, headerMerkleRoot *chainhash.Hash) (*transaction.MerklePath, []string, error) {
 	if len(stumps) == 0 {
 		return nil, nil, fmt.Errorf("no stumps to build compound BUMP")
 	}
@@ -548,6 +561,16 @@ func BuildCompoundBUMP(stumps []*models.Stump, subtreeHashes []chainhash.Hash, c
 
 	totalHeight := internalHeight + subtreeRootLayer
 
+	// Lifted final subtree (teranode: only the final subtree may be
+	// incomplete; when shorter than the first subtree's capacity its root is
+	// self-hashed up to the common height before top-tree composition).
+	// Derive how many lift levels this block uses by matching candidate
+	// top-tree roots against the canonical header root. 0 for uniform blocks
+	// and when headerMerkleRoot is nil (legacy behavior preserved).
+	liftLevels := deriveFinalSubtreeLift(subtreeHashes, internalHeight, headerMerkleRoot)
+	finalIdx := numSubtrees - 1
+	finalNaturalHeight := internalHeight - liftLevels
+
 	compound := &transaction.MerklePath{
 		BlockHeight: blockHeight,
 		Path:        make([][]*transaction.PathElement, totalHeight),
@@ -570,19 +593,26 @@ func BuildCompoundBUMP(stumps []*models.Stump, subtreeHashes []chainhash.Hash, c
 		if err != nil {
 			return nil, nil, fmt.Errorf("parse STUMP for subtree %d: %w", stump.SubtreeIndex, err)
 		}
-		// A STUMP taller than internalHeight is tolerated: merkle-service
+		// The lifted final subtree's STUMP is legitimately shorter: its
+		// natural height is internalHeight - liftLevels. Every other subtree
+		// is complete and must cover internalHeight levels.
+		requiredHeight := internalHeight
+		if stump.SubtreeIndex == finalIdx {
+			requiredHeight = finalNaturalHeight
+		}
+		// A STUMP taller than requiredHeight is tolerated: merkle-service
 		// sometimes delivers a STUMP at full block height, and only its first
-		// internalHeight levels are the subtree-internal path — the placement
-		// loop below reads exactly those. A STUMP SHORTER than internalHeight
+		// requiredHeight levels are the subtree-internal path — the placement
+		// loop below reads exactly those. A STUMP SHORTER than requiredHeight
 		// cannot cover its subtree and is rejected.
-		if len(path.Path) < internalHeight {
-			return nil, nil, fmt.Errorf("subtree %d STUMP has internal height %d, expected at least %d", stump.SubtreeIndex, len(path.Path), internalHeight)
+		if len(path.Path) < requiredHeight {
+			return nil, nil, fmt.Errorf("subtree %d STUMP has internal height %d, expected at least %d", stump.SubtreeIndex, len(path.Path), requiredHeight)
 		}
 		if stump.SubtreeIndex == 0 && coinbaseTxID != nil {
 			applyCoinbaseToSTUMP(path, coinbaseTxID, coinbaseBUMP)
 		}
 
-		for level := 0; level < internalHeight; level++ {
+		for level := 0; level < requiredHeight; level++ {
 			shift := uint64(stump.SubtreeIndex) << uint(internalHeight-level) //nolint:gosec // subtreeIndex is bounded by numSubtrees; height is small
 			for _, elem := range path.Path[level] {
 				elem.Offset += shift
@@ -595,15 +625,37 @@ func BuildCompoundBUMP(stumps []*models.Stump, subtreeHashes []chainhash.Hash, c
 		}
 	}
 
+	// Represent the final subtree's lift levels: from its natural height up
+	// to internalHeight the node self-hashes, which BRC-74 encodes as a
+	// duplicate-flag sibling. Only needed when its own leaves are present
+	// (STUMP placed above); a no-STUMP final slot is seeded pre-lifted below.
+	if liftLevels > 0 && haveSTUMP[finalIdx] {
+		dupTrue := true
+		for level := finalNaturalHeight; level < internalHeight; level++ {
+			nodeOffset := uint64(finalIdx) << uint(internalHeight-level)
+			addLeaf(compound, level, &transaction.PathElement{
+				Offset:    nodeOffset + 1,
+				Duplicate: &dupTrue,
+			})
+		}
+	}
+
 	// Seed the subtree-root layer with hashes for slots that have NO STUMP;
 	// slots that do will have their subtree root computed up from their
 	// level-0 leaves in the top-down pass below. The corrected
-	// subtreeHashes[0] flows through here when subtree 0 lacks a STUMP.
+	// subtreeHashes[0] flows through here when subtree 0 lacks a STUMP. The
+	// final slot is seeded with its LIFTED root so the top tree matches the
+	// canonical composition.
 	for i, subHash := range subtreeHashes {
 		if haveSTUMP[i] {
 			continue
 		}
 		hashCopy := subHash
+		if i == finalIdx {
+			for k := 0; k < liftLevels; k++ {
+				hashCopy = *merkleTreeParent(&hashCopy, &hashCopy)
+			}
+		}
 		addLeaf(compound, internalHeight, &transaction.PathElement{
 			Offset: uint64(i),
 			Hash:   &hashCopy,
@@ -613,6 +665,55 @@ func BuildCompoundBUMP(stumps []*models.Stump, subtreeHashes []chainhash.Hash, c
 	computeAndPadCompound(compound, internalHeight, numSubtrees)
 
 	return compound, txids, nil
+}
+
+// topTreeRoot folds subtree-root-layer hashes to the block merkle root using
+// Bitcoin-canonical duplicate-last-on-odd padding — the same rule
+// computeAndPadCompound applies at and above the subtree-root layer.
+func topTreeRoot(hs []chainhash.Hash) chainhash.Hash {
+	level := append([]chainhash.Hash(nil), hs...)
+	for len(level) > 1 {
+		if len(level)%2 == 1 {
+			level = append(level, level[len(level)-1])
+		}
+		next := make([]chainhash.Hash, len(level)/2)
+		for i := range next {
+			next[i] = *merkleTreeParent(&level[2*i], &level[2*i+1])
+		}
+		level = next
+	}
+	return level[0]
+}
+
+// deriveFinalSubtreeLift returns how many levels the block lifts its final
+// subtree's root before top-tree composition (0 = uniform block). teranode
+// lifts a final subtree that is shorter than the first subtree's capacity by
+// self-hashing its root once per missing level (model.Block CheckMerkleRoot
+// → RootHashPadded); a compound composed from the raw root disagrees with
+// the canonical header root for every such block.
+//
+// The lift amount is not carried in any input, so it is derived by matching:
+// candidate top-tree roots (final root lifted k = 0,1,2,… levels) are folded
+// and compared against the canonical headerMerkleRoot. subtreeHashes[0] must
+// already be coinbase-corrected. k=0 matches immediately for uniform blocks,
+// so the common case costs a single top-tree fold. Returns 0 when
+// headerMerkleRoot is nil or no candidate matches (legacy behavior — the
+// caller's ValidateCompoundRoot remains the final guard).
+func deriveFinalSubtreeLift(subtreeHashes []chainhash.Hash, internalHeight int, headerMerkleRoot *chainhash.Hash) int {
+	n := len(subtreeHashes)
+	if n < 2 || headerMerkleRoot == nil {
+		return 0
+	}
+	tops := append([]chainhash.Hash(nil), subtreeHashes...)
+	lifted := subtreeHashes[n-1]
+	for k := 0; k <= internalHeight; k++ {
+		tops[n-1] = lifted
+		if root := topTreeRoot(tops); root.IsEqual(headerMerkleRoot) {
+			return k
+		}
+		lifted = *merkleTreeParent(&lifted, &lifted)
+	}
+	return 0
 }
 
 // computeAndPadCompound fills in every missing intermediate node of a

--- a/bump/bump_test.go
+++ b/bump/bump_test.go
@@ -824,7 +824,7 @@ func TestBuildCompoundBUMP_AllTxsExtractable(t *testing.T) {
 		{BlockHash: "blockhash", SubtreeIndex: 1, StumpData: stump1},
 	}
 
-	compound, txids, err := BuildCompoundBUMP(stumps, subtreeHashes, nil)
+	compound, txids, err := BuildCompoundBUMP(stumps, subtreeHashes, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed: %v", err)
 	}
@@ -906,7 +906,7 @@ func TestBuildCompoundBUMP_CoinbaseReplacement(t *testing.T) {
 
 	cbBUMP := buildCoinbaseBUMP(allLeaves[0], coinbaseTxID, 1000000, subtreeHashes)
 
-	compound, txids, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP)
+	compound, txids, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed: %v", err)
 	}
@@ -989,7 +989,7 @@ func TestBuildCompoundBUMP_NoCoinbaseBUMP_MultiSubtree_FailsSafe(t *testing.T) {
 		{BlockHash: "block3", SubtreeIndex: 2, StumpData: stump2},
 	}
 
-	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil)
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed: %v", err)
 	}
@@ -1014,7 +1014,7 @@ func TestBuildCompoundBUMP_CoinbaseReplacement_SingleSubtree(t *testing.T) {
 
 	cbBUMP := buildCoinbaseBUMP(allLeaves[0], coinbaseTxID, 1000001, subtreeHashes)
 
-	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP)
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed: %v", err)
 	}
@@ -1141,7 +1141,7 @@ func TestExtractMinimalPathForTx_AllTxsExtractable(t *testing.T) {
 		{BlockHash: "blockhash", SubtreeIndex: 1, StumpData: stump1},
 	}
 
-	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil)
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed: %v", err)
 	}
@@ -1182,7 +1182,7 @@ func TestExtractMinimalPathForTx_TxNotFound(t *testing.T) {
 		{BlockHash: "blockhash", SubtreeIndex: 0, StumpData: stump0},
 	}
 
-	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes[:1], nil)
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes[:1], nil, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed: %v", err)
 	}
@@ -1212,7 +1212,7 @@ func TestValidateCompoundRoot_Passes(t *testing.T) {
 		}
 	}
 
-	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil)
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed: %v", err)
 	}
@@ -1233,7 +1233,7 @@ func TestValidateCompoundRoot_RejectsMismatch(t *testing.T) {
 		}
 	}
 
-	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil)
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed: %v", err)
 	}
@@ -1386,7 +1386,7 @@ func TestBuildCompoundBUMP_NonPow2SubtreeCounts(t *testing.T) {
 				}
 			}
 
-			compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil)
+			compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil, nil)
 			if err != nil {
 				t.Fatalf("BuildCompoundBUMP failed: %v", err)
 			}
@@ -1436,7 +1436,7 @@ func TestBuildCompoundBUMP_39Subtrees_StructuralShape(t *testing.T) {
 			StumpData:    buildFullSTUMP(allLeaves[s], 0, 700000),
 		}
 	}
-	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil)
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed: %v", err)
 	}
@@ -1535,7 +1535,7 @@ func TestBuildCompoundBUMP_NonPow2_WithCoinbase(t *testing.T) {
 		}
 	}
 
-	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP)
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed: %v", err)
 	}
@@ -1651,7 +1651,7 @@ func TestBuildCompoundBUMP_CoinbaseReplacement_OrderIndependence(t *testing.T) {
 				}
 			}
 
-			compound, _, err := BuildCompoundBUMP(stumps, localHashes, cbBUMP)
+			compound, _, err := BuildCompoundBUMP(stumps, localHashes, cbBUMP, nil)
 			if err != nil {
 				t.Fatalf("BuildCompoundBUMP failed: %v", err)
 			}
@@ -1763,7 +1763,7 @@ func TestBuildCompoundBUMP_FullBlockSubtree0STUMP_Block951360(t *testing.T) {
 		{BlockHash: "blk951360", SubtreeIndex: 2, StumpData: buildFullSTUMP(allLeaves[2], 0, 951360)},
 	}
 
-	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP)
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed: %v", err)
 	}
@@ -1819,7 +1819,7 @@ func TestBuildCompoundBUMP_NoSubtree0Stump_NonPow2(t *testing.T) {
 
 	cbBUMP := buildCoinbaseBUMP(allLeaves[0], coinbaseTxID, 1234567, subtreeHashes)
 
-	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP)
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed: %v", err)
 	}
@@ -2025,7 +2025,7 @@ func TestBuildCompoundBUMP_LargeBlock_DoesNotOOM(t *testing.T) {
 	}
 
 	start := time.Now()
-	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil)
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil, nil)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed for large block: %v", err)

--- a/bump/callback_inputs_test.go
+++ b/bump/callback_inputs_test.go
@@ -45,7 +45,7 @@ func TestBuildCompoundBUMP_CallbackInputs_16Subtrees(t *testing.T) {
 	cbSubtreeHashes := decodeHashesViaDisplayHex(t, subtreeHashes)
 	cbRoot := decodeHashViaDisplayHex(t, trueBlockRoot)
 
-	compound, _, err := BuildCompoundBUMP(stumps, cbSubtreeHashes, cbBUMP)
+	compound, _, err := BuildCompoundBUMP(stumps, cbSubtreeHashes, cbBUMP, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP (callback inputs): %v", err)
 	}

--- a/bump/issue167_test.go
+++ b/bump/issue167_test.go
@@ -51,7 +51,7 @@ func TestBuildCompoundBUMP_Issue167_SingleSubtreeNonPow2(t *testing.T) {
 		{BlockHash: "00000000000000000eb6ea115a5cb140ffeae7b673b4c5b6f3fac62e0adae3c5", SubtreeIndex: 0, StumpData: stumpData},
 	}
 
-	compound, txids, err := BuildCompoundBUMP(stumps, subtreeHashes, coinbaseBUMP)
+	compound, txids, err := BuildCompoundBUMP(stumps, subtreeHashes, coinbaseBUMP, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP returned error: %v", err)
 	}

--- a/bump/lifted_subtree_test.go
+++ b/bump/lifted_subtree_test.go
@@ -1,0 +1,216 @@
+package bump
+
+// Regression tests for issue #234: blocks whose FINAL subtree is shorter than
+// half the first subtree's capacity have their final root height-LIFTED by
+// teranode (one self-hash per missing level) before top-tree composition.
+// The compound builder must (a) derive the lift from the header merkle root,
+// (b) accept the final subtree's naturally-shorter STUMP and represent the
+// lift levels as duplicate-flag elements, and (c) seed a no-STUMP final slot
+// with the lifted root. Sibling of merkle-service#179.
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// liftHash self-hashes h k times — teranode's RootHashPadded lift step.
+func liftHash(h chainhash.Hash, k int) chainhash.Hash {
+	for i := 0; i < k; i++ {
+		h = *transaction.MerkleTreeParent(&h, &h)
+	}
+	return h
+}
+
+// liftedBlockRoot composes the canonical (teranode-style) block merkle root:
+// subtree roots with the final one lifted to the first subtree's height,
+// folded with duplicate-last-on-odd padding.
+func liftedBlockRoot(subtreeLeaves [][]chainhash.Hash) (chainhash.Hash, []chainhash.Hash, int) {
+	n := len(subtreeLeaves)
+	roots := make([]chainhash.Hash, n)
+	for i, leaves := range subtreeLeaves {
+		roots[i] = computeMerkleRootFromLeaves(leaves)
+	}
+	height := func(leafCount int) int {
+		h := 0
+		for 1<<h < leafCount {
+			h++
+		}
+		return h
+	}
+	lift := height(len(subtreeLeaves[0])) - height(len(subtreeLeaves[n-1]))
+	lifted := append([]chainhash.Hash(nil), roots...)
+	lifted[n-1] = liftHash(roots[n-1], lift)
+	var root chainhash.Hash
+	if n == 1 {
+		root = lifted[0]
+	} else {
+		root = computeMerkleRootFromLeaves(lifted)
+	}
+	return root, roots, lift
+}
+
+// TestBuildCompoundBUMP_LiftedFinalSubtree covers the lifted shapes end to
+// end. Each case asserts the compound validates against the canonical
+// (lifted) header root; cases with a tracked tx in the final subtree also
+// fold that tx's path explicitly.
+func TestBuildCompoundBUMP_LiftedFinalSubtree(t *testing.T) {
+	const blockHeight = 954978
+
+	cases := []struct {
+		name       string
+		shapes     []int // leaves per subtree; first is a power of two
+		stumpFinal bool  // tracked tx in the final subtree?
+		expectLift int
+	}{
+		{"8+3_lift1_finalSeeded", []int{8, 3}, false, 1},
+		{"8+3_lift1_finalStump", []int{8, 3}, true, 1},
+		{"8+2_lift2_finalStump", []int{8, 2}, true, 2},
+		{"8x3+2_lift2_multiTopLayers", []int{8, 8, 8, 2}, true, 2},
+		{"8+8_uniform_noLift", []int{8, 8}, true, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := len(tc.shapes)
+			subtreeLeaves := make([][]chainhash.Hash, n)
+			seed := 0
+			for i, count := range tc.shapes {
+				subtreeLeaves[i] = generateTxHashes(count + seed)[seed:]
+				seed += count
+			}
+
+			headerRoot, rawRoots, lift := liftedBlockRoot(subtreeLeaves)
+			if lift != tc.expectLift {
+				t.Fatalf("fixture lift = %d, want %d", lift, tc.expectLift)
+			}
+
+			// STUMP for a tracked tx in subtree 0 (offset 1), and optionally
+			// one in the final subtree (offset 0) at its NATURAL height —
+			// exactly what merkle-service delivers.
+			stumps := []*models.Stump{
+				{BlockHash: "blk", SubtreeIndex: 0, StumpData: buildSTUMP(subtreeLeaves[0], 1, blockHeight)},
+			}
+			if tc.stumpFinal {
+				stumps = append(stumps, &models.Stump{
+					BlockHash: "blk", SubtreeIndex: n - 1,
+					StumpData: buildSTUMP(subtreeLeaves[n-1], 0, blockHeight),
+				})
+			}
+
+			subtreeHashes := append([]chainhash.Hash(nil), rawRoots...)
+			compound, txids, err := BuildCompoundBUMP(stumps, subtreeHashes, nil, &headerRoot)
+			if err != nil {
+				t.Fatalf("BuildCompoundBUMP: %v", err)
+			}
+			if len(txids) == 0 {
+				t.Fatal("expected tracked txids")
+			}
+
+			if vErr := ValidateCompoundRoot(compound, &headerRoot); vErr != nil {
+				t.Fatalf("compound does not fold to the canonical lifted root: %v", vErr)
+			}
+
+			// Fold the sub0 tracked tx explicitly.
+			leaf0 := subtreeLeaves[0][1]
+			if got, err := compound.ComputeRoot(&leaf0); err != nil || !got.IsEqual(&headerRoot) {
+				t.Fatalf("sub0 tx path: got %v err %v, want %s", got, err, headerRoot)
+			}
+			// And the final-subtree tracked tx when present.
+			if tc.stumpFinal {
+				leafF := subtreeLeaves[n-1][0]
+				if got, err := compound.ComputeRoot(&leafF); err != nil || !got.IsEqual(&headerRoot) {
+					t.Fatalf("final-subtree tx path: got %v err %v, want %s", got, err, headerRoot)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildCompoundBUMP_LiftedFinalSubtree_WithCoinbase mirrors the full
+// production shape: coinbase placeholder at subtree-0 leaf 0, a full-height
+// coinbase BUMP whose block climb uses the LIFTED top tree (as teranode
+// ships it), placeholder-based subtreeHashes, and STUMPs in both subtrees.
+func TestBuildCompoundBUMP_LiftedFinalSubtree_WithCoinbase(t *testing.T) {
+	const blockHeight = 954978
+	placeholder := chainhash.Hash{}
+	for i := range placeholder {
+		placeholder[i] = 0xFF
+	}
+	coinbaseTxID := generateTxHashes(1)[0]
+
+	// Shapes {8, 2}: lift 2. Subtree 0 carries the placeholder at leaf 0.
+	sub0 := generateTxHashes(9)[1:9]
+	sub0[0] = placeholder
+	trueSub0 := append([]chainhash.Hash(nil), sub0...)
+	trueSub0[0] = coinbaseTxID
+	subF := generateTxHashes(11)[9:11]
+
+	rawRoots := []chainhash.Hash{
+		computeMerkleRootFromLeaves(sub0), // placeholder-based (as supplied)
+		computeMerkleRootFromLeaves(subF),
+	}
+	correctedRoots := []chainhash.Hash{
+		computeMerkleRootFromLeaves(trueSub0),
+		liftHash(rawRoots[1], 2),
+	}
+	headerRoot := computeMerkleRootFromLeaves(correctedRoots)
+
+	// Coinbase BUMP: subtree-internal path over the TRUE leaves plus the
+	// block climb across the corrected+lifted top tree.
+	cbBUMP := buildCoinbaseBUMP(sub0, coinbaseTxID, blockHeight, correctedRoots)
+
+	stumps := []*models.Stump{
+		{BlockHash: "blk", SubtreeIndex: 0, StumpData: buildFullSTUMP(sub0, 1, blockHeight)},
+		{BlockHash: "blk", SubtreeIndex: 1, StumpData: buildSTUMP(subF, 1, blockHeight)},
+	}
+
+	subtreeHashes := append([]chainhash.Hash(nil), rawRoots...)
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, cbBUMP, &headerRoot)
+	if err != nil {
+		t.Fatalf("BuildCompoundBUMP: %v", err)
+	}
+	if vErr := ValidateCompoundRoot(compound, &headerRoot); vErr != nil {
+		t.Fatalf("compound does not fold to the canonical lifted root: %v", vErr)
+	}
+	// Coinbase and a final-subtree tx must both fold to the header root.
+	if got, err := compound.ComputeRoot(&coinbaseTxID); err != nil || !got.IsEqual(&headerRoot) {
+		t.Fatalf("coinbase path: got %v err %v, want %s", got, err, headerRoot)
+	}
+	leafF := subF[1]
+	if got, err := compound.ComputeRoot(&leafF); err != nil || !got.IsEqual(&headerRoot) {
+		t.Fatalf("final-subtree tx path: got %v err %v, want %s", got, err, headerRoot)
+	}
+}
+
+// TestBuildCompoundBUMP_LiftedShape_NilHeaderFailsSafe locks two properties:
+// nil headerMerkleRoot preserves the legacy uniform-height behavior, and the
+// lifted fixtures genuinely exercise the lift (the legacy composition must
+// NOT fold to the canonical root — otherwise the tests above would pass for
+// trivial reasons).
+func TestBuildCompoundBUMP_LiftedShape_NilHeaderFailsSafe(t *testing.T) {
+	subtreeLeaves := [][]chainhash.Hash{
+		generateTxHashes(8),
+		generateTxHashes(11)[8:11],
+	}
+	headerRoot, rawRoots, lift := liftedBlockRoot(subtreeLeaves)
+	if lift != 1 {
+		t.Fatalf("fixture lift = %d, want 1", lift)
+	}
+
+	stumps := []*models.Stump{
+		{BlockHash: "blk", SubtreeIndex: 0, StumpData: buildSTUMP(subtreeLeaves[0], 1, 954978)},
+	}
+	subtreeHashes := append([]chainhash.Hash(nil), rawRoots...)
+
+	compound, _, err := BuildCompoundBUMP(stumps, subtreeHashes, nil, nil)
+	if err != nil {
+		t.Fatalf("legacy build should still construct: %v", err)
+	}
+	if vErr := ValidateCompoundRoot(compound, &headerRoot); vErr == nil {
+		t.Fatal("legacy (un-lifted) composition unexpectedly matched the lifted root — fixtures do not exercise the lift")
+	}
+}

--- a/services/bump_builder/builder.go
+++ b/services/bump_builder/builder.go
@@ -579,7 +579,7 @@ func (b *Builder) handleMessage(ctx context.Context, msg *kafka.Message) error {
 	logPerStumpAssembly(logger, stumps, subtreeHashes, coinbaseBUMP)
 
 	// 3. Build compound BUMP (STUMPs are sparse — only for subtrees with tracked txs)
-	compound, txids, err := bump.BuildCompoundBUMP(stumps, subtreeHashes, coinbaseBUMP)
+	compound, txids, err := bump.BuildCompoundBUMP(stumps, subtreeHashes, coinbaseBUMP, headerMerkleRoot)
 	if err != nil {
 		return fmt.Errorf("building compound BUMP: %w", err)
 	}

--- a/services/bump_builder/builder_test.go
+++ b/services/bump_builder/builder_test.go
@@ -414,7 +414,7 @@ func expectedCompoundRoot(t *testing.T, stumps []*models.Stump, subtreeHashes []
 	hashesCopy := make([]chainhash.Hash, len(subtreeHashes))
 	copy(hashesCopy, subtreeHashes)
 
-	compound, _, err := bump.BuildCompoundBUMP(stumpsCopy, hashesCopy, coinbaseBUMP)
+	compound, _, err := bump.BuildCompoundBUMP(stumpsCopy, hashesCopy, coinbaseBUMP, nil)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP failed: %v", err)
 	}
@@ -591,7 +591,7 @@ func TestBuilder_HandleMessage_ShortCircuit_BUMPAlreadyExists(t *testing.T) {
 	subtreeHash := mustHash(t, testTxidHex)
 	compound, _, err := bump.BuildCompoundBUMP(
 		[]*models.Stump{{BlockHash: blockHash, SubtreeIndex: 0, StumpData: stumpData}},
-		[]chainhash.Hash{subtreeHash}, nil,
+		[]chainhash.Hash{subtreeHash}, nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("BuildCompoundBUMP: %v", err)


### PR DESCRIPTION
Closes #234.

## The bug

Teranode allows only the **final** subtree of a block to be incomplete and, when it is shorter than the first subtree's capacity, **lifts** its root to the common height (one self-hash per missing level — `model.Block CheckMerkleRoot` → `RootHashPadded`) before composing the block merkle root. `BuildCompoundBUMP` assumed a **uniform internal height** for every subtree, breaking lifted blocks two ways:

1. A tracked tx in the lifted final subtree delivers a STUMP at its natural (shorter) height → rejected with `"STUMP has internal height N, expected at least M"` — the compound never builds.
2. With no STUMP in the final subtree, its slot was seeded with the **raw** root → the compound folds to a root the canonical chain disagrees with → `ValidateCompoundRoot` fail-safe rejects → txs stay `SEEN_ON_NETWORK` forever.

Both were observed on the mainnet 954978–956998 backlog. Proven bit-for-bit: one lift level reproduces block 954978's header root exactly (subtrees 32768 + 13687 leaves). Trigger: final subtree ≤ half the first subtree's capacity — bursty traffic creates it; steady single-subtree blocks never do, and the unit tests only used equal-size subtrees, which is why it survived. Sibling of bsv-blockchain/merkle-service#179 (fixed there by merkle-service#178).

## The fix

Self-contained in `BuildCompoundBUMP` via a new `headerMerkleRoot` parameter (nil preserves legacy behavior):

- **`deriveFinalSubtreeLift`** matches candidate top-tree roots (final root lifted k = 0, 1, 2, … levels) against the canonical header root. No new plumbing — works identically on the callback and datahub paths (both already hold the header root for validation), and k=0 matches immediately for uniform blocks, so the common case costs one top-tree fold.
- The final subtree's STUMP is **accepted at `internalHeight − lift`** and its lift levels are represented as BRC-74 **duplicate-flag** elements (`H(r‖r)` self-hash semantics).
- A **no-STUMP final slot is seeded with the lifted root**.

The single production call site (`builder.go`) passes the header root it already holds. Derivation failure (or nil header) degrades to today's behavior — `ValidateCompoundRoot` remains the final guard, so no wrong proof can ever be persisted.

## Tests

`TestBuildCompoundBUMP_LiftedFinalSubtree` — lift 1–2 across 2–4 subtrees (mirrors both failing mainnet shapes), tracked txs folded explicitly in **both** subtrees, plus a uniform-block control (derivation must not misfire).
`TestBuildCompoundBUMP_LiftedFinalSubtree_WithCoinbase` — full production mirror: coinbase placeholder at subtree-0 leaf 0, full-height coinbase BUMP with lifted block-climb, placeholder-based subtreeHashes.
`TestBuildCompoundBUMP_LiftedShape_NilHeaderFailsSafe` — negative: nil header = legacy behavior, and the legacy composition must NOT fold to the lifted root (proves the fixtures genuinely exercise the lift).

`go build ./... && go vet ./... && go test ./... -count=1 && magex lint` all pass. All 19 pre-existing `BuildCompoundBUMP` call sites/tests pass unchanged with `nil`.

## Post-merge

With merkle-service v0.4.3 (tail-first coinbase BUMPs) + this fix deployed, blocks with lifted final subtrees become fully mineable end-to-end: coinbase BUMP correct at ingestion, transaction compound proofs correct at composition.