### PR TITLE
fix(p2p): DNS-validate discovered DataHub URLs; probe all endpoints for truthful health

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -487,6 +487,12 @@ func (a chaintracksHeaderReader) GetHeaderByHash(ctx context.Context, hash *chai
 // every tick so a row whose DNS recovers is admitted within one interval.
 const endpointSourceValidationTTL = 5 * time.Minute
 
+// endpointSourceValidationCacheMax bounds the validation cache. Discovered
+// registry rows originate from untrusted p2p announcements; the cap keeps a
+// registry flooded with unique URLs from growing process memory without
+// bound. Far above the size of any real datahub fleet.
+const endpointSourceValidationCacheMax = 512
+
 // endpointSourceLookupTimeout bounds each DNS lookup during refresh so a
 // dead resolver cannot wedge the refresh tick (the synchronous first
 // refresh in teranode.Client.Start is separately capped, and lookups
@@ -524,10 +530,13 @@ type endpointSource struct {
 	// lookupIP is the DNS seam; nil is never stored — newEndpointSource
 	// installs the bounded default.
 	lookupIP func(ctx context.Context, host string) ([]net.IP, error)
-	// validated caches URLs that passed validation (URL → expiry UnixNano).
-	validated sync.Map
+	// validated caches URLs that passed validation. Bounded — see
+	// endpointSourceValidationCacheMax.
+	validated *ssrfguard.SuccessCache
 	// warned tracks URLs already logged at WARN so each rejected row logs
 	// loudly once per process and quietly (DEBUG) on the ~30s re-checks.
+	// Pruned against every listing, so it is bounded by the registry's
+	// current row count rather than by everything ever seen.
 	warnedMu sync.Mutex
 	warned   map[string]struct{}
 	logger   *zap.Logger
@@ -539,6 +548,7 @@ func newEndpointSource(st datahubLister, network string, includeDiscovered, allo
 		network:           network,
 		includeDiscovered: includeDiscovered,
 		allowPrivate:      allowPrivate,
+		validated:         ssrfguard.NewSuccessCache(endpointSourceValidationTTL, endpointSourceValidationCacheMax),
 		warned:            map[string]struct{}{},
 		logger:            logger,
 		lookupIP: func(ctx context.Context, host string) ([]net.IP, error) {
@@ -554,8 +564,10 @@ func (a *endpointSource) ListEndpointURLs(ctx context.Context) ([]string, error)
 	if err != nil {
 		return nil, err
 	}
+	current := make(map[string]struct{}, len(eps))
 	out := make([]string, 0, len(eps))
 	for _, ep := range eps {
+		current[ep.URL] = struct{}{}
 		if ep.Source == store.DatahubEndpointSourceDiscovered {
 			if !a.includeDiscovered {
 				continue
@@ -566,17 +578,28 @@ func (a *endpointSource) ListEndpointURLs(ctx context.Context) ([]string, error)
 		}
 		out = append(out, ep.URL)
 	}
+	a.pruneWarned(current)
 	return out, nil
+}
+
+// pruneWarned drops warn-dampening entries for URLs no longer present in
+// the registry listing, keeping the map bounded by the registry's current
+// size. A row that later reappears simply WARNs once more.
+func (a *endpointSource) pruneWarned(current map[string]struct{}) {
+	a.warnedMu.Lock()
+	defer a.warnedMu.Unlock()
+	for url := range a.warned {
+		if _, ok := current[url]; !ok {
+			delete(a.warned, url)
+		}
+	}
 }
 
 // validDiscoveredURL runs ssrfguard validation behind the success-only TTL
 // cache and handles rejection metering/log dampening.
 func (a *endpointSource) validDiscoveredURL(ctx context.Context, url string) bool {
-	if v, ok := a.validated.Load(url); ok {
-		if time.Now().UnixNano() < v.(int64) {
-			return true
-		}
-		a.validated.Delete(url)
+	if _, ok := a.validated.Get(url); ok {
+		return true
 	}
 
 	err := ssrfguard.ValidateURL(url, a.allowPrivate, func(host string) ([]net.IP, error) {
@@ -592,7 +615,7 @@ func (a *endpointSource) validDiscoveredURL(ctx context.Context, url string) boo
 		return false
 	}
 
-	a.validated.Store(url, time.Now().Add(endpointSourceValidationTTL).UnixNano())
+	a.validated.Put(url, "")
 	a.warnedMu.Lock()
 	delete(a.warned, url) // if it later goes bad again, WARN once more
 	a.warnedMu.Unlock()

--- a/app/app.go
+++ b/app/app.go
@@ -10,9 +10,12 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path"
+	"sync"
 	"time"
 
 	chaintrackslib "github.com/bsv-blockchain/go-chaintracks/chaintracks"
@@ -23,6 +26,7 @@ import (
 	"github.com/bsv-blockchain/arcade/events"
 	"github.com/bsv-blockchain/arcade/kafka"
 	"github.com/bsv-blockchain/arcade/merkleservice"
+	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/services"
 	"github.com/bsv-blockchain/arcade/services/api_server"
 	"github.com/bsv-blockchain/arcade/services/bump_builder"
@@ -32,6 +36,7 @@ import (
 	"github.com/bsv-blockchain/arcade/services/sse"
 	"github.com/bsv-blockchain/arcade/services/watchdog"
 	"github.com/bsv-blockchain/arcade/services/webhook"
+	"github.com/bsv-blockchain/arcade/ssrfguard"
 	"github.com/bsv-blockchain/arcade/store"
 	storefactory "github.com/bsv-blockchain/arcade/store/factory"
 	"github.com/bsv-blockchain/arcade/teranode"
@@ -123,7 +128,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *zap.Logger) (*De
 		ProbeTimeout:              time.Duration(cfg.Propagation.EndpointHealth.ProbeTimeoutMs) * time.Millisecond,
 		MinHealthyEndpoints:       cfg.Propagation.EndpointHealth.MinHealthyEndpoints,
 		RefreshInterval:           time.Duration(cfg.Propagation.EndpointHealth.RefreshIntervalMs) * time.Millisecond,
-		Source:                    endpointSource{st: st, network: cfg.Network, includeDiscovered: cfg.P2P.DatahubDiscovery},
+		Source:                    newEndpointSource(st, cfg.Network, cfg.P2P.DatahubDiscovery, cfg.P2P.AllowPrivateURLs, logger),
 		Logger:                    logger,
 	})
 
@@ -476,30 +481,138 @@ func (a chaintracksHeaderReader) GetHeaderByHash(ctx context.Context, hash *chai
 	return a.ct.GetHeaderByHash(ctx, hash)
 }
 
-// endpointSource adapts store.Store to teranode.EndpointSource by extracting
-// just the URL list. network scopes the listing to the configured Bitcoin
-// network so a store shared across pods (or reused after a network change)
-// never replays peers from a different network. When includeDiscovered is
-// false (operator disabled p2p.datahub_discovery), rows persisted as
-// source=discovered by prior runs are filtered out — the toggle now means
-// "ignore discovered URLs" end-to-end, not just "stop discovering new ones."
-type endpointSource struct {
-	st                store.Store
-	network           string
-	includeDiscovered bool
+// endpointSourceValidationTTL is how long a discovered URL that passed
+// validation skips re-validation (including its DNS round-trip) on
+// subsequent refresh ticks. Success-only: rejected URLs are re-checked
+// every tick so a row whose DNS recovers is admitted within one interval.
+const endpointSourceValidationTTL = 5 * time.Minute
+
+// endpointSourceLookupTimeout bounds each DNS lookup during refresh so a
+// dead resolver cannot wedge the refresh tick (the synchronous first
+// refresh in teranode.Client.Start is separately capped, and lookups
+// derive from the tick's ctx).
+const endpointSourceLookupTimeout = 2 * time.Second
+
+// datahubLister is the narrow store contract endpointSource needs;
+// extracted so tests can fake the registry without a real store.
+type datahubLister interface {
+	ListDatahubEndpoints(ctx context.Context, network string) ([]store.DatahubEndpoint, error)
 }
 
-func (a endpointSource) ListEndpointURLs(ctx context.Context) ([]string, error) {
+// endpointSource adapts the store's DatahubEndpoint registry to
+// teranode.EndpointSource. network scopes the listing to the configured
+// Bitcoin network so a store shared across pods (or reused after a network
+// change) never replays peers from a different network. When
+// includeDiscovered is false (operator disabled p2p.datahub_discovery),
+// rows persisted as source=discovered by prior runs are filtered out — the
+// toggle means "ignore discovered URLs" end-to-end, not just "stop
+// discovering new ones."
+//
+// Discovered rows are additionally re-validated with ssrfguard on every
+// listing (behind a success-only TTL cache): the p2p_client validates at
+// announcement intake, but rows persisted before that guard existed — or by
+// older builds — would otherwise flow straight into every pod's endpoint
+// set forever, since the registry has no eviction. Operator-configured rows
+// are exempt: static datahub_urls may legitimately point at
+// cluster-internal names.
+type endpointSource struct {
+	st                datahubLister
+	network           string
+	includeDiscovered bool
+	allowPrivate      bool
+
+	// lookupIP is the DNS seam; nil is never stored — newEndpointSource
+	// installs the bounded default.
+	lookupIP func(ctx context.Context, host string) ([]net.IP, error)
+	// validated caches URLs that passed validation (URL → expiry UnixNano).
+	validated sync.Map
+	// warned tracks URLs already logged at WARN so each rejected row logs
+	// loudly once per process and quietly (DEBUG) on the ~30s re-checks.
+	warnedMu sync.Mutex
+	warned   map[string]struct{}
+	logger   *zap.Logger
+}
+
+func newEndpointSource(st datahubLister, network string, includeDiscovered, allowPrivate bool, logger *zap.Logger) *endpointSource {
+	return &endpointSource{
+		st:                st,
+		network:           network,
+		includeDiscovered: includeDiscovered,
+		allowPrivate:      allowPrivate,
+		warned:            map[string]struct{}{},
+		logger:            logger,
+		lookupIP: func(ctx context.Context, host string) ([]net.IP, error) {
+			lctx, cancel := context.WithTimeout(ctx, endpointSourceLookupTimeout)
+			defer cancel()
+			return net.DefaultResolver.LookupIP(lctx, "ip", host)
+		},
+	}
+}
+
+func (a *endpointSource) ListEndpointURLs(ctx context.Context) ([]string, error) {
 	eps, err := a.st.ListDatahubEndpoints(ctx, a.network)
 	if err != nil {
 		return nil, err
 	}
 	out := make([]string, 0, len(eps))
 	for _, ep := range eps {
-		if !a.includeDiscovered && ep.Source == store.DatahubEndpointSourceDiscovered {
-			continue
+		if ep.Source == store.DatahubEndpointSourceDiscovered {
+			if !a.includeDiscovered {
+				continue
+			}
+			if !a.validDiscoveredURL(ctx, ep.URL) {
+				continue
+			}
 		}
 		out = append(out, ep.URL)
 	}
 	return out, nil
+}
+
+// validDiscoveredURL runs ssrfguard validation behind the success-only TTL
+// cache and handles rejection metering/log dampening.
+func (a *endpointSource) validDiscoveredURL(ctx context.Context, url string) bool {
+	if v, ok := a.validated.Load(url); ok {
+		if time.Now().UnixNano() < v.(int64) {
+			return true
+		}
+		a.validated.Delete(url)
+	}
+
+	err := ssrfguard.ValidateURL(url, a.allowPrivate, func(host string) ([]net.IP, error) {
+		return a.lookupIP(ctx, host)
+	})
+	if err != nil {
+		outcome := "invalid"
+		if errors.Is(err, ssrfguard.ErrBlockedAddress) {
+			outcome = "blocked"
+		}
+		metrics.TeranodeEndpointRefreshRejectedTotal.WithLabelValues(outcome).Inc()
+		a.logRejection(url, err)
+		return false
+	}
+
+	a.validated.Store(url, time.Now().Add(endpointSourceValidationTTL).UnixNano())
+	a.warnedMu.Lock()
+	delete(a.warned, url) // if it later goes bad again, WARN once more
+	a.warnedMu.Unlock()
+	return true
+}
+
+// logRejection logs a rejected registry row at WARN the first time a URL is
+// seen and DEBUG thereafter. A bad row is re-listed every refresh tick in
+// every pod; an unconditional WARN would drip permanently from a registry
+// row nobody has pruned yet.
+func (a *endpointSource) logRejection(url string, err error) {
+	a.warnedMu.Lock()
+	_, already := a.warned[url]
+	if !already {
+		a.warned[url] = struct{}{}
+	}
+	a.warnedMu.Unlock()
+	if already {
+		a.logger.Debug("skipping invalid discovered datahub url", zap.String("url", url), zap.Error(err))
+		return
+	}
+	a.logger.Warn("skipping invalid discovered datahub url", zap.String("url", url), zap.Error(err))
 }

--- a/app/endpoint_source_test.go
+++ b/app/endpoint_source_test.go
@@ -1,0 +1,167 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"go.uber.org/zap/zaptest"
+
+	"github.com/bsv-blockchain/arcade/store"
+)
+
+// fakeDatahubLister returns a fixed endpoint set, mimicking the registry.
+type fakeDatahubLister struct {
+	eps []store.DatahubEndpoint
+}
+
+func (f *fakeDatahubLister) ListDatahubEndpoints(_ context.Context, _ string) ([]store.DatahubEndpoint, error) {
+	return f.eps, nil
+}
+
+func configured(url string) store.DatahubEndpoint {
+	return store.DatahubEndpoint{URL: url, Network: "mainnet", Source: store.DatahubEndpointSourceConfigured}
+}
+
+func discovered(url string) store.DatahubEndpoint {
+	return store.DatahubEndpoint{URL: url, Network: "mainnet", Source: store.DatahubEndpointSourceDiscovered}
+}
+
+// TestEndpointSource_ConfiguredRowsBypassValidation: operator-configured
+// URLs may legitimately point at cluster-internal names; they must pass
+// through without any DNS traffic.
+func TestEndpointSource_ConfiguredRowsBypassValidation(t *testing.T) {
+	src := newEndpointSource(&fakeDatahubLister{eps: []store.DatahubEndpoint{
+		configured("http://teranode.internal.svc:8090/api/v1"),
+	}}, "mainnet", true, false, zaptest.NewLogger(t))
+	src.lookupIP = func(_ context.Context, host string) ([]net.IP, error) {
+		t.Fatalf("configured row triggered DNS lookup for %q", host)
+		return nil, nil
+	}
+
+	urls, err := src.ListEndpointURLs(context.Background())
+	if err != nil {
+		t.Fatalf("ListEndpointURLs: %v", err)
+	}
+	if len(urls) != 1 || urls[0] != "http://teranode.internal.svc:8090/api/v1" {
+		t.Fatalf("configured row filtered: %v", urls)
+	}
+}
+
+// TestEndpointSource_DiscoveredUnresolvableFiltered: the poisoned-registry
+// case — a discovered row whose hostname doesn't resolve (asset:8090) must
+// be dropped at refresh time in every pod.
+func TestEndpointSource_DiscoveredUnresolvableFiltered(t *testing.T) {
+	src := newEndpointSource(&fakeDatahubLister{eps: []store.DatahubEndpoint{
+		discovered("http://asset:8090/api/v1"),
+		discovered("https://peer.example/api/v1"),
+	}}, "mainnet", true, false, zaptest.NewLogger(t))
+	src.lookupIP = func(_ context.Context, host string) ([]net.IP, error) {
+		if host == "asset" {
+			return nil, fmt.Errorf("lookup asset: no such host")
+		}
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+
+	urls, err := src.ListEndpointURLs(context.Background())
+	if err != nil {
+		t.Fatalf("ListEndpointURLs: %v", err)
+	}
+	if len(urls) != 1 || urls[0] != "https://peer.example/api/v1" {
+		t.Fatalf("expected only the resolvable discovered row, got %v", urls)
+	}
+}
+
+// TestEndpointSource_ValidationCached: a discovered row that validates is
+// not re-resolved on the next listing (success-only TTL cache).
+func TestEndpointSource_ValidationCached(t *testing.T) {
+	src := newEndpointSource(&fakeDatahubLister{eps: []store.DatahubEndpoint{
+		discovered("https://peer.example/api/v1"),
+	}}, "mainnet", true, false, zaptest.NewLogger(t))
+	var lookups atomic.Int64
+	src.lookupIP = func(_ context.Context, _ string) ([]net.IP, error) {
+		lookups.Add(1)
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := src.ListEndpointURLs(context.Background()); err != nil {
+			t.Fatalf("ListEndpointURLs: %v", err)
+		}
+	}
+	if got := lookups.Load(); got != 1 {
+		t.Fatalf("expected 1 lookup across 3 listings, got %d", got)
+	}
+}
+
+// TestEndpointSource_RejectionNotCached: a row rejected while unresolvable
+// is admitted as soon as its DNS recovers — rejections are never cached.
+func TestEndpointSource_RejectionNotCached(t *testing.T) {
+	src := newEndpointSource(&fakeDatahubLister{eps: []store.DatahubEndpoint{
+		discovered("https://flaky.example/api/v1"),
+	}}, "mainnet", true, false, zaptest.NewLogger(t))
+	var resolvable atomic.Bool
+	src.lookupIP = func(_ context.Context, host string) ([]net.IP, error) {
+		if !resolvable.Load() {
+			return nil, fmt.Errorf("lookup %s: no such host", host)
+		}
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+
+	urls, _ := src.ListEndpointURLs(context.Background())
+	if len(urls) != 0 {
+		t.Fatalf("unresolvable row admitted: %v", urls)
+	}
+	resolvable.Store(true)
+	urls, _ = src.ListEndpointURLs(context.Background())
+	if len(urls) != 1 {
+		t.Fatalf("recovered row still filtered: %v", urls)
+	}
+}
+
+// TestEndpointSource_AllowPrivateAdmitsPrivateResolution: with
+// p2p.allow_private_urls=true (local/standalone deployments), a discovered
+// row resolving to RFC1918 is admitted — but an unresolvable one still isn't.
+func TestEndpointSource_AllowPrivateAdmitsPrivateResolution(t *testing.T) {
+	src := newEndpointSource(&fakeDatahubLister{eps: []store.DatahubEndpoint{
+		discovered("http://teranode.local:8090/api/v1"),
+		discovered("http://asset:8090/api/v1"),
+	}}, "mainnet", true, true, zaptest.NewLogger(t))
+	src.lookupIP = func(_ context.Context, host string) ([]net.IP, error) {
+		if host == "asset" {
+			return nil, fmt.Errorf("lookup asset: no such host")
+		}
+		return []net.IP{net.ParseIP("10.0.0.5")}, nil
+	}
+
+	urls, err := src.ListEndpointURLs(context.Background())
+	if err != nil {
+		t.Fatalf("ListEndpointURLs: %v", err)
+	}
+	if len(urls) != 1 || urls[0] != "http://teranode.local:8090/api/v1" {
+		t.Fatalf("expected privately-resolving row only, got %v", urls)
+	}
+}
+
+// TestEndpointSource_DiscoveredExcludedWhenDiscoveryOff pins the existing
+// includeDiscovered toggle alongside the new validation path.
+func TestEndpointSource_DiscoveredExcludedWhenDiscoveryOff(t *testing.T) {
+	src := newEndpointSource(&fakeDatahubLister{eps: []store.DatahubEndpoint{
+		configured("https://seed.example/api/v1"),
+		discovered("https://peer.example/api/v1"),
+	}}, "mainnet", false, false, zaptest.NewLogger(t))
+	src.lookupIP = func(_ context.Context, host string) ([]net.IP, error) {
+		t.Fatalf("lookup should not run when discovery is off, got %q", host)
+		return nil, nil
+	}
+
+	urls, err := src.ListEndpointURLs(context.Background())
+	if err != nil {
+		t.Fatalf("ListEndpointURLs: %v", err)
+	}
+	if len(urls) != 1 || urls[0] != "https://seed.example/api/v1" {
+		t.Fatalf("expected configured row only, got %v", urls)
+	}
+}

--- a/config.example.standalone.yaml
+++ b/config.example.standalone.yaml
@@ -108,7 +108,9 @@ p2p:
   # storage_path: ""           # defaults to <storage_path>/p2p; stores p2p_key.hex
   # bootstrap_peers: []        # override/extend the built-in defaults for the selected network
   # enable_mdns: false
-  # allow_private_urls: false  # accept loopback/RFC1918 URLs from peers
+  # allow_private_urls: false  # accept discovered URLs on loopback/RFC1918/link-local/CGNAT
+  # addresses, including DNS names that RESOLVE to those ranges. Unresolvable
+  # hostnames are rejected regardless. Configured datahub_urls are never validated.
 
 # Embedded block-header tracker. Serves /chaintracks/v1/* and /chaintracks/v2/*
 # on the api-server. Default storage is <storage_path>/chaintracks.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -109,7 +109,10 @@ p2p:
   # bootstrap_peers: []        # override the built-in defaults; also feeds chaintracks
   # (unless chaintracks.p2p.msgbus.bootstrappeers is set explicitly)
   # enable_mdns: false
-  # allow_private_urls: false  # accept loopback/RFC1918/link-local URLs from peers
+  # allow_private_urls: false  # accept discovered URLs on loopback/RFC1918/link-local/CGNAT
+  # addresses, including DNS names that RESOLVE to those ranges. Unresolvable
+  # hostnames (e.g. a peer announcing its cluster-internal service name) are
+  # rejected regardless. Statically configured datahub_urls are never validated.
 
 health:
   port: 8081

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -589,7 +589,7 @@ var P2PNodeStatusMessagesTotal = promauto.NewCounter(prometheus.CounterOpts{
 var P2PEndpointDiscoveryTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "arcade_p2p_endpoint_discovery_total",
 	Help: "Datahub URL discovery outcomes from peer announcements.",
-}, []string{labelOutcome}) // registered, invalid, blocked, no_url, error
+}, []string{labelOutcome}) // registered, invalid, blocked, no_url, no_store, error
 
 // ---------------------------------------------------------------------------
 // callback path — inbound merkle-service callbacks

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -522,6 +522,16 @@ var TeranodeEndpointCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "Number of registered datahub endpoints, by source.",
 }, []string{"source"})
 
+// TeranodeEndpointRefreshRejectedTotal counts registry rows rejected by URL
+// validation at refresh time (app.endpointSource). Nonzero means the shared
+// DatahubEndpoint registry contains rows that predate discovery-time
+// validation (or a peer's DNS broke after registration) — candidates for
+// pruning.
+var TeranodeEndpointRefreshRejectedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_teranode_endpoint_refresh_rejected_total",
+	Help: "Registry datahub endpoints rejected at refresh time by URL validation.",
+}, []string{labelOutcome}) // blocked, invalid
+
 // ---------------------------------------------------------------------------
 // kafka
 // ---------------------------------------------------------------------------
@@ -579,7 +589,7 @@ var P2PNodeStatusMessagesTotal = promauto.NewCounter(prometheus.CounterOpts{
 var P2PEndpointDiscoveryTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "arcade_p2p_endpoint_discovery_total",
 	Help: "Datahub URL discovery outcomes from peer announcements.",
-}, []string{labelOutcome}) // registered, invalid, no_url, error
+}, []string{labelOutcome}) // registered, invalid, blocked, no_url, error
 
 // ---------------------------------------------------------------------------
 // callback path — inbound merkle-service callbacks

--- a/openspec/changes/harden-datahub-discovery/proposal.md
+++ b/openspec/changes/harden-datahub-discovery/proposal.md
@@ -1,0 +1,19 @@
+# Harden DataHub discovery: DNS-validated URLs + truthful endpoint health
+
+## Why
+
+The public `/health` endpoint reported `http://asset:8090/api/v1` — a peer's cluster-internal service name, unreachable from arcade — as a healthy discovered DataHub URL. Two gaps compounded: (1) discovery validation was purely syntactic, so any non-IP-literal hostname was accepted without checking that it resolves or where it resolves to, and the URL then persisted forever in the shared registry (no eviction); (2) per-endpoint circuit-breaker state only ever changed in the propagation pod, because the recovery probe targeted already-unhealthy endpoints and only broadcast outcomes recorded failures — so in the api-server pod (which serves `/health`) every endpoint stayed `healthy: true` forever. merkle-service fixed the same announcement-validation bug class in its PR #181; this change mirrors that pattern.
+
+## What Changes
+
+- **New `ssrfguard` package** (ported from merkle-service): URL validation with scheme allowlist, userinfo rejection, metadata-hostname deny list, blocked-IP predicate (loopback/link-local/RFC1918/CGNAT/ULA/unspecified/multicast), and — the key addition over the old validator — DNS resolution of non-literal hostnames with every resolved IP checked. Unresolvable hostnames are rejected regardless of `p2p.allow_private_urls`.
+- **Discovery-time validation** (`services/p2p_client`): announcements are validated with ssrfguard behind a success-only 5-minute TTL cache (injectable DNS lookup, 2s bound); rejections are metered (`invalid` vs `blocked`) and logged with peer ID.
+- **Refresh-time filter** (`app.endpointSource`): `source=discovered` registry rows are re-validated on every listing (same cache design), neutralizing rows persisted before this guard existed. Operator-configured rows are exempt. New metric `arcade_teranode_endpoint_refresh_rejected_total{outcome}`.
+- **Probe-all** (`teranode.Client`): the background probe loop now probes every endpoint, not just unhealthy ones, feeding a dedicated `consecutiveProbeFailures` counter (threshold shared with the fast track). Probe success on a healthy endpoint resets only the probe counter — never the broadcast-path counters — so the slow-track breaker still trips for reachable-but-useless endpoints. Unhealthy-endpoint recovery semantics are unchanged.
+
+## Impact
+
+- `/health` `datahub_urls[].healthy` now reflects reality in every pod (~90s to demote a dead endpoint); unresolvable URLs disappear from the list entirely.
+- `arcade_teranode_endpoint_healthy` updates in non-broadcasting pods; `min_healthy_endpoints` warnings may fire more often (truthful signal).
+- No new config keys; `p2p.allow_private_urls` now also gates DNS-resolved private addresses.
+- Out of scope (follow-ups): registry eviction/LastSeen pruning; dial-time `CheckDialAddress` guard on the broadcast transport (DNS-rebinding window).

--- a/openspec/changes/harden-datahub-discovery/specs/datahub-endpoint-health/spec.md
+++ b/openspec/changes/harden-datahub-discovery/specs/datahub-endpoint-health/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Background probing covers every endpoint
+
+The teranode client's background probe loop SHALL probe **every** registered endpoint on each probe interval — healthy endpoints included — so that a pod with no broadcast traffic (api-server, sse, watchdog) still demotes unreachable endpoints and its health surface reflects reality. Probe outcomes SHALL be recorded on a dedicated consecutive-probe-failure counter that trips the endpoint to `unhealthy` at the same threshold as the fast track (`failure_threshold`, default 3).
+
+A probe success against a **healthy** endpoint SHALL reset only the probe-failure counter and SHALL NOT reset either broadcast-path counter (`consecutiveFailures`, `consecutiveBroadcastFailures`) — a reachable `/health` says nothing about whether broadcasts succeed, and resetting them would prevent the slow-track breaker from ever tripping while probes run. A probe success against an **unhealthy** endpoint SHALL perform full recovery exactly as before: all counters reset, state returns to healthy (any HTTP response, including 4xx/5xx, counts as reachable).
+
+#### Scenario: Dead endpoint demoted without broadcast traffic
+
+- **WHEN** a registered endpoint stops accepting connections and the pod issues no broadcasts
+- **THEN** after `failure_threshold` consecutive failed probes the endpoint transitions to `unhealthy` (logged with reason `probe`), its health gauge drops to 0, and `GetEndpointStatuses` reports `healthy: false`.
+
+#### Scenario: Probe successes do not mask broadcast failures
+
+- **WHEN** an endpoint's `/health` responds 200 to every probe while broadcasts to it consistently return non-2xx
+- **THEN** `consecutiveBroadcastFailures` accumulates across broadcasts uninterrupted by probe successes and the endpoint trips at `broadcast_failure_threshold` as if probing were disabled.
+
+#### Scenario: Recovery contract unchanged
+
+- **WHEN** an unhealthy endpoint answers a probe with any HTTP response (including 404)
+- **THEN** the endpoint returns to `healthy` with all failure counters reset.

--- a/openspec/changes/harden-datahub-discovery/specs/p2p-datahub-discovery/spec.md
+++ b/openspec/changes/harden-datahub-discovery/specs/p2p-datahub-discovery/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Reject unsafe URLs
+
+The service SHALL reject any discovered URL that is structurally invalid (unparseable, non-`http`/`https` scheme, empty host, or containing userinfo), whose hostname is on the cloud-metadata deny list, whose host **fails DNS resolution or resolves to no addresses**, or any of whose resolved addresses (or IP literal) falls in a blocked range — loopback, link-local, RFC1918 private, CGNAT (100.64.0.0/10), IPv6 unique-local, unspecified, or multicast — unless the operator explicitly opts in via `p2p.allow_private_urls: true`. The opt-in SHALL NOT admit unresolvable hostnames, metadata-deny-list hostnames, or unspecified/multicast destinations. Validation SHALL resolve hostnames at most once per URL per 5-minute window (success-only cache; rejections are always re-validated).
+
+#### Scenario: Public HTTPS URL
+
+- **WHEN** a peer announces `https://public.example.com` and it resolves to a public address
+- **THEN** the URL passes validation and is submitted for registration.
+
+#### Scenario: Unresolvable cluster-internal hostname
+
+- **WHEN** a peer announces `http://asset:8090/api/v1` (its own cluster-internal service name) and the hostname does not resolve from this deployment
+- **THEN** the URL is rejected regardless of `allow_private_urls`, a warning including the peer ID and rejected URL is logged, the rejection is counted with outcome `invalid`, and the URL is not registered.
+
+#### Scenario: Hostname resolving to a private address
+
+- **WHEN** a peer announces `http://internal.corp.local` which resolves to `10.0.0.5` and `p2p.allow_private_urls` is false
+- **THEN** the URL is rejected with outcome `blocked` and not registered.
+
+#### Scenario: Private RFC1918 URL with default config
+
+- **WHEN** a peer announces `http://192.168.5.10:8080` and `p2p.allow_private_urls` is false
+- **THEN** the URL is rejected, a warning including the peer ID and the rejected URL is logged, and the URL is not registered.
+
+#### Scenario: Loopback URL with opt-in
+
+- **WHEN** a peer announces `http://127.0.0.1:8080` and `p2p.allow_private_urls` is true
+- **THEN** the URL passes validation and is submitted for registration.
+
+#### Scenario: Non-HTTP scheme
+
+- **WHEN** a peer announces `ftp://peer.example/` or `file:///etc/passwd`
+- **THEN** the URL is rejected and logged, regardless of `allow_private_urls`.
+
+#### Scenario: Repeat announcement uses the validation cache
+
+- **WHEN** a peer re-announces a URL that passed validation within the last 5 minutes
+- **THEN** the URL is accepted without a new DNS resolution and the registration upsert still occurs (LastSeen advances).
+
+### Requirement: Registry rows are re-validated at refresh time
+
+Every pod's endpoint refresh SHALL re-validate `source=discovered` registry rows with the same URL validation (behind the same success-only cache) before registering them into the in-memory endpoint set, so rows persisted before validation existed — or whose DNS has since broken — never enter any pod's broadcast or health surface. Rows with `source=configured` SHALL be exempt: statically configured `datahub_urls` are operator-controlled and may legitimately use cluster-internal names. Rejections SHALL be counted (`arcade_teranode_endpoint_refresh_rejected_total{outcome}`) and logged at WARN once per URL per process, DEBUG thereafter.
+
+#### Scenario: Poisoned registry row is filtered
+
+- **WHEN** the registry contains a discovered row `http://asset:8090/api/v1` persisted by an older build and the hostname does not resolve
+- **THEN** every pod's refresh skips the row, it appears in no pod's `/health` output or broadcast set, and the rejection counter increments.
+
+#### Scenario: Configured internal URL passes through
+
+- **WHEN** the registry contains a configured row pointing at a cluster-internal name
+- **THEN** the row is registered without validation or DNS traffic.

--- a/openspec/changes/harden-datahub-discovery/tasks.md
+++ b/openspec/changes/harden-datahub-discovery/tasks.md
@@ -1,0 +1,34 @@
+# Tasks
+
+## 1. ssrfguard package
+
+- [x] 1.1 Port `ssrfguard` from merkle-service as a top-level arcade package: `ValidateURL`, `IsBlockedIP`, `IsBlockedHostname`, `CheckDialAddress`, `ErrInvalidURL`/`ErrBlockedAddress` sentinels.
+- [x] 1.2 Fix the CGNAT (100.64.0.0/10) doc/code mismatch from the merkle copy: add the explicit range check.
+- [x] 1.3 Port the test table; add CGNAT boundary cases.
+
+## 2. Discovery-time validation (services/p2p_client)
+
+- [x] 2.1 `validateURL` delegates to `ssrfguard.ValidateURL` with an injectable lookup; delete `isPrivateHost`.
+- [x] 2.2 Add `lookupIP` seam (default `net.DefaultResolver.LookupIP`, 2s timeout) and a success-only 5-minute TTL cache on `Client`.
+- [x] 2.3 Split the rejection metric outcome: `blocked` (SSRF policy) vs `invalid` (malformed/unresolvable) on `arcade_p2p_endpoint_discovery_total`.
+- [x] 2.4 Tests: flip the "dns name resolving privately is treated as public" case; unresolvable-hostname (`asset:8090`) rejection; cache skips repeat lookups; upsert-per-announcement preserved.
+
+## 3. Refresh-time filter (app.endpointSource)
+
+- [x] 3.1 `newEndpointSource` with `datahubLister` seam; discovered rows validated behind the TTL cache, configured rows exempt.
+- [x] 3.2 WARN-once/DEBUG-thereafter log dampening per URL; un-warn on recovery.
+- [x] 3.3 New metric `arcade_teranode_endpoint_refresh_rejected_total{outcome}`.
+- [x] 3.4 Tests: configured bypass, unresolvable filtered, cache, rejection-not-cached, allow-private opt-in, discovery-off exclusion.
+
+## 4. Probe-all (teranode.Client)
+
+- [x] 4.1 Add `consecutiveProbeFailures` to `endpointHealth`; document why it is separate from the broadcast counters.
+- [x] 4.2 `recordProbeFailure` (trips at `failureThreshold`, reason="probe") and `recordProbeSuccess` (full recovery when unhealthy; probe-counter-only reset when healthy).
+- [x] 4.3 `probeOnce` probes all endpoints; `probeEndpoint` routes outcomes to the probe counter; `RecordSuccess` also resets the probe counter.
+- [x] 4.4 Tests: unreachable healthy endpoint demoted by probes alone; probe successes do not reset either broadcast counter; probe-counter consecutive semantics; existing recovery tests unchanged.
+
+## 5. Surface + docs
+
+- [x] 5.1 api-server test: `/health` flips a dead endpoint to `healthy:false` with zero broadcast traffic.
+- [x] 5.2 Update `allow_private_urls` comments in both example configs.
+- [x] 5.3 Update the p2p-datahub-discovery spec (Reject unsafe URLs requirement) and add the probe-all requirement to datahub-endpoint-health.

--- a/services/api_server/handlers_health_test.go
+++ b/services/api_server/handlers_health_test.go
@@ -1,10 +1,12 @@
 package api_server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -120,4 +122,44 @@ func TestHandleHealth_NilTeranode_ReturnsEmptyArray(t *testing.T) {
 	if string(raw["healthy"]) != "true" {
 		t.Errorf("expected healthy to be `true` in JSON, got %s", string(raw["healthy"]))
 	}
+}
+
+// TestHandleHealth_UnreachableEndpointFlipsUnhealthy is the end-to-end proof
+// for the production complaint: /health reported a registered-but-dead
+// endpoint as healthy:true forever, because the api-server pod never
+// broadcasts and the probe loop only targeted already-unhealthy endpoints.
+// With probe-all, the endpoint flips to healthy:false with zero broadcast
+// traffic — driven purely by the background probe loop.
+func TestHandleHealth_UnreachableEndpointFlipsUnhealthy(t *testing.T) {
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	deadURL := dead.URL
+	dead.Close() // port now refuses connections
+
+	tc := teranode.NewClient([]string{deadURL}, "", teranode.HealthConfig{
+		FailureThreshold: 3,
+		ProbeInterval:    10 * time.Millisecond,
+		ProbeTimeout:     200 * time.Millisecond,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tc.Start(ctx)
+	defer tc.Close()
+
+	srv := &Server{
+		cfg:      &config.Config{},
+		logger:   zap.NewNop(),
+		teranode: tc,
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		_, resp, _ := doHealth(t, srv)
+		if len(resp.DatahubURLs) == 1 && !resp.DatahubURLs[0].Healthy {
+			return // /health now tells the truth
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("/health kept reporting an unreachable endpoint as healthy for 2s")
 }

--- a/services/p2p_client/client.go
+++ b/services/p2p_client/client.go
@@ -17,7 +17,9 @@ package p2p_client
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -29,6 +31,7 @@ import (
 	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/kafka"
 	"github.com/bsv-blockchain/arcade/metrics"
+	"github.com/bsv-blockchain/arcade/ssrfguard"
 	"github.com/bsv-blockchain/arcade/store"
 )
 
@@ -66,6 +69,24 @@ func defaultClientFactory(ctx context.Context, cfg p2pclient.Config) (teraClient
 	return cfg.Initialize(ctx, "arcade")
 }
 
+// dnsLookupTimeout bounds each DNS resolution performed while validating a
+// discovered URL. handleNodeStatus runs on the single consume goroutine, so
+// an unbounded lookup against a dead resolver would stall all announcement
+// processing.
+const dnsLookupTimeout = 2 * time.Second
+
+// discoveryValidationTTL is how long a successfully validated URL skips
+// re-validation (including the DNS round-trip). Success-only: rejections are
+// never cached, so a peer that fixes its DNS or config is re-accepted on its
+// very next announcement. Mirrors merkle-service's announcement validation.
+const discoveryValidationTTL = 5 * time.Minute
+
+// validatedURL is the value cached per raw announced URL.
+type validatedURL struct {
+	normalized string
+	expiry     int64 // UnixNano
+}
+
 type Client struct {
 	cfg           *config.Config
 	logger        *zap.Logger
@@ -76,6 +97,14 @@ type Client struct {
 	done          chan struct{}
 	wg            sync.WaitGroup
 	stopOnce      sync.Once
+
+	// lookupIP resolves a hostname during URL validation. Overridable in
+	// tests so validation never hits real DNS; nil is never stored — New
+	// installs the bounded default.
+	lookupIP func(ctx context.Context, host string) ([]net.IP, error)
+	// validatedURLs caches successful validations (raw URL → validatedURL)
+	// so repeat announcements of the same URL skip the DNS round-trip.
+	validatedURLs sync.Map
 }
 
 func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, st EndpointWriter) *Client {
@@ -86,6 +115,11 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, st En
 		store:         st,
 		clientFactory: defaultClientFactory,
 		done:          make(chan struct{}),
+		lookupIP: func(ctx context.Context, host string) ([]net.IP, error) {
+			lctx, cancel := context.WithTimeout(ctx, dnsLookupTimeout)
+			defer cancel()
+			return net.DefaultResolver.LookupIP(lctx, "ip", host)
+		},
 	}
 }
 
@@ -246,15 +280,8 @@ func (c *Client) handleNodeStatus(ctx context.Context, msg teranodep2p.NodeStatu
 		return
 	}
 
-	normalized, err := validateURL(raw, c.cfg.P2P.AllowPrivateURLs)
-	if err != nil {
-		metrics.P2PEndpointDiscoveryTotal.WithLabelValues("invalid").Inc()
-		c.logger.Warn(
-			"rejected discovered datahub url",
-			zap.String("peer_id", msg.PeerID),
-			zap.String("url", raw),
-			zap.Error(err),
-		)
+	normalized, ok := c.validateDatahubURL(ctx, msg.PeerID, raw)
+	if !ok {
 		return
 	}
 
@@ -271,7 +298,7 @@ func (c *Client) handleNodeStatus(ctx context.Context, msg teranodep2p.NodeStatu
 		return
 	}
 	upsertCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	err = c.store.UpsertDatahubEndpoint(upsertCtx, store.DatahubEndpoint{
+	err := c.store.UpsertDatahubEndpoint(upsertCtx, store.DatahubEndpoint{
 		URL:      normalized,
 		Network:  c.cfg.Network,
 		Source:   store.DatahubEndpointSourceDiscovered,
@@ -293,6 +320,46 @@ func (c *Client) handleNodeStatus(ctx context.Context, msg teranodep2p.NodeStatu
 		zap.String("peer_id", msg.PeerID),
 		zap.String("url", normalized),
 	)
+}
+
+// validateDatahubURL runs the full discovered-URL validation (scheme, SSRF
+// ranges, DNS resolvability — see validateURL) behind a success-only TTL
+// cache, so repeat announcements of a known-good URL skip the DNS
+// round-trip. Rejections are metered by kind: "blocked" for SSRF-policy
+// rejections (private/metadata destinations), "invalid" for everything else
+// (malformed, bad scheme, unresolvable hostname).
+func (c *Client) validateDatahubURL(ctx context.Context, peerID, raw string) (string, bool) {
+	if v, ok := c.validatedURLs.Load(raw); ok {
+		entry := v.(validatedURL)
+		if time.Now().UnixNano() < entry.expiry {
+			return entry.normalized, true
+		}
+		c.validatedURLs.Delete(raw)
+	}
+
+	normalized, err := validateURL(raw, c.cfg.P2P.AllowPrivateURLs, func(host string) ([]net.IP, error) {
+		return c.lookupIP(ctx, host)
+	})
+	if err != nil {
+		outcome := "invalid"
+		if errors.Is(err, ssrfguard.ErrBlockedAddress) {
+			outcome = "blocked"
+		}
+		metrics.P2PEndpointDiscoveryTotal.WithLabelValues(outcome).Inc()
+		c.logger.Warn(
+			"rejected discovered datahub url",
+			zap.String("peer_id", peerID),
+			zap.String("url", raw),
+			zap.Error(err),
+		)
+		return "", false
+	}
+
+	c.validatedURLs.Store(raw, validatedURL{
+		normalized: normalized,
+		expiry:     time.Now().Add(discoveryValidationTTL).UnixNano(),
+	})
+	return normalized, true
 }
 
 // zapBusLogger adapts *zap.Logger to the message-bus logger interface, which

--- a/services/p2p_client/client.go
+++ b/services/p2p_client/client.go
@@ -81,11 +81,11 @@ const dnsLookupTimeout = 2 * time.Second
 // very next announcement. Mirrors merkle-service's announcement validation.
 const discoveryValidationTTL = 5 * time.Minute
 
-// validatedURL is the value cached per raw announced URL.
-type validatedURL struct {
-	normalized string
-	expiry     int64 // UnixNano
-}
+// discoveryValidationCacheMax bounds the validation cache. Announced URLs
+// are attacker-influenced input; the cap keeps a peer spraying unique valid
+// URLs from growing process memory without bound. Far above the size of any
+// real datahub fleet.
+const discoveryValidationCacheMax = 512
 
 type Client struct {
 	cfg           *config.Config
@@ -102,9 +102,10 @@ type Client struct {
 	// tests so validation never hits real DNS; nil is never stored — New
 	// installs the bounded default.
 	lookupIP func(ctx context.Context, host string) ([]net.IP, error)
-	// validatedURLs caches successful validations (raw URL → validatedURL)
+	// validatedURLs caches successful validations (raw URL → normalized)
 	// so repeat announcements of the same URL skip the DNS round-trip.
-	validatedURLs sync.Map
+	// Bounded — see discoveryValidationCacheMax.
+	validatedURLs *ssrfguard.SuccessCache
 }
 
 func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, st EndpointWriter) *Client {
@@ -120,6 +121,7 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, st En
 			defer cancel()
 			return net.DefaultResolver.LookupIP(lctx, "ip", host)
 		},
+		validatedURLs: ssrfguard.NewSuccessCache(discoveryValidationTTL, discoveryValidationCacheMax),
 	}
 }
 
@@ -329,12 +331,8 @@ func (c *Client) handleNodeStatus(ctx context.Context, msg teranodep2p.NodeStatu
 // rejections (private/metadata destinations), "invalid" for everything else
 // (malformed, bad scheme, unresolvable hostname).
 func (c *Client) validateDatahubURL(ctx context.Context, peerID, raw string) (string, bool) {
-	if v, ok := c.validatedURLs.Load(raw); ok {
-		entry := v.(validatedURL)
-		if time.Now().UnixNano() < entry.expiry {
-			return entry.normalized, true
-		}
-		c.validatedURLs.Delete(raw)
+	if normalized, ok := c.validatedURLs.Get(raw); ok {
+		return normalized, true
 	}
 
 	normalized, err := validateURL(raw, c.cfg.P2P.AllowPrivateURLs, func(host string) ([]net.IP, error) {
@@ -355,10 +353,7 @@ func (c *Client) validateDatahubURL(ctx context.Context, peerID, raw string) (st
 		return "", false
 	}
 
-	c.validatedURLs.Store(raw, validatedURL{
-		normalized: normalized,
-		expiry:     time.Now().Add(discoveryValidationTTL).UnixNano(),
-	})
+	c.validatedURLs.Put(raw, normalized)
 	return normalized, true
 }
 

--- a/services/p2p_client/client_test.go
+++ b/services/p2p_client/client_test.go
@@ -2,8 +2,10 @@ package p2p_client
 
 import (
 	"context"
+	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -81,6 +83,11 @@ func newTestClient(t *testing.T, fc *fakeTeraClient) (*Client, *fakeEndpointWrit
 	w := &fakeEndpointWriter{}
 	c := New(cfg, zaptest.NewLogger(t), nil, w)
 	c.clientFactory = func(_ context.Context, _ p2pclient.Config) (teraClient, error) { return fc, nil }
+	// Existing tests announce hostnames like https://peer.example — resolve
+	// everything to a public IP so validation never touches real DNS.
+	c.lookupIP = func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
 	return c, w
 }
 
@@ -352,5 +359,52 @@ func TestClient_DisabledDiscoveryOpensNoBus(t *testing.T) {
 	}
 	if err := c.Stop(); err != nil {
 		t.Errorf("Stop returned: %v", err)
+	}
+}
+
+// TestClient_UnresolvableURLNotPersisted is the production regression case:
+// a peer announcing its own cluster-internal service name (unresolvable from
+// this cluster) must never enter the shared endpoint registry.
+func TestClient_UnresolvableURLNotPersisted(t *testing.T) {
+	fc := newFakeTeraClient("sender")
+	c, w := newTestClient(t, fc)
+	c.lookupIP = func(_ context.Context, host string) ([]net.IP, error) {
+		return nil, &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
+	}
+	_, stop := runStart(t, c)
+	defer stop()
+
+	fc.ch <- teranodep2p.NodeStatusMessage{
+		PeerID:  "sender",
+		BaseURL: "http://asset:8090/api/v1",
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if calls := w.snapshot(); len(calls) != 0 {
+		t.Errorf("unresolvable URL reached the store: %+v", calls)
+	}
+}
+
+// TestClient_ValidationCacheSkipsRepeatLookups confirms the success-only TTL
+// cache: three announcements of one URL cost exactly one DNS lookup, while
+// the upsert-per-announcement contract (LastSeen advancing) is preserved.
+func TestClient_ValidationCacheSkipsRepeatLookups(t *testing.T) {
+	fc := newFakeTeraClient("sender")
+	c, w := newTestClient(t, fc)
+	var lookups atomic.Int64
+	c.lookupIP = func(_ context.Context, _ string) ([]net.IP, error) {
+		lookups.Add(1)
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	_, stop := runStart(t, c)
+	defer stop()
+
+	for i := 0; i < 3; i++ {
+		fc.ch <- teranodep2p.NodeStatusMessage{PeerID: "sender", BaseURL: "https://peer.example"}
+	}
+
+	waitForUpserts(t, w, 3)
+	if got := lookups.Load(); got != 1 {
+		t.Errorf("expected exactly 1 DNS lookup across 3 announcements, got %d", got)
 	}
 }

--- a/services/p2p_client/node_status.go
+++ b/services/p2p_client/node_status.go
@@ -1,13 +1,12 @@
 package p2p_client
 
 import (
-	"errors"
-	"fmt"
 	"net"
-	"net/url"
 	"strings"
 
 	teranodep2p "github.com/bsv-blockchain/teranode/services/p2p"
+
+	"github.com/bsv-blockchain/arcade/ssrfguard"
 )
 
 // pickDatahubURL returns the URL peers should use to propagate transactions.
@@ -23,37 +22,19 @@ func pickDatahubURL(m teranodep2p.NodeStatusMessage) string {
 // validateURL enforces that a discovered URL is safe to POST transactions to.
 // It returns the normalized form (single trailing slash trimmed) or an error
 // with a human-readable reason suitable for a warn-level log.
-func validateURL(raw string, allowPrivate bool) (string, error) {
+//
+// Validation is delegated to ssrfguard.ValidateURL: scheme allowlist,
+// userinfo rejection, metadata-hostname deny list, and — the part the old
+// in-package validator lacked — DNS resolution of non-literal hostnames with
+// every resolved IP checked against the blocked ranges. An unresolvable
+// hostname (e.g. a peer announcing its own cluster-internal service name
+// like "asset") is rejected regardless of allowPrivate: it can never be
+// reached from this cluster and must not enter the shared endpoint registry.
+// lookup is injectable for tests; nil falls back to net.LookupIP.
+func validateURL(raw string, allowPrivate bool, lookup func(host string) ([]net.IP, error)) (string, error) {
 	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return "", errors.New("empty url")
-	}
-	u, err := url.Parse(raw)
-	if err != nil {
-		return "", fmt.Errorf("parse: %w", err)
-	}
-	scheme := strings.ToLower(u.Scheme)
-	if scheme != "http" && scheme != "https" {
-		return "", fmt.Errorf("unsupported scheme %q", u.Scheme)
-	}
-	host := u.Hostname()
-	if host == "" {
-		return "", errors.New("empty host")
-	}
-	if !allowPrivate && isPrivateHost(host) {
-		return "", fmt.Errorf("private address %q (enable p2p.allow_private_urls to accept)", host)
+	if err := ssrfguard.ValidateURL(raw, allowPrivate, lookup); err != nil {
+		return "", err
 	}
 	return strings.TrimSuffix(raw, "/"), nil
-}
-
-// isPrivateHost returns true for loopback, link-local, and RFC1918 addresses.
-// A hostname that doesn't parse as an IP is treated as public — DNS names
-// resolving to private ranges are the operator's problem, not ours, since
-// resolving here would add a network round-trip per announcement.
-func isPrivateHost(host string) bool {
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return false
-	}
-	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsPrivate()
 }

--- a/services/p2p_client/node_status_test.go
+++ b/services/p2p_client/node_status_test.go
@@ -1,6 +1,8 @@
 package p2p_client
 
 import (
+	"fmt"
+	"net"
 	"testing"
 
 	teranodep2p "github.com/bsv-blockchain/teranode/services/p2p"
@@ -28,32 +30,68 @@ func TestPickDatahubURL(t *testing.T) {
 	}
 }
 
+// Lookup stubs. validateURL only resolves non-literal hostnames, so
+// IP-literal cases use noLookup to assert DNS is never consulted for them.
+func publicLookup(string) ([]net.IP, error)  { return []net.IP{net.ParseIP("93.184.216.34")}, nil }
+func privateLookup(string) ([]net.IP, error) { return []net.IP{net.ParseIP("10.0.0.5")}, nil }
+func multiLookup(string) ([]net.IP, error) {
+	return []net.IP{net.ParseIP("93.184.216.34"), net.ParseIP("10.0.0.5")}, nil
+}
+
+func unresolvableLookup(host string) ([]net.IP, error) {
+	return nil, fmt.Errorf("lookup %s: no such host", host)
+}
+
 func TestValidateURL(t *testing.T) {
+	// noLookup fails the test if DNS is consulted — used for IP-literal and
+	// syntactically-invalid cases that must be decided without resolution.
+	noLookup := func(host string) ([]net.IP, error) {
+		t.Fatalf("unexpected DNS lookup for %q", host)
+		return nil, nil
+	}
+
 	cases := []struct {
 		name         string
 		raw          string
 		allowPrivate bool
+		lookup       func(string) ([]net.IP, error)
 		wantErr      bool
 		want         string
 	}{
-		{"public https", "https://public.example.com", false, false, "https://public.example.com"},
-		{"public https trailing slash trimmed", "https://public.example.com/", false, false, "https://public.example.com"},
-		{"public http", "http://public.example.com:8080", false, false, "http://public.example.com:8080"},
-		{"rfc1918 rejected", "http://192.168.5.10:8080", false, true, ""},
-		{"rfc1918 allowed with opt-in", "http://192.168.5.10:8080", true, false, "http://192.168.5.10:8080"},
-		{"loopback rejected", "http://127.0.0.1:8080", false, true, ""},
-		{"loopback allowed with opt-in", "http://127.0.0.1:8080", true, false, "http://127.0.0.1:8080"},
-		{"link-local rejected", "http://169.254.1.1", false, true, ""},
-		{"ipv6 loopback rejected", "http://[::1]:8080", false, true, ""},
-		{"ftp rejected", "ftp://peer.example/", false, true, ""},
-		{"file scheme rejected", "file:///etc/passwd", true, true, ""},
-		{"empty host rejected", "https://", false, true, ""},
-		{"empty string rejected", "", false, true, ""},
-		{"dns name resolving privately is treated as public", "http://internal.corp.local", false, false, "http://internal.corp.local"},
+		{"public https", "https://public.example.com", false, publicLookup, false, "https://public.example.com"},
+		{"public https trailing slash trimmed", "https://public.example.com/", false, publicLookup, false, "https://public.example.com"},
+		{"public http", "http://public.example.com:8080", false, publicLookup, false, "http://public.example.com:8080"},
+		{"rfc1918 rejected", "http://192.168.5.10:8080", false, noLookup, true, ""},
+		{"rfc1918 allowed with opt-in", "http://192.168.5.10:8080", true, noLookup, false, "http://192.168.5.10:8080"},
+		{"loopback rejected", "http://127.0.0.1:8080", false, noLookup, true, ""},
+		{"loopback allowed with opt-in", "http://127.0.0.1:8080", true, noLookup, false, "http://127.0.0.1:8080"},
+		{"link-local rejected", "http://169.254.1.1", false, noLookup, true, ""},
+		{"ipv6 loopback rejected", "http://[::1]:8080", false, noLookup, true, ""},
+		{"ftp rejected", "ftp://peer.example/", false, noLookup, true, ""},
+		{"file scheme rejected", "file:///etc/passwd", true, noLookup, true, ""},
+		{"empty host rejected", "https://", false, noLookup, true, ""},
+		{"empty string rejected", "", false, noLookup, true, ""},
+		{"userinfo rejected", "https://user@public.example.com", false, noLookup, true, ""},
+
+		// DNS-resolution cases — the gap the old validator had. A hostname
+		// resolving privately used to be "treated as public"; now every
+		// resolved IP is checked.
+		{"dns name resolving privately rejected", "http://internal.corp.local", false, privateLookup, true, ""},
+		{"dns name resolving privately allowed with opt-in", "http://internal.corp.local", true, privateLookup, false, "http://internal.corp.local"},
+		{"multi-IP with one private rejected", "https://mixed.example.com", false, multiLookup, true, ""},
+
+		// The headline production bug: a peer announcing its own
+		// cluster-internal service name. Unresolvable from here — rejected
+		// regardless of allow_private_urls.
+		{"unresolvable hostname rejected", "http://asset:8090/api/v1", false, unresolvableLookup, true, ""},
+		{"unresolvable hostname rejected even with opt-in", "http://asset:8090/api/v1", true, unresolvableLookup, true, ""},
+
+		// Metadata deny-list holds even with the private opt-in.
+		{"metadata hostname rejected with opt-in", "http://metadata.google.internal/computeMetadata", true, publicLookup, true, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := validateURL(tc.raw, tc.allowPrivate)
+			got, err := validateURL(tc.raw, tc.allowPrivate, tc.lookup)
 			if tc.wantErr {
 				if err == nil {
 					t.Errorf("validateURL(%q) = %q, nil — want error", tc.raw, got)

--- a/ssrfguard/cache.go
+++ b/ssrfguard/cache.go
@@ -1,0 +1,75 @@
+package ssrfguard
+
+import (
+	"sync"
+	"time"
+)
+
+// SuccessCache is a bounded, TTL'd cache for successful URL validations.
+// Only successes belong in it — rejections must always re-validate so a
+// peer that fixes its DNS or config is re-accepted immediately.
+//
+// The bound matters because cache keys originate from untrusted p2p
+// announcements: without a cap, a peer announcing many unique-but-valid
+// URLs (each cached for the TTL) could grow the map without limit for the
+// life of the process. At capacity, Put first sweeps expired entries; if
+// the cache is still full the new entry is simply not cached — validation
+// still happens, callers just lose the caching benefit under churn, which
+// is the safe failure mode.
+type SuccessCache struct {
+	ttl time.Duration
+	max int
+
+	mu      sync.Mutex
+	entries map[string]successEntry
+}
+
+type successEntry struct {
+	value  string
+	expiry time.Time
+}
+
+// NewSuccessCache returns a cache holding at most maxEntries values for up
+// to ttl each. maxEntries must be > 0.
+func NewSuccessCache(ttl time.Duration, maxEntries int) *SuccessCache {
+	return &SuccessCache{
+		ttl:     ttl,
+		max:     maxEntries,
+		entries: make(map[string]successEntry),
+	}
+}
+
+// Get returns the cached value for key if present and unexpired. Expired
+// entries are deleted on access.
+func (c *SuccessCache) Get(key string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok {
+		return "", false
+	}
+	if time.Now().After(e.expiry) {
+		delete(c.entries, key)
+		return "", false
+	}
+	return e.value, true
+}
+
+// Put caches value under key for the cache TTL. At capacity it sweeps
+// expired entries first; if still full, the entry is dropped (see type doc).
+func (c *SuccessCache) Put(key, value string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.entries[key]; !exists && len(c.entries) >= c.max {
+		now := time.Now()
+		for k, e := range c.entries {
+			if now.After(e.expiry) {
+				delete(c.entries, k)
+			}
+		}
+		if len(c.entries) >= c.max {
+			return
+		}
+	}
+	c.entries[key] = successEntry{value: value, expiry: time.Now().Add(c.ttl)}
+}

--- a/ssrfguard/ssrfguard.go
+++ b/ssrfguard/ssrfguard.go
@@ -19,9 +19,17 @@
 // and either turn arcade's propagation path into an SSRF primitive against
 // cloud metadata endpoints / RFC1918 neighbors, or pollute the shared
 // endpoint registry with URLs that can never be reached from this cluster.
-// We block by destination IP rather than hostname so an announcer cannot
-// bypass via DNS, IP literal, or rebinding, and we treat DNS-resolution
-// failure as invalid — an unresolvable name must not enter the registry.
+// ValidateURL blocks by destination IP rather than hostname — checking
+// every address the name resolves to at validation time — and treats
+// DNS-resolution failure as invalid, so an unresolvable name never enters
+// the registry.
+//
+// Validation-time resolution alone does not defeat DNS rebinding: a
+// hostname can resolve publicly when validated and privately when later
+// dialed. Closing that window requires wiring CheckDialAddress into the
+// dialer (net.Dialer.Control) of any client that connects to validated
+// URLs; callers that skip the dial-time hook accept the rebinding
+// residual risk.
 package ssrfguard
 
 import (

--- a/ssrfguard/ssrfguard.go
+++ b/ssrfguard/ssrfguard.go
@@ -1,0 +1,212 @@
+// Package ssrfguard implements a shared SSRF (Server-Side Request Forgery)
+// blocking predicate for URLs arcade learns from untrusted sources — most
+// importantly DataHub URLs announced by teranode peers over p2p, which
+// arcade later POSTs transactions to from inside the cluster.
+//
+// Ported from merkle-service's internal/ssrfguard (see merkle-service PR
+// #181, which fixed the same bug class at its p2p announcement intake) so
+// the two repos validate discovered URLs identically.
+//
+// # Threat model
+//
+// A p2p peer announces the DataHub URL other nodes should propagate
+// transactions to. Without guards a hostile (or simply misconfigured) peer
+// can announce, e.g.,
+//
+//	http://169.254.169.254/latest/meta-data/iam/security-credentials/
+//	http://asset:8090/api/v1  (its own cluster-internal service name)
+//
+// and either turn arcade's propagation path into an SSRF primitive against
+// cloud metadata endpoints / RFC1918 neighbors, or pollute the shared
+// endpoint registry with URLs that can never be reached from this cluster.
+// We block by destination IP rather than hostname so an announcer cannot
+// bypass via DNS, IP literal, or rebinding, and we treat DNS-resolution
+// failure as invalid — an unresolvable name must not enter the registry.
+package ssrfguard
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// ErrBlockedAddress is returned when a URL or destination address points
+// at a private/loopback/link-local/multicast/unspecified IP and the
+// caller has not opted in to allow private destinations.
+var ErrBlockedAddress = errors.New("destination address is blocked by SSRF policy")
+
+// ErrInvalidURL is returned when a URL is structurally invalid (parse
+// failure, missing scheme/host, disallowed scheme, unresolvable host, etc.).
+var ErrInvalidURL = errors.New("invalid URL")
+
+// blockedHostnames is a small deny list of hostnames that are considered
+// SSRF-relevant on top of the IP-based predicate. They mostly resolve to
+// link-local IPs (e.g. 169.254.169.254) which are already covered by
+// IsLinkLocalUnicast, but we list them defensively so the rejection
+// message is human-readable when someone tries them by name.
+var blockedHostnames = map[string]struct{}{
+	"metadata.google.internal": {},
+	"metadata":                 {},
+	"metadata.goog":            {},
+	"169.254.169.254":          {},
+	"fd00:ec2::254":            {}, // AWS IMDSv2 link-local IPv6
+}
+
+// cgnatNet is 100.64.0.0/10 (RFC 6598 shared address space / carrier-grade
+// NAT). Go's IP.IsPrivate only covers RFC1918, so CGNAT needs an explicit
+// check. (merkle-service's copy documents CGNAT but never checks it — fixed
+// here; worth upstreaming.)
+var cgnatNet = net.IPNet{IP: net.IPv4(100, 64, 0, 0), Mask: net.CIDRMask(10, 32)}
+
+// IsBlockedIP reports whether ip is on the SSRF deny-list. The deny-list
+// covers loopback, link-local unicast/multicast, multicast, RFC1918
+// private (10/8, 172.16/12, 192.168/16) and CGNAT (100.64/10),
+// unique-local IPv6 (fc00::/7), the IPv4 unspecified address (0.0.0.0)
+// and the IPv6 unspecified address (::). Loopback covers 127/8 and ::1.
+//
+// Pass allowPrivate=true to opt out of the private/loopback/link-local
+// checks (operator-controlled escape hatch for testing or legitimately
+// internal deployments).
+func IsBlockedIP(ip net.IP, allowPrivate bool) bool {
+	if ip == nil {
+		// A nil IP cannot be safely dialed; treat as blocked.
+		return true
+	}
+	if ip.IsUnspecified() {
+		// 0.0.0.0 and :: never identify a real remote host. They
+		// resolve to the local machine's own listening sockets, which
+		// is exactly what an SSRF attacker wants.
+		return true
+	}
+	if ip.IsMulticast() || ip.IsInterfaceLocalMulticast() || ip.IsLinkLocalMulticast() {
+		return true
+	}
+	if allowPrivate {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsPrivate() {
+		return true
+	}
+	if v4 := ip.To4(); v4 != nil && cgnatNet.Contains(v4) {
+		return true
+	}
+	// IPv6 unique local (fc00::/7) — IsPrivate covers this in Go 1.17+
+	// but we keep an explicit fallback for clarity / future-proofing.
+	if ip.To4() == nil && len(ip) == net.IPv6len && ip[0]&0xfe == 0xfc {
+		return true
+	}
+	return false
+}
+
+// IsBlockedHostname returns true if the hostname (lowercased, port
+// stripped) matches a known cloud metadata or internal hostname.
+// Hostname-based blocking is a best-effort defense-in-depth check on top
+// of IP-based blocking; the IP check is authoritative.
+func IsBlockedHostname(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return false
+	}
+	// Strip an optional brackets + port from IPv6 literals.
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	_, ok := blockedHostnames[host]
+	return ok
+}
+
+// ValidateURL parses raw and rejects it if the URL is malformed, uses a
+// scheme other than http/https, has no host, or resolves to a blocked
+// destination. lookup is the DNS function used to resolve a hostname to
+// IP addresses; pass net.LookupIP in production and a stub in tests. If
+// lookup is nil, net.LookupIP is used.
+//
+// allowPrivate lets operators opt in to private/loopback/link-local
+// destinations. The metadata-hostname, unspecified/multicast, and
+// DNS-resolvability checks remain in force regardless.
+func ValidateURL(raw string, allowPrivate bool, lookup func(host string) ([]net.IP, error)) error {
+	if raw == "" {
+		return fmt.Errorf("%w: empty URL", ErrInvalidURL)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidURL, err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("%w: scheme %q not allowed (must be http or https)", ErrInvalidURL, u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("%w: missing host", ErrInvalidURL)
+	}
+	// Reject userinfo entirely — `https://example.com:80@127.0.0.1/` would
+	// parse with Hostname() == "127.0.0.1" so the IP check below already
+	// catches the canonical form, but stripping userinfo also dodges any
+	// downstream tooling that incorrectly treats user@host as the host.
+	if u.User != nil {
+		return fmt.Errorf("%w: URL must not contain userinfo", ErrInvalidURL)
+	}
+
+	if IsBlockedHostname(host) {
+		return fmt.Errorf("%w: hostname %q is on the metadata-endpoint deny list", ErrBlockedAddress, host)
+	}
+
+	// If host is an IP literal, check it directly. Otherwise resolve and
+	// check every returned address — an attacker who controls DNS could
+	// otherwise return a single internal address that we miss if we only
+	// check the first.
+	if ip := net.ParseIP(host); ip != nil {
+		if IsBlockedIP(ip, allowPrivate) {
+			return fmt.Errorf("%w: %s", ErrBlockedAddress, ip.String())
+		}
+		return nil
+	}
+
+	if lookup == nil {
+		lookup = net.LookupIP
+	}
+	ips, err := lookup(host)
+	if err != nil {
+		// DNS resolution failure at discovery time is treated as a
+		// validation error so the caller knows the URL is unusable; a
+		// cluster-internal name like "asset" must not enter the shared
+		// endpoint registry only to fail on every propagation attempt.
+		return fmt.Errorf("%w: failed to resolve %s: %w", ErrInvalidURL, host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("%w: %s did not resolve to any addresses", ErrInvalidURL, host)
+	}
+	for _, ip := range ips {
+		if IsBlockedIP(ip, allowPrivate) {
+			return fmt.Errorf("%w: %s resolves to %s", ErrBlockedAddress, host, ip.String())
+		}
+	}
+	return nil
+}
+
+// CheckDialAddress validates a host:port address that the dialer is
+// about to connect to. Used as a hook in net.Dialer.Control so DNS
+// rebinding or any host that slipped past ValidateURL is rejected at
+// connection time. address is the canonical "ip:port" form passed to
+// the network stack — it is always an IP literal at this point.
+func CheckDialAddress(address string, allowPrivate bool) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		// If we can't even parse the address, fail closed.
+		return fmt.Errorf("%w: cannot parse dial address %q: %w", ErrBlockedAddress, address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// Dialer.Control receives the resolved IP, so a non-IP host is
+		// itself anomalous; refuse rather than guess.
+		return fmt.Errorf("%w: dial address %q is not an IP", ErrBlockedAddress, host)
+	}
+	if IsBlockedIP(ip, allowPrivate) {
+		return fmt.Errorf("%w: refusing to dial %s", ErrBlockedAddress, ip.String())
+	}
+	return nil
+}

--- a/ssrfguard/ssrfguard_test.go
+++ b/ssrfguard/ssrfguard_test.go
@@ -1,0 +1,282 @@
+package ssrfguard
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestIsBlockedIP(t *testing.T) {
+	cases := []struct {
+		name         string
+		ip           string
+		allowPrivate bool
+		blocked      bool
+	}{
+		{"loopback v4", "127.0.0.1", false, true},
+		{"loopback v4 random", "127.10.20.30", false, true},
+		{"loopback v6", "::1", false, true},
+		{"link-local v4 metadata", "169.254.169.254", false, true},
+		{"link-local v4 generic", "169.254.0.1", false, true},
+		{"link-local v6", "fe80::1", false, true},
+		{"rfc1918 10/8", "10.0.0.1", false, true},
+		{"rfc1918 172.16/12", "172.16.0.1", false, true},
+		{"rfc1918 172.31/12 edge", "172.31.255.255", false, true},
+		{"rfc1918 192.168/16", "192.168.1.1", false, true},
+		{"unspecified v4", "0.0.0.0", false, true},
+		{"unspecified v6", "::", false, true},
+		{"multicast v4", "224.0.0.1", false, true},
+		{"multicast v6", "ff02::1", false, true},
+		{"unique-local v6", "fc00::1", false, true},
+		{"unique-local v6 fd", "fd12:3456:789a::1", false, true},
+		{"cgnat 100.64/10 low", "100.64.0.1", false, true},
+		{"cgnat 100.64/10 high", "100.127.255.254", false, true},
+		{"just below cgnat", "100.63.255.255", false, false},
+		{"just above cgnat", "100.128.0.1", false, false},
+		{"cgnat (allowPrivate)", "100.64.0.1", true, false},
+		{"public v4", "8.8.8.8", false, false},
+		{"public v6", "2606:4700:4700::1111", false, false},
+		{"public v4 (allowPrivate)", "8.8.8.8", true, false},
+		// allowPrivate flips RFC1918/loopback/link-local but NOT
+		// unspecified/multicast which are never reachable destinations.
+		{"loopback (allowPrivate)", "127.0.0.1", true, false},
+		{"rfc1918 (allowPrivate)", "10.0.0.1", true, false},
+		{"link-local (allowPrivate)", "169.254.169.254", true, false},
+		{"unspecified (allowPrivate)", "0.0.0.0", true, true},
+		{"multicast (allowPrivate)", "224.0.0.1", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ip := net.ParseIP(tc.ip)
+			if ip == nil {
+				t.Fatalf("could not parse %q as IP", tc.ip)
+			}
+			got := IsBlockedIP(ip, tc.allowPrivate)
+			if got != tc.blocked {
+				t.Fatalf("IsBlockedIP(%s, allowPrivate=%v) = %v, want %v", tc.ip, tc.allowPrivate, got, tc.blocked)
+			}
+		})
+	}
+}
+
+func TestIsBlockedIP_NilIP(t *testing.T) {
+	if !IsBlockedIP(nil, false) {
+		t.Fatal("nil IP should be blocked")
+	}
+	if !IsBlockedIP(nil, true) {
+		t.Fatal("nil IP should be blocked even when allowPrivate=true")
+	}
+}
+
+func TestIsBlockedHostname(t *testing.T) {
+	cases := []struct {
+		host    string
+		blocked bool
+	}{
+		{"metadata.google.internal", true},
+		{"METADATA.GOOGLE.INTERNAL", true},
+		{"metadata", true},
+		{"169.254.169.254", true},
+		{"example.com", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			got := IsBlockedHostname(tc.host)
+			if got != tc.blocked {
+				t.Fatalf("IsBlockedHostname(%q) = %v, want %v", tc.host, got, tc.blocked)
+			}
+		})
+	}
+}
+
+// stubLookup builds a fake DNS function for tests.
+func stubLookup(m map[string][]string) func(string) ([]net.IP, error) {
+	return func(host string) ([]net.IP, error) {
+		ips, ok := m[host]
+		if !ok {
+			return nil, fmt.Errorf("no such host: %s", host)
+		}
+		out := make([]net.IP, 0, len(ips))
+		for _, s := range ips {
+			out = append(out, net.ParseIP(s))
+		}
+		return out, nil
+	}
+}
+
+func TestValidateURL_AcceptsPublic(t *testing.T) {
+	lookup := stubLookup(map[string][]string{
+		"example.com": {"93.184.216.34"},
+	})
+	if err := ValidateURL("https://example.com/foo", false, lookup); err != nil {
+		t.Fatalf("expected accept, got %v", err)
+	}
+}
+
+func TestValidateURL_RejectsBadScheme(t *testing.T) {
+	cases := []string{
+		"file:///etc/passwd",
+		"gopher://evil.example.com/",
+		"ftp://example.com/",
+		"javascript:alert(1)",
+	}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			err := ValidateURL(raw, false, nil)
+			if !errors.Is(err, ErrInvalidURL) {
+				t.Fatalf("expected ErrInvalidURL, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateURL_RejectsIPLiterals(t *testing.T) {
+	cases := []string{
+		"http://127.0.0.1/foo",
+		"http://10.0.0.1/foo",
+		"http://192.168.1.1/foo",
+		"http://172.16.0.1/foo",
+		"http://172.31.255.255/foo",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://0.0.0.0/foo",
+		"http://[::1]/foo",
+		"http://[fe80::1]/foo",
+		"http://[fc00::1]/foo",
+	}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			err := ValidateURL(raw, false, nil)
+			if !errors.Is(err, ErrBlockedAddress) {
+				t.Fatalf("expected ErrBlockedAddress, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateURL_RejectsResolvedToPrivate(t *testing.T) {
+	lookup := stubLookup(map[string][]string{
+		"sneaky.example.com": {"10.0.0.42"},
+	})
+	err := ValidateURL("https://sneaky.example.com/foo", false, lookup)
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress for hostname resolving to RFC1918, got %v", err)
+	}
+}
+
+func TestValidateURL_RejectsAnyOfMultiResolved(t *testing.T) {
+	// Attacker DNS returns one public + one private; must reject.
+	lookup := stubLookup(map[string][]string{
+		"mixed.example.com": {"8.8.8.8", "10.0.0.1"},
+	})
+	err := ValidateURL("https://mixed.example.com/foo", false, lookup)
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress when any resolved IP is private, got %v", err)
+	}
+}
+
+func TestValidateURL_RejectsUserinfo(t *testing.T) {
+	// Even though Go's url.Parse correctly extracts hostname=127.0.0.1,
+	// we explicitly reject userinfo to dodge downstream parser quirks.
+	err := ValidateURL("https://example.com:80@127.0.0.1/foo", false, nil)
+	if !errors.Is(err, ErrInvalidURL) && !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected rejection of userinfo URL, got %v", err)
+	}
+}
+
+func TestValidateURL_RejectsMetadataHostname(t *testing.T) {
+	lookup := stubLookup(map[string][]string{
+		"metadata.google.internal": {"8.8.8.8"}, // Even if it "resolves" public.
+	})
+	err := ValidateURL("https://metadata.google.internal/computeMetadata/v1/", false, lookup)
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress for metadata hostname, got %v", err)
+	}
+}
+
+func TestValidateURL_AllowPrivateOptIn(t *testing.T) {
+	lookup := stubLookup(map[string][]string{
+		"internal.example": {"10.0.0.1"},
+	})
+	// allowPrivate=true: same input now passes.
+	if err := ValidateURL("https://internal.example/foo", true, lookup); err != nil {
+		t.Fatalf("expected accept with allowPrivate=true, got %v", err)
+	}
+	if err := ValidateURL("http://127.0.0.1:8080/cb", true, nil); err != nil {
+		t.Fatalf("expected accept with allowPrivate=true, got %v", err)
+	}
+}
+
+func TestValidateURL_DNSFailureIsValidationError(t *testing.T) {
+	lookup := stubLookup(map[string][]string{}) // empty = always errors
+	err := ValidateURL("https://nonexistent.example/", false, lookup)
+	if !errors.Is(err, ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL on DNS failure, got %v", err)
+	}
+}
+
+func TestValidateURL_EmptyAndMissingPieces(t *testing.T) {
+	if err := ValidateURL("", false, nil); !errors.Is(err, ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL for empty, got %v", err)
+	}
+	if err := ValidateURL("https:///foo", false, nil); !errors.Is(err, ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL for missing host, got %v", err)
+	}
+	// url.Parse rejects this with a parse error.
+	if err := ValidateURL("http://[::1", false, nil); !errors.Is(err, ErrInvalidURL) {
+		t.Fatalf("expected ErrInvalidURL for malformed IPv6 literal, got %v", err)
+	}
+}
+
+func TestCheckDialAddress(t *testing.T) {
+	cases := []struct {
+		name         string
+		address      string
+		allowPrivate bool
+		blocked      bool
+	}{
+		{"loopback", "127.0.0.1:8080", false, true},
+		{"loopback v6", "[::1]:443", false, true},
+		{"private", "10.0.0.1:80", false, true},
+		{"link-local", "169.254.169.254:80", false, true},
+		{"public", "93.184.216.34:443", false, false},
+		{"loopback (allowPrivate)", "127.0.0.1:8080", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckDialAddress(tc.address, tc.allowPrivate)
+			if !tc.blocked {
+				if err != nil {
+					t.Fatalf("expected accept, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected block, got nil")
+			}
+			if !errors.Is(err, ErrBlockedAddress) {
+				t.Fatalf("expected ErrBlockedAddress, got %v", err)
+			}
+			meaningful := strings.Contains(err.Error(), "refusing") ||
+				strings.Contains(err.Error(), "blocked") ||
+				strings.Contains(err.Error(), "is not an IP") ||
+				strings.Contains(err.Error(), "cannot parse")
+			if !meaningful {
+				t.Fatalf("expected meaningful message, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckDialAddress_Malformed(t *testing.T) {
+	if err := CheckDialAddress("not-a-real-address", false); !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress, got %v", err)
+	}
+	// Hostname rather than IP — Dialer.Control always receives an IP, so a
+	// non-IP host is anomalous and must fail closed.
+	if err := CheckDialAddress("example.com:80", false); !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress for non-IP host, got %v", err)
+	}
+}

--- a/ssrfguard/ssrfguard_test.go
+++ b/ssrfguard/ssrfguard_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestIsBlockedIP(t *testing.T) {
@@ -278,5 +279,38 @@ func TestCheckDialAddress_Malformed(t *testing.T) {
 	// non-IP host is anomalous and must fail closed.
 	if err := CheckDialAddress("example.com:80", false); !errors.Is(err, ErrBlockedAddress) {
 		t.Fatalf("expected ErrBlockedAddress for non-IP host, got %v", err)
+	}
+}
+
+func TestSuccessCache_TTLAndBound(t *testing.T) {
+	c := NewSuccessCache(50*time.Millisecond, 2)
+
+	c.Put("a", "va")
+	if v, ok := c.Get("a"); !ok || v != "va" {
+		t.Fatalf("Get(a) = %q,%v — want va,true", v, ok)
+	}
+
+	// At capacity with unexpired entries, new keys are not cached (safe
+	// failure mode: validation still runs, just uncached).
+	c.Put("b", "vb")
+	c.Put("c", "vc")
+	if _, ok := c.Get("c"); ok {
+		t.Fatal("cache exceeded its bound: c should not have been cached")
+	}
+
+	// Updating an existing key at capacity must still work.
+	c.Put("a", "va2")
+	if v, _ := c.Get("a"); v != "va2" {
+		t.Fatalf("update at capacity failed: got %q", v)
+	}
+
+	// After TTL, expired entries are swept on Put and misses on Get.
+	time.Sleep(60 * time.Millisecond)
+	if _, ok := c.Get("a"); ok {
+		t.Fatal("expired entry served")
+	}
+	c.Put("c", "vc")
+	if v, ok := c.Get("c"); !ok || v != "vc" {
+		t.Fatalf("Put after expiry sweep failed: %q,%v", v, ok)
 	}
 }

--- a/teranode/client.go
+++ b/teranode/client.go
@@ -60,11 +60,11 @@ const (
 // guarded by the enclosing Client's RWMutex — the struct itself is not
 // independently thread-safe.
 //
-// Two parallel failure counters drive the same `state` field:
+// Three parallel failure counters drive the same `state` field:
 //
 //   - consecutiveFailures: fast track for reachability failures (no HTTP
-//     response received — DNS, transport, timeout). Trips at
-//     failureThreshold (default 3).
+//     response received — DNS, transport, timeout) observed on the
+//     broadcast path. Trips at failureThreshold (default 3).
 //   - consecutiveBroadcastFailures: slow track for non-2xx responses. Trips
 //     at broadcastFailureThreshold (default 10). Catches the case where an
 //     endpoint is responding but consistently rejecting our payload —
@@ -72,12 +72,24 @@ const (
 //     peers whose validation rules disagree with ours, are alive but
 //     useless to us. Without this, every broadcast wasted a worker slot on
 //     them.
+//   - consecutiveProbeFailures: reachability failures observed by the
+//     background probe loop, which probes EVERY endpoint (not just
+//     unhealthy ones). Trips at failureThreshold. This is what lets pods
+//     that never broadcast (api-server, sse, watchdog) demote a dead
+//     endpoint so their /health output reflects reality. It is deliberately
+//     a separate counter: a probe success on a healthy endpoint must NOT
+//     reset the broadcast-path counters, otherwise a 30s probe cadence
+//     against an endpoint whose /health answers — but whose POST /txs
+//     always fails — would keep resetting the slow track and the breaker
+//     could never trip.
 //
-// Either counter tripping marks the endpoint unhealthy; a single 2xx
-// response resets both.
+// Any counter tripping marks the endpoint unhealthy; a single 2xx broadcast
+// response (RecordSuccess) or a probe success on an unhealthy endpoint
+// resets all three.
 type endpointHealth struct {
 	consecutiveFailures          int
 	consecutiveBroadcastFailures int
+	consecutiveProbeFailures     int
 	lastFailure                  time.Time
 	state                        healthState
 	source                       healthSource
@@ -364,7 +376,7 @@ func (c *Client) AddEndpoints(urls []string) int {
 	return added
 }
 
-// RecordSuccess resets both failure counters to zero (a successful 2xx
+// RecordSuccess resets all failure counters to zero (a successful 2xx
 // response is the canonical signal of full endpoint health) and, if the
 // endpoint was previously unhealthy, transitions it back to healthy.
 // Unknown URLs are silently ignored so callers don't need to pre-check.
@@ -379,6 +391,7 @@ func (c *Client) RecordSuccess(url string) {
 	transitioned := h.state == stateUnhealthy
 	h.consecutiveFailures = 0
 	h.consecutiveBroadcastFailures = 0
+	h.consecutiveProbeFailures = 0
 	h.state = stateHealthy
 	source := h.source
 	c.recomputeBelowThresholdLocked()
@@ -471,6 +484,83 @@ func (c *Client) RecordBroadcastFailure(url string) {
 			zap.String("reason", "persistent_non_2xx"),
 		)
 	}
+}
+
+// recordProbeFailure increments the probe-failure counter for an endpoint
+// and transitions it to unhealthy once the counter reaches failureThreshold.
+// Kept separate from RecordFailure so probe outcomes and broadcast outcomes
+// can't mask each other (see the endpointHealth doc comment).
+func (c *Client) recordProbeFailure(url string) {
+	n := normalizeURL(url)
+	c.mu.Lock()
+	h, ok := c.health[n]
+	if !ok {
+		c.mu.Unlock()
+		return
+	}
+	h.consecutiveProbeFailures++
+	h.lastFailure = time.Now()
+	transitioned := false
+	if h.state == stateHealthy && h.consecutiveProbeFailures >= c.failureThreshold {
+		h.state = stateUnhealthy
+		transitioned = true
+	}
+	source := h.source
+	consecutive := h.consecutiveProbeFailures
+	c.recomputeBelowThresholdLocked()
+	c.mu.Unlock()
+	if transitioned {
+		metrics.TeranodeEndpointHealth.WithLabelValues(n, sourceLabel(source)).Set(0)
+		c.logger.Warn(
+			"endpoint unhealthy",
+			zap.String("endpoint", n),
+			zap.Int("consecutive_probe_failures", consecutive),
+			zap.String("from", "healthy"),
+			zap.String("to", "unhealthy"),
+			zap.String("reason", "probe"),
+		)
+	}
+}
+
+// recordProbeSuccess handles a successful probe (any HTTP response).
+//
+// For an unhealthy endpoint this is the recovery signal and behaves exactly
+// like RecordSuccess: all counters reset, state flips back to healthy —
+// preserving the long-standing probe-recovery contract (any response, even
+// 4xx/5xx, proves reachability; usefulness is re-judged by the slow track
+// once broadcasts resume).
+//
+// For a healthy endpoint it resets ONLY the probe counter. The broadcast
+// counters are deliberately untouched: /health answering says nothing about
+// whether POST /txs works, and zeroing them here would neuter both
+// broadcast-path breakers for any pod running probes (i.e. all of them).
+func (c *Client) recordProbeSuccess(url string) {
+	n := normalizeURL(url)
+	c.mu.Lock()
+	h, ok := c.health[n]
+	if !ok {
+		c.mu.Unlock()
+		return
+	}
+	if h.state == stateUnhealthy {
+		h.consecutiveFailures = 0
+		h.consecutiveBroadcastFailures = 0
+		h.consecutiveProbeFailures = 0
+		h.state = stateHealthy
+		source := h.source
+		c.recomputeBelowThresholdLocked()
+		c.mu.Unlock()
+		metrics.TeranodeEndpointHealth.WithLabelValues(n, sourceLabel(source)).Set(1)
+		c.logger.Info(
+			"endpoint healthy",
+			zap.String("endpoint", n),
+			zap.String("from", "unhealthy"),
+			zap.String("to", "healthy"),
+		)
+		return
+	}
+	h.consecutiveProbeFailures = 0
+	c.mu.Unlock()
 }
 
 // sourceLabel converts the internal healthSource enum to the metric label value.
@@ -582,16 +672,19 @@ func (c *Client) probeLoop(ctx context.Context) {
 	}
 }
 
-// probeOnce collects the current unhealthy set under an RLock, then probes
+// probeOnce snapshots the full endpoint list under an RLock, then probes
 // each endpoint concurrently so one slow probe doesn't block the others.
+//
+// Healthy endpoints are probed too — not just unhealthy ones. Pods that
+// never broadcast (api-server, sse, watchdog) have no other signal that a
+// registered endpoint went dark, so without this their health map (and the
+// public /health datahub_urls output) reported dead endpoints healthy
+// forever. Probe outcomes feed the dedicated probe counter, never the
+// broadcast counters (see recordProbeSuccess).
 func (c *Client) probeOnce(ctx context.Context) {
 	c.mu.RLock()
-	var targets []string
-	for _, ep := range c.endpoints {
-		if h, ok := c.health[ep]; ok && h.state == stateUnhealthy {
-			targets = append(targets, ep)
-		}
-	}
+	targets := make([]string, len(c.endpoints))
+	copy(targets, c.endpoints)
 	c.mu.RUnlock()
 	if len(targets) == 0 {
 		return
@@ -610,7 +703,9 @@ func (c *Client) probeOnce(ctx context.Context) {
 
 // probeEndpoint issues a single GET /health. A non-nil HTTP response counts
 // as reachable regardless of status code; a transport error or context
-// timeout counts as a failure.
+// timeout counts as a failure. Outcomes are recorded on the probe-specific
+// counter so probes can demote unreachable endpoints (and recover unhealthy
+// ones) without touching the broadcast-path breaker counters.
 func (c *Client) probeEndpoint(ctx context.Context, endpoint string) {
 	start := time.Now()
 	probeCtx, cancel := context.WithTimeout(ctx, c.probeTimeout)
@@ -618,18 +713,18 @@ func (c *Client) probeEndpoint(ctx context.Context, endpoint string) {
 	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, endpoint+"/health", nil)
 	if err != nil {
 		observeRequest("probe", 0, start)
-		c.RecordFailure(endpoint)
+		c.recordProbeFailure(endpoint)
 		return
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		observeRequest("probe", 0, start)
-		c.RecordFailure(endpoint)
+		c.recordProbeFailure(endpoint)
 		return
 	}
 	observeRequest("probe", resp.StatusCode, start)
 	drainAndClose(resp.Body)
-	c.RecordSuccess(endpoint)
+	c.recordProbeSuccess(endpoint)
 }
 
 // observeRequest records latency + status class for an outbound HTTP request.

--- a/teranode/health_test.go
+++ b/teranode/health_test.go
@@ -371,3 +371,143 @@ func TestProbe_StopsOnClose(t *testing.T) {
 		t.Fatal("Close did not return within 2s")
 	}
 }
+
+// TestProbe_TripsUnreachableHealthyEndpoint is the truthful-health
+// regression test: a registered-but-unreachable endpoint must be demoted by
+// the probe loop alone — no broadcast traffic — so pods that never
+// broadcast (api-server serving /health) stop reporting dead endpoints as
+// healthy.
+func TestProbe_TripsUnreachableHealthyEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	deadURL := srv.URL
+	srv.Close() // port now refuses connections
+
+	c := NewClient([]string{deadURL}, "", HealthConfig{
+		FailureThreshold: 3,
+		ProbeInterval:    10 * time.Millisecond,
+		ProbeTimeout:     200 * time.Millisecond,
+	})
+	if len(c.GetHealthyEndpoints()) != 1 {
+		t.Fatal("endpoint should start healthy")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.Start(ctx)
+	defer c.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		statuses := c.GetEndpointStatuses()
+		if len(statuses) == 1 && !statuses[0].Healthy {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("probe loop did not demote an unreachable healthy endpoint within 2s")
+}
+
+// TestProbe_HealthySuccess_DoesNotResetBroadcastCounter guards the reason
+// probe outcomes use a dedicated counter: an endpoint whose /health answers
+// 200 but whose broadcasts persistently fail non-2xx must still trip the
+// slow track, even with fast probes succeeding between every failure.
+func TestProbe_HealthySuccess_DoesNotResetBroadcastCounter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient([]string{srv.URL}, "", HealthConfig{
+		FailureThreshold:          3,
+		BroadcastFailureThreshold: 5,
+		ProbeInterval:             5 * time.Millisecond,
+		ProbeTimeout:              200 * time.Millisecond,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.Start(ctx)
+	defer c.Close()
+
+	for i := 0; i < 5; i++ {
+		// Several probe intervals pass between failures; each probe succeeds
+		// against the live server. If probe success reset the broadcast
+		// counter, the threshold could never be reached.
+		time.Sleep(15 * time.Millisecond)
+		c.RecordBroadcastFailure(srv.URL)
+	}
+	if got := len(c.GetHealthyEndpoints()); got != 0 {
+		t.Fatal("slow-track breaker did not trip: probe successes must not reset consecutiveBroadcastFailures")
+	}
+}
+
+// TestProbe_HealthySuccess_DoesNotResetReachabilityCounter is the fast-track
+// sibling: broadcast-path transport failures must accumulate to the
+// threshold regardless of interleaved probe successes.
+func TestProbe_HealthySuccess_DoesNotResetReachabilityCounter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient([]string{srv.URL}, "", HealthConfig{
+		FailureThreshold: 3,
+		ProbeInterval:    5 * time.Millisecond,
+		ProbeTimeout:     200 * time.Millisecond,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.Start(ctx)
+	defer c.Close()
+
+	for i := 0; i < 3; i++ {
+		time.Sleep(15 * time.Millisecond)
+		c.RecordFailure(srv.URL)
+	}
+	if got := len(c.GetHealthyEndpoints()); got != 0 {
+		t.Fatal("fast-track breaker did not trip: probe successes must not reset consecutiveFailures")
+	}
+}
+
+// TestRecordProbeCounters_UnitSemantics pins the probe counter's consecutive
+// semantics and the full-recovery contract without any HTTP traffic.
+func TestRecordProbeCounters_UnitSemantics(t *testing.T) {
+	c := NewClient([]string{testEndpointA}, "", HealthConfig{FailureThreshold: 3})
+
+	// Two failures + a success: counter resets, still healthy.
+	c.recordProbeFailure(testEndpointA)
+	c.recordProbeFailure(testEndpointA)
+	c.recordProbeSuccess(testEndpointA)
+	c.recordProbeFailure(testEndpointA)
+	c.recordProbeFailure(testEndpointA)
+	if len(c.GetHealthyEndpoints()) != 1 {
+		t.Fatal("non-consecutive probe failures must not trip the breaker")
+	}
+
+	// Third consecutive failure trips.
+	c.recordProbeFailure(testEndpointA)
+	if len(c.GetHealthyEndpoints()) != 0 {
+		t.Fatal("3rd consecutive probe failure should trip the breaker")
+	}
+
+	// Probe success on an unhealthy endpoint = full recovery: all counters
+	// reset, so the slow track needs its full threshold again afterwards.
+	c.RecordBroadcastFailure(testEndpointA) // accumulate some pre-recovery state
+	c.recordProbeSuccess(testEndpointA)
+	if len(c.GetHealthyEndpoints()) != 1 {
+		t.Fatal("probe success should recover an unhealthy endpoint")
+	}
+	// 9 more broadcast failures shouldn't trip a threshold of 10 if the
+	// pre-recovery failure was wiped.
+	for i := 0; i < 9; i++ {
+		c.RecordBroadcastFailure(testEndpointA)
+	}
+	if len(c.GetHealthyEndpoints()) != 1 {
+		t.Fatal("recovery must reset consecutiveBroadcastFailures (9 < threshold 10)")
+	}
+	c.RecordBroadcastFailure(testEndpointA)
+	if len(c.GetHealthyEndpoints()) != 0 {
+		t.Fatal("10th consecutive broadcast failure should trip")
+	}
+}


### PR DESCRIPTION
## Problem

`https://arcade-v2-us-1.bsvblockchain.tech/health` reports `{url: "http://asset:8090/api/v1", source: "discovered", healthy: true}` — a peer's cluster-internal service name, unreachable from arcade. Two independent gaps:

1. **Discovery validation was syntactic-only** (`services/p2p_client/node_status.go`): the private-address check applied to IP *literals* only, so a bare hostname like `asset` passed without any check that it resolves or where it resolves to — a gap the old test suite explicitly documented as intended behavior. The URL then persisted forever in the shared registry (no TTL/eviction) and re-entered every pod's endpoint set on every 30s refresh.
2. **Health state never updated outside the propagation pod**: the recovery probe only targeted *already-unhealthy* endpoints, and only broadcast outcomes recorded failures. The api-server pod (which serves `/health`) never broadcasts, so its per-pod circuit-breaker map reported every endpoint `healthy: true` forever.

## Fix

Mirrors merkle-service #181's announcement-validation pattern:

- **New `ssrfguard` package** (ported from merkle-service; fixed the CGNAT 100.64/10 doc-vs-code gap during the port): scheme allowlist, userinfo rejection, cloud-metadata deny list, blocked-IP predicate, and DNS resolution of non-literal hostnames with **every** resolved IP checked. **Unresolvable hostnames are rejected regardless of `p2p.allow_private_urls`.**
- **Discovery intake** (`p2p_client`): announcements validated behind a success-only 5-min TTL cache (2s DNS bound, injectable lookup for tests); rejects metered `invalid`/`blocked` + WARN with peer ID. `asset:8090` never reaches the registry.
- **Refresh-time filter** (`app.endpointSource`): `source=discovered` registry rows re-validated on every listing — **neutralizes the already-poisoned registry row with no data migration**. Operator-configured `datahub_urls` are exempt (may legitimately be cluster-internal). New metric `arcade_teranode_endpoint_refresh_rejected_total{outcome}`; WARN once per URL per process, DEBUG thereafter.
- **Probe ALL endpoints** (`teranode.Client`): the probe loop now probes healthy endpoints too, via a dedicated `consecutiveProbeFailures` counter (trips at `failure_threshold`, reason="probe"). Crucial subtlety: probe success on a *healthy* endpoint resets **only** the probe counter — never the broadcast counters — otherwise a 30s probe cadence against an endpoint whose `/health` answers (but whose `POST /txs` always fails) would perpetually reset the slow-track breaker. Recovery of unhealthy endpoints is byte-for-byte the old contract (any HTTP response counts, incl. 4xx).

## Outcome

- `asset:8090` disappears from `/health` and every broadcast set after rollout.
- A dead-but-resolvable endpoint flips to `healthy: false` in **every** pod within ~90s (3 × 30s probes), no broadcast traffic needed.
- Probe load: ~8 endpoints × ~6 pods / 30s ≈ 1.6 req/s fleet-wide.

## Tests

- `ssrfguard`: ported table + CGNAT boundary cases.
- `p2p_client`: flipped the line-52 "privately-resolving DNS name treated as public" case; headline `asset:8090` unresolvable-rejection; cache = 1 lookup per URL per TTL; upsert-per-announcement preserved.
- `app`: configured-bypass (lookup stub fails test if called), poisoned-row filtering, cache, rejection-never-cached, allow-private opt-in, discovery-off.
- `teranode`: probe demotes an unreachable healthy endpoint; probe successes do NOT reset either broadcast counter (the trap tests); probe-counter consecutive semantics; existing recovery tests pass unchanged.
- `api_server`: end-to-end — `/health` flips a dead endpoint to `healthy:false` driven purely by the probe loop (the exact production complaint).
- Full suite + `magex lint` green. openspec change `harden-datahub-discovery` validates.

## Rollout notes

- No new config keys; no defaults change. `p2p.allow_private_urls` (default false) now also gates DNS-*resolved* private addresses. Static `datahub_urls` are never validated, so local/standalone setups keep working.
- `/health` will start reporting `healthy: false` for genuinely dead endpoints in all pods, and `arcade_teranode_endpoint_healthy` now updates in non-broadcasting pods — check dashboards/alerts keyed on those; `min_healthy_endpoints` WARNs may fire more (signal becoming truthful).
- Follow-ups (documented in the openspec proposal): registry LastSeen pruning; dial-time `ssrfguard.CheckDialAddress` on the broadcast transport to close the DNS-rebinding window.