### PR TITLE
fix(sse): indexed fan-out token check to stop the second OOM loop

### DIFF
--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -175,6 +175,10 @@ func (m *mockStore) IterateStatusesByToken(context.Context, string, time.Time, [
 	return nil
 }
 
+func (m *mockStore) TokenHasSubmissionForTx(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
 func (m *mockStore) UpdateDeliveryStatus(context.Context, string, models.Status, int, *time.Time) error {
 	return nil
 }

--- a/services/sse/manager.go
+++ b/services/sse/manager.go
@@ -173,13 +173,16 @@ func (m *Manager) fanOut(ctx context.Context, status *models.TransactionStatus) 
 }
 
 // txBelongsToToken reports whether txid was submitted with the given
-// callback token. Per-event submissions lookup; cached only by the
-// database layer.
+// callback token. Runs once per event per token-filtered client, so it
+// uses the store's indexed by-txid existence probe. It MUST NOT load the
+// token's submission list: a token can hold millions of submissions, and
+// materializing them per event is what OOM-killed this service the
+// moment a mega-token client survived catchup into fan-out.
 func (m *Manager) txBelongsToToken(ctx context.Context, txid, token string) bool {
 	if m.store == nil {
 		return false
 	}
-	subs, err := m.store.GetSubmissionsByToken(ctx, token)
+	ok, err := m.store.TokenHasSubmissionForTx(ctx, token, txid)
 	if err != nil {
 		m.logger.Warn(
 			"submission lookup failed",
@@ -188,12 +191,7 @@ func (m *Manager) txBelongsToToken(ctx context.Context, txid, token string) bool
 		)
 		return false
 	}
-	for _, s := range subs {
-		if s.TxID == txid {
-			return true
-		}
-	}
-	return false
+	return ok
 }
 
 // Register adds a client to the registry.

--- a/services/sse/sse_test.go
+++ b/services/sse/sse_test.go
@@ -123,6 +123,18 @@ func (s *sseStoreStub) IterateStatusesByToken(_ context.Context, token string, s
 	return nil
 }
 
+// TokenHasSubmissionForTx mirrors the real backends' membership probe.
+func (s *sseStoreStub) TokenHasSubmissionForTx(_ context.Context, token, txid string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, sub := range s.subsByToken[token] {
+		if sub.TxID == txid {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (s *sseStoreStub) setStatus(txid string, status *models.TransactionStatus) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -154,6 +154,10 @@ func (s *fakeStore) GetSubmissionsByToken(context.Context, string) ([]*models.Su
 func (s *fakeStore) IterateStatusesByToken(context.Context, string, time.Time, []models.Status, func(*models.TransactionStatus) error) error {
 	return nil
 }
+
+func (s *fakeStore) TokenHasSubmissionForTx(context.Context, string, string) (bool, error) {
+	return false, nil
+}
 func (s *fakeStore) InsertStump(context.Context, *models.Stump) error { return nil }
 func (s *fakeStore) GetStumpsByBlockHash(context.Context, string) ([]*models.Stump, error) {
 	return nil, nil

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -1525,6 +1525,22 @@ loop:
 	return subs, nil
 }
 
+// TokenHasSubmissionForTx resolves via the txid secondary index (a txid
+// has a handful of submissions) — never the token side, which can hold
+// millions.
+func (s *Store) TokenHasSubmissionForTx(ctx context.Context, callbackToken, txid string) (bool, error) {
+	subs, err := s.GetSubmissionsByTxID(ctx, txid)
+	if err != nil {
+		return false, err
+	}
+	for _, sub := range subs {
+		if sub.CallbackToken == callbackToken {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {
 	subs, err := s.GetSubmissionsByToken(ctx, callbackToken)
 	if err != nil {

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -1517,6 +1517,21 @@ func (s *Store) GetSubmissionsByToken(ctx context.Context, callbackToken string)
 	return s.submissionsByIndex(ctx, idxSubTokenPrefix(callbackToken))
 }
 
+// TokenHasSubmissionForTx resolves via the by-txid index (a txid has a
+// handful of submissions) — never the token index, which can hold millions.
+func (s *Store) TokenHasSubmissionForTx(ctx context.Context, callbackToken, txid string) (bool, error) {
+	subs, err := s.GetSubmissionsByTxID(ctx, txid)
+	if err != nil {
+		return false, err
+	}
+	for _, sub := range subs {
+		if sub.CallbackToken == callbackToken {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {
 	subs, err := s.GetSubmissionsByToken(ctx, callbackToken)
 	if err != nil {

--- a/store/pebble/pebble_test.go
+++ b/store/pebble/pebble_test.go
@@ -1236,3 +1236,41 @@ func TestIterateStatusesByToken(t *testing.T) {
 		t.Errorf("iteration continued after fn error: %d calls", calls)
 	}
 }
+
+// TestTokenHasSubmissionForTx covers the SSE fan-out membership probe:
+// match, wrong-token, and unknown-txid cases.
+func TestTokenHasSubmissionForTx(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	subs := []*models.Submission{
+		{SubmissionID: "p1", TxID: "tx-probe", CallbackToken: "tok-1", CreatedAt: time.Now()},
+		{SubmissionID: "p2", TxID: "tx-probe", CallbackToken: "tok-2", CreatedAt: time.Now()},
+		{SubmissionID: "p3", TxID: "tx-solo", CallbackToken: "tok-1", CreatedAt: time.Now()},
+	}
+	for _, sub := range subs {
+		if err := s.InsertSubmission(ctx, sub); err != nil {
+			t.Fatalf("insert %s: %v", sub.SubmissionID, err)
+		}
+	}
+
+	cases := []struct {
+		token, txid string
+		want        bool
+	}{
+		{"tok-1", "tx-probe", true},
+		{"tok-2", "tx-probe", true},
+		{"tok-2", "tx-solo", false},  // txid exists, different token
+		{"tok-1", "tx-ghost", false}, // unknown txid
+		{"tok-none", "tx-probe", false},
+	}
+	for _, tc := range cases {
+		got, err := s.TokenHasSubmissionForTx(ctx, tc.token, tc.txid)
+		if err != nil {
+			t.Fatalf("TokenHasSubmissionForTx(%s,%s): %v", tc.token, tc.txid, err)
+		}
+		if got != tc.want {
+			t.Errorf("TokenHasSubmissionForTx(%s,%s) = %v, want %v", tc.token, tc.txid, got, tc.want)
+		}
+	}
+}

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -1127,6 +1127,18 @@ func (s *Store) GetSubmissionsByToken(ctx context.Context, token string) ([]*mod
 	return s.submissions(ctx, "callback_token = $1", token)
 }
 
+// TokenHasSubmissionForTx is an indexed existence probe: keyed on txid
+// first (idx_sub_txid; a txid has a handful of submissions) rather than
+// the token side (idx_sub_token; a token can have millions).
+func (s *Store) TokenHasSubmissionForTx(ctx context.Context, callbackToken, txid string) (bool, error) {
+	const q = `SELECT EXISTS(SELECT 1 FROM submissions WHERE txid = $1 AND callback_token = $2)`
+	var exists bool
+	if err := s.pool.QueryRow(ctx, q, txid, callbackToken).Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
 func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {
 	// Projection only — no raw_tx, no merkle_path, no enrichment. This is
 	// the SSE catchup hot path over potentially millions of submissions.

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -1490,3 +1490,41 @@ func TestIterateStatusesByToken(t *testing.T) {
 		t.Errorf("iteration continued after fn error: %d calls", calls)
 	}
 }
+
+// TestTokenHasSubmissionForTx covers the SSE fan-out membership probe:
+// match, wrong-token, and unknown-txid cases.
+func TestTokenHasSubmissionForTx(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	subs := []*models.Submission{
+		{SubmissionID: "p1", TxID: "tx-probe", CallbackToken: "tok-1", CreatedAt: time.Now()},
+		{SubmissionID: "p2", TxID: "tx-probe", CallbackToken: "tok-2", CreatedAt: time.Now()},
+		{SubmissionID: "p3", TxID: "tx-solo", CallbackToken: "tok-1", CreatedAt: time.Now()},
+	}
+	for _, sub := range subs {
+		if err := s.InsertSubmission(ctx, sub); err != nil {
+			t.Fatalf("insert %s: %v", sub.SubmissionID, err)
+		}
+	}
+
+	cases := []struct {
+		token, txid string
+		want        bool
+	}{
+		{"tok-1", "tx-probe", true},
+		{"tok-2", "tx-probe", true},
+		{"tok-2", "tx-solo", false},  // txid exists, different token
+		{"tok-1", "tx-ghost", false}, // unknown txid
+		{"tok-none", "tx-probe", false},
+	}
+	for _, tc := range cases {
+		got, err := s.TokenHasSubmissionForTx(ctx, tc.token, tc.txid)
+		if err != nil {
+			t.Fatalf("TokenHasSubmissionForTx(%s,%s): %v", tc.token, tc.txid, err)
+		}
+		if got != tc.want {
+			t.Errorf("TokenHasSubmissionForTx(%s,%s) = %v, want %v", tc.token, tc.txid, got, tc.want)
+		}
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -217,6 +217,15 @@ type Store interface {
 	// GetSubmissionsByToken retrieves all submissions for a callback token
 	GetSubmissionsByToken(ctx context.Context, callbackToken string) ([]*models.Submission, error)
 
+	// TokenHasSubmissionForTx reports whether txid has a submission registered
+	// under callbackToken. This is the SSE fan-out hot path — called once per
+	// event per token-filtered client — so implementations MUST resolve it via
+	// the by-txid index (a txid has a handful of submissions) and MUST NOT
+	// materialize the token's submission list: a single token can hold
+	// millions of submissions, and loading them per event is what OOM-killed
+	// the SSE service.
+	TokenHasSubmissionForTx(ctx context.Context, callbackToken, txid string) (bool, error)
+
 	// IterateStatusesByToken streams the current status of every DISTINCT
 	// txid registered under callbackToken through fn, in ascending
 	// status-timestamp order. Rows are PROJECTED for streaming delivery —


### PR DESCRIPTION
## Problem

After v0.9.6 rolled out, US SSE pods went straight back into an OOM crashloop (exit 137, ~30s after start). EU pods on the identical build run clean with 0 restarts.

Diagnosis: v0.9.6's catchup fix worked — and that's exactly what exposed this. The mega-token client (2.26M submissions) now **survives catchup and stays connected into fan-out**, where `Manager.txBelongsToToken` called `GetSubmissionsByToken` on **every fanned-out event**, materializing the token's entire submission list (~500MB of structs) per event inside the 512Mi limit. The pod log timeline matches exactly: startup → catchup completes → `subscriber channel full, dropping update` (the manager's consume loop stalled inside the giant store call) → OOMKilled one second later. EU has no token-filtered clients, so its fan-out never runs the check.

This is the second instance of the same bug class as #237: nothing on a hot path may materialize a mega-token's full submission list.

## Fix

New `store.TokenHasSubmissionForTx(ctx, token, txid)` existence probe, keyed on the **txid side** — a txid has a handful of submissions while a token can have millions:

- postgres: `SELECT EXISTS(SELECT 1 FROM submissions WHERE txid=$1 AND callback_token=$2)` via the existing `idx_sub_txid` (no schema change)
- pebble: by-txid index lookup, token compared over the few rows
- aerospike: txid secondary-index query, same comparison

`txBelongsToToken` uses the probe; interface doc forbids the list-materialization pattern on this path.

## Tests

- `store/pebble` + `store/postgres` (`-tags=postgres`): match / wrong-token / unknown-txid probe cases.
- `services/sse`: the existing token-filter test now exercises the probe path; full suite + `magex lint` green.

## Rollout

Needs a release + flux bump (v0.9.7). Until it lands, the US crashloop stops as soon as the SSE client disconnects; the EU cluster is unaffected.