### PR TITLE
fix(metrics): pre-register vec children so post-rollout bursts survive increase()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/testcontainers/testcontainers-go v0.43.0
@@ -257,7 +258,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/polydawn/refmt v0.90.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.69.0 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect

--- a/metrics/preregister.go
+++ b/metrics/preregister.go
@@ -1,0 +1,36 @@
+package metrics
+
+import "github.com/bsv-blockchain/arcade/models"
+
+// Vec children (labeled series) only come into existence on their first
+// observation. A series born between two scrapes starts at its burst value,
+// and PromQL increase()/rate() can never count anything before a series'
+// first sample — so every deploy or pod restart silently swallowed the first
+// burst per label pair (a single block marking hundreds of txs MINED
+// registered as ~0 on dashboards). Services call these helpers at
+// construction time so every series they can emit is exported at 0 from the
+// first scrape.
+
+// PreRegisterStatusTransitions instantiates the StatusTransitionAge children
+// for every lattice-valid (from → to) pair of the given target statuses.
+// Each service passes only the transitions it actually observes to keep the
+// exported-series count bounded per pod.
+func PreRegisterStatusTransitions(tos ...models.Status) {
+	for _, to := range tos {
+		for _, from := range models.AllStatuses() {
+			if to.CanTransitionFrom(from) {
+				StatusTransitionAge.WithLabelValues(string(from), string(to))
+			}
+		}
+	}
+}
+
+// PreRegisterTxSubmissions instantiates every {route, result} child of
+// APITxsSubmittedTotal. The api-server calls this at construction time.
+func PreRegisterTxSubmissions() {
+	for _, route := range []string{"/tx", "/txs"} {
+		for _, result := range []string{"new", "duplicate", "retry_rejected"} {
+			APITxsSubmittedTotal.WithLabelValues(route, result)
+		}
+	}
+}

--- a/metrics/preregister_test.go
+++ b/metrics/preregister_test.go
@@ -1,0 +1,98 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// gatherFamily returns the MetricFamily with the given name from the default
+// registry, or nil if no series for it exist yet.
+func gatherFamily(t *testing.T, name string) *dto.MetricFamily {
+	t.Helper()
+	fams, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, f := range fams {
+		if f.GetName() == name {
+			return f
+		}
+	}
+	return nil
+}
+
+// labelValue extracts a label value from a metric, or "" if absent.
+func labelValue(m *dto.Metric, name string) string {
+	for _, lp := range m.GetLabel() {
+		if lp.GetName() == name {
+			return lp.GetValue()
+		}
+	}
+	return ""
+}
+
+func TestPreRegisterStatusTransitionsCreatesLatticeValidChildrenAtZero(t *testing.T) {
+	PreRegisterStatusTransitions(models.StatusMined)
+
+	fam := gatherFamily(t, "arcade_status_transition_age_seconds")
+	if fam == nil {
+		t.Fatal("arcade_status_transition_age_seconds has no series after pre-registration")
+	}
+
+	found := map[[2]string]*dto.Metric{}
+	for _, m := range fam.GetMetric() {
+		found[[2]string{labelValue(m, "from"), labelValue(m, "to")}] = m
+	}
+
+	// Every lattice-valid predecessor of MINED must exist as a child. Pairs
+	// no other test observes must sit at zero — proving they were created by
+	// pre-registration, not by an observation.
+	for _, from := range []models.Status{
+		models.StatusStumpProcessing, models.StatusPendingRetry,
+		models.StatusSeenMultipleNodes, models.StatusReceived,
+	} {
+		m, ok := found[[2]string{string(from), string(models.StatusMined)}]
+		if !ok {
+			t.Errorf("child series {from=%s,to=MINED} not pre-registered", from)
+			continue
+		}
+		if got := m.GetHistogram().GetSampleCount(); got != 0 {
+			t.Errorf("child {from=%s,to=MINED} sample count = %d, want 0", from, got)
+		}
+	}
+
+	// Lattice-disallowed pairs must NOT be fabricated.
+	if _, ok := found[[2]string{string(models.StatusImmutable), string(models.StatusMined)}]; ok {
+		t.Error("child {from=IMMUTABLE,to=MINED} was pre-registered but IMMUTABLE→MINED is lattice-disallowed")
+	}
+}
+
+func TestPreRegisterTxSubmissionsCreatesAllRouteResultChildrenAtZero(t *testing.T) {
+	PreRegisterTxSubmissions()
+
+	fam := gatherFamily(t, "arcade_api_txs_submitted_total")
+	if fam == nil {
+		t.Fatal("arcade_api_txs_submitted_total has no series after pre-registration")
+	}
+
+	found := map[[2]string]*dto.Metric{}
+	for _, m := range fam.GetMetric() {
+		found[[2]string{labelValue(m, "route"), labelValue(m, "result")}] = m
+	}
+
+	for _, route := range []string{"/tx", "/txs"} {
+		for _, result := range []string{"new", "duplicate", "retry_rejected"} {
+			m, ok := found[[2]string{route, result}]
+			if !ok {
+				t.Errorf("child series {route=%s,result=%s} not pre-registered", route, result)
+				continue
+			}
+			if got := m.GetCounter().GetValue(); got != 0 {
+				t.Errorf("child {route=%s,result=%s} = %v, want 0", route, result, got)
+			}
+		}
+	}
+}

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -100,6 +100,18 @@ const (
 	StatusImmutable = Status("IMMUTABLE")
 )
 
+// AllStatuses returns every defined Status, in lifecycle order. Callers that
+// enumerate the status domain (metric pre-registration, exhaustive lattice
+// checks) use this instead of maintaining their own copy of the const block.
+func AllStatuses() []Status {
+	return []Status{
+		StatusUnknown, StatusReceived, StatusSentToNetwork,
+		StatusAcceptedByNetwork, StatusSeenOnNetwork, StatusSeenMultipleNodes,
+		StatusDoubleSpendAttempted, StatusRejected, StatusPendingRetry,
+		StatusStumpProcessing, StatusMined, StatusImmutable,
+	}
+}
+
 // terminalStatuses lists statuses that represent a final outcome for a
 // transaction. A row already in one of these states must never be overwritten
 // by a lower-priority update (e.g. a late SEEN_ON_NETWORK callback arriving

--- a/services/api_server/server.go
+++ b/services/api_server/server.go
@@ -74,6 +74,11 @@ type submissionRecord struct {
 }
 
 func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publisher events.Publisher, st store.Store, tracker *store.TxTracker, tc *teranode.Client, mc *merkleservice.Client, val *validator.Validator) *Server {
+	// Export every series this service can emit at 0 from the first scrape —
+	// a series born mid-burst is invisible to increase() until its second
+	// sample, which undercounted submissions after every rollout.
+	metrics.PreRegisterTxSubmissions()
+	metrics.PreRegisterStatusTransitions(models.StatusSeenOnNetwork, models.StatusSeenMultipleNodes)
 	return &Server{
 		cfg:            cfg,
 		logger:         logger.Named("api-server"),

--- a/services/bump_builder/builder.go
+++ b/services/bump_builder/builder.go
@@ -72,6 +72,11 @@ func New(
 	teranodeClient *teranode.Client,
 	chainHeader ChainHeaderReader,
 ) *Builder {
+	// Export every series this service can emit at 0 from the first scrape —
+	// a series born mid-burst is invisible to increase() until its second
+	// sample, which made a whole block's MINED transitions vanish from
+	// dashboards after every rollout.
+	metrics.PreRegisterStatusTransitions(models.StatusMined)
 	return &Builder{
 		cfg:         cfg,
 		logger:      logger.Named("bump-builder"),

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -231,6 +231,10 @@ const defaultMaxParallelChunks = 4
 // don't need coordination. In production every replica should receive a
 // non-nil Leaser so only one reaper is active at a time across the cluster.
 func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publisher events.Publisher, st store.Store, leaser store.Leaser, tc *teranode.Client, mc *merkleservice.Client) *Propagator {
+	// Export every series this service can emit at 0 from the first scrape —
+	// a series born mid-burst is invisible to increase() until its second
+	// sample, which zeroed the REJECTED count after every rollout.
+	metrics.PreRegisterStatusTransitions(models.StatusAcceptedByNetwork, models.StatusRejected)
 	merkleConcurrency := cfg.Propagation.MerkleConcurrency
 	if merkleConcurrency <= 0 {
 		merkleConcurrency = 10


### PR DESCRIPTION
## Problem

Prometheus vec children are created lazily on first observation. A series born between two scrapes starts at its burst value, and PromQL `increase()`/`rate()` can never count anything before a series' first sample. Every deploy recreates all children, so the first burst per label pair vanishes from dashboards.

Observed on mainnet (2026-07-09): a rollout at 19:09 UTC recreated all series; block 957149 marked 308 tracked txs MINED at 19:21, but `arcade_status_transition_age_seconds_count{to="MINED"}` was born at 307 and registered as ~1 on the Coralogix dashboards. The plain counter `arcade_bump_builder_txids_mined_total` (registered at 0 from process start) counted all 308 — confirming the mechanism. Submissions undercounted the same way on fresh api-server pods (~30 of ~500 lost).

## Fix

- `metrics.PreRegisterStatusTransitions(tos ...models.Status)` — instantiates the lattice-valid `(from → to)` children of `arcade_status_transition_age_seconds`. Called from each emitting service's constructor with only the transitions it observes, keeping added series bounded per pod:
  - api-server: `SEEN_ON_NETWORK`, `SEEN_MULTIPLE_NODES`
  - propagation: `ACCEPTED_BY_NETWORK`, `REJECTED`
  - bump-builder: `MINED`
- `metrics.PreRegisterTxSubmissions()` — instantiates all `{route, result}` children of `arcade_api_txs_submitted_total` (api-server).
- `models.AllStatuses()` — single source of truth for enumerating the status domain.

Companion dashboard change (count MINED from the plain counter): bsv-blockchain/bsva-infra-flux#243.

## Testing

- New `metrics/preregister_test.go`: children exist at 0 after pre-registration (proving creation, not observation); lattice-disallowed pairs (e.g. `IMMUTABLE→MINED`) are not fabricated; all 6 `{route, result}` submission children present at 0.
- `go test ./...` green, `golangci-lint run` clean.