### PR TITLE
feat(api-server): reject non-final txs at intake with an actionable reason

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -19,11 +19,13 @@ import (
 	"time"
 
 	chaintrackslib "github.com/bsv-blockchain/go-chaintracks/chaintracks"
+	chaintracksconfig "github.com/bsv-blockchain/go-chaintracks/config"
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"go.uber.org/zap"
 
 	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/events"
+	"github.com/bsv-blockchain/arcade/finality"
 	"github.com/bsv-blockchain/arcade/kafka"
 	"github.com/bsv-blockchain/arcade/merkleservice"
 	"github.com/bsv-blockchain/arcade/metrics"
@@ -62,6 +64,10 @@ type Deps struct {
 	// that consume it (chaintracks_server, bump-builder canonical-root
 	// validation) must nil-guard.
 	Chaintracks chaintrackslib.Chaintracks
+	// FinalityChecker runs the api-server's nLockTime/BIP113 intake gate.
+	// nil (no chain source, or validator.disable_finality_check) disables
+	// the gate; the checker itself is nil-receiver-safe.
+	FinalityChecker *finality.Checker
 }
 
 // Bootstrap creates every shared dependency the services rely on, in the
@@ -204,6 +210,35 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *zap.Logger) (*De
 		chainTracks = ct
 	}
 
+	// Chain source for the api-server's nLockTime/BIP113 finality gate
+	// (issue #245). In mode=all the embedded chaintracks above is reused; in
+	// microservice deployments the api-server pod runs with chaintracks
+	// disabled (see modeNeedsChaintracks), so when the operator points
+	// chaintracks.mode=remote at the chaintracks pod we construct the cheap
+	// HTTP client here — no P2P, no storage, no ChainManager. No source →
+	// nil checker → gate off (fail-open by design; teranode stays the
+	// authority).
+	var finalityChecker *finality.Checker
+	if !cfg.Validator.DisableFinalityCheck && modeNeedsFinality(cfg.Mode) {
+		var reader finality.ChainReader
+		if chainTracks != nil {
+			reader = chainTracks
+		} else if cfg.Chaintracks.Mode == chaintracksconfig.ModeRemote && cfg.Chaintracks.URL != "" {
+			remote, remoteErr := cfg.Chaintracks.Initialize(ctx, "arcade-finality", nil)
+			if remoteErr != nil {
+				logger.Warn("finality pre-check disabled: remote chaintracks init failed", zap.Error(remoteErr))
+			} else {
+				reader = remote
+			}
+		}
+		if reader != nil {
+			finalityChecker = finality.NewChecker(reader, logger,
+				finality.WithUnavailableHook(metrics.APIFinalityPrecheckUnavailableTotal.Inc))
+		} else {
+			logger.Info("finality pre-check disabled: no chain source (enable chaintracks_server or set chaintracks.mode=remote with a URL)")
+		}
+	}
+
 	// Hydrate the TxTracker from the store BEFORE handing it to api-server.
 	// Gated to modes that actually consume it: only api-server reads
 	// deps.TxTracker (see BuildServices). Without hydration a restart leaves the
@@ -241,18 +276,19 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *zap.Logger) (*De
 	}
 
 	deps := &Deps{
-		Cfg:            cfg,
-		Logger:         logger,
-		Broker:         broker,
-		Producer:       producer,
-		Publisher:      publisher,
-		Store:          st,
-		Leaser:         leaser,
-		TxTracker:      txTracker,
-		TeranodeClient: teranodeClient,
-		MerkleClient:   merkleClient,
-		Validator:      txVal,
-		Chaintracks:    chainTracks,
+		Cfg:             cfg,
+		Logger:          logger,
+		Broker:          broker,
+		Producer:        producer,
+		Publisher:       publisher,
+		Store:           st,
+		Leaser:          leaser,
+		TxTracker:       txTracker,
+		TeranodeClient:  teranodeClient,
+		MerkleClient:    merkleClient,
+		Validator:       txVal,
+		Chaintracks:     chainTracks,
+		FinalityChecker: finalityChecker,
 	}
 
 	cleanup := func() {
@@ -300,6 +336,15 @@ func modeNeedsChaintracks(mode string) bool {
 	default:
 		return false
 	}
+}
+
+// modeNeedsFinality reports whether the configured mode constructs a service
+// that consumes Deps.FinalityChecker — only api-server does (the intake
+// finality gate). Deliberately NOT part of modeNeedsChaintracks: the gate
+// uses the remote chaintracks client in microservice deployments precisely
+// so api-server pods never spin up an embedded ChainManager.
+func modeNeedsFinality(mode string) bool {
+	return mode == "all" || mode == "api-server"
 }
 
 // modeNeedsTxTracker reports whether the configured mode constructs a service
@@ -415,7 +460,7 @@ func BuildServices(d *Deps) []services.Service {
 	}
 
 	if shouldRun("api-server") {
-		svcs = append(svcs, api_server.New(cfg, d.Logger, d.Producer, d.Publisher, d.Store, d.TxTracker, d.TeranodeClient, d.MerkleClient, d.Validator))
+		svcs = append(svcs, api_server.New(cfg, d.Logger, d.Producer, d.Publisher, d.Store, d.TxTracker, d.TeranodeClient, d.MerkleClient, d.Validator, d.FinalityChecker))
 	}
 	if shouldRun("bump-builder") {
 		// chainHeader is nil when chaintracks is disabled — bump-builder

--- a/app/app.go
+++ b/app/app.go
@@ -210,34 +210,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *zap.Logger) (*De
 		chainTracks = ct
 	}
 
-	// Chain source for the api-server's nLockTime/BIP113 finality gate
-	// (issue #245). In mode=all the embedded chaintracks above is reused; in
-	// microservice deployments the api-server pod runs with chaintracks
-	// disabled (see modeNeedsChaintracks), so when the operator points
-	// chaintracks.mode=remote at the chaintracks pod we construct the cheap
-	// HTTP client here — no P2P, no storage, no ChainManager. No source →
-	// nil checker → gate off (fail-open by design; teranode stays the
-	// authority).
-	var finalityChecker *finality.Checker
-	if !cfg.Validator.DisableFinalityCheck && modeNeedsFinality(cfg.Mode) {
-		var reader finality.ChainReader
-		if chainTracks != nil {
-			reader = chainTracks
-		} else if cfg.Chaintracks.Mode == chaintracksconfig.ModeRemote && cfg.Chaintracks.URL != "" {
-			remote, remoteErr := cfg.Chaintracks.Initialize(ctx, "arcade-finality", nil)
-			if remoteErr != nil {
-				logger.Warn("finality pre-check disabled: remote chaintracks init failed", zap.Error(remoteErr))
-			} else {
-				reader = remote
-			}
-		}
-		if reader != nil {
-			finalityChecker = finality.NewChecker(reader, logger,
-				finality.WithUnavailableHook(metrics.APIFinalityPrecheckUnavailableTotal.Inc))
-		} else {
-			logger.Info("finality pre-check disabled: no chain source (enable chaintracks_server or set chaintracks.mode=remote with a URL)")
-		}
-	}
+	finalityChecker := buildFinalityChecker(ctx, cfg, chainTracks, st, logger)
 
 	// Hydrate the TxTracker from the store BEFORE handing it to api-server.
 	// Gated to modes that actually consume it: only api-server reads
@@ -345,6 +318,49 @@ func modeNeedsChaintracks(mode string) bool {
 // so api-server pods never spin up an embedded ChainManager.
 func modeNeedsFinality(mode string) bool {
 	return mode == "all" || mode == "api-server"
+}
+
+// buildFinalityChecker wires the chain sources for the api-server's
+// nLockTime/BIP113 finality gate (issue #245). In mode=all the embedded
+// chaintracks is reused; in microservice deployments the api-server pod runs
+// with chaintracks disabled (see modeNeedsChaintracks), so when the operator
+// points chaintracks.mode=remote at the chaintracks pod the cheap HTTP
+// client is constructed here — no P2P, no storage, no ChainManager. The
+// store always backs a height-only fallback (adopted from PR #181): without
+// any chaintracks source, height-based locktimes are still gated while
+// timestamp locktimes fail open (they need MTP). Teranode stays the
+// authority in every degraded mode.
+func buildFinalityChecker(ctx context.Context, cfg *config.Config, chainTracks chaintrackslib.Chaintracks, st store.Store, logger *zap.Logger) *finality.Checker {
+	if cfg.Validator.DisableFinalityCheck || !modeNeedsFinality(cfg.Mode) {
+		return nil
+	}
+
+	reader := finalityChainReader(ctx, cfg, chainTracks, logger)
+	if reader == nil {
+		logger.Info("finality pre-check degraded to height-only: no MTP source (enable chaintracks_server or set chaintracks.mode=remote with a URL)")
+	}
+
+	return finality.NewChecker(reader, logger,
+		finality.WithHeightFallback(st),
+		finality.WithUnavailableHook(metrics.APIFinalityPrecheckUnavailableTotal.Inc))
+}
+
+// finalityChainReader picks the finality gate's chain source: the shared
+// embedded chaintracks when it exists, else a remote go-chaintracks client
+// when configured, else nil.
+func finalityChainReader(ctx context.Context, cfg *config.Config, chainTracks chaintrackslib.Chaintracks, logger *zap.Logger) finality.ChainReader {
+	if chainTracks != nil {
+		return chainTracks
+	}
+	if cfg.Chaintracks.Mode != chaintracksconfig.ModeRemote || cfg.Chaintracks.URL == "" {
+		return nil
+	}
+	remote, err := cfg.Chaintracks.Initialize(ctx, "arcade-finality", nil)
+	if err != nil {
+		logger.Warn("finality pre-check disabled: remote chaintracks init failed", zap.Error(err))
+		return nil
+	}
+	return remote
 }
 
 // modeNeedsTxTracker reports whether the configured mode constructs a service

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -151,6 +151,14 @@ health:
 #   # teratestnet/regtest where the upstream Teranode is also configured
 #   # to accept zero-fee txs. Leave false on mainnet and testnet.
 #   # accept_zero_fee: false
+#   # disable_finality_check turns off the nLockTime/BIP113 intake gate
+#   # that rejects provably non-final txs with an actionable reason
+#   # (issue #245). The gate needs a chain source: the embedded
+#   # chaintracks (mode=all) or chaintracks.mode=remote pointed at the
+#   # chaintracks pod (note: the URL must include the /chaintracks path
+#   # prefix). Without one it silently fails open, so this switch is only
+#   # an emergency escape hatch.
+#   # disable_finality_check: false
 
 # SSRF guard for client-supplied callback URLs. The api-server rejects
 # X-CallbackUrl values whose host is loopback / link-local / RFC1918 /

--- a/config/config.go
+++ b/config/config.go
@@ -672,6 +672,12 @@ type ValidatorConfig struct {
 	// false (default) on mainnet and any environment that should enforce
 	// the production fee floor. Takes precedence over MinFeePerKB.
 	AcceptZeroFee bool `mapstructure:"accept_zero_fee"`
+
+	// DisableFinalityCheck turns off the api-server's nLockTime/BIP113
+	// intake gate (issue #245). The gate is UX-only — teranode remains
+	// authoritative and the check fails open when chain state is
+	// unavailable — so this exists purely as an emergency escape hatch.
+	DisableFinalityCheck bool `mapstructure:"disable_finality_check"`
 }
 
 // DefaultValidatorMinFeePerKB is the production fee floor in satoshis

--- a/deploy/api-server.yaml
+++ b/deploy/api-server.yaml
@@ -43,6 +43,16 @@ spec:
               value: "aerospike-0.aerospike.arcade.svc.cluster.local:3000"
             - name: ARCADE_AEROSPIKE_NAMESPACE
               value: "arcade"
+            # Chain source for the nLockTime/BIP113 finality gate at intake
+            # (issue #245): the remote client keeps this pod free of an
+            # embedded ChainManager. The URL must include the /chaintracks
+            # path prefix — the go-chaintracks client appends /v2/* to it
+            # and arcade's chaintracks pod serves /chaintracks/v2/*.
+            # Without these vars the gate is skipped (fail-open).
+            - name: ARCADE_CHAINTRACKS_MODE
+              value: "remote"
+            - name: ARCADE_CHAINTRACKS_URL
+              value: "http://chaintracks.arcade.svc.cluster.local:8083/chaintracks"
             # HOST_IP feeds OTEL_EXPORTER_OTLP_ENDPOINT below to reach the
             # node-local OTLP collector via the Kubernetes downward API; it
             # MUST be defined before its $(HOST_IP) use. Telemetry itself

--- a/deploy/bump-builder.yaml
+++ b/deploy/bump-builder.yaml
@@ -41,11 +41,14 @@ spec:
               value: "arcade"
             # Talk to the chaintracks pod over HTTP instead of running an
             # embedded ChainManager + upstream header poller in this pod.
-            # The chaintracks Service exposes /chaintracks/v1/* on 8083.
+            # The URL must include the /chaintracks path prefix: the
+            # go-chaintracks remote client appends /v2/* to the base URL and
+            # arcade's chaintracks pod serves /chaintracks/v2/*. The previous
+            # suffix-less value 404'd on every request.
             - name: ARCADE_CHAINTRACKS_MODE
               value: "remote"
             - name: ARCADE_CHAINTRACKS_URL
-              value: "http://chaintracks.arcade.svc.cluster.local:8083"
+              value: "http://chaintracks.arcade.svc.cluster.local:8083/chaintracks"
             # HOST_IP feeds OTEL_EXPORTER_OTLP_ENDPOINT below to reach the
             # node-local OTLP collector via the Kubernetes downward API; it
             # MUST be defined before its $(HOST_IP) use. Telemetry itself

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -51,6 +51,13 @@ const (
 	StatusTxSize StatusCode = 474
 	// StatusMinedAncestorsNotInBUMP indicates mined ancestors not found in BUMPs.
 	StatusMinedAncestorsNotInBUMP StatusCode = 475
+	// StatusNotFinal indicates a non-final transaction: its nLockTime has not
+	// been reached (BIP113 median-time-past for timestamps, next block height
+	// for heights) and at least one input sequence is non-final. Resubmitting
+	// the identical transaction after the lock expires is expected to succeed.
+	// 474/475 already extend ARC's published table (which ends at 473); 476
+	// continues that arcade-local range.
+	StatusNotFinal StatusCode = 476
 )
 
 // arcDocURL is the base URL for ARC error documentation.
@@ -186,6 +193,9 @@ func NewErrorFields(status StatusCode, extraInfo string) *ErrorFields {
 	case StatusMinedAncestorsNotInBUMP:
 		fields.Title = "Mined ancestors not found in BUMPs"
 		fields.Detail = "BEEF validation failed: couldn't find mined ancestor of the transaction in provided BUMPs"
+	case StatusNotFinal:
+		fields.Title = "Transaction not final"
+		fields.Detail = "Transaction nLockTime is in the future and input sequence numbers are not final; resubmit once the locktime expires"
 	default:
 		fields.Status = int(StatusGeneric)
 		fields.Type = fmt.Sprintf("%s%d", arcDocURL, StatusGeneric)

--- a/finality/finality.go
+++ b/finality/finality.go
@@ -1,0 +1,130 @@
+// Package finality implements the nLockTime/nSequence transaction-finality
+// check (BIP113) that teranode applies at mempool admission but arcade's
+// embedded BDK validator does not: teranode enforces it one layer above the
+// TxValidator arcade calls (teranode services/validator/Validator.go
+// validateInternal → util.IsTransactionFinal), and its propagation surface
+// strips the UTXO_NON_FINAL reason to a generic "failed to validate
+// transaction". Running the same check at arcade intake turns that opaque
+// terminal rejection into an immediate, actionable error (issue #245).
+//
+// The check is deliberately a pure-Go sibling of the validator package, which
+// needs CGO/BDK to build; keeping it separate lets it be tested everywhere.
+//
+// Semantics mirror teranode util/lock_time.go exactly, including the strict
+// inequalities: a transaction is final when every input sequence is
+// 0xffffffff, when nLockTime is zero, or when nLockTime is exceeded by the
+// comparison value — the next block height for lock times below 500000000,
+// the chain tip's median-time-past (BIP113, NOT wall-clock time, which runs
+// 1–2.5h ahead of MTP on mainnet) for lock times at or above it.
+package finality
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+)
+
+// lockTimeThreshold is the nLockTime value below which the lock is a block
+// height and at/above which it is a unix timestamp.
+const lockTimeThreshold uint32 = 500_000_000
+
+// targetBlockSeconds is the expected mainnet block interval, used only to
+// humanize the ETA of height-based locks.
+const targetBlockSeconds = 600
+
+// NotFinalError reports a transaction that is provably non-final against the
+// supplied chain context. It renders an actionable message telling the
+// submitter when the transaction becomes broadcastable and how to opt out of
+// locktime semantics entirely.
+type NotFinalError struct {
+	// LockTime is the transaction's nLockTime.
+	LockTime uint32
+	// HeightBased is true when LockTime is below lockTimeThreshold and was
+	// compared against NextBlockHeight rather than MedianTimePast.
+	HeightBased bool
+	// NextBlockHeight is the height the transaction would be mined at
+	// (chain tip + 1), the comparison value for height-based locks.
+	NextBlockHeight uint32
+	// MedianTimePast is the chain tip's BIP113 median-time-past, the
+	// comparison value for timestamp-based locks.
+	MedianTimePast uint32
+}
+
+const remediation = "resubmit then, or set all input sequence numbers to 0xffffffff (or nLockTime to 0) if immediate broadcast is intended"
+
+func (e *NotFinalError) Error() string {
+	if e.HeightBased {
+		blocks := uint64(e.LockTime) + 1 - uint64(e.NextBlockHeight)
+		return fmt.Sprintf(
+			"transaction is not final: nLockTime %d is a block height and the next block height must exceed it before broadcast; the next block is %d, ~%d blocks (~%s) remaining; %s",
+			e.LockTime, e.NextBlockHeight, blocks, humanizeSeconds(blocks*targetBlockSeconds), remediation,
+		)
+	}
+	wait := uint64(e.LockTime) + 1 - uint64(e.MedianTimePast)
+	return fmt.Sprintf(
+		"transaction is not final: nLockTime %d (%s) is a timestamp and the chain's median-time-past must exceed it before broadcast; current median-time-past is %d (%s), expected to become final in ~%s; %s",
+		e.LockTime, rfc3339(e.LockTime), e.MedianTimePast, rfc3339(e.MedianTimePast), humanizeSeconds(wait), remediation,
+	)
+}
+
+// IsTransactionFinal mirrors teranode's util.IsTransactionFinal (consensus
+// rule TNJ-13) on go-sdk types. nextBlockHeight is the height the transaction
+// would be mined at (chain tip + 1); medianTimePast is the tip's BIP113 MTP.
+// It returns nil for a final transaction and a *NotFinalError otherwise.
+func IsTransactionFinal(tx *sdkTx.Transaction, nextBlockHeight, medianTimePast uint32) error {
+	if len(tx.Inputs) == 0 {
+		return errors.New("transactions with no inputs are not valid, and therefore not final")
+	}
+
+	allSequencesFinal := true
+	for _, input := range tx.Inputs {
+		allSequencesFinal = allSequencesFinal && input.SequenceNumber == sdkTx.DefaultSequenceNumber
+	}
+	if allSequencesFinal {
+		return nil
+	}
+
+	if tx.LockTime == 0 {
+		return nil
+	}
+
+	if tx.LockTime < lockTimeThreshold {
+		if nextBlockHeight > tx.LockTime {
+			return nil
+		}
+		return &NotFinalError{LockTime: tx.LockTime, HeightBased: true, NextBlockHeight: nextBlockHeight, MedianTimePast: medianTimePast}
+	}
+
+	if medianTimePast > tx.LockTime {
+		return nil
+	}
+	return &NotFinalError{LockTime: tx.LockTime, NextBlockHeight: nextBlockHeight, MedianTimePast: medianTimePast}
+}
+
+func rfc3339(unix uint32) string {
+	return time.Unix(int64(unix), 0).UTC().Format(time.RFC3339)
+}
+
+// humanizeSeconds renders a coarse duration ("11m", "3h50m", "2d4h"),
+// rounding minutes up so an ETA never reads as already elapsed.
+func humanizeSeconds(seconds uint64) string {
+	minutes := (seconds + 59) / 60
+	switch {
+	case minutes < 60:
+		return fmt.Sprintf("%dm", minutes)
+	case minutes < 24*60:
+		if minutes%60 == 0 {
+			return fmt.Sprintf("%dh", minutes/60)
+		}
+		return fmt.Sprintf("%dh%dm", minutes/60, minutes%60)
+	default:
+		days := minutes / (24 * 60)
+		hours := (minutes % (24 * 60)) / 60
+		if hours == 0 {
+			return fmt.Sprintf("%dd", days)
+		}
+		return fmt.Sprintf("%dd%dh", days, hours)
+	}
+}

--- a/finality/finality_test.go
+++ b/finality/finality_test.go
@@ -1,0 +1,189 @@
+package finality
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+)
+
+// txWith builds a transaction with the given locktime and one input per
+// sequence number.
+func txWith(lockTime uint32, sequences ...uint32) *sdkTx.Transaction {
+	tx := &sdkTx.Transaction{Version: 2, LockTime: lockTime}
+	for _, seq := range sequences {
+		tx.Inputs = append(tx.Inputs, &sdkTx.TransactionInput{SequenceNumber: seq})
+	}
+	return tx
+}
+
+func TestIsTransactionFinal(t *testing.T) {
+	const (
+		finalSeq    = uint32(0xffffffff)
+		nonFinalSeq = uint32(0xfffffffe)
+	)
+
+	tests := []struct {
+		name            string
+		tx              *sdkTx.Transaction
+		nextBlockHeight uint32
+		medianTimePast  uint32
+		wantFinal       bool
+		wantHeightBased bool
+	}{
+		{
+			// Regression vector from bsv-blockchain/arcade#245: timestamp
+			// locktime ahead of MTP with a non-final input sequence.
+			name:            "issue 245 timestamp locktime ahead of MTP is not final",
+			tx:              txWith(1783806110, nonFinalSeq, finalSeq),
+			nextBlockHeight: 957458,
+			medianTimePast:  1783805456,
+			wantFinal:       false,
+			wantHeightBased: false,
+		},
+		{
+			name:            "all input sequences final ignores future locktime",
+			tx:              txWith(1783806110, finalSeq, finalSeq),
+			nextBlockHeight: 957458,
+			medianTimePast:  1783805456,
+			wantFinal:       true,
+		},
+		{
+			name:            "locktime zero is final despite non-final sequence",
+			tx:              txWith(0, nonFinalSeq),
+			nextBlockHeight: 100,
+			medianTimePast:  100,
+			wantFinal:       true,
+		},
+		{
+			name:            "one non-final sequence among final ones enforces locktime",
+			tx:              txWith(1783806110, finalSeq, nonFinalSeq, finalSeq),
+			nextBlockHeight: 957458,
+			medianTimePast:  1783805456,
+			wantFinal:       false,
+			wantHeightBased: false,
+		},
+		{
+			name:            "timestamp locktime equal to MTP is not final (strict)",
+			tx:              txWith(1783806110, nonFinalSeq),
+			nextBlockHeight: 957458,
+			medianTimePast:  1783806110,
+			wantFinal:       false,
+			wantHeightBased: false,
+		},
+		{
+			name:            "timestamp locktime below MTP is final",
+			tx:              txWith(1783806110, nonFinalSeq),
+			nextBlockHeight: 957458,
+			medianTimePast:  1783806111,
+			wantFinal:       true,
+		},
+		{
+			name:            "height locktime below next height is final",
+			tx:              txWith(900100, nonFinalSeq),
+			nextBlockHeight: 900101,
+			medianTimePast:  0,
+			wantFinal:       true,
+		},
+		{
+			name:            "height locktime equal to next height is not final (strict)",
+			tx:              txWith(900101, nonFinalSeq),
+			nextBlockHeight: 900101,
+			medianTimePast:  0,
+			wantFinal:       false,
+			wantHeightBased: true,
+		},
+		{
+			name:            "locktime just below threshold uses height branch",
+			tx:              txWith(499999999, nonFinalSeq),
+			nextBlockHeight: 100,
+			medianTimePast:  4000000000,
+			wantFinal:       false,
+			wantHeightBased: true,
+		},
+		{
+			name:            "locktime at threshold uses timestamp branch",
+			tx:              txWith(500000000, nonFinalSeq),
+			nextBlockHeight: 4000000000,
+			medianTimePast:  100,
+			wantFinal:       false,
+			wantHeightBased: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := IsTransactionFinal(tt.tx, tt.nextBlockHeight, tt.medianTimePast)
+			if tt.wantFinal {
+				if err != nil {
+					t.Fatalf("IsTransactionFinal() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("IsTransactionFinal() = nil, want NotFinalError")
+			}
+			var nfe *NotFinalError
+			if !errors.As(err, &nfe) {
+				t.Fatalf("IsTransactionFinal() = %T (%v), want *NotFinalError", err, err)
+			}
+			if nfe.HeightBased != tt.wantHeightBased {
+				t.Errorf("HeightBased = %v, want %v", nfe.HeightBased, tt.wantHeightBased)
+			}
+			if nfe.LockTime != tt.tx.LockTime {
+				t.Errorf("LockTime = %d, want %d", nfe.LockTime, tt.tx.LockTime)
+			}
+		})
+	}
+}
+
+func TestIsTransactionFinalNoInputs(t *testing.T) {
+	err := IsTransactionFinal(&sdkTx.Transaction{Version: 2, LockTime: 1}, 100, 100)
+	if err == nil {
+		t.Fatal("IsTransactionFinal() = nil for zero-input tx, want error")
+	}
+	var nfe *NotFinalError
+	if errors.As(err, &nfe) {
+		t.Fatalf("zero-input tx should not yield *NotFinalError, got %v", err)
+	}
+}
+
+func TestNotFinalErrorMessageTimestamp(t *testing.T) {
+	err := IsTransactionFinal(txWith(1783806110, 0xfffffffe), 957458, 1783805456)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"transaction is not final", // greps consistently with teranode's UTXO_NON_FINAL
+		"1783806110",               // raw locktime
+		"2026-07-11T21:41:50Z",     // RFC3339 render of the locktime
+		"1783805456",               // current median-time-past
+		"~11m",                     // ETA until final (654s rounds up to 11m)
+		"0xffffffff",               // remediation hint
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message %q missing %q", msg, want)
+		}
+	}
+}
+
+func TestNotFinalErrorMessageHeight(t *testing.T) {
+	err := IsTransactionFinal(txWith(900123, 0xfffffffe), 900101, 0)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"transaction is not final",
+		"900123",     // locktime as height
+		"900101",     // next block height
+		"23 blocks",  // 900123+1-900101 blocks remaining
+		"0xffffffff", // remediation hint
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message %q missing %q", msg, want)
+		}
+	}
+}

--- a/finality/mtp.go
+++ b/finality/mtp.go
@@ -1,0 +1,204 @@
+package finality
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/bsv-blockchain/go-chaintracks/chaintracks"
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+	"go.uber.org/zap"
+)
+
+// mtpWindow is the number of block timestamps whose median forms the BIP113
+// median-time-past.
+const mtpWindow = 11
+
+const (
+	defaultTTL          = 15 * time.Second
+	defaultFetchTimeout = time.Second
+)
+
+// ChainReader is the slice of go-chaintracks used to derive the finality
+// comparison values. Both the embedded ChainManager and the remote HTTP
+// client satisfy it.
+type ChainReader interface {
+	GetTip(ctx context.Context) *chaintracks.BlockHeader
+	GetHeaders(ctx context.Context, height, count uint32) ([]*chaintracks.BlockHeader, error)
+}
+
+// CheckerOption configures a Checker.
+type CheckerOption func(*Checker)
+
+// WithTTL sets how long a fetched tip/MTP snapshot is trusted before the tip
+// is re-read.
+func WithTTL(ttl time.Duration) CheckerOption {
+	return func(c *Checker) { c.ttl = ttl }
+}
+
+// WithFetchTimeout bounds the total chain-state fetch per Check call; on
+// expiry the check fails open.
+func WithFetchTimeout(d time.Duration) CheckerOption {
+	return func(c *Checker) { c.fetchTimeout = d }
+}
+
+// WithUnavailableHook registers a callback invoked each time chain state
+// could not be obtained and the check failed open (metrics hook).
+func WithUnavailableHook(fn func()) CheckerOption {
+	return func(c *Checker) { c.onUnavailable = fn }
+}
+
+type snapshot struct {
+	tipHash   chainhash.Hash
+	tipHeight uint32
+	mtp       uint32
+	fetchedAt time.Time
+}
+
+// Checker evaluates transaction finality against cached chain state. It is
+// safe for concurrent use and nil-receiver-safe: a nil *Checker accepts every
+// transaction, so callers need no wiring guards.
+//
+// The verdict uses arcade's view of the tip, which can trail (or, briefly,
+// lead) the view of the teranode that ultimately admits the transaction.
+// Divergence is confined to roughly one block around the finality boundary
+// and self-heals: a false accept falls through to today's generic network
+// rejection, a false reject clears on resubmission.
+type Checker struct {
+	reader        ChainReader
+	logger        *zap.Logger
+	ttl           time.Duration
+	fetchTimeout  time.Duration
+	onUnavailable func()
+
+	mu   sync.Mutex
+	snap snapshot
+}
+
+// NewChecker builds a Checker over the given chain source. A nil reader
+// yields a nil Checker (checks disabled, everything accepted).
+func NewChecker(reader ChainReader, logger *zap.Logger, opts ...CheckerOption) *Checker {
+	if reader == nil {
+		return nil
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	c := &Checker{
+		reader:       reader,
+		logger:       logger,
+		ttl:          defaultTTL,
+		fetchTimeout: defaultFetchTimeout,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Check returns a *NotFinalError when tx is provably non-final against the
+// current chain state, nil otherwise. Transactions decidable without chain
+// state (all input sequences final, or nLockTime zero) never trigger chain
+// I/O. When chain state cannot be obtained the check fails open — teranode
+// remains the authority; this gate only exists to give submitters a usable
+// error message.
+func (c *Checker) Check(ctx context.Context, tx *sdkTx.Transaction) error {
+	if c == nil {
+		return nil
+	}
+
+	if lockTimeIrrelevant(tx) {
+		return nil
+	}
+
+	tipHeight, mtp, ok := c.chainState(ctx)
+	if !ok {
+		return nil
+	}
+
+	return IsTransactionFinal(tx, tipHeight+1, mtp)
+}
+
+// lockTimeIrrelevant reports whether finality is decidable as "final" without
+// chain state.
+func lockTimeIrrelevant(tx *sdkTx.Transaction) bool {
+	if tx.LockTime == 0 {
+		return true
+	}
+	for _, input := range tx.Inputs {
+		if input.SequenceNumber != sdkTx.DefaultSequenceNumber {
+			return false
+		}
+	}
+	return true
+}
+
+// chainState returns the tip height and MTP, from cache when fresh. ok is
+// false when chain state is unavailable (fail open).
+func (c *Checker) chainState(ctx context.Context) (tipHeight, mtp uint32, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.snap.fetchedAt.IsZero() && time.Since(c.snap.fetchedAt) < c.ttl {
+		return c.snap.tipHeight, c.snap.mtp, true
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.fetchTimeout)
+	defer cancel()
+
+	tip := c.reader.GetTip(ctx)
+	if tip == nil {
+		return c.unavailable("chain tip unavailable", nil)
+	}
+
+	// MTP only changes when the tip does; on an unchanged tip just refresh
+	// the snapshot's age. Keying on the hash (not height) also catches
+	// reorgs, where the MTP can move in either direction.
+	if tip.Hash == c.snap.tipHash && !c.snap.fetchedAt.IsZero() {
+		c.snap.fetchedAt = time.Now()
+		return c.snap.tipHeight, c.snap.mtp, true
+	}
+
+	start := uint32(0)
+	count := tip.Height + 1
+	if tip.Height >= mtpWindow-1 {
+		start = tip.Height - (mtpWindow - 1)
+		count = mtpWindow
+	}
+	headers, err := c.reader.GetHeaders(ctx, start, count)
+	if err != nil {
+		return c.unavailable("chain headers unavailable", err)
+	}
+	if len(headers) == 0 {
+		return c.unavailable("chain returned no headers", nil)
+	}
+
+	timestamps := make([]uint32, 0, len(headers))
+	for _, h := range headers {
+		if h == nil || h.Header == nil {
+			continue
+		}
+		timestamps = append(timestamps, h.Timestamp)
+	}
+	if len(timestamps) == 0 {
+		return c.unavailable("chain returned no header timestamps", nil)
+	}
+	sort.Slice(timestamps, func(i, j int) bool { return timestamps[i] < timestamps[j] })
+	median := timestamps[len(timestamps)/2]
+	if median == 0 {
+		return c.unavailable("chain median-time-past is zero", nil)
+	}
+
+	c.snap = snapshot{tipHash: tip.Hash, tipHeight: tip.Height, mtp: median, fetchedAt: time.Now()}
+	return c.snap.tipHeight, c.snap.mtp, true
+}
+
+func (c *Checker) unavailable(reason string, err error) (uint32, uint32, bool) {
+	c.logger.Warn("finality pre-check skipped: "+reason, zap.Error(err))
+	if c.onUnavailable != nil {
+		c.onUnavailable()
+	}
+	return 0, 0, false
+}

--- a/finality/mtp.go
+++ b/finality/mtp.go
@@ -29,6 +29,16 @@ type ChainReader interface {
 	GetHeaders(ctx context.Context, height, count uint32) ([]*chaintracks.BlockHeader, error)
 }
 
+// HeightReader supplies just the current best block height. The arcade store
+// satisfies it (GetActiveTipBlockHeight). It backs the height-only fallback:
+// height-based locktimes can be gated from the store alone — no chaintracks
+// required — while timestamp locktimes need MTP and fail open without a full
+// ChainReader. (Adopted from PR #181, which used the store as its only
+// height source.)
+type HeightReader interface {
+	GetActiveTipBlockHeight(ctx context.Context) (uint64, error)
+}
+
 // CheckerOption configures a Checker.
 type CheckerOption func(*Checker)
 
@@ -50,6 +60,13 @@ func WithUnavailableHook(fn func()) CheckerOption {
 	return func(c *Checker) { c.onUnavailable = fn }
 }
 
+// WithHeightFallback wires a height-only chain source consulted when the
+// full ChainReader is absent or failing. Height-based locktimes are then
+// still gated; timestamp locktimes fail open (they need MTP).
+func WithHeightFallback(hr HeightReader) CheckerOption {
+	return func(c *Checker) { c.heightReader = hr }
+}
+
 type snapshot struct {
 	tipHash   chainhash.Hash
 	tipHeight uint32
@@ -68,6 +85,7 @@ type snapshot struct {
 // rejection, a false reject clears on resubmission.
 type Checker struct {
 	reader        ChainReader
+	heightReader  HeightReader
 	logger        *zap.Logger
 	ttl           time.Duration
 	fetchTimeout  time.Duration
@@ -77,12 +95,10 @@ type Checker struct {
 	snap snapshot
 }
 
-// NewChecker builds a Checker over the given chain source. A nil reader
-// yields a nil Checker (checks disabled, everything accepted).
+// NewChecker builds a Checker over the given chain source(s). With neither a
+// reader nor a WithHeightFallback source it yields a nil Checker (checks
+// disabled, everything accepted).
 func NewChecker(reader ChainReader, logger *zap.Logger, opts ...CheckerOption) *Checker {
-	if reader == nil {
-		return nil
-	}
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -94,6 +110,9 @@ func NewChecker(reader ChainReader, logger *zap.Logger, opts ...CheckerOption) *
 	}
 	for _, opt := range opts {
 		opt(c)
+	}
+	if c.reader == nil && c.heightReader == nil {
+		return nil
 	}
 	return c
 }
@@ -113,12 +132,58 @@ func (c *Checker) Check(ctx context.Context, tx *sdkTx.Transaction) error {
 		return nil
 	}
 
-	tipHeight, mtp, ok := c.chainState(ctx)
-	if !ok {
+	if c.reader != nil {
+		if tipHeight, mtp, ok := c.chainState(ctx); ok {
+			return IsTransactionFinal(tx, tipHeight+1, mtp)
+		}
+		// chainState already logged and counted the unavailability; the
+		// height-only fallback below may still gate height-based locks.
+	}
+
+	return c.checkHeightOnly(ctx, tx)
+}
+
+// checkHeightOnly gates height-based locktimes from the HeightReader alone.
+// Timestamp locktimes need MTP, which a height source cannot supply — those
+// fail open. The height source is the local store, so no caching is needed.
+func (c *Checker) checkHeightOnly(ctx context.Context, tx *sdkTx.Transaction) error {
+	if c.heightReader == nil {
 		return nil
 	}
 
-	return IsTransactionFinal(tx, tipHeight+1, mtp)
+	if tx.LockTime >= lockTimeThreshold {
+		if c.reader == nil {
+			// With a full reader this was already counted by chainState.
+			c.noteUnavailable("timestamp locktime needs median-time-past; only a height source is configured", nil)
+		}
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.fetchTimeout)
+	defer cancel()
+
+	height, err := c.heightReader.GetActiveTipBlockHeight(ctx)
+	if err != nil {
+		c.noteUnavailable("chain height unavailable", err)
+		return nil
+	}
+	if height == 0 {
+		// A store with no mined rows yet reports 0; rejecting against a
+		// fabricated next-height of 1 would bounce every height-locked tx.
+		c.noteUnavailable("chain height is zero (no mined rows yet)", nil)
+		return nil
+	}
+
+	return IsTransactionFinal(tx, nextHeightU32(height), 0)
+}
+
+// nextHeightU32 saturates height+1 to the uint32 range. Real heights never
+// approach 2^32; the clamp makes the conversion provably bounded (gosec G115).
+func nextHeightU32(height uint64) uint32 {
+	if height >= uint64(^uint32(0)) {
+		return ^uint32(0)
+	}
+	return uint32(height) + 1
 }
 
 // lockTimeIrrelevant reports whether finality is decidable as "final" without
@@ -196,9 +261,13 @@ func (c *Checker) chainState(ctx context.Context) (tipHeight, mtp uint32, ok boo
 }
 
 func (c *Checker) unavailable(reason string, err error) (uint32, uint32, bool) {
-	c.logger.Warn("finality pre-check skipped: "+reason, zap.Error(err))
+	c.noteUnavailable(reason, err)
+	return 0, 0, false
+}
+
+func (c *Checker) noteUnavailable(reason string, err error) {
+	c.logger.Warn("finality pre-check degraded: "+reason, zap.Error(err))
 	if c.onUnavailable != nil {
 		c.onUnavailable()
 	}
-	return 0, 0, false
 }

--- a/finality/mtp_test.go
+++ b/finality/mtp_test.go
@@ -1,0 +1,229 @@
+package finality
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-chaintracks/chaintracks"
+	"github.com/bsv-blockchain/go-sdk/block"
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+)
+
+// fakeReader is a ChainReader with programmable results and call counters.
+type fakeReader struct {
+	tip          *chaintracks.BlockHeader
+	headers      []*chaintracks.BlockHeader
+	headersErr   error
+	blockOnCtx   bool
+	tipCalls     int
+	headersCalls int
+}
+
+func (f *fakeReader) GetTip(ctx context.Context) *chaintracks.BlockHeader {
+	f.tipCalls++
+	if f.blockOnCtx {
+		<-ctx.Done()
+		return nil
+	}
+	return f.tip
+}
+
+func (f *fakeReader) GetHeaders(_ context.Context, _, _ uint32) ([]*chaintracks.BlockHeader, error) {
+	f.headersCalls++
+	return f.headers, f.headersErr
+}
+
+func header(height uint32, timestamp uint32) *chaintracks.BlockHeader {
+	h := &chaintracks.BlockHeader{
+		Header: &block.Header{Timestamp: timestamp},
+		Height: height,
+	}
+	h.Hash = chainhash.HashH([]byte{byte(height), byte(height >> 8), byte(height >> 16), byte(timestamp)})
+	return h
+}
+
+// chainAt builds a reader whose tip is at the given height with the given
+// timestamps for the last len(timestamps) blocks ending at the tip.
+func chainAt(tipHeight uint32, timestamps ...uint32) *fakeReader {
+	headers := make([]*chaintracks.BlockHeader, len(timestamps))
+	for i, ts := range timestamps {
+		headers[i] = header(tipHeight-uint32(len(timestamps)-1-i), ts)
+	}
+	return &fakeReader{tip: headers[len(headers)-1], headers: headers}
+}
+
+// nonFinalTx needs chain state: timestamp locktime with a non-final sequence.
+func nonFinalTx(lockTime uint32) *sdkTx.Transaction {
+	return txWith(lockTime, 0xfffffffe)
+}
+
+func TestCheckerComputesBIP113MedianOfLast11(t *testing.T) {
+	// Unsorted timestamps; sorted median (index 5 of 11) is 5000.
+	reader := chainAt(957457,
+		9000, 1000, 5000, 3000, 7000, 2000, 8000, 4000, 6000, 500, 9500)
+	c := NewChecker(reader, nil)
+
+	err := c.Check(context.Background(), nonFinalTx(2_000_000_000))
+	var nfe *NotFinalError
+	if !errors.As(err, &nfe) {
+		t.Fatalf("Check() = %v, want *NotFinalError", err)
+	}
+	if nfe.MedianTimePast != 5000 {
+		t.Errorf("MedianTimePast = %d, want 5000", nfe.MedianTimePast)
+	}
+	if nfe.NextBlockHeight != 957458 {
+		t.Errorf("NextBlockHeight = %d, want 957458", nfe.NextBlockHeight)
+	}
+}
+
+func TestCheckerShortChainUsesAvailableHeaders(t *testing.T) {
+	// Tip height 4: only 5 headers exist; median is sorted index 2.
+	reader := chainAt(4, 300, 100, 500, 200, 400)
+	c := NewChecker(reader, nil)
+
+	err := c.Check(context.Background(), nonFinalTx(2_000_000_000))
+	var nfe *NotFinalError
+	if !errors.As(err, &nfe) {
+		t.Fatalf("Check() = %v, want *NotFinalError", err)
+	}
+	if nfe.MedianTimePast != 300 {
+		t.Errorf("MedianTimePast = %d, want 300", nfe.MedianTimePast)
+	}
+}
+
+func TestCheckerFinalVerdictAgainstFetchedMTP(t *testing.T) {
+	reader := chainAt(100,
+		1_600_000_000, 1_600_000_001, 1_600_000_002, 1_600_000_003, 1_600_000_004, 1_600_000_005,
+		1_600_000_006, 1_600_000_007, 1_600_000_008, 1_600_000_009, 1_600_000_010)
+	c := NewChecker(reader, nil)
+
+	// Median is 1_600_000_005; a timestamp locktime below it is final.
+	if err := c.Check(context.Background(), nonFinalTx(1_600_000_004)); err != nil {
+		t.Fatalf("Check() = %v, want nil (locktime below fetched MTP)", err)
+	}
+}
+
+func TestCheckerFastPathSkipsChainIO(t *testing.T) {
+	reader := chainAt(100, 1000)
+	c := NewChecker(reader, nil)
+
+	if err := c.Check(context.Background(), txWith(2_000_000_000, 0xffffffff)); err != nil {
+		t.Fatalf("all-final-sequence tx: Check() = %v, want nil", err)
+	}
+	if err := c.Check(context.Background(), txWith(0, 0xfffffffe)); err != nil {
+		t.Fatalf("locktime-zero tx: Check() = %v, want nil", err)
+	}
+	if reader.tipCalls != 0 || reader.headersCalls != 0 {
+		t.Errorf("chain I/O on fast path: tipCalls=%d headersCalls=%d, want 0/0", reader.tipCalls, reader.headersCalls)
+	}
+}
+
+func TestCheckerCachesWithinTTL(t *testing.T) {
+	reader := chainAt(100, 1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010)
+	c := NewChecker(reader, nil, WithTTL(time.Hour))
+
+	_ = c.Check(context.Background(), nonFinalTx(2_000_000_000))
+	_ = c.Check(context.Background(), nonFinalTx(2_000_000_000))
+
+	if reader.tipCalls != 1 || reader.headersCalls != 1 {
+		t.Errorf("tipCalls=%d headersCalls=%d, want 1/1 (second check served from cache)", reader.tipCalls, reader.headersCalls)
+	}
+}
+
+func TestCheckerTTLExpiryUnchangedTipReusesMTP(t *testing.T) {
+	reader := chainAt(100, 1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010)
+	c := NewChecker(reader, nil, WithTTL(0))
+
+	_ = c.Check(context.Background(), nonFinalTx(2_000_000_000))
+	_ = c.Check(context.Background(), nonFinalTx(2_000_000_000))
+
+	if reader.tipCalls != 2 {
+		t.Errorf("tipCalls = %d, want 2 (TTL expired)", reader.tipCalls)
+	}
+	if reader.headersCalls != 1 {
+		t.Errorf("headersCalls = %d, want 1 (tip unchanged, MTP reused)", reader.headersCalls)
+	}
+}
+
+func TestCheckerTipChangeRecomputesMTP(t *testing.T) {
+	reader := chainAt(100, 1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010)
+	c := NewChecker(reader, nil, WithTTL(0))
+
+	err := c.Check(context.Background(), nonFinalTx(2_000_000_000))
+	var nfe *NotFinalError
+	if !errors.As(err, &nfe) || nfe.MedianTimePast != 1005 {
+		t.Fatalf("first check: %v, want MTP 1005", err)
+	}
+
+	// New tip: reorg to a chain whose MTP moved backwards.
+	next := chainAt(101, 900, 901, 902, 903, 904, 905, 906, 907, 908, 909, 910)
+	reader.tip = next.tip
+	reader.headers = next.headers
+
+	err = c.Check(context.Background(), nonFinalTx(2_000_000_000))
+	if !errors.As(err, &nfe) || nfe.MedianTimePast != 905 {
+		t.Fatalf("after tip change: %v, want MTP 905", err)
+	}
+	if nfe.NextBlockHeight != 102 {
+		t.Errorf("NextBlockHeight = %d, want 102", nfe.NextBlockHeight)
+	}
+	if reader.headersCalls != 2 {
+		t.Errorf("headersCalls = %d, want 2 (recompute on tip change)", reader.headersCalls)
+	}
+}
+
+func TestCheckerFailsOpen(t *testing.T) {
+	valid := chainAt(100, 1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010)
+
+	tests := []struct {
+		name   string
+		reader *fakeReader
+	}{
+		{"nil tip", &fakeReader{tip: nil}},
+		{"headers error", &fakeReader{tip: valid.tip, headersErr: errors.New("boom")}},
+		{"empty headers", &fakeReader{tip: valid.tip, headers: nil}},
+		{"zero MTP", chainAt(100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unavailable := 0
+			c := NewChecker(tt.reader, nil, WithUnavailableHook(func() { unavailable++ }))
+			if err := c.Check(context.Background(), nonFinalTx(2_000_000_000)); err != nil {
+				t.Fatalf("Check() = %v, want nil (fail-open)", err)
+			}
+			if unavailable != 1 {
+				t.Errorf("unavailable hook calls = %d, want 1", unavailable)
+			}
+		})
+	}
+}
+
+func TestCheckerFetchBudget(t *testing.T) {
+	reader := &fakeReader{blockOnCtx: true}
+	c := NewChecker(reader, nil, WithFetchTimeout(50*time.Millisecond))
+
+	start := time.Now()
+	err := c.Check(context.Background(), nonFinalTx(2_000_000_000))
+	if err != nil {
+		t.Fatalf("Check() = %v, want nil (fail-open on timeout)", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("Check took %v, want bounded by fetch timeout", elapsed)
+	}
+}
+
+func TestCheckerNilReceiverIsNoop(t *testing.T) {
+	var c *Checker
+	if err := c.Check(context.Background(), nonFinalTx(2_000_000_000)); err != nil {
+		t.Fatalf("nil checker: Check() = %v, want nil", err)
+	}
+}
+
+func TestNewCheckerNilReaderYieldsNil(t *testing.T) {
+	if c := NewChecker(nil, nil); c != nil {
+		t.Fatalf("NewChecker(nil, ...) = %v, want nil", c)
+	}
+}

--- a/finality/mtp_test.go
+++ b/finality/mtp_test.go
@@ -2,6 +2,7 @@ package finality
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"testing"
 	"time"
@@ -41,7 +42,10 @@ func header(height uint32, timestamp uint32) *chaintracks.BlockHeader {
 		Header: &block.Header{Timestamp: timestamp},
 		Height: height,
 	}
-	h.Hash = chainhash.HashH([]byte{byte(height), byte(height >> 8), byte(height >> 16), byte(timestamp)})
+	var seed [8]byte
+	binary.BigEndian.PutUint32(seed[:4], height)
+	binary.BigEndian.PutUint32(seed[4:], timestamp)
+	h.Hash = chainhash.HashH(seed[:])
 	return h
 }
 
@@ -49,8 +53,10 @@ func header(height uint32, timestamp uint32) *chaintracks.BlockHeader {
 // timestamps for the last len(timestamps) blocks ending at the tip.
 func chainAt(tipHeight uint32, timestamps ...uint32) *fakeReader {
 	headers := make([]*chaintracks.BlockHeader, len(timestamps))
-	for i, ts := range timestamps {
-		headers[i] = header(tipHeight-uint32(len(timestamps)-1-i), ts)
+	height := tipHeight
+	for i := len(timestamps) - 1; i >= 0; i-- {
+		headers[i] = header(height, timestamps[i])
+		height--
 	}
 	return &fakeReader{tip: headers[len(headers)-1], headers: headers}
 }
@@ -212,6 +218,114 @@ func TestCheckerFetchBudget(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
 		t.Errorf("Check took %v, want bounded by fetch timeout", elapsed)
+	}
+}
+
+// fakeHeightReader is a HeightReader with programmable results.
+type fakeHeightReader struct {
+	height uint64
+	err    error
+	calls  int
+}
+
+func (f *fakeHeightReader) GetActiveTipBlockHeight(context.Context) (uint64, error) {
+	f.calls++
+	return f.height, f.err
+}
+
+func TestCheckerHeightFallbackGatesHeightLocks(t *testing.T) {
+	// No full ChainReader — only the store-height fallback (#181's stance).
+	c := NewChecker(nil, nil, WithHeightFallback(&fakeHeightReader{height: 799_999}))
+	if c == nil {
+		t.Fatal("NewChecker with height fallback only must yield a checker")
+	}
+
+	// Next block = 800_000; a lock at exactly that height is non-final
+	// (strict inequality, matching teranode).
+	err := c.Check(context.Background(), txWith(800_000, 0xfffffffe))
+	var nfe *NotFinalError
+	if !errors.As(err, &nfe) {
+		t.Fatalf("Check() = %v, want *NotFinalError", err)
+	}
+	if !nfe.HeightBased || nfe.NextBlockHeight != 800_000 {
+		t.Errorf("got HeightBased=%v NextBlockHeight=%d, want true/800000", nfe.HeightBased, nfe.NextBlockHeight)
+	}
+
+	// A lock below the next height is final.
+	c2 := NewChecker(nil, nil, WithHeightFallback(&fakeHeightReader{height: 800_000}))
+	if err := c2.Check(context.Background(), txWith(800_000, 0xfffffffe)); err != nil {
+		t.Fatalf("Check() = %v, want nil (next height 800001 > lock 800000)", err)
+	}
+}
+
+func TestCheckerHeightFallbackFailsOpenForTimestampLocks(t *testing.T) {
+	unavailable := 0
+	c := NewChecker(nil, nil,
+		WithHeightFallback(&fakeHeightReader{height: 800_000}),
+		WithUnavailableHook(func() { unavailable++ }))
+
+	if err := c.Check(context.Background(), nonFinalTx(2_000_000_000)); err != nil {
+		t.Fatalf("Check() = %v, want nil (timestamp lock needs MTP, fail open)", err)
+	}
+	if unavailable != 1 {
+		t.Errorf("unavailable hook calls = %d, want 1", unavailable)
+	}
+}
+
+func TestCheckerHeightFallbackFailsOpenOnErrorOrZeroHeight(t *testing.T) {
+	tests := []struct {
+		name string
+		hr   *fakeHeightReader
+	}{
+		{"height error", &fakeHeightReader{err: errors.New("boom")}},
+		{"zero height (empty store)", &fakeHeightReader{height: 0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unavailable := 0
+			c := NewChecker(nil, nil,
+				WithHeightFallback(tt.hr),
+				WithUnavailableHook(func() { unavailable++ }))
+			if err := c.Check(context.Background(), txWith(800_000, 0xfffffffe)); err != nil {
+				t.Fatalf("Check() = %v, want nil (fail open)", err)
+			}
+			if unavailable != 1 {
+				t.Errorf("unavailable hook calls = %d, want 1", unavailable)
+			}
+		})
+	}
+}
+
+func TestCheckerPrefersFullReaderOverHeightFallback(t *testing.T) {
+	reader := chainAt(100, 1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010)
+	hr := &fakeHeightReader{height: 999_999}
+	c := NewChecker(reader, nil, WithHeightFallback(hr))
+
+	err := c.Check(context.Background(), nonFinalTx(2_000_000_000))
+	var nfe *NotFinalError
+	if !errors.As(err, &nfe) || nfe.NextBlockHeight != 101 {
+		t.Fatalf("Check() = %v, want NotFinalError with NextBlockHeight 101 from the full reader", err)
+	}
+	if hr.calls != 0 {
+		t.Errorf("height fallback consulted %d times despite healthy full reader, want 0", hr.calls)
+	}
+}
+
+func TestCheckerFallsBackToHeightWhenReaderFails(t *testing.T) {
+	// Full reader configured but broken: height locks still gate via the
+	// store fallback; the unavailability is still counted.
+	unavailable := 0
+	c := NewChecker(&fakeReader{tip: nil}, nil,
+		WithHeightFallback(&fakeHeightReader{height: 799_998}),
+		WithUnavailableHook(func() { unavailable++ }))
+
+	err := c.Check(context.Background(), txWith(800_000, 0xfffffffe))
+	var nfe *NotFinalError
+	if !errors.As(err, &nfe) || !nfe.HeightBased {
+		t.Fatalf("Check() = %v, want height-based NotFinalError via fallback", err)
+	}
+	if unavailable != 1 {
+		t.Errorf("unavailable hook calls = %d, want 1 (MTP source failed)", unavailable)
 	}
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -212,6 +212,25 @@ var APITxsSubmittedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "Transactions submitted via the API by route and dedup result (new|duplicate|retry_rejected). Counted per transaction, not per request.",
 }, []string{"route", "result"})
 
+// APIFinalityRejectionsTotal counts transactions rejected at intake by the
+// nLockTime/BIP113 finality gate, by route. These are terminal REJECTED
+// verdicts with an actionable reason; the submitter is expected to resubmit
+// once the lock expires (issue #245).
+var APIFinalityRejectionsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_api_finality_rejections_total",
+	Help: "Transactions rejected at intake as non-final (nLockTime/BIP113), by route.",
+}, []string{"route"})
+
+// APIFinalityPrecheckUnavailableTotal counts finality pre-checks skipped
+// because chain state (tip/headers via chaintracks) was unavailable. The
+// gate fails open — teranode remains the authority — so a sustained rate
+// here means non-final txs are once again bouncing off the network with
+// generic errors instead of being caught at intake.
+var APIFinalityPrecheckUnavailableTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "arcade_api_finality_precheck_unavailable_total",
+	Help: "Finality pre-checks skipped (failed open) because chain state was unavailable.",
+})
+
 // StuckTransientTxs counts transactions sitting in a transient status
 // (RECEIVED, ACCEPTED_BY_NETWORK) for longer than the stale-transient
 // threshold (1h), within the reaper's 24h scan lookback. Unlike

--- a/metrics/preregister.go
+++ b/metrics/preregister.go
@@ -32,6 +32,7 @@ func PreRegisterTxSubmissions() {
 		for _, result := range []string{"new", "duplicate", "retry_rejected"} {
 			APITxsSubmittedTotal.WithLabelValues(route, result)
 		}
+		APIFinalityRejectionsTotal.WithLabelValues(route)
 	}
 }
 

--- a/openapi/arcade.openapi.yaml
+++ b/openapi/arcade.openapi.yaml
@@ -202,6 +202,13 @@ paths:
             Malformed request, decode failure, empty transaction, validation
             failure, or unsafe callback URL. On validation failure a terminal
             `REJECTED` row is persisted so subscribers see the outcome.
+
+            Validation includes an nLockTime/BIP113 finality gate: a
+            transaction whose locktime is still ahead of the chain's
+            median-time-past (with a non-final input sequence) is rejected
+            with a reason stating when it becomes final. Resubmit the
+            identical transaction after that time and it re-enters the
+            broadcast pipeline.
           content:
             application/json:
               schema:

--- a/services/api_server/finality_handler_test.go
+++ b/services/api_server/finality_handler_test.go
@@ -1,0 +1,225 @@
+package api_server
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bsv-blockchain/go-chaintracks/chaintracks"
+	"github.com/bsv-blockchain/go-sdk/block"
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/script"
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/finality"
+	"github.com/bsv-blockchain/arcade/kafka"
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// fixedChainReader serves a static 11-block chain whose BIP113
+// median-time-past is testChainMTP at tip height testChainTip.
+type fixedChainReader struct{}
+
+const (
+	testChainTip = uint32(100)
+	testChainMTP = uint32(1_600_000_005)
+)
+
+func (fixedChainReader) GetTip(context.Context) *chaintracks.BlockHeader {
+	h := &chaintracks.BlockHeader{Header: &block.Header{Timestamp: 1_600_000_010}, Height: testChainTip}
+	h.Hash = chainhash.HashH([]byte{1})
+	return h
+}
+
+func (fixedChainReader) GetHeaders(_ context.Context, start, count uint32) ([]*chaintracks.BlockHeader, error) {
+	headers := make([]*chaintracks.BlockHeader, 0, count)
+	for i := uint32(0); i < count; i++ {
+		headers = append(headers, &chaintracks.BlockHeader{
+			Header: &block.Header{Timestamp: 1_600_000_000 + start + i},
+			Height: start + i,
+		})
+	}
+	return headers, nil
+}
+
+// makeLockTimeTx builds a parseable single-input tx with the given locktime
+// and input sequence number.
+func makeLockTimeTx(t *testing.T, lockTime, sequence uint32) []byte {
+	t.Helper()
+	tx := sdkTx.NewTransaction()
+	tx.LockTime = lockTime
+	sourceTxID := chainhash.HashH([]byte("parent"))
+	tx.Inputs = append(tx.Inputs, &sdkTx.TransactionInput{
+		SourceTXID:       &sourceTxID,
+		SourceTxOutIndex: 0,
+		UnlockingScript:  &script.Script{},
+		SequenceNumber:   sequence,
+	})
+	return tx.Bytes()
+}
+
+func newFinalityTestServer(broker *kafka.RecordingBroker, ms *mockStore, pub *recordingCallbackPub) (*Server, *gin.Engine) {
+	gin.SetMode(gin.TestMode)
+	srv := &Server{
+		cfg:            &config.Config{CallbackToken: testCallbackToken},
+		logger:         zap.NewNop(),
+		producer:       kafka.NewProducer(broker),
+		store:          ms,
+		publisher:      pub,
+		finality:       finality.NewChecker(fixedChainReader{}, zap.NewNop()),
+		submissionCh:   make(chan submissionRecord, submissionRecorderBuffer),
+		submissionStop: make(chan struct{}),
+	}
+	router := gin.New()
+	srv.registerRoutes(router)
+	return srv, router
+}
+
+// TestHandleSubmitTransaction_NonFinal_RejectedWithReason pins the intake
+// finality gate (issue #245): a tx whose timestamp locktime is ahead of the
+// chain MTP with a non-final input sequence must be rejected synchronously
+// with an actionable reason, persist a REJECTED row with that reason, and
+// never reach the propagation topic.
+func TestHandleSubmitTransaction_NonFinal_RejectedWithReason(t *testing.T) {
+	ms := &mockStore{}
+	pub := &recordingCallbackPub{}
+	broker := &kafka.RecordingBroker{}
+	_, router := newFinalityTestServer(broker, ms, pub)
+
+	rawTx := makeLockTimeTx(t, 1_700_000_000, 0xfffffffe) // locktime > MTP
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/tx", bytes.NewReader(rawTx))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "transaction is not final") {
+		t.Errorf("response %q missing finality reason", w.Body.String())
+	}
+
+	// Nothing may reach Kafka — the tx must not be broadcast.
+	if got := totalMessages(broker); got != 0 {
+		t.Errorf("expected 0 published Kafka messages for non-final tx, got %d", got)
+	}
+
+	// A terminal REJECTED row with the finality reason must be persisted.
+	ms.mu.Lock()
+	calls := append([]*models.TransactionStatus(nil), ms.updateStatusCalls...)
+	ms.mu.Unlock()
+	var sawReject bool
+	for _, c := range calls {
+		if c.Status == models.StatusRejected && strings.Contains(c.ExtraInfo, "transaction is not final") {
+			sawReject = true
+			break
+		}
+	}
+	if !sawReject {
+		t.Errorf("expected REJECTED row carrying the finality reason; UpdateStatus calls=%v", calls)
+	}
+
+	// Live subscribers must see the terminal outcome with the reason.
+	pub.mu.Lock()
+	publishes := append([]*models.TransactionStatus(nil), pub.publishes...)
+	pub.mu.Unlock()
+	if len(publishes) != 1 || publishes[0].Status != models.StatusRejected {
+		t.Fatalf("expected exactly 1 REJECTED publish, got %v", publishes)
+	}
+	if !strings.Contains(publishes[0].ExtraInfo, "transaction is not final") {
+		t.Errorf("publish ExtraInfo %q missing finality reason", publishes[0].ExtraInfo)
+	}
+}
+
+// TestHandleSubmitTransaction_FinalLockTime_Proceeds proves the gate does not
+// disturb final transactions: a locktime already below the chain MTP passes
+// through to the normal accept/publish path.
+func TestHandleSubmitTransaction_FinalLockTime_Proceeds(t *testing.T) {
+	ms := &mockStore{}
+	pub := &recordingCallbackPub{}
+	broker := &kafka.RecordingBroker{}
+	_, router := newFinalityTestServer(broker, ms, pub)
+
+	rawTx := makeLockTimeTx(t, 1_500_000_000, 0xfffffffe) // locktime < MTP
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/tx", bytes.NewReader(rawTx))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := totalMessages(broker); got != 1 {
+		t.Errorf("expected 1 published Kafka message, got %d", got)
+	}
+}
+
+// TestHandleSubmitTransaction_NoFinalityChecker_Proceeds pins nil-safety:
+// deployments without a chain source skip the gate entirely.
+func TestHandleSubmitTransaction_NoFinalityChecker_Proceeds(t *testing.T) {
+	ms := &mockStore{}
+	broker := &kafka.RecordingBroker{}
+	gin.SetMode(gin.TestMode)
+	srv := &Server{
+		cfg:            &config.Config{CallbackToken: testCallbackToken},
+		logger:         zap.NewNop(),
+		producer:       kafka.NewProducer(broker),
+		store:          ms,
+		submissionCh:   make(chan submissionRecord, submissionRecorderBuffer),
+		submissionStop: make(chan struct{}),
+	}
+	router := gin.New()
+	srv.registerRoutes(router)
+
+	rawTx := makeLockTimeTx(t, 1_700_000_000, 0xfffffffe)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/tx", bytes.NewReader(rawTx))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 with nil finality checker, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleSubmitTransactions_BatchNonFinal_AbortsWithTxid mirrors the
+// batch contract for validation failures: the offending txid is named and
+// the whole batch aborts before any publish.
+func TestHandleSubmitTransactions_BatchNonFinal_AbortsWithTxid(t *testing.T) {
+	ms := &mockStore{}
+	pub := &recordingCallbackPub{}
+	broker := &kafka.RecordingBroker{}
+	_, router := newFinalityTestServer(broker, ms, pub)
+
+	finalRaw := makeLockTimeTx(t, 0, 0xffffffff)
+	nonFinalRaw := makeLockTimeTx(t, 1_700_000_000, 0xfffffffe)
+	nonFinalTx, _, err := sdkTx.NewTransactionFromStream(nonFinalRaw)
+	if err != nil {
+		t.Fatalf("parse non-final tx: %v", err)
+	}
+
+	body := append(append([]byte(nil), finalRaw...), nonFinalRaw...)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/txs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), nonFinalTx.TxID().String()) {
+		t.Errorf("response %q missing offending txid %s", w.Body.String(), nonFinalTx.TxID().String())
+	}
+	if !strings.Contains(w.Body.String(), "transaction is not final") {
+		t.Errorf("response %q missing finality reason", w.Body.String())
+	}
+	if got := totalMessages(broker); got != 0 {
+		t.Errorf("expected 0 published Kafka messages for aborted batch, got %d", got)
+	}
+}

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/bsv-blockchain/arcade/callbackurl"
 	"github.com/bsv-blockchain/arcade/config"
+	arcerrors "github.com/bsv-blockchain/arcade/errors"
 	"github.com/bsv-blockchain/arcade/kafka"
 	"github.com/bsv-blockchain/arcade/logfields"
 	"github.com/bsv-blockchain/arcade/metrics"
@@ -656,12 +657,15 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 	// wraps), so without this a non-final tx is broadcast and bounced by the
 	// network with an opaque generic error (issue #245). Runs after the
 	// validator so its fail-open behavior can never mask a validation error.
-	if err := s.finality.Check(c.Request.Context(), parsedTx); err != nil {
+	// The ArcError wrap attaches StatusNotFinal for structured consumers
+	// without changing the reason text (same pattern as mapTeranodeError).
+	if fErr := s.finality.Check(c.Request.Context(), parsedTx); fErr != nil {
+		fErr = arcerrors.NewArcError(fErr, arcerrors.StatusNotFinal)
 		metrics.APIFinalityRejectionsTotal.WithLabelValues("/tx").Inc()
-		s.rejectAtIntake(c.Request.Context(), txid, err.Error(), opts)
+		s.rejectAtIntake(c.Request.Context(), txid, fErr.Error(), opts)
 		c.JSON(http.StatusBadRequest, gin.H{
 			jsonKeyError: "transaction failed validation",
-			"reason":     err.Error(),
+			"reason":     fErr.Error(),
 		})
 		return
 	}
@@ -933,6 +937,7 @@ func (s *Server) handleSubmitTransactions(c *gin.Context) {
 	// matches the validation contract above.
 	for _, p := range parsed {
 		if fErr := s.finality.Check(c.Request.Context(), p.tx); fErr != nil {
+			fErr = arcerrors.NewArcError(fErr, arcerrors.StatusNotFinal)
 			metrics.APIFinalityRejectionsTotal.WithLabelValues("/txs").Inc()
 			s.rejectAtIntake(c.Request.Context(), p.txid, fErr.Error(), opts)
 			c.JSON(http.StatusBadRequest, gin.H{

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -651,6 +651,21 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 		}
 	}
 
+	// nLockTime/BIP113 finality gate. The embedded validator above does not
+	// check finality (teranode enforces it a layer above the TxValidator it
+	// wraps), so without this a non-final tx is broadcast and bounced by the
+	// network with an opaque generic error (issue #245). Runs after the
+	// validator so its fail-open behavior can never mask a validation error.
+	if err := s.finality.Check(c.Request.Context(), parsedTx); err != nil {
+		metrics.APIFinalityRejectionsTotal.WithLabelValues("/tx").Inc()
+		s.rejectAtIntake(c.Request.Context(), txid, err.Error(), opts)
+		c.JSON(http.StatusBadRequest, gin.H{
+			jsonKeyError: "transaction failed validation",
+			"reason":     err.Error(),
+		})
+		return
+	}
+
 	// Dedup CAS via GetOrInsertStatus. Two submitters racing on the
 	// same txid both attempt the insert; the loser sees inserted=false
 	// and returns 202 idempotently without re-publishing.
@@ -910,6 +925,22 @@ func (s *Server) handleSubmitTransactions(c *gin.Context) {
 				})
 				return
 			}
+		}
+	}
+
+	// nLockTime/BIP113 finality gate per tx; see handleSubmitTransaction for
+	// the rationale. Aborts the whole batch naming the offending txid —
+	// matches the validation contract above.
+	for _, p := range parsed {
+		if fErr := s.finality.Check(c.Request.Context(), p.tx); fErr != nil {
+			metrics.APIFinalityRejectionsTotal.WithLabelValues("/txs").Inc()
+			s.rejectAtIntake(c.Request.Context(), p.txid, fErr.Error(), opts)
+			c.JSON(http.StatusBadRequest, gin.H{
+				jsonKeyError: "transaction failed validation",
+				"txid":       p.txid,
+				"reason":     fErr.Error(),
+			})
+			return
 		}
 	}
 

--- a/services/api_server/routes.go
+++ b/services/api_server/routes.go
@@ -167,7 +167,7 @@ var routeDocs = []RouteDoc{
 		},
 		ResponseStatus: "202 Accepted",
 		ResponseBody:   "{\n  \"txid\": \"<hex>\",\n  \"status\": 202,\n  \"txStatus\": \"RECEIVED\"\n}\n\n// Idempotent re-submit of a txid Arcade has already seen (txStatus echoes the existing state):\n{\n  \"txid\": \"<hex>\",\n  \"status\": 202,\n  \"txStatus\": \"SEEN_ON_NETWORK\"\n}",
-		Notes:          "Returns 400 with a reason field on validation failure (also persisted as a terminal REJECTED row, so subscribers see the outcome). 503 with Retry-After: 1 is returned when the broker is under backpressure; the transaction was not queued and a retry is safe.",
+		Notes:          "Returns 400 with a reason field on validation failure (also persisted as a terminal REJECTED row, so subscribers see the outcome). This includes non-final transactions (nLockTime ahead of the chain's median-time-past with a non-final input sequence): the reason states when the tx becomes final — resubmit it then and it re-enters the broadcast pipeline. 503 with Retry-After: 1 is returned when the broker is under backpressure; the transaction was not queued and a retry is safe.",
 	},
 	{
 		Method:      "POST",

--- a/services/api_server/server.go
+++ b/services/api_server/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/events"
+	"github.com/bsv-blockchain/arcade/finality"
 	"github.com/bsv-blockchain/arcade/kafka"
 	"github.com/bsv-blockchain/arcade/logfields"
 	"github.com/bsv-blockchain/arcade/merkleservice"
@@ -52,7 +53,12 @@ type Server struct {
 	// unset, in which case the handler skips validation. Production
 	// wiring through New requires it.
 	validator *validator.Validator
-	server    *http.Server
+	// finality runs the nLockTime/BIP113 pre-check in the submit handler,
+	// rejecting provably non-final txs with an actionable reason instead of
+	// letting teranode bounce them with a generic error (issue #245).
+	// Nil-safe: nil (no chain source configured, or disabled) skips the gate.
+	finality *finality.Checker
+	server   *http.Server
 
 	// submissionCh decouples the InsertSubmission Pebble write from the HTTP
 	// handler tail latency. recordSubmission enqueues onto it via a non-
@@ -73,7 +79,7 @@ type submissionRecord struct {
 	sub *models.Submission
 }
 
-func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publisher events.Publisher, st store.Store, tracker *store.TxTracker, tc *teranode.Client, mc *merkleservice.Client, val *validator.Validator) *Server {
+func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publisher events.Publisher, st store.Store, tracker *store.TxTracker, tc *teranode.Client, mc *merkleservice.Client, val *validator.Validator, fin *finality.Checker) *Server {
 	// Export every series this service can emit at 0 from the first scrape —
 	// a series born mid-burst is invisible to increase() until its second
 	// sample, which undercounted submissions after every rollout.
@@ -89,6 +95,7 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 		teranode:       tc,
 		merkleClient:   mc,
 		validator:      val,
+		finality:       fin,
 		submissionCh:   make(chan submissionRecord, submissionRecorderBuffer),
 		submissionStop: make(chan struct{}),
 	}

--- a/tests/smoke/harness.go
+++ b/tests/smoke/harness.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	chaintracksconfig "github.com/bsv-blockchain/go-chaintracks/config"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
@@ -39,6 +40,12 @@ type smokeOptions struct {
 	// TeranodeURL is the single fake-teranode endpoint arcade sees via
 	// DatahubURLs. Required.
 	TeranodeURL string
+	// ChaintracksRemoteURL, when set, points chaintracks.mode=remote at a
+	// stub chaintracks HTTP server, which arms the api-server's
+	// nLockTime/BIP113 finality gate. Empty (the default) leaves the gate
+	// disabled — the suite's baseline, proving the gate fails open when no
+	// chain source exists.
+	ChaintracksRemoteURL string
 }
 
 // startArcadeSmoke boots arcade in-process via app.Bootstrap +
@@ -170,6 +177,7 @@ func buildSmokeConfig(t *testing.T, port int, opts smokeOptions) *config.Config 
 			SubscriberBuffer: config.DefaultEventsSubscriberBuffer,
 		},
 		ChaintracksServer: config.ChaintracksServerConfig{Enabled: false},
+		Chaintracks:       chaintracksRemoteConfig(opts.ChaintracksRemoteURL),
 		Propagation: config.PropagationConfig{
 			MerkleConcurrency: 2,
 			RetryMaxAttempts:  1,
@@ -203,6 +211,16 @@ func buildSmokeConfig(t *testing.T, port int, opts smokeOptions) *config.Config 
 		},
 	}
 	return cfg
+}
+
+// chaintracksRemoteConfig returns a remote-mode chaintracks config pointed
+// at url, or the zero config (mode unset → no chain source, finality gate
+// off) when url is empty.
+func chaintracksRemoteConfig(url string) chaintracksconfig.Config {
+	if url == "" {
+		return chaintracksconfig.Config{}
+	}
+	return chaintracksconfig.Config{Mode: chaintracksconfig.ModeRemote, URL: url}
 }
 
 // waitReady polls the configured api-server port until it accepts a TCP

--- a/tests/smoke/nonfinal_tx_test.go
+++ b/tests/smoke/nonfinal_tx_test.go
@@ -1,0 +1,165 @@
+//go:build smoke
+
+package smoke
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-chaintracks/chaintracks"
+	"github.com/bsv-blockchain/go-sdk/block"
+)
+
+// stubChaintracksMTP is the median-time-past the stub chain reports: every
+// header carries this timestamp, so the BIP113 median is exactly this value.
+const stubChaintracksMTP = uint32(1_600_000_000)
+
+// newStubChaintracks serves the two go-chaintracks remote-client endpoints
+// the finality gate's Checker uses: /v2/tip (JSON BlockHeader) and
+// /v2/headers (raw concatenated 80-byte headers). All headers carry
+// stubChaintracksMTP as their timestamp.
+func newStubChaintracks(t *testing.T) *httptest.Server {
+	t.Helper()
+	tipHeight := uint32(120)
+
+	makeHeader := func() *block.Header {
+		return &block.Header{Version: 1, Timestamp: stubChaintracksMTP, Bits: 0x207fffff}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/tip", func(w http.ResponseWriter, _ *http.Request) {
+		h := makeHeader()
+		tip := &chaintracks.BlockHeader{Header: h, Height: tipHeight, Hash: h.Hash()}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tip)
+	})
+	mux.HandleFunc("/v2/headers", func(w http.ResponseWriter, r *http.Request) {
+		count, err := strconv.Atoi(r.URL.Query().Get("count"))
+		if err != nil || count <= 0 {
+			http.Error(w, "bad count", http.StatusBadRequest)
+			return
+		}
+		for i := 0; i < count; i++ {
+			_, _ = w.Write(makeHeader().Bytes())
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newLockTimeTx mints a validator-passing tx (same OP_TRUE fake-utxo shape
+// as newValidatableTx) with an explicit locktime and input sequence.
+func newLockTimeTx(lockTime, sequence uint32) *bt.Tx {
+	tx := newValidatableTx(bytes.Repeat([]byte{0x02}, 32), 0, 0)
+	tx.LockTime = lockTime
+	tx.Inputs[0].SequenceNumber = sequence
+	return tx
+}
+
+// postSingleTx POSTs one tx in EF encoding to arcade's /tx endpoint and
+// returns the status code and response body.
+func postSingleTx(rt *arcadeRuntime, tx *bt.Tx) (int, string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rt.baseURL+"/tx", bytes.NewReader(tx.ExtendedBytes()))
+	if err != nil {
+		return 0, "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, "", fmt.Errorf("post /tx: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body), nil
+}
+
+func getTxStatus(rt *arcadeRuntime, txid string) (int, string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rt.baseURL+"/tx/"+txid, nil)
+	if err != nil {
+		return 0, "", fmt.Errorf("build request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, "", fmt.Errorf("get /tx: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body), nil
+}
+
+// TestSmoke_NonFinalTxRejectedAtIntake exercises the nLockTime/BIP113
+// finality gate end-to-end through the real boot path (issue #245): arcade
+// boots with chaintracks.mode=remote pointed at a stub chain, a non-final
+// tx is rejected synchronously with an actionable reason (never reaching
+// teranode), the reason is durable on GET /tx/{txid}, and an
+// otherwise-identical final tx broadcasts normally.
+func TestSmoke_NonFinalTxRejectedAtIntake(t *testing.T) {
+	recorder := newRecordingTeranode(t)
+	stub := newStubChaintracks(t)
+	rt := startArcadeSmoke(t, smokeOptions{
+		TeranodeURL:          recorder.URL(),
+		ChaintracksRemoteURL: stub.URL,
+	})
+
+	// Non-final: timestamp locktime one hour past the stub chain's MTP,
+	// with a non-final input sequence — the exact shape from issue #245.
+	nonFinal := newLockTimeTx(stubChaintracksMTP+3600, 0xfffffffe)
+	code, body, err := postSingleTx(rt, nonFinal)
+	if err != nil {
+		t.Fatalf("submit non-final tx: %v", err)
+	}
+	if code != http.StatusBadRequest {
+		t.Fatalf("non-final tx: expected 400, got %d: %s", code, body)
+	}
+	if !strings.Contains(body, "transaction is not final") {
+		t.Errorf("response %q missing finality reason", body)
+	}
+
+	// The rejection must be durable and carry the reason for late readers.
+	code, body, err = getTxStatus(rt, nonFinal.TxID())
+	if err != nil {
+		t.Fatalf("get non-final tx status: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Fatalf("GET /tx/%s: expected 200, got %d: %s", nonFinal.TxID(), code, body)
+	}
+	if !strings.Contains(body, "REJECTED") || !strings.Contains(body, "transaction is not final") {
+		t.Errorf("status body %q missing REJECTED + finality reason", body)
+	}
+
+	// Final: locktime already below the MTP — must broadcast normally.
+	final := newLockTimeTx(stubChaintracksMTP-3600, 0xfffffffe)
+	code, body, err = postSingleTx(rt, final)
+	if err != nil {
+		t.Fatalf("submit final tx: %v", err)
+	}
+	if code != http.StatusAccepted {
+		t.Fatalf("final tx: expected 202, got %d: %s", code, body)
+	}
+	if err := recorder.WaitForTxCount(1, 30*time.Second); err != nil {
+		t.Fatalf("final tx never reached teranode: %v", err)
+	}
+	for _, batch := range recorder.Snapshot() {
+		for _, txid := range batch.TxIDs {
+			if txid == nonFinal.TxID() {
+				t.Fatalf("non-final tx %s was broadcast to teranode", txid)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #245 — and supersedes #181 (see "Relation to #181" below).

Teranode rejects non-final transactions (nLockTime ahead of the chain's BIP113 median-time-past with a non-final input sequence) at mempool admission, and its propagation surface strips the `UTXO_NON_FINAL → TX_LOCK_TIME` reason down to a generic `PROCESSING (4): [ProcessTransaction][…] failed to validate transaction`. Arcade's embedded BDK validator does not check finality (teranode enforces it one layer above the `TxValidator` arcade calls), so arcade accepted such txs at intake, broadcast them, and terminally REJECTED them with an unusable error. Issue #245's transaction sat exactly in this window: locktime 21:41:50 UTC, submitted 23:20–23:41 while mainnet MTP was 20:49–21:31, mined in block 957,459 — the first block after MTP crossed its locktime.

This PR adds the same BIP113 finality check at arcade intake, so non-final txs are rejected synchronously with an actionable reason:

```
transaction is not final: nLockTime 1783806110 (2026-07-11T21:41:50Z) is a timestamp and the
chain's median-time-past must exceed it before broadcast; current median-time-past is
1783805456 (2026-07-11T21:30:56Z), expected to become final in ~11m; resubmit then, or set
all input sequence numbers to 0xffffffff (or nLockTime to 0) if immediate broadcast is intended
```

## Changes

- **`finality/` (new, pure Go — no CGO/BDK)**: `IsTransactionFinal` is a line-for-line port of teranode `util/lock_time.go` (strict inequalities, all-final-sequence short-circuit, locktime 0, height/timestamp threshold at 500000000), returning a typed `NotFinalError` that renders the actionable message with an ETA. `Checker` sources tip height + MTP (median of the last 11 header timestamps, matching teranode's `CalculateMedianTimestamp`) from any `ChainReader` — both the embedded go-chaintracks ChainManager and the remote HTTP client qualify — with a tip-hash-keyed ~15s cache, a ~1s fetch budget, and **fail-open** semantics: no chain state → the gate is skipped and teranode remains the authority. Nil-receiver-safe.
- **`services/api_server`**: the gate runs in `handleSubmitTransaction` and `handleSubmitTransactions` after BDK validation (fail-open ⇒ ordering never changes the accept set). Non-final ⇒ existing `rejectAtIntake` path: HTTP 400 with the reason, durable terminal REJECTED row with `extraInfo`, REJECTED publish for SSE/webhooks. Resubmitting the identical tx once final re-broadcasts via the existing `retry_rejected` path — no new status or hold queue.
- **`app`**: in `mode=all` the embedded chaintracks is reused; in microservice deployments the api-server pod (which deliberately runs no embedded ChainManager) constructs the cheap go-chaintracks **remote** client when `chaintracks.mode=remote` + URL are set. No MTP source → the gate degrades to height-only via the store fallback below.
- **`config`**: `validator.disable_finality_check` escape hatch (default off).
- **Height-only fallback (adopted from #181)**: the store's `GetActiveTipBlockHeight` backs a `WithHeightFallback` source, so deployments with no chaintracks (or a failing one) still gate height-based locktimes — with teranode's strict inequality — while timestamp locktimes fail open (they need MTP). A zero height (empty store) fails open rather than bouncing every height-locked tx.
- **`errors`**: `NotFinalError` is wrapped as `StatusNotFinal` (476, continuing the arcade-local 474/475 extension of ARC's table) without changing the reason text — parity with #181's status mapping, same pattern as `mapTeranodeError`.
- **`metrics`**: `arcade_api_finality_rejections_total{route}` and `arcade_api_finality_precheck_unavailable_total` (fail-open visibility), pre-registered.
- **`deploy`**: api-server gets `ARCADE_CHAINTRACKS_MODE/URL`; docs in `config.example.yaml`, route notes, OpenAPI.

## ⚠ Drive-by fix: chaintracks remote URL was 404ing

The go-chaintracks remote client requests `{baseURL}/v2/…` while arcade's chaintracks service mounts routes under `/chaintracks/v2/…`. `deploy/bump-builder.yaml`'s existing suffix-less URL (`http://chaintracks…:8083`) therefore 404'd on every request. Both deploy files now use `…:8083/chaintracks`. Please verify with `curl <url>/v2/tip` in staging before rollout.

## Relation to #181

#181 (thank you @sirdeggen — it correctly identified the missing check and this PR reuses its teranode `util.IsTransactionFinal` framing) gates time-based locktimes on the **wall clock**, reasoning that "a lock that has elapsed against now() has certainly elapsed against MTP". The implication runs the other way: wall clock ≥ MTP means MTP-final ⇒ now-final, not the reverse. The #245 transaction is the counterexample — locktime 21:41:50, submitted 23:41 (passes wall clock) while MTP was 21:30:56 (teranode rejects). The common wallet failure mode (anti-fee-sniping locktime ≈ signing time, submitted within MTP's 1–2.5h lag) sits precisely in that gap, so the wall-clock gate would not have caught #245. It also uses `>=` where teranode uses strict `>` (a tx with `lockTime == tip+1` would pass the gate and still bounce; #181's own boundary tests stop one block short of the divergent case). This PR compares against real MTP from chaintracks and mirrors teranode's inequalities exactly, with tests pinning both boundaries. Two things #181 did better have been adopted here: its store-based height source (as the fallback described above) and its ARC status mapping (as `StatusNotFinal`).

## Known limits (documented in code)

- Arcade's cached MTP can trail/lead the admitting teranode's view by ≤ ~1 block near the finality boundary; both directions self-heal (generic network rejection as today, or resubmit).
- The gate is UX-only: it fails open on chaintracks outages (counted + logged) rather than blocking intake.

## Test plan

- [x] `finality/`: TDD unit suite — #245 regression vector, strict-inequality boundaries both sides of the 500000000 threshold, mixed sequences, MTP median math (11 + short chains), cache TTL/tip-change/reorg, fail-open cases, fetch budget, nil-safety, height-only fallback (gates height locks, fails open for timestamp locks / errors / zero height, defers to a healthy full reader)
- [x] `services/api_server`: non-final → 400 + REJECTED row + publish with reason + nothing on Kafka; final tx unchanged; nil checker unchanged; batch aborts naming the offending txid
- [x] `tests/smoke`: new end-to-end test through the real boot path with a stub chaintracks (non-final → 400 + durable reason on `GET /tx/{txid}`; final tx broadcasts; non-final never reaches teranode); existing suite (chaintracks disabled) stays green, proving fail-open
- [x] `go build ./...`, `go vet`, full `go test ./...`
