### PR TITLE
fix(events): subscribe from latest offset — stop full-backlog replay on every pod start

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -175,6 +175,9 @@ health:
 # Going beyond ~65536 just delays the drop rather than addressing the
 # slow-consumer root cause. Memory cost is roughly
 # subscribers × subscriber_buffer × ~500 bytes per slot.
+# Subscribers are live-only: their consumer groups start at the topic head,
+# and history missed while a pod was down recovers via store-backed paths
+# (SSE Last-Event-ID catchup, webhook retry reaper), not Kafka replay.
 # events:
 #   subscriber_buffer: 4096
 

--- a/events/events.go
+++ b/events/events.go
@@ -5,8 +5,10 @@
 // out to clients without depending on which pod the mutation came from.
 //
 // The default backend is Kafka — every Subscribe call mints a unique consumer
-// group so each subscriber receives every event (mirroring the in-memory
-// broadcast semantics of the old arcade's monolithic Publisher).
+// group so each subscriber receives every event published after subscription
+// (mirroring the in-memory broadcast semantics of the old arcade's monolithic
+// Publisher). Groups start at the topic head: subscribers are live-only, and
+// missed history recovers through store-backed paths, never Kafka replay.
 package events
 
 import (

--- a/events/kafka_publisher.go
+++ b/events/kafka_publisher.go
@@ -30,8 +30,11 @@ const dropLogInterval = 5 * time.Second
 // change. Publish JSON-encodes the TransactionStatus and sends it under
 // kafka.TopicStatusUpdate keyed by txid (so updates for the same tx land on
 // the same partition in real Kafka). Subscribe spins up a dedicated
-// consumer group with a random ID — every caller gets every message,
-// regardless of how many other subscribers are running.
+// consumer group with a random ID — every caller gets every message
+// published after it subscribed, regardless of how many other subscribers
+// are running. History is never served from Kafka: subscribers are
+// live-only by contract, and missed events recover through store-backed
+// paths (SSE Last-Event-ID catchup, webhook retry reaper).
 // DefaultSubscriberBuffer is the fallback channel capacity used when
 // NewKafkaPublisher is called with a non-positive subscriberBuffer.
 const DefaultSubscriberBuffer = 4096
@@ -115,9 +118,17 @@ func (p *KafkaPublisher) PublishBulk(ctx context.Context, template *models.Trans
 
 // Subscribe joins a fresh consumer group on TopicStatusUpdate and returns a
 // channel that yields decoded TransactionStatus values until ctx is canceled.
-// The unique groupID guarantees this subscriber sees every message — useful
-// when multiple subscribers (SSE manager + webhook service) coexist in the
-// same process or across pods.
+// The unique groupID guarantees this subscriber sees every message published
+// from subscription time onward — useful when multiple subscribers (SSE
+// manager + webhook service) coexist in the same process or across pods.
+//
+// The group starts at the LATEST offset. A fresh random group with
+// StartOldest silently replays the topic's entire retained backlog on every
+// pod start (~145k messages / >1GB of JSON in a busy deployment — this
+// OOM-crashlooped the 512Mi sse pods) and delivers stale duplicates to any
+// client connected mid-replay. Subscribers here are live-only by contract:
+// history belongs to the store (SSE Last-Event-ID catchup, webhook reaper),
+// never to Kafka replay.
 //
 // caller is a low-cardinality identifier (e.g. "sse", "webhook") used as a
 // Prometheus label on EventsSubscriberDroppedTotal so an operator can tell
@@ -151,6 +162,10 @@ func (p *KafkaPublisher) Subscribe(ctx context.Context, caller string) (<-chan *
 		Broker:  p.producer.Broker(),
 		GroupID: groupID,
 		Topics:  []string{kafka.TopicStatusUpdate},
+		// Live-only: see the Subscribe doc comment. Never StartOldest here —
+		// a random per-process group has no committed offsets, so oldest
+		// means a full backlog replay on every single pod start.
+		StartOffset: kafka.StartLatest,
 		Handler: func(ctx context.Context, msg *kafka.Message) error {
 			var status models.TransactionStatus
 			if jsonErr := json.Unmarshal(msg.Value, &status); jsonErr != nil {
@@ -232,7 +247,8 @@ type kafkaSubscription struct {
 
 // uniqueGroupID returns a per-call group identifier. Used so each Subscribe
 // gets its own consumer group, which in turn guarantees every subscriber
-// sees every message (the broker fans out across distinct groups).
+// sees every message published after it joined (the broker fans out across
+// distinct groups; each group starts at the topic head — see Subscribe).
 func uniqueGroupID() (string, error) {
 	var b [12]byte
 	if _, err := rand.Read(b[:]); err != nil {

--- a/kafka/broker.go
+++ b/kafka/broker.go
@@ -27,7 +27,12 @@ type Broker interface {
 	// receives each message once across all its subscriptions (standard Kafka
 	// consumer-group semantics). The returned Subscription is driven by calling
 	// its Consume method.
-	Subscribe(groupID string, topics []string) (Subscription, error)
+	//
+	// start selects where the group begins when it has NO committed offsets;
+	// once the group commits, the stored offset always wins. See StartOffset
+	// for when each value is appropriate. The memory broker retains nothing,
+	// so every subscription there is inherently StartLatest.
+	Subscribe(groupID string, topics []string, start StartOffset) (Subscription, error)
 
 	// PartitionCount reports how many partitions the given topic has. Returns
 	// ErrTopicNotFound if the topic does not exist on the broker. Memory-backed
@@ -40,6 +45,24 @@ type Broker interface {
 	// calls return an error.
 	Close() error
 }
+
+// StartOffset selects where a consumer group with NO committed offsets
+// begins. It is consulted only before the group's first commit (Sarama's
+// Consumer.Offsets.Initial semantics); after that the stored offset wins,
+// so durable groups are unaffected by the choice on redeploys.
+//
+//   - StartOldest (zero value): full retained history. Correct for durable
+//     stable-group consumers (propagation, bump-builder) that must not skip
+//     unprocessed messages on first deployment.
+//   - StartLatest: head of topic. Correct for ephemeral per-process groups
+//     (events subscribers) whose backlog is pure waste: replaying it burns
+//     memory/CPU on every pod start and delivers stale duplicates.
+type StartOffset int
+
+const (
+	StartOldest StartOffset = iota
+	StartLatest
+)
 
 // ErrTopicNotFound is returned by PartitionCount when the topic does not exist.
 var ErrTopicNotFound = brokerSentinelError("topic not found")

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -75,6 +75,12 @@ type ConsumerConfig struct {
 	// per-partition state in local variables without any cross-goroutine
 	// synchronization.
 	ClaimHandler ClaimHandler
+	// StartOffset selects where the group begins when it has no committed
+	// offsets. The zero value (StartOldest) is correct for durable
+	// stable-group consumers that must not skip history on first deployment;
+	// ephemeral random-group subscribers should set StartLatest so a fresh
+	// pod doesn't replay the topic's entire retained backlog.
+	StartOffset StartOffset
 }
 
 func NewConsumerGroup(cfg ConsumerConfig) (*ConsumerGroup, error) {
@@ -88,7 +94,7 @@ func NewConsumerGroup(cfg ConsumerConfig) (*ConsumerGroup, error) {
 	if cfg.Handler == nil && cfg.ClaimHandler == nil {
 		return nil, fmt.Errorf("ConsumerConfig: either Handler or ClaimHandler must be set")
 	}
-	sub, err := cfg.Broker.Subscribe(cfg.GroupID, cfg.Topics)
+	sub, err := cfg.Broker.Subscribe(cfg.GroupID, cfg.Topics, cfg.StartOffset)
 	if err != nil {
 		return nil, fmt.Errorf("subscribing: %w", err)
 	}

--- a/kafka/memory_broker.go
+++ b/kafka/memory_broker.go
@@ -203,7 +203,10 @@ func (b *memoryBroker) publish(ctx context.Context, topic, key string, value []b
 	return nil
 }
 
-func (b *memoryBroker) Subscribe(groupID string, topics []string) (Subscription, error) {
+// Subscribe ignores the StartOffset parameter: the memory broker retains
+// nothing, so every subscription is inherently StartLatest — only messages
+// published while a mailbox exists are ever delivered.
+func (b *memoryBroker) Subscribe(groupID string, topics []string, _ StartOffset) (Subscription, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.closed {

--- a/kafka/memory_broker_test.go
+++ b/kafka/memory_broker_test.go
@@ -17,7 +17,7 @@ func TestMemoryBroker_PublishSubscribe(t *testing.T) {
 	b := NewMemoryBroker(16)
 	defer func() { _ = b.Close() }()
 
-	sub, err := b.Subscribe("group-a", []string{"topic-x"})
+	sub, err := b.Subscribe("group-a", []string{"topic-x"}, StartOldest)
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestMemoryBroker_MultipleGroupsBroadcast(t *testing.T) {
 	wg.Add(2)
 
 	start := func(groupID string, counter *atomic.Int32) {
-		sub, err := b.Subscribe(groupID, []string{"fanout"})
+		sub, err := b.Subscribe(groupID, []string{"fanout"}, StartOldest)
 		if err != nil {
 			t.Errorf("subscribe %s: %v", groupID, err)
 			return
@@ -193,7 +193,7 @@ func TestMemoryBroker_CloseRacePublish(t *testing.T) {
 		const numGroups = 8
 		subs := make([]Subscription, 0, numGroups)
 		for g := 0; g < numGroups; g++ {
-			s, err := b.Subscribe(fmt.Sprintf("g-%d", g), []string{"race"})
+			s, err := b.Subscribe(fmt.Sprintf("g-%d", g), []string{"race"}, StartOldest)
 			if err != nil {
 				t.Fatalf("subscribe: %v", err)
 			}
@@ -280,7 +280,7 @@ func TestMemoryBroker_CloseAfterAllowsNewSendsToFail(t *testing.T) {
 	if err := b.SendBatch(context.Background(), "t", []KeyValue{{Key: "k", Value: "v"}}); err == nil {
 		t.Errorf("expected error batch-sending to closed broker, got nil")
 	}
-	if _, err := b.Subscribe("g", []string{"t"}); err == nil {
+	if _, err := b.Subscribe("g", []string{"t"}, StartOldest); err == nil {
 		t.Errorf("expected error subscribing to closed broker, got nil")
 	}
 
@@ -298,7 +298,7 @@ func TestMemoryBroker_CloseAfterAllowsNewSendsToFail(t *testing.T) {
 func TestMemoryBroker_SlowSubscriberDoesNotBlockClose(t *testing.T) {
 	b := NewMemoryBroker(2) // tiny buffer so we can fill it fast
 
-	sub, err := b.Subscribe("slow", []string{"t"})
+	sub, err := b.Subscribe("slow", []string{"t"}, StartOldest)
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -361,7 +361,7 @@ func TestMemoryBroker_SendTimeoutBackpressure(t *testing.T) {
 	// drains the per-(group, topic) mailbox into a merged channel of equal
 	// capacity, so the total slack between the producer's Send and a stuck
 	// consumer is 2 * buffer + 1 (one in-flight in forward).
-	sub, err := b.Subscribe("group-stall", []string{"topic-stall"})
+	sub, err := b.Subscribe("group-stall", []string{"topic-stall"}, StartOldest)
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
@@ -385,5 +385,78 @@ func TestMemoryBroker_SendTimeoutBackpressure(t *testing.T) {
 	}
 	if elapsed < 40*time.Millisecond || elapsed > 500*time.Millisecond {
 		t.Errorf("expected ~50ms backpressure wait, got %v", elapsed)
+	}
+}
+
+// TestMemoryBroker_SubscribeIsLiveOnly locks in the semantics the
+// StartOffset design leans on: the memory broker retains nothing, so a
+// subscription only ever sees messages published while its mailbox exists —
+// regardless of the StartOffset requested. Messages published before
+// Subscribe are gone for good.
+func TestMemoryBroker_SubscribeIsLiveOnly(t *testing.T) {
+	for _, start := range []StartOffset{StartOldest, StartLatest} {
+		t.Run(fmt.Sprintf("start=%d", start), func(t *testing.T) {
+			b := NewMemoryBroker(16)
+			defer func() { _ = b.Close() }()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			// Publish history with no subscriber — must never be delivered.
+			// SendAsync (not Send) because with no mailbox Send has nowhere
+			// to deliver; either way the message is dropped, which is the
+			// semantics under test.
+			for i := 0; i < 3; i++ {
+				if err := b.SendAsync(ctx, "live-only", "k", []byte(fmt.Sprintf("history-%d", i))); err != nil {
+					t.Fatalf("send history: %v", err)
+				}
+			}
+
+			sub, err := b.Subscribe("group-live", []string{"live-only"}, start)
+			if err != nil {
+				t.Fatalf("subscribe: %v", err)
+			}
+			defer func() { _ = sub.Close() }()
+
+			received := make(chan *Message, 8)
+			go func() {
+				_ = sub.Consume(ctx, func(claim Claim) error {
+					for {
+						select {
+						case msg, ok := <-claim.Messages():
+							if !ok {
+								return nil
+							}
+							received <- msg
+						case <-claim.Context().Done():
+							return nil
+						}
+					}
+				})
+			}()
+
+			// Give the consumer a moment to engage before publishing live.
+			time.Sleep(10 * time.Millisecond)
+
+			if err := b.Send(ctx, "live-only", "k", []byte("live")); err != nil {
+				t.Fatalf("send live: %v", err)
+			}
+
+			select {
+			case msg := <-received:
+				if string(msg.Value) != "live" {
+					t.Fatalf("first delivered message = %q, want %q — pre-subscription history leaked", msg.Value, "live")
+				}
+			case <-ctx.Done():
+				t.Fatal("timed out waiting for live message")
+			}
+
+			// Nothing else may arrive: history must not trickle in late.
+			select {
+			case msg := <-received:
+				t.Fatalf("unexpected extra message %q — pre-subscription history leaked", msg.Value)
+			case <-time.After(50 * time.Millisecond):
+			}
+		})
 	}
 }

--- a/kafka/partitions_test.go
+++ b/kafka/partitions_test.go
@@ -17,7 +17,7 @@ type stubPartitionBroker struct {
 	err    error
 }
 
-func (b *stubPartitionBroker) Subscribe(string, []string) (Subscription, error) {
+func (b *stubPartitionBroker) Subscribe(string, []string, StartOffset) (Subscription, error) {
 	panic("stubPartitionBroker: Subscribe not implemented")
 }
 

--- a/kafka/sarama_broker.go
+++ b/kafka/sarama_broker.go
@@ -270,16 +270,28 @@ func buildRecordHeaders(hdrs map[string][]byte) []sarama.RecordHeader {
 	return rh
 }
 
-func (b *saramaBroker) Subscribe(groupID string, topics []string) (Subscription, error) {
-	saramaCfg := sarama.NewConfig()
-	saramaCfg.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.NewBalanceStrategyRoundRobin()}
-	saramaCfg.Consumer.Offsets.Initial = sarama.OffsetOldest
-
-	group, err := sarama.NewConsumerGroup(b.brokers, groupID, saramaCfg)
+func (b *saramaBroker) Subscribe(groupID string, topics []string, start StartOffset) (Subscription, error) {
+	group, err := sarama.NewConsumerGroup(b.brokers, groupID, newSaramaConsumerConfig(start))
 	if err != nil {
 		return nil, fmt.Errorf("creating consumer group %s: %w", groupID, err)
 	}
 	return &saramaSubscription{group: group, topics: topics}, nil
+}
+
+// newSaramaConsumerConfig maps the broker-neutral StartOffset onto Sarama's
+// Consumer.Offsets.Initial. Initial is only consulted when the group has no
+// committed offsets, so durable stable-group consumers are unaffected by it
+// after their first commit; for fresh random groups it decides between
+// replaying the topic's entire retained backlog (OffsetOldest) and starting
+// at the head (OffsetNewest).
+func newSaramaConsumerConfig(start StartOffset) *sarama.Config {
+	saramaCfg := sarama.NewConfig()
+	saramaCfg.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.NewBalanceStrategyRoundRobin()}
+	saramaCfg.Consumer.Offsets.Initial = sarama.OffsetOldest
+	if start == StartLatest {
+		saramaCfg.Consumer.Offsets.Initial = sarama.OffsetNewest
+	}
+	return saramaCfg
 }
 
 func (b *saramaBroker) PartitionCount(topic string) (int, error) {

--- a/kafka/sarama_broker_test.go
+++ b/kafka/sarama_broker_test.go
@@ -180,3 +180,29 @@ func TestSaramaBroker_Close_WaitsForDrainers(t *testing.T) {
 		t.Fatal("drainer goroutines leaked past Close()")
 	}
 }
+
+// TestNewSaramaConsumerConfig_StartOffset pins the StartOffset →
+// Consumer.Offsets.Initial mapping. This is the primary guard for the
+// live-only events-subscriber contract: sarama consumer groups aren't
+// mockable, so the config seam is the closest unit-testable point. A
+// regression back to OffsetOldest for StartLatest callers silently
+// reintroduces the full-backlog replay that OOM-crashlooped the sse pods.
+func TestNewSaramaConsumerConfig_StartOffset(t *testing.T) {
+	tests := []struct {
+		name  string
+		start StartOffset
+		want  int64
+	}{
+		{name: "zero value defaults to oldest", start: StartOldest, want: sarama.OffsetOldest},
+		{name: "latest maps to newest", start: StartLatest, want: sarama.OffsetNewest},
+		{name: "out-of-range values fall back to oldest", start: StartOffset(42), want: sarama.OffsetOldest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newSaramaConsumerConfig(tt.start)
+			if got := cfg.Consumer.Offsets.Initial; got != tt.want {
+				t.Errorf("Consumer.Offsets.Initial = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/kafka/testing.go
+++ b/kafka/testing.go
@@ -77,7 +77,7 @@ func (b *RecordingBroker) SendBatch(_ context.Context, _ string, msgs []KeyValue
 
 // Subscribe is not implemented — callers that need real delivery should use
 // NewMemoryBroker instead.
-func (b *RecordingBroker) Subscribe(string, []string) (Subscription, error) {
+func (b *RecordingBroker) Subscribe(string, []string, StartOffset) (Subscription, error) {
 	panic("RecordingBroker: Subscribe not supported — use NewMemoryBroker for consume tests")
 }
 

--- a/services/sse/manager.go
+++ b/services/sse/manager.go
@@ -50,11 +50,14 @@ type Client struct {
 // every update out to every registered client. New clients register at
 // /events connect time; deregister on disconnect.
 //
+// The subscription is live-only (it starts at the topic head): anything a
+// client missed while disconnected is served from the store by sendCatchup
+// via Last-Event-ID, never by Kafka replay.
+//
 // Token-based filtering happens in the fan-out path: every event is
-// checked against each client's token via store.GetSubmissionsByToken.
-// The implementation is O(clients × submissions) per event, which is
-// acceptable for the workloads this service targets; a follow-up could
-// cache token→txid mappings if hot.
+// checked against each client's token via the indexed existence probe
+// store.TokenHasSubmissionForTx — O(1)-ish per (event, client). Nothing on
+// this path may materialize a token's full submission list (see #237/#238).
 type Manager struct {
 	publisher events.Publisher
 	store     store.Store

--- a/services/webhook/service.go
+++ b/services/webhook/service.go
@@ -234,11 +234,13 @@ func (s *Service) Start(ctx context.Context) error {
 			default:
 				// Pool saturated — every worker is blocked on a slow
 				// callback and the work queue is full. Drop with metric;
-				// the lost update is recoverable via the durable Kafka
-				// offset on reconnect, and we'd rather drop here than
-				// back-pressure the upstream subscriber channel (which
-				// would multiply the impact across this and other
-				// subscribers in the same publisher).
+				// recovery is store-backed (failed-POST retries via
+				// NextRetryAt swept by the reaper, plus CAS dedup gating on
+				// the next transition), NOT Kafka replay — the subscription
+				// is an ephemeral random group with no durable offsets. We'd
+				// rather drop here than back-pressure the upstream subscriber
+				// channel (which would multiply the impact across this and
+				// other subscribers in the same publisher).
 				metrics.WebhookPoolSaturatedTotal.Inc()
 				s.logger.Warn(
 					"webhook delivery pool saturated, dropping status",

--- a/tests/e2e/kafka_offsets_test.go
+++ b/tests/e2e/kafka_offsets_test.go
@@ -1,0 +1,163 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/redpanda"
+
+	"github.com/bsv-blockchain/arcade/kafka"
+)
+
+// TestKafkaStartOffset proves the StartOffset contract against real Kafka
+// semantics (redpanda), which the memory broker cannot express:
+//
+//   - StartLatest: a fresh random consumer group never receives messages
+//     published before it subscribed — the exact property that stops sse
+//     pods from replaying the topic's entire retained backlog (and OOMing)
+//     on every start.
+//   - StartOldest (zero value): a fresh group receives the full retained
+//     history, which durable stable-group consumers (propagation,
+//     bump-builder) rely on for their pre-first-commit deployment.
+//
+// Only the redpanda container is started — not the full harness — so the
+// test stays cheap enough to run alongside the smoke tests.
+func TestKafkaStartOffset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping container-backed test in -short mode")
+	}
+	provider, err := testcontainers.NewDockerProvider()
+	if err != nil {
+		t.Skipf("no container runtime reachable (NewDockerProvider): %v", err)
+	}
+	if err := provider.Health(context.Background()); err != nil {
+		t.Skipf("container runtime not healthy: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	rp, err := redpanda.Run(
+		ctx,
+		"docker.redpanda.com/redpandadata/redpanda:v26.1.9",
+		redpanda.WithAutoCreateTopics(),
+	)
+	if err != nil {
+		t.Fatalf("start redpanda: %v", err)
+	}
+	t.Cleanup(func() { _ = rp.Terminate(context.Background()) })
+
+	seed, err := rp.KafkaSeedBroker(ctx)
+	if err != nil {
+		t.Fatalf("seed broker: %v", err)
+	}
+
+	broker, err := kafka.NewSaramaBroker([]string{seed}, "e2e-offsets")
+	if err != nil {
+		t.Fatalf("new broker: %v", err)
+	}
+	t.Cleanup(func() { _ = broker.Close() })
+
+	t.Run("StartLatest skips pre-subscription history", func(t *testing.T) {
+		const topic = "offsets.latest"
+		const history = 25
+
+		for i := 0; i < history; i++ {
+			if err := broker.Send(ctx, topic, "k", []byte(fmt.Sprintf("history-%d", i))); err != nil {
+				t.Fatalf("send history: %v", err)
+			}
+		}
+
+		first := consumeFirst(ctx, t, broker, topic, "latest-group", kafka.StartLatest, func(stop <-chan struct{}) {
+			// Publish sentinels until the consumer observes one. The loop
+			// (rather than a single send) absorbs the group-join window:
+			// OffsetNewest pins the group to the head at join time, and any
+			// sentinel published after that is delivered. If ANY history
+			// message were delivered it would necessarily arrive before the
+			// first sentinel, so checking the first message is sufficient.
+			ticker := time.NewTicker(200 * time.Millisecond)
+			defer ticker.Stop()
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				case <-ticker.C:
+					_ = broker.Send(ctx, topic, "k", []byte(fmt.Sprintf("sentinel-%d", i)))
+				}
+			}
+		})
+
+		if len(first) < len("sentinel-") || string(first[:len("sentinel-")]) != "sentinel-" {
+			t.Fatalf("first delivered message = %q — pre-subscription history replayed under StartLatest", first)
+		}
+	})
+
+	t.Run("StartOldest replays full history", func(t *testing.T) {
+		const topic = "offsets.oldest"
+
+		if err := broker.Send(ctx, topic, "k", []byte("history-0")); err != nil {
+			t.Fatalf("send history: %v", err)
+		}
+
+		first := consumeFirst(ctx, t, broker, topic, "oldest-group", kafka.StartOldest, nil)
+		if string(first) != "history-0" {
+			t.Fatalf("first delivered message = %q, want history-0 — StartOldest lost pre-subscription history", first)
+		}
+	})
+}
+
+// consumeFirst subscribes with the given StartOffset and returns the value of
+// the first message delivered. If background is non-nil it runs concurrently
+// (e.g. a sentinel publisher) and is stopped once the first message lands.
+func consumeFirst(ctx context.Context, t *testing.T, broker kafka.Broker, topic, group string, start kafka.StartOffset, background func(stop <-chan struct{})) []byte {
+	t.Helper()
+
+	sub, err := broker.Subscribe(group, []string{topic}, start)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	t.Cleanup(func() { _ = sub.Close() })
+
+	consumeCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	received := make(chan []byte, 1)
+	go func() {
+		_ = sub.Consume(consumeCtx, func(claim kafka.Claim) error {
+			for {
+				select {
+				case msg, ok := <-claim.Messages():
+					if !ok {
+						return nil
+					}
+					select {
+					case received <- msg.Value:
+					default: // only the first message matters
+					}
+					return nil
+				case <-claim.Context().Done():
+					return nil
+				}
+			}
+		})
+	}()
+
+	if background != nil {
+		stop := make(chan struct{})
+		defer close(stop)
+		go background(stop)
+	}
+
+	select {
+	case v := <-received:
+		return v
+	case <-consumeCtx.Done():
+		t.Fatalf("timed out waiting for first message on %s (group %s)", topic, group)
+		return nil
+	}
+}


### PR DESCRIPTION
## Problem

v0.9.7 (with #237 + #238) still OOM-crashlooped the US SSE pods: both fresh pods were OOMKilled 1–2× within ~30–50s of the 19:07Z rollout, logging **nothing** after `SSE service listening` — no connection, no catchup, no channel-full warn. The prior fixes both require a connected client; this failure fires with zero clients.

**Root cause — third instance of the same bug class.** Every `events.Subscribe` mints a fresh random consumer group (`uniqueGroupID`), and the sarama broker globally set `Consumer.Offsets.Initial = OffsetOldest`. A brand-new group has no committed offsets, so **every SSE pod start silently replayed the entire retained `arcade.tx_status` backlog** — measured live on bsva-us-1: 16 partitions × ~9k retained messages ≈ **145k messages, ~7–11KB avg ≈ >1GB of JSON** — through `json.Unmarshal` + the ×5000 bulk unfan, under 500m CPU / 512Mi with no `GOMEMLIMIT`. Whether the GC wins that race is a coin flip: Coralogix shows fresh pods ramping 121→299Mi within a minute, dying between scrapes, and survivors settling at ~30Mi. The dozens of dead `arcade-events-<hash>` groups on redpanda corroborate. EU never OOMs only because its backlog is small.

The replay is pure waste: these subscribers are live-only by contract — SSE catchup is store-served via Last-Event-ID (#237), webhook recovery is the `NextRetryAt` reaper + CAS dedup. It's also a correctness wart: a client connected mid-replay receives ancient duplicate events.

## Fix

New `kafka.StartOffset` enum plumbed through `Broker.Subscribe` / `ConsumerConfig`; `events.KafkaPublisher.Subscribe` requests `StartLatest` (→ `sarama.OffsetNewest`).

| Consumer | Group | Start |
|---|---|---|
| SSE manager | random per pod | **latest** |
| Webhook service | random per pod | **latest** |
| Propagation | stable `<cg>-propagation` | oldest (unchanged, zero value) |
| Bump-builder | stable `<cg>-bump-builder` | oldest (unchanged, zero value) |

`Offsets.Initial` is only consulted before a group's first commit, so the durable stable-group consumers are unaffected. The memory broker retains nothing and documents the param as an inherent no-op. Stale doc comments fixed along the way (webhook's "durable Kafka offset" claim; manager's `GetSubmissionsByToken` reference).

## Tests

- `kafka`: sarama config mapping table test; memory-broker live-only test.
- `tests/e2e/kafka_offsets_test.go` (redpanda testcontainer, lean — no full harness): `StartLatest` group's first delivered message is post-subscription (never one of 25 pre-published history messages); `StartOldest` group receives history. **Verified locally against a real redpanda: both subtests pass in ~15s.**
- Full suite + `magex lint` green.

## Known trade-off

Webhook events published while **all** webhook-hosting pods are simultaneously down are no longer accidentally recovered by replay (a missed transition now only delivers when a later transition for that tx arrives). Multi-replica rolling deploys keep ≥1 subscribed pod, so exposure is full-fleet outages. Principled follow-up: a stable shared consumer group for webhook.

## Rollout

Needs a release (v0.9.8) + flux bump. Complementary defense-in-depth already open: bsva-infra-flux#247 (`GOMEMLIMIT=400MiB` on sse).