### PR TITLE
fix(sse): stream bounded, non-terminal catchup to stop OOM kills

### DIFF
--- a/models/transaction.go
+++ b/models/transaction.go
@@ -119,6 +119,19 @@ func (s Status) IsTerminal() bool {
 	return ok
 }
 
+// NonTerminalStatuses returns the statuses a transaction can still move on
+// from — the "pending" set a reconnecting client needs replayed. Everything
+// terminal (MINED, IMMUTABLE, REJECTED, DOUBLE_SPEND_ATTEMPTED) is excluded:
+// terminal history is queryable via the REST API and replaying it wholesale
+// is what made SSE catchup unbounded.
+func NonTerminalStatuses() []Status {
+	return []Status{
+		StatusReceived, StatusSentToNetwork, StatusAcceptedByNetwork,
+		StatusSeenOnNetwork, StatusSeenMultipleNodes,
+		StatusPendingRetry, StatusStumpProcessing,
+	}
+}
+
 // DisallowedPreviousStatuses returns statuses that CANNOT transition to this status.
 // Used by stores' UpdateStatus implementations (and CanTransitionFrom) to prevent
 // invalid status transitions — most importantly, to prevent terminal statuses

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -171,6 +171,10 @@ func (m *mockStore) GetSubmissionsByToken(context.Context, string) ([]*models.Su
 	return nil, nil
 }
 
+func (m *mockStore) IterateStatusesByToken(context.Context, string, time.Time, []models.Status, func(*models.TransactionStatus) error) error {
+	return nil
+}
+
 func (m *mockStore) UpdateDeliveryStatus(context.Context, string, models.Status, int, *time.Time) error {
 	return nil
 }

--- a/services/sse/manager.go
+++ b/services/sse/manager.go
@@ -3,6 +3,7 @@ package sse
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -302,27 +303,47 @@ func (s *Service) handleEvents(c *gin.Context) {
 	}
 }
 
-// sendCatchup replays the current persisted status of every txid
-// registered under the supplied token. When `since` is non-zero only
-// statuses with a timestamp strictly after `since` are emitted (the
-// Last-Event-ID reconnect contract). When `since` is zero every status
-// is emitted — used as the initial-state replay on a fresh connect.
+// catchupMaxFrames bounds a single catchup replay. A well-behaved token
+// has a small pending set (fresh connect) or a short disconnect window
+// (Last-Event-ID), so the cap only bites pathological histories — where
+// truncating beats the alternative this cap replaced: replaying millions
+// of frames used to OOM the whole pod, killing every connected client.
+const catchupMaxFrames = 10_000
+
+// errCatchupCapped stops the catchup iteration at catchupMaxFrames.
+// Internal sentinel, never surfaced to the client.
+var errCatchupCapped = errors.New("sse catchup frame cap reached")
+
+// sendCatchup replays persisted statuses for txids registered under the
+// supplied token. When `since` is non-zero, every status with a timestamp
+// strictly after `since` is emitted (the Last-Event-ID reconnect contract —
+// the window is naturally bounded by the disconnect duration). When `since`
+// is zero (fresh connect), only NON-TERMINAL statuses are replayed: that's
+// the actionable pending state a client needs on connect; terminal history
+// is queryable via GET /tx/:id, and replaying it wholesale is what used to
+// OOM this service (a token with 2.2M submissions × a GetStatus per txid,
+// each MINED row parsing its block's compound BUMP, inside a 512Mi limit).
+//
+// The store streams a projection (no raw tx, no merkle-path enrichment) in
+// ascending timestamp order, so replayed event ids stay monotonic for
+// Last-Event-ID resume.
 func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, since time.Time) {
-	subs, err := s.store.GetSubmissionsByToken(ctx, token)
-	if err != nil {
-		return
+	var only []models.Status
+	if since.IsZero() {
+		only = models.NonTerminalStatuses()
 	}
-	for _, sub := range subs {
-		status, err := s.store.GetStatus(ctx, sub.TxID)
-		if err != nil || status == nil {
-			continue
+	frames := 0
+	err := s.store.IterateStatusesByToken(ctx, token, since, only, func(status *models.TransactionStatus) error {
+		if frames >= catchupMaxFrames {
+			return errCatchupCapped
 		}
-		if !since.IsZero() && !status.Timestamp.After(since) {
-			continue
-		}
-		if err := writeStatus(w, status); err != nil {
-			return
-		}
+		frames++
+		return writeStatus(w, status)
+	})
+	if errors.Is(err, errCatchupCapped) {
+		s.logger.Warn("sse catchup truncated at frame cap",
+			zap.Int("cap", catchupMaxFrames),
+			zap.Bool("fresh_connect", since.IsZero()))
 	}
 }
 

--- a/services/sse/sse_test.go
+++ b/services/sse/sse_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -24,6 +26,8 @@ import (
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/store"
 )
+
+const tokA = "tok-A"
 
 // fakePublisher is a test-only events.Publisher. It captures published
 // updates and lets tests synthesize subscriber-side delivery.
@@ -62,8 +66,9 @@ func (p *fakePublisher) Subscribe(_ context.Context, _ string) (<-chan *models.T
 func (p *fakePublisher) Close() error { return nil }
 
 // sseStoreStub is a minimum-surface fake. The SSE service only touches
-// GetSubmissionsByToken and GetStatus on the Store; embed the interface
-// so every other method panics if accidentally called.
+// GetSubmissionsByToken, GetStatus, and IterateStatusesByToken on the
+// Store; embed the interface so every other method panics if
+// accidentally called.
 type sseStoreStub struct {
 	store.Store
 
@@ -82,6 +87,40 @@ func (s *sseStoreStub) GetStatus(_ context.Context, txid string) (*models.Transa
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.statusByTx[txid], nil
+}
+
+// IterateStatusesByToken mirrors the real backends: distinct txids under
+// the token, current status projection, since/only filters, ascending
+// timestamp order.
+func (s *sseStoreStub) IterateStatusesByToken(_ context.Context, token string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {
+	s.mu.RLock()
+	seen := make(map[string]bool)
+	var statuses []*models.TransactionStatus
+	for _, sub := range s.subsByToken[token] {
+		if seen[sub.TxID] {
+			continue
+		}
+		seen[sub.TxID] = true
+		st := s.statusByTx[sub.TxID]
+		if st == nil {
+			continue
+		}
+		if !since.IsZero() && !st.Timestamp.After(since) {
+			continue
+		}
+		if len(onlyStatuses) > 0 && !slices.Contains(onlyStatuses, st.Status) {
+			continue
+		}
+		statuses = append(statuses, st)
+	}
+	s.mu.RUnlock()
+	sort.Slice(statuses, func(i, j int) bool { return statuses[i].Timestamp.Before(statuses[j].Timestamp) })
+	for _, st := range statuses {
+		if err := fn(st); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *sseStoreStub) setStatus(txid string, status *models.TransactionStatus) {
@@ -119,7 +158,7 @@ func setupSSEService(t *testing.T, st *sseStoreStub) (*Service, *gin.Engine, *fa
 func TestSSEFrameFormat(t *testing.T) {
 	st := &sseStoreStub{
 		subsByToken: map[string][]*models.Submission{
-			"tok-A": {{TxID: "abc", CallbackToken: "tok-A"}},
+			tokA: {{TxID: "abc", CallbackToken: tokA}},
 		},
 	}
 	_, router, pub, cancel := setupSSEService(t, st)
@@ -128,7 +167,7 @@ func TestSSEFrameFormat(t *testing.T) {
 	srv := httptest.NewServer(router)
 	defer srv.Close()
 
-	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/events?callbackToken=tok-A", nil)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/events?callbackToken="+tokA, nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET /events: %v", err)
@@ -174,7 +213,7 @@ func TestSSEFrameFormat(t *testing.T) {
 func TestSSETokenFilter(t *testing.T) {
 	st := &sseStoreStub{
 		subsByToken: map[string][]*models.Submission{
-			"tok-A": {{TxID: "match", CallbackToken: "tok-A"}},
+			tokA: {{TxID: "match", CallbackToken: tokA}},
 		},
 	}
 	_, router, pub, cancel := setupSSEService(t, st)
@@ -183,7 +222,7 @@ func TestSSETokenFilter(t *testing.T) {
 	srv := httptest.NewServer(router)
 	defer srv.Close()
 
-	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/events?callbackToken=tok-A", nil)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/events?callbackToken="+tokA, nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET /events: %v", err)
@@ -212,9 +251,9 @@ func TestSSECatchup(t *testing.T) {
 
 	st := &sseStoreStub{
 		subsByToken: map[string][]*models.Submission{
-			"tok-A": {
-				{TxID: "old", CallbackToken: "tok-A"},
-				{TxID: "new", CallbackToken: "tok-A"},
+			tokA: {
+				{TxID: "old", CallbackToken: tokA},
+				{TxID: "new", CallbackToken: tokA},
 			},
 		},
 		statusByTx: map[string]*models.TransactionStatus{
@@ -229,7 +268,7 @@ func TestSSECatchup(t *testing.T) {
 	defer srv.Close()
 
 	since := older.Add(time.Minute).UnixNano() // strictly between older and newer
-	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/events?callbackToken=tok-A", nil)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/events?callbackToken="+tokA, nil)
 	req.Header.Set("Last-Event-ID", fmt.Sprintf("%d", since))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -246,6 +285,133 @@ func TestSSECatchup(t *testing.T) {
 	}
 	if strings.Contains(frame, `"txid":"old"`) {
 		t.Errorf("older tx should not have replayed: %q", frame)
+	}
+}
+
+// TestSSECatchupFreshConnectNonTerminalOnly verifies the OOM fix: a
+// connect WITHOUT Last-Event-ID replays only non-terminal statuses.
+// Terminal history (MINED/REJECTED/...) is queryable via the REST API
+// and replaying it wholesale is what used to OOM the pod.
+func TestSSECatchupFreshConnectNonTerminalOnly(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{
+			tokA: {
+				{TxID: "mined", CallbackToken: tokA},
+				{TxID: "rejected", CallbackToken: tokA},
+				{TxID: "pending", CallbackToken: tokA},
+			},
+		},
+		statusByTx: map[string]*models.TransactionStatus{
+			"mined":    {TxID: "mined", Status: models.StatusMined, Timestamp: now.Add(-2 * time.Minute)},
+			"rejected": {TxID: "rejected", Status: models.StatusRejected, Timestamp: now.Add(-time.Minute)},
+			"pending":  {TxID: "pending", Status: models.StatusSeenOnNetwork, Timestamp: now},
+		},
+	}
+	_, router, _, cancel := setupSSEService(t, st)
+	defer cancel()
+
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	// Fresh connect: no Last-Event-ID header.
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/events?callbackToken="+tokA, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /events: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	frame, err := readNextSSEFrame(resp.Body, 2*time.Second)
+	if err != nil {
+		t.Fatalf("read frame: %v", err)
+	}
+	if !strings.Contains(frame, `"txid":"pending"`) {
+		t.Errorf("expected non-terminal tx in catchup, got %q", frame)
+	}
+	if strings.Contains(frame, `"txid":"mined"`) || strings.Contains(frame, `"txid":"rejected"`) {
+		t.Errorf("terminal statuses must not replay on fresh connect: %q", frame)
+	}
+}
+
+// TestSSECatchupReconnectIncludesTerminal verifies the Last-Event-ID
+// contract survives the OOM fix: a reconnect with a since watermark
+// still replays terminal transitions that happened during the
+// disconnect window (that's how a client learns its tx mined).
+func TestSSECatchupReconnectIncludesTerminal(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{
+			tokA: {{TxID: "minedRecently", CallbackToken: tokA}},
+		},
+		statusByTx: map[string]*models.TransactionStatus{
+			"minedRecently": {TxID: "minedRecently", Status: models.StatusMined, Timestamp: now},
+		},
+	}
+	_, router, _, cancel := setupSSEService(t, st)
+	defer cancel()
+
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	since := now.Add(-time.Minute).UnixNano()
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/events?callbackToken="+tokA, nil)
+	req.Header.Set("Last-Event-ID", fmt.Sprintf("%d", since))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /events: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	frame, err := readNextSSEFrame(resp.Body, 2*time.Second)
+	if err != nil {
+		t.Fatalf("read frame: %v", err)
+	}
+	if !strings.Contains(frame, `"txid":"minedRecently"`) {
+		t.Errorf("expected terminal tx in reconnect catchup, got %q", frame)
+	}
+}
+
+// nopFlusher satisfies the sseWriter flusher contract without a live
+// HTTP connection so the cap test doesn't stream 10k frames through
+// httptest.
+type nopFlusher struct{ http.ResponseWriter }
+
+func (nopFlusher) Flush() {}
+
+// TestSSECatchupFrameCap verifies the backstop: catchup stops at
+// catchupMaxFrames instead of replaying an unbounded history.
+func TestSSECatchupFrameCap(t *testing.T) {
+	n := catchupMaxFrames + 500
+	subs := make([]*models.Submission, 0, n)
+	statuses := make(map[string]*models.TransactionStatus, n)
+	base := time.Now().UTC().Add(-time.Duration(n) * time.Second)
+	for i := 0; i < n; i++ {
+		txid := fmt.Sprintf("tx-%06d", i)
+		subs = append(subs, &models.Submission{TxID: txid, CallbackToken: "tok-big"})
+		statuses[txid] = &models.TransactionStatus{
+			TxID:      txid,
+			Status:    models.StatusSeenOnNetwork,
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+		}
+	}
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{"tok-big": subs},
+		statusByTx:  statuses,
+	}
+	svc := &Service{
+		cfg:    &config.Config{SSE: config.SSEConfig{Enabled: true}},
+		logger: zap.NewNop(),
+		store:  st,
+	}
+
+	rec := httptest.NewRecorder()
+	w := &sseWriter{w: rec, f: nopFlusher{rec}}
+	svc.sendCatchup(t.Context(), w, "tok-big", time.Time{})
+
+	frames := strings.Count(rec.Body.String(), "\nevent: status\n")
+	if frames != catchupMaxFrames {
+		t.Errorf("catchup frames = %d, want cap %d", frames, catchupMaxFrames)
 	}
 }
 

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -150,6 +150,10 @@ func (s *fakeStore) InsertSubmission(context.Context, *models.Submission) error 
 func (s *fakeStore) GetSubmissionsByToken(context.Context, string) ([]*models.Submission, error) {
 	return nil, nil
 }
+
+func (s *fakeStore) IterateStatusesByToken(context.Context, string, time.Time, []models.Status, func(*models.TransactionStatus) error) error {
+	return nil
+}
 func (s *fakeStore) InsertStump(context.Context, *models.Stump) error { return nil }
 func (s *fakeStore) GetStumpsByBlockHash(context.Context, string) ([]*models.Stump, error) {
 	return nil, nil

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -1525,6 +1525,65 @@ loop:
 	return subs, nil
 }
 
+func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {
+	subs, err := s.GetSubmissionsByToken(ctx, callbackToken)
+	if err != nil {
+		return err
+	}
+	only := make(map[models.Status]struct{}, len(onlyStatuses))
+	for _, st := range onlyStatuses {
+		only[st] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(subs))
+	// Projection only — per-key Get with just the status/timestamp/block
+	// bins (never raw_tx or merkle_path) and no enrichMerklePath. Filter
+	// BEFORE collecting so the sort buffer holds the matching set only.
+	matched := make([]*models.TransactionStatus, 0, 64)
+	for _, sub := range subs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if _, dup := seen[sub.TxID]; dup {
+			continue
+		}
+		seen[sub.TxID] = struct{}{}
+		key, kErr := s.key(setTransactions, sub.TxID)
+		if kErr != nil {
+			continue
+		}
+		rec, gErr := s.client.Get(s.readPolicy(ctx), key, "status", "timestamp", "block_hash", "block_height")
+		if gErr != nil || rec == nil {
+			continue
+		}
+		st := recordToStatus(rec, sub.TxID)
+		if st == nil {
+			continue
+		}
+		if !since.IsZero() && !st.Timestamp.After(since) {
+			continue
+		}
+		if len(only) > 0 {
+			if _, ok := only[st.Status]; !ok {
+				continue
+			}
+		}
+		matched = append(matched, &models.TransactionStatus{
+			TxID:        st.TxID,
+			Status:      st.Status,
+			Timestamp:   st.Timestamp,
+			BlockHash:   st.BlockHash,
+			BlockHeight: st.BlockHeight,
+		})
+	}
+	sort.Slice(matched, func(i, j int) bool { return matched[i].Timestamp.Before(matched[j].Timestamp) })
+	for _, st := range matched {
+		if err := fn(st); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *Store) GetSubmissionsByToken(ctx context.Context, token string) ([]*models.Submission, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -1517,6 +1517,57 @@ func (s *Store) GetSubmissionsByToken(ctx context.Context, callbackToken string)
 	return s.submissionsByIndex(ctx, idxSubTokenPrefix(callbackToken))
 }
 
+func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {
+	subs, err := s.GetSubmissionsByToken(ctx, callbackToken)
+	if err != nil {
+		return err
+	}
+	only := make(map[models.Status]struct{}, len(onlyStatuses))
+	for _, st := range onlyStatuses {
+		only[st] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(subs))
+	// Projection only — readStatus without enrichMerklePath, RawTx and
+	// MerklePath stripped. Filter BEFORE collecting so the sort buffer holds
+	// the (small) matching set, not the token's full history.
+	matched := make([]*models.TransactionStatus, 0, 64)
+	for _, sub := range subs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if _, dup := seen[sub.TxID]; dup {
+			continue
+		}
+		seen[sub.TxID] = struct{}{}
+		st, rErr := s.readStatus(sub.TxID)
+		if rErr != nil || st == nil {
+			continue
+		}
+		if !since.IsZero() && !st.Timestamp.After(since) {
+			continue
+		}
+		if len(only) > 0 {
+			if _, ok := only[st.Status]; !ok {
+				continue
+			}
+		}
+		matched = append(matched, &models.TransactionStatus{
+			TxID:        st.TxID,
+			Status:      st.Status,
+			Timestamp:   st.Timestamp,
+			BlockHash:   st.BlockHash,
+			BlockHeight: st.BlockHeight,
+		})
+	}
+	sort.Slice(matched, func(i, j int) bool { return matched[i].Timestamp.Before(matched[j].Timestamp) })
+	for _, st := range matched {
+		if err := fn(st); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *Store) submissionsByIndex(ctx context.Context, prefix []byte) ([]*models.Submission, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/store/pebble/pebble_test.go
+++ b/store/pebble/pebble_test.go
@@ -1148,3 +1148,91 @@ func TestBlockProcessing_MarkParked_SkipsOrphanedAndMissing(t *testing.T) {
 		t.Errorf("Status=%q, want orphaned (park must not override)", got.Status)
 	}
 }
+
+// TestIterateStatusesByToken covers the SSE-catchup hot path: distinct
+// txids, since/only filters, ascending order, and the no-heavy-fields
+// projection (raw tx / merkle path stripped).
+func TestIterateStatusesByToken(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	base := time.Now().Add(-time.Hour).UTC().Truncate(time.Millisecond)
+	rows := []*models.TransactionStatus{
+		{TxID: "tx-mined", Status: models.StatusMined, Timestamp: base, RawTx: []byte{0xde, 0xad}, MerklePath: []byte{0xbe, 0xef}},
+		{TxID: "tx-pending", Status: models.StatusSeenOnNetwork, Timestamp: base.Add(time.Minute)},
+		{TxID: "tx-received", Status: models.StatusReceived, Timestamp: base.Add(2 * time.Minute)},
+		{TxID: "tx-other", Status: models.StatusReceived, Timestamp: base.Add(3 * time.Minute)},
+	}
+	for _, r := range rows {
+		if _, _, err := s.GetOrInsertStatus(ctx, r); err != nil {
+			t.Fatalf("insert %s: %v", r.TxID, err)
+		}
+	}
+	subs := []*models.Submission{
+		{SubmissionID: "s1", TxID: "tx-mined", CallbackToken: "tok-1", CreatedAt: base},
+		{SubmissionID: "s2", TxID: "tx-pending", CallbackToken: "tok-1", CreatedAt: base},
+		// Duplicate submission for the same txid — must not double-emit.
+		{SubmissionID: "s3", TxID: "tx-pending", CallbackToken: "tok-1", CreatedAt: base},
+		{SubmissionID: "s4", TxID: "tx-received", CallbackToken: "tok-1", CreatedAt: base},
+		{SubmissionID: "s5", TxID: "tx-other", CallbackToken: "tok-2", CreatedAt: base},
+	}
+	for _, sub := range subs {
+		if err := s.InsertSubmission(ctx, sub); err != nil {
+			t.Fatalf("insert submission %s: %v", sub.SubmissionID, err)
+		}
+	}
+
+	collect := func(since time.Time, only []models.Status) []*models.TransactionStatus {
+		t.Helper()
+		var got []*models.TransactionStatus
+		if err := s.IterateStatusesByToken(ctx, "tok-1", since, only, func(st *models.TransactionStatus) error {
+			got = append(got, st)
+			return nil
+		}); err != nil {
+			t.Fatalf("IterateStatusesByToken: %v", err)
+		}
+		return got
+	}
+
+	// Unfiltered: 3 distinct txids in ascending timestamp order, projected.
+	got := collect(time.Time{}, nil)
+	if len(got) != 3 {
+		t.Fatalf("unfiltered rows = %d, want 3 (%+v)", len(got), got)
+	}
+	wantOrder := []string{"tx-mined", "tx-pending", "tx-received"}
+	for i, want := range wantOrder {
+		if got[i].TxID != want {
+			t.Errorf("row %d = %s, want %s", i, got[i].TxID, want)
+		}
+	}
+	if len(got[0].RawTx) != 0 || len(got[0].MerklePath) != 0 {
+		t.Errorf("projection leaked heavy fields: rawTx=%d merklePath=%d bytes", len(got[0].RawTx), len(got[0].MerklePath))
+	}
+
+	// onlyStatuses filter: non-terminal only drops the MINED row.
+	got = collect(time.Time{}, models.NonTerminalStatuses())
+	if len(got) != 2 || got[0].TxID != "tx-pending" || got[1].TxID != "tx-received" {
+		t.Fatalf("non-terminal rows = %+v, want [tx-pending tx-received]", got)
+	}
+
+	// since filter is strictly-after: cutting at tx-pending's timestamp
+	// leaves only tx-received.
+	got = collect(base.Add(time.Minute), nil)
+	if len(got) != 1 || got[0].TxID != "tx-received" {
+		t.Fatalf("since rows = %+v, want [tx-received]", got)
+	}
+
+	// fn error stops iteration and propagates.
+	sentinel := errors.New("stop")
+	calls := 0
+	err := s.IterateStatusesByToken(ctx, "tok-1", time.Time{}, nil, func(*models.TransactionStatus) error {
+		calls++
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("fn error not propagated: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("iteration continued after fn error: %d calls", calls)
+	}
+}

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -1127,6 +1127,49 @@ func (s *Store) GetSubmissionsByToken(ctx context.Context, token string) ([]*mod
 	return s.submissions(ctx, "callback_token = $1", token)
 }
 
+func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {
+	// Projection only — no raw_tx, no merkle_path, no enrichment. This is
+	// the SSE catchup hot path over potentially millions of submissions.
+	q := `
+SELECT t.txid, t.status, t.timestamp_at, COALESCE(t.block_hash, ''), COALESCE(t.block_height, 0)
+FROM transactions t
+WHERE t.txid IN (SELECT DISTINCT txid FROM submissions WHERE callback_token = $1)`
+	args := []any{callbackToken}
+	if !since.IsZero() {
+		args = append(args, since)
+		q += fmt.Sprintf(" AND t.timestamp_at > $%d", len(args))
+	}
+	if len(onlyStatuses) > 0 {
+		vals := make([]string, len(onlyStatuses))
+		for i, st := range onlyStatuses {
+			vals[i] = string(st)
+		}
+		args = append(args, vals)
+		q += fmt.Sprintf(" AND t.status = ANY($%d)", len(args))
+	}
+	q += " ORDER BY t.timestamp_at ASC"
+
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return fmt.Errorf("iterate statuses by token: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		st := &models.TransactionStatus{}
+		var status string
+		var height int64
+		if err := rows.Scan(&st.TxID, &status, &st.Timestamp, &st.BlockHash, &height); err != nil {
+			return fmt.Errorf("scan status row: %w", err)
+		}
+		st.Status = models.Status(status)
+		st.BlockHeight = uint64(height) //nolint:gosec // heights are non-negative
+		if err := fn(st); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
 func (s *Store) submissions(ctx context.Context, where string, arg any) ([]*models.Submission, error) {
 	q := `
 SELECT submission_id, txid, callback_url, callback_token, full_status_updates,

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -1402,6 +1402,7 @@ func TestBlockProcessing_MarkParked_SkipsOrphanedAndMissing(t *testing.T) {
 		t.Errorf("Status=%q, want orphaned (park must not override)", got.Status)
 	}
 }
+
 // TestIterateStatusesByToken covers the SSE-catchup hot path: distinct
 // txids, since/only filters, ascending order, and the no-heavy-fields
 // projection (raw tx / merkle path stripped).

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -1402,3 +1402,90 @@ func TestBlockProcessing_MarkParked_SkipsOrphanedAndMissing(t *testing.T) {
 		t.Errorf("Status=%q, want orphaned (park must not override)", got.Status)
 	}
 }
+// TestIterateStatusesByToken covers the SSE-catchup hot path: distinct
+// txids, since/only filters, ascending order, and the no-heavy-fields
+// projection (raw tx / merkle path stripped).
+func TestIterateStatusesByToken(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	base := time.Now().Add(-time.Hour).UTC().Truncate(time.Millisecond)
+	rows := []*models.TransactionStatus{
+		{TxID: "tx-mined", Status: models.StatusMined, Timestamp: base, RawTx: []byte{0xde, 0xad}, MerklePath: []byte{0xbe, 0xef}},
+		{TxID: "tx-pending", Status: models.StatusSeenOnNetwork, Timestamp: base.Add(time.Minute)},
+		{TxID: "tx-received", Status: models.StatusReceived, Timestamp: base.Add(2 * time.Minute)},
+		{TxID: "tx-other", Status: models.StatusReceived, Timestamp: base.Add(3 * time.Minute)},
+	}
+	for _, r := range rows {
+		if _, _, err := s.GetOrInsertStatus(ctx, r); err != nil {
+			t.Fatalf("insert %s: %v", r.TxID, err)
+		}
+	}
+	subs := []*models.Submission{
+		{SubmissionID: "s1", TxID: "tx-mined", CallbackToken: "tok-1", CreatedAt: base},
+		{SubmissionID: "s2", TxID: "tx-pending", CallbackToken: "tok-1", CreatedAt: base},
+		// Duplicate submission for the same txid — must not double-emit.
+		{SubmissionID: "s3", TxID: "tx-pending", CallbackToken: "tok-1", CreatedAt: base},
+		{SubmissionID: "s4", TxID: "tx-received", CallbackToken: "tok-1", CreatedAt: base},
+		{SubmissionID: "s5", TxID: "tx-other", CallbackToken: "tok-2", CreatedAt: base},
+	}
+	for _, sub := range subs {
+		if err := s.InsertSubmission(ctx, sub); err != nil {
+			t.Fatalf("insert submission %s: %v", sub.SubmissionID, err)
+		}
+	}
+
+	collect := func(since time.Time, only []models.Status) []*models.TransactionStatus {
+		t.Helper()
+		var got []*models.TransactionStatus
+		if err := s.IterateStatusesByToken(ctx, "tok-1", since, only, func(st *models.TransactionStatus) error {
+			got = append(got, st)
+			return nil
+		}); err != nil {
+			t.Fatalf("IterateStatusesByToken: %v", err)
+		}
+		return got
+	}
+
+	// Unfiltered: 3 distinct txids in ascending timestamp order, projected.
+	got := collect(time.Time{}, nil)
+	if len(got) != 3 {
+		t.Fatalf("unfiltered rows = %d, want 3 (%+v)", len(got), got)
+	}
+	wantOrder := []string{"tx-mined", "tx-pending", "tx-received"}
+	for i, want := range wantOrder {
+		if got[i].TxID != want {
+			t.Errorf("row %d = %s, want %s", i, got[i].TxID, want)
+		}
+	}
+	if len(got[0].RawTx) != 0 || len(got[0].MerklePath) != 0 {
+		t.Errorf("projection leaked heavy fields: rawTx=%d merklePath=%d bytes", len(got[0].RawTx), len(got[0].MerklePath))
+	}
+
+	// onlyStatuses filter: non-terminal only drops the MINED row.
+	got = collect(time.Time{}, models.NonTerminalStatuses())
+	if len(got) != 2 || got[0].TxID != "tx-pending" || got[1].TxID != "tx-received" {
+		t.Fatalf("non-terminal rows = %+v, want [tx-pending tx-received]", got)
+	}
+
+	// since filter is strictly-after: cutting at tx-pending's timestamp
+	// leaves only tx-received.
+	got = collect(base.Add(time.Minute), nil)
+	if len(got) != 1 || got[0].TxID != "tx-received" {
+		t.Fatalf("since rows = %+v, want [tx-received]", got)
+	}
+
+	// fn error stops iteration and propagates.
+	sentinel := errors.New("stop")
+	calls := 0
+	err := s.IterateStatusesByToken(ctx, "tok-1", time.Time{}, nil, func(*models.TransactionStatus) error {
+		calls++
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("fn error not propagated: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("iteration continued after fn error: %d calls", calls)
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -217,6 +217,19 @@ type Store interface {
 	// GetSubmissionsByToken retrieves all submissions for a callback token
 	GetSubmissionsByToken(ctx context.Context, callbackToken string) ([]*models.Submission, error)
 
+	// IterateStatusesByToken streams the current status of every DISTINCT
+	// txid registered under callbackToken through fn, in ascending
+	// status-timestamp order. Rows are PROJECTED for streaming delivery —
+	// txid, status, timestamp, block hash/height only. Implementations MUST
+	// NOT load raw_tx or enrich the merkle path: this is the SSE catchup hot
+	// path, called for tokens with millions of submissions, and per-row
+	// compound-BUMP parsing is what OOMed the SSE service. Filters: when
+	// since is non-zero, only statuses with Timestamp strictly after since
+	// are emitted; when onlyStatuses is non-empty, only rows in one of those
+	// statuses are emitted. fn returning a non-nil error stops the iteration
+	// and surfaces that error to the caller.
+	IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error
+
 	// UpdateDeliveryStatus updates the delivery tracking for a submission
 	UpdateDeliveryStatus(ctx context.Context, submissionID string, lastStatus models.Status, retryCount int, nextRetry *time.Time) error
 


### PR DESCRIPTION
## Problem

SSE pods on mainnet are being OOM-killed within minutes of a client connecting. Diagnosis (from Coralogix metrics + traces):

- A fresh `GET /events?callbackToken=...` connect ran `sendCatchup`, which materialized **every submission for the token** (top token: **2,261,658 submissions**) and then issued **one `GetStatus` per txid**.
- Each MINED status (**1.98M** of them) enriches the merkle path by parsing its block's **compound BUMP** through an 8-entry LRU — massive transient allocations per row.
- Inside a 512Mi limit the pod dies mid-replay, the client auto-reconnects to the next pod, and the loop serially kills every SSE pod. v0.9.4 pods without a connected catchup client sit steady at 18–33MiB — this is a performance bug, **not** an undersized limit.

## Fix

New `store.IterateStatusesByToken(ctx, token, since, onlyStatuses, fn)`:

- Streams the current status of every **DISTINCT** txid under the token, ascending by timestamp (keeps `Last-Event-ID` ids monotonic).
- **Projection only**: txid / status / timestamp / block hash+height. Never loads `raw_tx`, never enriches the merkle path.
- Implemented in postgres (single `IN (SELECT DISTINCT ...)` query), pebble, and aerospike (projected per-key `Get` with explicit bins).

`sendCatchup` semantics:

- **Fresh connect** (no `Last-Event-ID`): replays **only non-terminal statuses** — the actionable pending set. Terminal history remains queryable via the REST API; replaying millions of MINED rows on every connect is what OOMed the service.
- **Reconnect** (`Last-Event-ID`): contract unchanged — everything strictly after the watermark, terminal transitions included, so clients still learn their txs mined while disconnected.
- `catchupMaxFrames = 10_000` backstop; truncation logs a warning instead of killing the pod.

Adds `models.NonTerminalStatuses()` (complement of `IsTerminal()`).

## Tests

- `store/pebble` + `store/postgres` (`-tags=postgres`, embedded): distinct-txid dedupe, ascending order, strictly-after `since`, `onlyStatuses` filter, heavy-field projection, fn-error propagation.
- `services/sse`: fresh connect replays non-terminal only; reconnect still includes terminal transitions after the watermark; frame cap stops at exactly `catchupMaxFrames`; existing frame-format/token-filter/catchup/fan-out tests still green.
- `go test ./...` + `magex lint` clean.