### PR TITLE
feat(propagation): stuck-transient-tx gauges for alerting on stalled lifecycles

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -199,6 +199,28 @@ var PropagationReaperReadyDepth = promauto.NewGauge(prometheus.GaugeOpts{
 	Help: "Number of stale SEEN_ON_NETWORK rows ready for rebroadcast at the last reaper tick.",
 })
 
+// StuckTransientTxs counts transactions sitting in a transient status
+// (RECEIVED, ACCEPTED_BY_NETWORK) for longer than the stale-transient
+// threshold (1h), within the reaper's 24h scan lookback. Unlike
+// PropagationReaperReadyDepth it is uncapped, split per status, and covers
+// ACCEPTED_BY_NETWORK (which the rebroadcast path deliberately ignores).
+// Computed on the leader's reaper tick; non-leaders report 0, so aggregate
+// with max() across pods. A sustained non-zero value means the SEEN
+// state-transfer for those txs never arrived — the primary alerting signal
+// for a stalled subtree-callback pipeline.
+var StuckTransientTxs = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "arcade_stuck_transient_txs",
+	Help: "Transactions stuck in a transient status for over 1h (24h lookback), by status. Leader-computed; aggregate with max().",
+}, []string{"status"})
+
+// OldestTransientTxAge reports the age in seconds of the oldest transaction
+// currently stuck in each transient status (0 when none). Same computation
+// cadence and aggregation semantics as StuckTransientTxs.
+var OldestTransientTxAge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "arcade_oldest_transient_tx_age_seconds",
+	Help: "Age of the oldest transaction stuck in each transient status (seconds; 0 when none). Leader-computed; aggregate with max().",
+}, []string{"status"})
+
 // ---------------------------------------------------------------------------
 // bump_builder
 // ---------------------------------------------------------------------------

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -199,6 +199,19 @@ var PropagationReaperReadyDepth = promauto.NewGauge(prometheus.GaugeOpts{
 	Help: "Number of stale SEEN_ON_NETWORK rows ready for rebroadcast at the last reaper tick.",
 })
 
+// APITxsSubmittedTotal counts individual transactions submitted through the
+// API, by route and dedup result. Unlike the HTTP request histogram (one
+// sample per request), this counts PER TRANSACTION — the /txs batch route
+// submits many txs in one request, so request counts undercount submissions
+// by the batch factor. result=new is the "unique txids submitted" series
+// dashboards should use; duplicate = idempotent resubmit of a known txid;
+// retry_rejected = resubmit of a previously rejected txid (re-enters the
+// broadcast pipeline).
+var APITxsSubmittedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_api_txs_submitted_total",
+	Help: "Transactions submitted via the API by route and dedup result (new|duplicate|retry_rejected). Counted per transaction, not per request.",
+}, []string{"route", "result"})
+
 // StuckTransientTxs counts transactions sitting in a transient status
 // (RECEIVED, ACCEPTED_BY_NETWORK) for longer than the stale-transient
 // threshold (1h), within the reaper's 24h scan lookback. Unlike

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -654,6 +654,7 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 	// Dedup CAS via GetOrInsertStatus. Two submitters racing on the
 	// same txid both attempt the insert; the loser sees inserted=false
 	// and returns 202 idempotently without re-publishing.
+	submitResult := "new"
 	if s.store != nil {
 		row := &models.TransactionStatus{
 			TxID:      txid,
@@ -681,6 +682,7 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 			// both RECEIVED and REJECTED produce the same callback
 			// prefilter behavior because every forward status allows
 			// transitioning from either.
+			submitResult = "retry_rejected"
 		case !inserted && existing != nil:
 			// Idempotent re-submit: row already exists at a non-REJECTED
 			// status. Register the txid with the in-process TxTracker so
@@ -690,6 +692,7 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 			if s.txTracker != nil {
 				s.txTracker.Add(txid, existing.Status)
 			}
+			metrics.APITxsSubmittedTotal.WithLabelValues("/tx", "duplicate").Inc()
 			s.recordSubmission(c.Request.Context(), txid, opts)
 			c.JSON(http.StatusAccepted, submitResponse{
 				TxID:     txid,
@@ -699,6 +702,8 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 			return
 		}
 	}
+
+	metrics.APITxsSubmittedTotal.WithLabelValues("/tx", submitResult).Inc()
 
 	// Register the tx with the in-process TxTracker so the bump-builder
 	// recognizes it when its block is processed.
@@ -914,6 +919,7 @@ func (s *Server) handleSubmitTransactions(c *gin.Context) {
 	// best-effort behavior.
 	toPublish := make([]parsedItem, 0, len(parsed))
 	duplicates := 0
+	newSubmits, retryRejected := 0, 0
 	if s.store != nil {
 		ctx := c.Request.Context()
 		for _, p := range parsed {
@@ -929,6 +935,7 @@ func (s *Server) handleSubmitTransactions(c *gin.Context) {
 			switch {
 			case dedupErr != nil:
 				s.logger.Error("dedup CAS failed", logfields.TxID(p.txid), zap.Error(dedupErr))
+				newSubmits++
 				toPublish = append(toPublish, p)
 			case !inserted && existing != nil && existing.Status == models.StatusRejected:
 				// Resubmission of a previously-rejected tx: add to
@@ -938,6 +945,7 @@ func (s *Server) handleSubmitTransactions(c *gin.Context) {
 				// pipeline. The status row stays at REJECTED until the
 				// new broadcast produces a verdict. Mirrors
 				// handleSubmitTransaction.
+				retryRejected++
 				toPublish = append(toPublish, p)
 			case !inserted && existing != nil:
 				duplicates++
@@ -950,12 +958,17 @@ func (s *Server) handleSubmitTransactions(c *gin.Context) {
 				}
 				s.recordSubmission(ctx, p.txid, opts)
 			default:
+				newSubmits++
 				toPublish = append(toPublish, p)
 			}
 		}
 	} else {
 		toPublish = parsed
+		newSubmits = len(parsed)
 	}
+	metrics.APITxsSubmittedTotal.WithLabelValues("/txs", "new").Add(float64(newSubmits))
+	metrics.APITxsSubmittedTotal.WithLabelValues("/txs", "duplicate").Add(float64(duplicates))
+	metrics.APITxsSubmittedTotal.WithLabelValues("/txs", "retry_rejected").Add(float64(retryRejected))
 
 	// Register every accepted tx with the in-process TxTracker so the
 	// bump-builder's filterTrackedTxids recognizes them when their block

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -2238,3 +2238,79 @@ func TestHandleCallback_BlockProcessed_ForwardsEnrichmentFields(t *testing.T) {
 		t.Errorf("CoinbaseBUMP = %x, want deadbeef", decoded.CoinbaseBUMP)
 	}
 }
+
+// counterVal reads a labeled counter for delta assertions.
+func counterVal(route, result string) float64 {
+	return testutil.ToFloat64(metrics.APITxsSubmittedTotal.WithLabelValues(route, result))
+}
+
+// TestSubmitCounters_BatchCountsPerTransaction is the regression for the
+// submissions-metric bug: the HTTP request histogram counts one sample per
+// request, so a 3-tx /txs batch read as ONE submission on dashboards.
+// arcade_api_txs_submitted_total must count per transaction.
+func TestSubmitCounters_BatchCountsPerTransaction(t *testing.T) {
+	broker := &kafka.RecordingBroker{}
+	_, router := setupServer(broker) // no store: every parsed tx counts as new
+
+	before := counterVal("/txs", "new")
+
+	body := bytes.Repeat(makeMinimalTx(), 3)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/txs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := counterVal("/txs", "new") - before; got != 3 {
+		t.Errorf("txs_submitted{/txs,new} delta = %v, want 3 (one per transaction, not per request)", got)
+	}
+}
+
+// TestSubmitCounters_SingleDedupResults pins the result label on the single
+// submit route: a fresh insert counts as new; an idempotent resubmit counts
+// as duplicate (and is not double-counted as new).
+func TestSubmitCounters_SingleDedupResults(t *testing.T) {
+	broker := &kafka.RecordingBroker{}
+
+	// Fresh insert.
+	msNew := &mockStore{getOrInsertFn: func(st *models.TransactionStatus) (*models.TransactionStatus, bool, error) {
+		return st, true, nil
+	}}
+	_, router := setupServerWithStore(broker, msNew)
+	beforeNew, beforeDup := counterVal("/tx", "new"), counterVal("/tx", "duplicate")
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/tx", bytes.NewReader(makeMinimalTx()))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := counterVal("/tx", "new") - beforeNew; got != 1 {
+		t.Errorf("txs_submitted{/tx,new} delta = %v, want 1", got)
+	}
+
+	// Idempotent duplicate.
+	existing := &models.TransactionStatus{Status: models.StatusSeenOnNetwork}
+	msDup := &mockStore{getOrInsertFn: func(st *models.TransactionStatus) (*models.TransactionStatus, bool, error) {
+		return existing, false, nil
+	}}
+	_, router2 := setupServerWithStore(broker, msDup)
+	beforeNew = counterVal("/tx", "new")
+
+	req2 := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/tx", bytes.NewReader(makeMinimalTx()))
+	req2.Header.Set("Content-Type", "application/octet-stream")
+	w2 := httptest.NewRecorder()
+	router2.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusAccepted {
+		t.Fatalf("duplicate resubmit: expected 202, got %d: %s", w2.Code, w2.Body.String())
+	}
+	if got := counterVal("/tx", "duplicate") - beforeDup; got != 1 {
+		t.Errorf("txs_submitted{/tx,duplicate} delta = %v, want 1", got)
+	}
+	if got := counterVal("/tx", "new") - beforeNew; got != 0 {
+		t.Errorf("duplicate resubmit must not count as new (delta %v)", got)
+	}
+}

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -2294,7 +2294,7 @@ func TestSubmitCounters_SingleDedupResults(t *testing.T) {
 
 	// Idempotent duplicate.
 	existing := &models.TransactionStatus{Status: models.StatusSeenOnNetwork}
-	msDup := &mockStore{getOrInsertFn: func(st *models.TransactionStatus) (*models.TransactionStatus, bool, error) {
+	msDup := &mockStore{getOrInsertFn: func(_ *models.TransactionStatus) (*models.TransactionStatus, bool, error) {
 		return existing, false, nil
 	}}
 	_, router2 := setupServerWithStore(broker, msDup)

--- a/services/propagation/reaper.go
+++ b/services/propagation/reaper.go
@@ -7,6 +7,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/bsv-blockchain/arcade/logfields"
 	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
 )
@@ -38,7 +39,33 @@ const (
 	staleReceivedAge       = time.Hour
 	staleScanLookback      = 24 * time.Hour
 	reaperRebroadcastBatch = 200
+
+	// stuckTransientAge is the threshold for the StuckTransientTxs /
+	// OldestTransientTxAge gauges: a tx sitting in RECEIVED or
+	// ACCEPTED_BY_NETWORK longer than this counts as stuck — the SEEN
+	// state-transfer for it never arrived. Kept equal to the rebroadcast
+	// stale ages so "stuck" means the same thing everywhere.
+	stuckTransientAge = time.Hour
 )
+
+// stuckTransientStatuses are the transient statuses the stuck gauges track.
+// RECEIVED is partially self-healed by the rebroadcast arm below;
+// ACCEPTED_BY_NETWORK has no self-heal path, which is exactly why it needs
+// the visibility.
+var stuckTransientStatuses = []models.Status{
+	models.StatusReceived,
+	models.StatusAcceptedByNetwork,
+}
+
+// zeroStuckTransientGauges resets the leader-computed stuck gauges. Called on
+// non-leader ticks so a pod that lost the lease doesn't keep exporting its
+// last leader-era values (the current leader's values then win under max()).
+func zeroStuckTransientGauges() {
+	for _, st := range stuckTransientStatuses {
+		metrics.StuckTransientTxs.WithLabelValues(string(st)).Set(0)
+		metrics.OldestTransientTxAge.WithLabelValues(string(st)).Set(0)
+	}
+}
 
 // reaperLeaseName is the well-known key every replica uses to coordinate
 // reaper ownership. One lease per propagation deployment.
@@ -84,6 +111,7 @@ func (p *Propagator) tryReap(ctx context.Context) {
 		if heldUntil.IsZero() {
 			metrics.PropagationReaperTickTotal.WithLabelValues("skipped_no_leader").Inc()
 			metrics.PropagationReaperLease.Set(0)
+			zeroStuckTransientGauges()
 			p.logger.Debug("reaper: not leader, skipping tick")
 			return
 		}
@@ -117,10 +145,34 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 	seenDeadline := now.Add(-staleSeenOnNetworkAge)
 	receivedDeadline := now.Add(-staleReceivedAge)
 
+	stuckTransientDeadline := now.Add(-stuckTransientAge)
+	type transientStats struct {
+		count  int
+		oldest time.Time
+	}
+	stuckTransient := make(map[models.Status]*transientStats, len(stuckTransientStatuses))
+	for _, s := range stuckTransientStatuses {
+		stuckTransient[s] = &transientStats{}
+	}
+
 	stuck := make([]propagationMsg, 0, reaperRebroadcastBatch)
 	err := p.store.IterateStatusesSince(ctx, since, func(st *models.TransactionStatus) error {
+		// Stuck-transient accounting runs on EVERY row (regardless of RawTx
+		// or the rebroadcast cap): the gauges must be an uncapped census of
+		// txs whose SEEN state-transfer never arrived, including
+		// ACCEPTED_BY_NETWORK rows the rebroadcast arm below never touches.
+		if ts, ok := stuckTransient[st.Status]; ok && st.Timestamp.Before(stuckTransientDeadline) {
+			ts.count++
+			if ts.oldest.IsZero() || st.Timestamp.Before(ts.oldest) {
+				ts.oldest = st.Timestamp
+			}
+		}
+
 		if len(stuck) >= reaperRebroadcastBatch {
-			return errReaperBatchFull
+			// Rebroadcast batch is full — keep walking for the census, just
+			// stop collecting. (Previously the walk aborted here, which also
+			// capped any counting at the batch size.)
+			return nil
 		}
 		if len(st.RawTx) == 0 {
 			// No body to rebroadcast. Pre-reaper-population rows
@@ -144,13 +196,13 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 		default:
 			// Terminal statuses (REJECTED, DOUBLE_SPEND_ATTEMPTED, MINED,
 			// IMMUTABLE) and transient in-between states are not the
-			// reaper's job.
+			// reaper's job to rebroadcast.
 			return nil
 		}
 		stuck = append(stuck, propagationMsg{TXID: st.TxID, RawTx: st.RawTx})
 		return nil
 	})
-	if err != nil && !errors.Is(err, errReaperBatchFull) && !errors.Is(err, context.Canceled) {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		p.logger.Error("reaper: scan failed", zap.Error(err))
 		return
 	}
@@ -161,6 +213,23 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 	// leaves a stale non-zero value visible to dashboards after the
 	// backlog drains, which used to make the metric misleading.
 	metrics.PropagationReaperReadyDepth.Set(float64(len(stuck)))
+
+	// Publish the stuck-transient census the same way: every tick, zero
+	// included, so the gauges always reflect the latest completed scan.
+	for status, ts := range stuckTransient {
+		metrics.StuckTransientTxs.WithLabelValues(string(status)).Set(float64(ts.count))
+		age := 0.0
+		if !ts.oldest.IsZero() {
+			age = now.Sub(ts.oldest).Seconds()
+		}
+		metrics.OldestTransientTxAge.WithLabelValues(string(status)).Set(age)
+		if ts.count > 0 {
+			p.logger.Warn("reaper: transactions stuck in transient status past threshold",
+				logfields.Status(string(status)),
+				zap.Int("count", ts.count),
+				zap.Float64("oldest_age_seconds", age))
+		}
+	}
 
 	if len(stuck) == 0 {
 		return
@@ -208,9 +277,3 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 	}
 	p.applyTerminalStatuses(ctx, terminalStatuses, accepted, rejected)
 }
-
-// errReaperBatchFull halts the IterateStatusesSince walk once we've
-// accumulated reaperRebroadcastBatch stuck rows. Sentinel error so
-// IterateStatusesSince surfaces it cleanly without being mistaken for
-// a backend error.
-var errReaperBatchFull = errors.New("reaper batch full")

--- a/services/propagation/reaper_test.go
+++ b/services/propagation/reaper_test.go
@@ -2,10 +2,15 @@ package propagation
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
 )
 
@@ -89,5 +94,133 @@ func TestReapOnce_ReceivedSelection(t *testing.T) {
 	}
 	if got := log.count("register:"); got != 2 {
 		t.Errorf("total register count = %d, want 2; events=%v", got, log.all())
+	}
+}
+
+// gaugeVal reads a labeled gauge value for assertions.
+func gaugeVal(t *testing.T, vec *prometheus.GaugeVec, label string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(vec.WithLabelValues(label))
+}
+
+// TestReapOnce_StuckTransientCensus pins the stuck-transient gauges (issue:
+// alerting on txs whose SEEN state-transfer never arrived):
+//   - RECEIVED and ACCEPTED_BY_NETWORK rows older than stuckTransientAge are
+//     counted — INCLUDING body-less rows the rebroadcast arm skips;
+//   - ACCEPTED_BY_NETWORK is counted but NOT rebroadcast (no behavior change);
+//   - fresh transient rows and terminal rows are not counted;
+//   - the oldest-age gauge reflects the oldest stuck row per status.
+func TestReapOnce_StuckTransientCensus(t *testing.T) {
+	now := time.Now()
+	stale2h := now.Add(-2 * time.Hour)
+	stale3h := now.Add(-3 * time.Hour)
+	recent := now.Add(-10 * time.Minute)
+
+	log := &eventLog{}
+	ms := newMockStore()
+	ms.replayRows = []*models.TransactionStatus{
+		// counted: RECEIVED stuck (with and without body)
+		{TxID: "recv-stale-body", Status: models.StatusReceived, RawTx: []byte{0x01}, Timestamp: stale2h},
+		{TxID: "recv-stale-nobody", Status: models.StatusReceived, Timestamp: stale3h},
+		// counted: ACCEPTED_BY_NETWORK stuck (the previously-invisible case)
+		{TxID: "acc-stale", Status: models.StatusAcceptedByNetwork, RawTx: []byte{0x02}, Timestamp: stale2h},
+		// not counted: fresh transient rows
+		{TxID: "recv-recent", Status: models.StatusReceived, RawTx: []byte{0x03}, Timestamp: recent},
+		{TxID: "acc-recent", Status: models.StatusAcceptedByNetwork, Timestamp: recent},
+		// not counted: terminal + other states
+		{TxID: "mined-old", Status: models.StatusMined, Timestamp: stale3h},
+		{TxID: "seen-old", Status: models.StatusSeenOnNetwork, RawTx: []byte{0x04}, Timestamp: stale2h},
+	}
+
+	merkleSrv := newMerkleServer(log, http.StatusOK)
+	defer merkleSrv.Close()
+	teranodeSrv := newTeranodeServer(log, http.StatusOK)
+	defer teranodeSrv.Close()
+
+	p := newPropagator(merkleSrv.URL, teranodeSrv.URL, ms)
+	p.reapOnce(context.Background())
+
+	if got := gaugeVal(t, metrics.StuckTransientTxs, string(models.StatusReceived)); got != 2 {
+		t.Errorf("stuck RECEIVED = %v, want 2 (body-less rows must be counted)", got)
+	}
+	if got := gaugeVal(t, metrics.StuckTransientTxs, string(models.StatusAcceptedByNetwork)); got != 1 {
+		t.Errorf("stuck ACCEPTED_BY_NETWORK = %v, want 1", got)
+	}
+	// Oldest RECEIVED is the 3h row: age must exceed 2.5h.
+	if got := gaugeVal(t, metrics.OldestTransientTxAge, string(models.StatusReceived)); got < 2.5*3600 {
+		t.Errorf("oldest RECEIVED age = %vs, want > 9000s", got)
+	}
+	// ACCEPTED_BY_NETWORK must NOT be rebroadcast (census only).
+	if got := log.count("register:acc-stale"); got != 0 {
+		t.Errorf("ACCEPTED_BY_NETWORK row was rebroadcast; census must not change rebroadcast behavior")
+	}
+	// Rebroadcast arm unchanged: stale RECEIVED with body + stale SEEN.
+	if got := log.count("register:recv-stale-body"); got != 1 {
+		t.Errorf("stale RECEIVED with body not rebroadcast; events=%v", log.all())
+	}
+}
+
+// TestReapOnce_StuckTransientCensus_ZeroesWhenClear: a scan finding nothing
+// stuck must reset the gauges to 0 (no stale non-zero readings after a
+// backlog drains).
+func TestReapOnce_StuckTransientCensus_ZeroesWhenClear(t *testing.T) {
+	// Seed non-zero values as if a previous tick found stuck rows.
+	metrics.StuckTransientTxs.WithLabelValues(string(models.StatusReceived)).Set(7)
+	metrics.OldestTransientTxAge.WithLabelValues(string(models.StatusAcceptedByNetwork)).Set(1234)
+
+	log := &eventLog{}
+	ms := newMockStore()
+	ms.replayRows = []*models.TransactionStatus{
+		{TxID: "recv-recent", Status: models.StatusReceived, RawTx: []byte{0x01}, Timestamp: time.Now().Add(-time.Minute)},
+	}
+	merkleSrv := newMerkleServer(log, http.StatusOK)
+	defer merkleSrv.Close()
+	teranodeSrv := newTeranodeServer(log, http.StatusOK)
+	defer teranodeSrv.Close()
+
+	p := newPropagator(merkleSrv.URL, teranodeSrv.URL, ms)
+	p.reapOnce(context.Background())
+
+	for _, status := range stuckTransientStatuses {
+		if got := gaugeVal(t, metrics.StuckTransientTxs, string(status)); got != 0 {
+			t.Errorf("stuck %s = %v, want 0 after clean scan", status, got)
+		}
+		if got := gaugeVal(t, metrics.OldestTransientTxAge, string(status)); got != 0 {
+			t.Errorf("oldest %s age = %v, want 0 after clean scan", status, got)
+		}
+	}
+}
+
+// TestReapOnce_CensusUncappedByRebroadcastBatch: the census must keep
+// counting past the rebroadcast batch cap (the old walk aborted at
+// reaperRebroadcastBatch, silently truncating any census).
+func TestReapOnce_CensusUncappedByRebroadcastBatch(t *testing.T) {
+	now := time.Now()
+	stale := now.Add(-2 * time.Hour)
+
+	log := &eventLog{}
+	ms := newMockStore()
+	total := reaperRebroadcastBatch + 50
+	for i := 0; i < total; i++ {
+		ms.replayRows = append(ms.replayRows, &models.TransactionStatus{
+			TxID:      fmt.Sprintf("recv-%04d", i),
+			Status:    models.StatusReceived,
+			RawTx:     []byte{0x01},
+			Timestamp: stale,
+		})
+	}
+	merkleSrv := newMerkleServer(log, http.StatusOK)
+	defer merkleSrv.Close()
+	teranodeSrv := newTeranodeServer(log, http.StatusOK)
+	defer teranodeSrv.Close()
+
+	p := newPropagator(merkleSrv.URL, teranodeSrv.URL, ms)
+	p.reapOnce(context.Background())
+
+	if got := gaugeVal(t, metrics.StuckTransientTxs, string(models.StatusReceived)); got != float64(total) {
+		t.Errorf("stuck RECEIVED = %v, want %d (census must not be capped at the rebroadcast batch)", got, total)
+	}
+	if got := log.count("register:"); got != reaperRebroadcastBatch {
+		t.Errorf("rebroadcast count = %d, want %d (batch cap unchanged)", got, reaperRebroadcastBatch)
 	}
 }


### PR DESCRIPTION
## Why

Operations wants an alert for "transactions stuck in a transient state for over an hour" (RECEIVED / ACCEPTED_BY_NETWORK — implies the SEEN_ON_NETWORK state-transfer never arrived). **No existing signal can express this:**
- `arcade_status_transition_age_seconds` only observes txs that *do* transition — a stuck tx emits nothing
- `arcade_propagation_reaper_ready_depth` conflates RECEIVED with the SEEN states, caps at the 200-row rebroadcast batch, skips body-less rows
- **ACCEPTED_BY_NETWORK is invisible to every metric** (the reaper's rebroadcast switch deliberately ignores it)

## What

Two gauges, computed on the propagation reaper's leader tick:
- **`arcade_stuck_transient_txs{status}`** — uncapped count of txs in RECEIVED / ACCEPTED_BY_NETWORK older than 1h (24h scan lookback)
- **`arcade_oldest_transient_tx_age_seconds{status}`** — age of the oldest stuck tx (0 when none)

Implementation piggybacks on the reaper's existing 24h `IterateStatusesSince` walk — **no new store queries, no interface change**. The census counts every row in a tracked status past the threshold, regardless of `RawTx`, and past the rebroadcast cap: the walk no longer aborts at `reaperRebroadcastBatch` (collection still caps at 200; counting continues). Gauges are set on every leader tick (zero included) and **zeroed on non-leader ticks**, so a pod that loses the lease doesn't export stale leader-era values — aggregate with `max()` across pods. A WARN log fires when any census bucket is non-zero.

**Rebroadcast behavior is unchanged** — ACCEPTED_BY_NETWORK is counted, never rebroadcast; batch cap, RawTx skip, and stale thresholds identical (pinned by tests).

## Tests

- `TestReapOnce_StuckTransientCensus` — counts body-less RECEIVED rows, counts ACCEPTED_BY_NETWORK (and asserts it is NOT rebroadcast), ignores fresh/terminal rows, oldest-age correctness
- `TestReapOnce_StuckTransientCensus_ZeroesWhenClear` — gauges reset to 0 after a clean scan
- `TestReapOnce_CensusUncappedByRebroadcastBatch` — census counts past the 200-row cap while the rebroadcast cap itself is unchanged
- Existing reaper tests pass unchanged

`go build && go vet && go test ./... && magex lint` all green.

## Downstream

Feeds the Coralogix alert "Arcade — transactions stuck in transient state >1h" (threshold >10 per network, P2 → Slack), created once this ships in a release: `max by (cx_application_name)(arcade_stuck_transient_txs{status=~"RECEIVED|ACCEPTED_BY_NETWORK"}) > 10`.

---

**Also in this PR: `arcade_api_txs_submitted_total{route,result}`** — per-transaction submission counter. Dashboards were counting TX submissions via the HTTP request histogram (one sample per request), so a `/txs` batch of N transactions read as ONE submission (observed live: 22 requests vs 202 actual txs). Counted at the intake dedup stage: `new` (unique first-time txid — the dashboard series), `duplicate` (idempotent resubmit), `retry_rejected` (resubmit of a previously rejected txid). Tests pin per-transaction batch semantics and the result split.