### PR TITLE
perf(bump-builder): skip grace window when the expected-STUMP set is complete

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -37,13 +37,19 @@ Alert on the failure outcomes, enumerated explicitly:
 
 ```promql
 rate(arcade_bump_builder_build_duration_seconds_count{
-  outcome=~"parse_failed|incomplete_stumps|fetch_failed|no_subtrees|build_failed|validation_failed|store_failed"
+  outcome=~"parse_failed|deferred_incomplete|fetch_failed|no_subtrees|build_failed|validation_failed|store_failed"
 }[5m]) > 0
 ```
 
-**Do not** write `{outcome!="success"}` — three outcomes are benign and would
-fire it:
+**Do not** negate the successful-build labels (e.g.
+`{outcome!~"finalized_complete_no_grace|grace_waited"}`) — five outcomes are
+benign and would fire it:
 
+- `finalized_complete_no_grace` — BUMP built; merkle's expected-STUMP set was
+  already complete on arrival, so the grace window was skipped. The common
+  case on a healthy deployment.
+- `grace_waited` — BUMP built via the grace-window path (completeness could
+  not be verified up-front).
 - `short_circuited` — a BUMP already existed, so a redelivered `BLOCK_PROCESSED`
   skipped the rebuild. Expected whenever `/reprocess` re-drives a block.
 - `no_stumps` — the block contained no tracked txs. Expected on most blocks.
@@ -52,8 +58,9 @@ fire it:
 `no_stumps` is benign *per block* but its rate is a real signal: it cannot be
 distinguished from "merkle-service STUMP callbacks were dropped". Alert on
 `arcade_bump_builder_empty_stump_blocks_total` separately, and read it next to
-`arcade_bump_builder_build_duration_seconds_count{outcome="success"}` — a high
-empty-stump rate with a near-zero success rate means STUMPs are not landing.
+`arcade_bump_builder_build_duration_seconds_count{outcome=~"finalized_complete_no_grace|grace_waited"}`
+— a high empty-stump rate with a near-zero build rate means STUMPs are not
+landing.
 
 ## Dashboard recipes
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -258,23 +258,29 @@ var OldestTransientTxAge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 // ---------------------------------------------------------------------------
 
 // BumpBuilderBuildDuration measures end-to-end wall time from BLOCK_PROCESSED
-// receipt (after grace window) to BUMP persisted.
+// receipt to terminal disposition — including the grace-window wait when one
+// was needed (completeness-first ordering skips the wait entirely when
+// merkle's expected-STUMP set is already satisfied on arrival).
 //
-// Every terminal disposition of handleMessage lands here exactly once. Only
-// `success` means a BUMP was built and persisted. Three outcomes are benign
-// non-failures: `short_circuited` (a BUMP already existed, so a redelivery was
-// skipped), `no_stumps` (block contains no tracked txs) and `context_canceled`
+// Every terminal disposition of handleMessage lands here exactly once. Two
+// outcomes mean a BUMP was built and persisted: `finalized_complete_no_grace`
+// (expected-STUMP set complete on the first read — no grace wait) and
+// `grace_waited` (built via the grace-window path; also stamped when the
+// window is configured to 0). Three more are benign non-failures:
+// `short_circuited` (a BUMP already existed, so a redelivery was skipped),
+// `no_stumps` (block contains no tracked txs) and `context_canceled`
 // (shutdown). The rest are failures:
 //
-//	parse_failed, incomplete_stumps, fetch_failed, no_subtrees,
+//	parse_failed, deferred_incomplete, fetch_failed, no_subtrees,
 //	build_failed, validation_failed, store_failed
 //
 // Alert by matching the failure outcomes positively — outcome=~"parse_failed|
-// incomplete_stumps|fetch_failed|no_subtrees|build_failed|validation_failed|
-// store_failed" (the list above). Do NOT write outcome!="success": besides
-// success, it also matches the benign short_circuited/no_stumps/context_canceled,
-// and it silently starts matching any new benign outcome someone adds. Keep this
-// list and the rule in README.md in sync when adding an outcome.
+// deferred_incomplete|fetch_failed|no_subtrees|build_failed|validation_failed|
+// store_failed" (the list above). Do NOT negate the benign labels (e.g.
+// outcome!~"finalized_complete_no_grace|grace_waited"): a negation also
+// matches short_circuited/no_stumps/context_canceled, and it silently starts
+// matching any new benign outcome someone adds. Keep this list and the rule
+// in README.md in sync when adding an outcome.
 var BumpBuilderBuildDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name:    "arcade_bump_builder_build_duration_seconds",
 	Help:    "Time to build and persist one compound BUMP, by outcome.",
@@ -321,11 +327,16 @@ var BumpBuilderBlockDataSourceTotal = promauto.NewCounterVec(prometheus.CounterO
 	Help: "Block data source used for compound BUMP construction, by source (callback|datahub).",
 }, []string{"source"})
 
-// BumpBuilderGraceWaitTotal counts how often the grace window was respected.
-// (Almost always; useful as a smoke metric.)
+// BumpBuilderGraceWaitTotal counts BLOCK_PROCESSED handlers that actually
+// waited the grace window before re-reading STUMPs — i.e. completeness could
+// not be verified from the first STUMP read (expected set unsatisfied, or
+// absent with STUMPs present). Handlers whose expected-STUMP set was already
+// complete on arrival skip the wait and never increment this, so the ratio of
+// this counter to blocks_processed_total tracks how often the window still
+// earns its latency cost.
 var BumpBuilderGraceWaitTotal = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "arcade_bump_builder_grace_window_waits_total",
-	Help: "BLOCK_PROCESSED handlers that waited the grace window before reading STUMPs.",
+	Help: "BLOCK_PROCESSED handlers that waited the grace window before re-reading STUMPs.",
 })
 
 // BumpBuilderEmptyStumpBlocksTotal counts BLOCK_PROCESSED messages that
@@ -345,7 +356,9 @@ var BumpBuilderEmptyStumpBlocksTotal = promauto.NewCounter(prometheus.CounterOpt
 // was NOT fully satisfied by the STUMPs arcade had stored once the grace window
 // elapsed. Such a block is deliberately left un-finalized (processed_at stays
 // NULL) so the watchdog re-drives it via merkle's /reprocess, which re-emits the
-// missing STUMPs and BLOCK_PROCESSED. This is the metric that makes the
+// missing STUMPs and BLOCK_PROCESSED. On BumpBuilderBuildDuration these land
+// as outcome="deferred_incomplete" (renamed from "incomplete_stumps" when
+// completeness-first grace handling landed). This is the metric that makes the
 // previously-silent partial-STUMP drop visible: unlike the all-missing case
 // (empty_stump_blocks_total), a block missing only SOME of its STUMPs used to
 // build a valid-looking BUMP and lose the absent subtree's txs with no signal.

--- a/metrics/preregister.go
+++ b/metrics/preregister.go
@@ -44,10 +44,13 @@ func PreRegisterTxSubmissions() {
 // exists to close, so the failure outcomes matter most here. Unexported so no
 // other package can mutate the shared slice.
 var bumpBuildOutcomes = []string{
-	// benign
-	"success", "short_circuited", "no_stumps", "context_canceled",
+	// benign — the two build dispositions (finalized_complete_no_grace when
+	// the expected-STUMP set was already complete on arrival and the grace
+	// window was skipped, grace_waited otherwise) plus the non-build ones
+	"finalized_complete_no_grace", "grace_waited",
+	"short_circuited", "no_stumps", "context_canceled",
 	// failures
-	"parse_failed", "incomplete_stumps", "fetch_failed",
+	"parse_failed", "deferred_incomplete", "fetch_failed",
 	"no_subtrees", "build_failed", "validation_failed", "store_failed",
 }
 

--- a/metrics/preregister_test.go
+++ b/metrics/preregister_test.go
@@ -97,6 +97,32 @@ func TestPreRegisterTxSubmissionsCreatesAllRouteResultChildrenAtZero(t *testing.
 	}
 }
 
+// TestBumpOutcomesIncludeGraceDispositions pins the outcome-label migration
+// that landed with completeness-first grace handling: the flat `success`
+// label split into the two benign build dispositions
+// (`finalized_complete_no_grace` when the expected-STUMP set was already
+// complete on arrival, `grace_waited` otherwise), and the failure label
+// `incomplete_stumps` was renamed `deferred_incomplete`. The closed set must
+// carry the new labels — and must NOT resurrect the retired ones, or the
+// pre-registration guarantee (and the alert recipe in README.md) silently
+// diverges from what builder.go actually stamps.
+func TestBumpOutcomesIncludeGraceDispositions(t *testing.T) {
+	got := make(map[string]bool, len(bumpBuildOutcomes))
+	for _, o := range bumpBuildOutcomes {
+		got[o] = true
+	}
+	for _, want := range []string{"finalized_complete_no_grace", "grace_waited", "deferred_incomplete"} {
+		if !got[want] {
+			t.Errorf("bumpBuildOutcomes missing %q", want)
+		}
+	}
+	for _, retired := range []string{"success", "incomplete_stumps"} {
+		if got[retired] {
+			t.Errorf("bumpBuildOutcomes still contains retired label %q", retired)
+		}
+	}
+}
+
 func TestPreRegisterBumpOutcomesCreatesEveryOutcomeChildAtZero(t *testing.T) {
 	PreRegisterBumpOutcomes()
 

--- a/openspec/changes/skip-grace-when-complete/.openspec.yaml
+++ b/openspec/changes/skip-grace-when-complete/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/skip-grace-when-complete/design.md
+++ b/openspec/changes/skip-grace-when-complete/design.md
@@ -1,0 +1,38 @@
+# Design — completeness-first grace-window handling
+
+## Context
+
+`services/bump_builder/builder.go:handleMessage` used to run: short-circuit → **wait grace window** → read STUMPs → completeness gate → build/finalize. The grace window (`bump_builder.grace_window_ms`, default 30s) defends against STUMP callbacks whose first HTTP attempt 5xx'd and are retrying asynchronously — merkle's stumpGate only waits for the first attempt of each STUMP before releasing BLOCK_PROCESSED.
+
+Since merkle PR #162, the callback carries `expectedSubtreeIndices` (`models.CallbackMessage.ExpectedSubtreeIndices`), giving arcade a proof of completeness that makes the unconditional wait unnecessary in the common case.
+
+## Decision 1: read-before-grace, three-way dispatch
+
+`handleMessage` now resolves its STUMP set via `resolveStumps` (extracted, like `tryShortCircuit`, to keep nesting under the lint bar):
+
+1. **Complete** (`len(expected) > 0 && missing == ∅` on the first read): skip the window, build from the first read. Disposition `finalized_complete_no_grace`. INFO log `expected STUMP set complete — skipping grace window` with `{expected_stumps, received_stumps}`.
+2. **Absent + zero** (`len(expected) == 0 && len(stumps) == 0`): finalize immediately as an empty block (WARN unchanged, `EmptyStumpBlocksTotal`, `markBlockProcessed(hash, 0)`), outcome `no_stumps` — no grace wait first. Absent means "expect zero": merkle ≥ v0.4.5 always emits the field when the block has tracked txs (compat floor documented in proposal.md).
+3. **Everything else** (expected set unsatisfied, or absent with STUMPs present — pre-#162 merkle, unverifiable): WARN when the set is absent, then wait the window (ctx-cancellable, `GraceWaitTotal.Inc()`), re-read, and re-run the completeness gate. Missing after the wait → defer (outcome `deferred_incomplete`, `IncompleteStumpsTotal`); zero after the wait → empty-block finalize; else build with disposition `grace_waited`. With `grace_window_ms: 0` there is no second store read — the first read's set is reused.
+
+`BumpBuilderStumpCount` is observed exactly once per message, on the STUMP set that reaches the decision (first read when the wait is skipped, re-read otherwise).
+
+## Decision 2: watchdog interplay — no store change
+
+Both stale predicates key on `processed_at` being unset (`store/postgres/postgres.go` `ListStaleBlockProcessingStatus`: `processed_at IS NULL AND status='active' AND header_seen_at < $1 AND block_height >= $2`; aerospike mirrors the semantics with an in-memory filter). The empty-block finalize stamps `processed_at` via `MarkBlockProcessed(hash, 0, now)`, whose upsert only writes `processed_at` on conflict — the chaintracks-supplied height survives. So finalized empty blocks already leave the stale scan in both stores; calling `MarkBlockBUMPBuilt` for a block with no BUMP row would lie about BUMP existence for zero benefit, and a SQL carve-out is unnecessary. The smallest correct change is **zero lines of store code plus one pinning test** (`TestBlockProcessing_ListStale_ExcludesFinalizedEmptyBlock`) so a future predicate change (e.g. adding `bump_built_at IS NULL`) can't silently resurrect the empty-block re-drive storm.
+
+## Decision 3: outcome label migration
+
+`arcade_bump_builder_build_duration_seconds{outcome}` has a closed, pre-registered label set (PR #244: `metrics/preregister.go` `bumpBuildOutcomes`, doc-comment contract on the metric, positively-enumerated failure regex in `metrics/README.md`). A flat `success` can no longer say whether the window was paid, and keeping it while adding a sibling would make `outcome="success"` silently undercount. So:
+
+| Old | New | Class |
+|---|---|---|
+| `success` | `finalized_complete_no_grace` \| `grace_waited` | benign |
+| `incomplete_stumps` | `deferred_incomplete` | failure |
+| all others | unchanged | as today |
+
+All four touch-points move in one commit: the closed set, the metric doc comment, the README recipe, and the pre-registration tests. Dashboards filtering `outcome="success"` migrate to `outcome=~"finalized_complete_no_grace|grace_waited"`.
+
+## Risks
+
+- **Pre-#162 merkle**: absent+zero now finalizes without the wait; a genuinely-late STUMP from an old merkle would be orphaned (block already stamped). Accepted: compat floor is merkle ≥ v0.4.5, and the previous behavior only narrowed the race rather than closing it.
+- **Second store read per grace-waited message**: one extra `GetStumpsByBlockHash` for blocks that actually wait; complete blocks now do exactly one read (same count as before, minus the 30s).

--- a/openspec/changes/skip-grace-when-complete/proposal.md
+++ b/openspec/changes/skip-grace-when-complete/proposal.md
@@ -1,0 +1,24 @@
+# Skip the bump-builder grace window when the expected-STUMP set is complete
+
+## Why
+
+Every BLOCK_PROCESSED pays the full `bump_builder.grace_window_ms` (default 30s, 15s in compose) before bump-builder even reads its STUMPs — a fixed MINED-latency floor on every block. The window exists solely to ride out STUMP callbacks whose first HTTP attempt got a 5xx and are retrying asynchronously (merkle's stumpGate releases BLOCK_PROCESSED after the first attempt). But since merkle PR #162, BLOCK_PROCESSED carries `expectedSubtreeIndices` — the exact set of subtree indices that produced a STUMP. When every expected index is already stored on arrival, nothing can still be in flight that we need: the wait is pure latency with zero correctness benefit. The same window also serializes recovery drains: a watchdog /reprocess storm re-delivers many blocks whose STUMPs are all present, and each one still burned the full window.
+
+## What Changes
+
+- **Completeness-first ordering in `handleMessage`**: STUMPs are read BEFORE the grace window. If the expected set is present and fully satisfied, build immediately (grace skipped). If the expected set is absent AND zero STUMPs are stored, finalize immediately as an empty block (absent means "expect zero"). Only an unverifiable shape — expected set unsatisfied, or absent with STUMPs present — still waits the window, re-reads, and re-runs the completeness gate.
+- **Outcome label migration** on `arcade_bump_builder_build_duration_seconds{outcome}`: `success` splits into `finalized_complete_no_grace` (completeness verified pre-grace) and `grace_waited` (every other successful build); `incomplete_stumps` renames to `deferred_incomplete`. Closed set, pre-registration, doc comment, and the README alert recipe updated together.
+- **No store change**: both stores' stale predicates key on `processed_at`, which the empty-block finalize already stamps; a pinning regression test guards the predicate.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `bump-builder`: grace-window handling becomes conditional on expected-STUMP-set completeness; empty-block finalization no longer waits the window.
+
+## Impact
+
+- **Latency**: blocks whose STUMPs all landed before BLOCK_PROCESSED (the healthy steady state) go MINED up to `grace_window_ms` sooner. Watchdog re-drives of complete blocks drain without the per-block wait.
+- **Metric/dashboard migration (breaking for queries)**: dashboards or alerts filtering `outcome="success"` must move to `outcome=~"finalized_complete_no_grace|grace_waited"`; `incomplete_stumps` → `deferred_incomplete`. The README failure-regex recipe is updated in the same commit.
+- **Compatibility floor**: the absent-expected-set + zero-STUMPs case now finalizes immediately instead of waiting the window first. This is safe against merkle-service ≥ v0.4.5 (which always emits `expectedSubtreeIndices` when the block has tracked txs, so "absent" provably means "expect zero"). Against an older merkle, a block whose only STUMPs were still retrying at BLOCK_PROCESSED time would finalize empty; pre-#162 merkle deployments should not run with this arcade version.
+- **Config**: none. `bump_builder.grace_window_ms` keeps its meaning as the incomplete-set fallback window.

--- a/openspec/changes/skip-grace-when-complete/specs/bump-builder/spec.md
+++ b/openspec/changes/skip-grace-when-complete/specs/bump-builder/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Grace window is conditional on expected-STUMP-set completeness
+
+The BUMP builder SHALL read the stored STUMPs for a block BEFORE waiting the configured grace window (`bump_builder.grace_window_ms`), and SHALL wait the window only when completeness of the STUMP set cannot be verified from that first read. When merkle-service's expected-STUMP set (`expectedSubtreeIndices` on BLOCK_PROCESSED) is fully satisfied by the stored STUMPs, the builder SHALL build the compound BUMP immediately.
+
+#### Scenario: Expected set complete on arrival
+
+- **WHEN** a BLOCK_PROCESSED message arrives with `expectedSubtreeIndices: [0, 1]` and STUMPs for subtrees 0 and 1 are already stored
+- **THEN** the builder SHALL skip the grace window, build the compound BUMP from the stored STUMPs, stamp `processed_at`, and record the build under outcome `finalized_complete_no_grace`.
+
+#### Scenario: Expected set incomplete — wait, then defer
+
+- **WHEN** a BLOCK_PROCESSED message arrives with `expectedSubtreeIndices: [0, 1]` and only subtree 0's STUMP is stored, and the missing STUMP has not arrived by the end of the grace window
+- **THEN** the builder SHALL wait the full grace window, re-read the STUMPs, and — the set still being incomplete — leave the block un-finalized (no BUMP, no `processed_at`) so the watchdog re-drives it via `/reprocess`, recording the message under outcome `deferred_incomplete`.
+
+#### Scenario: Expected set incomplete — late STUMP lands within the window
+
+- **WHEN** a BLOCK_PROCESSED message arrives with `expectedSubtreeIndices: [0]`, no STUMP stored, and subtree 0's STUMP is stored while the grace window is running
+- **THEN** the builder SHALL find the completed set on the post-window re-read, build the compound BUMP, and stamp `processed_at`, recording the build under outcome `grace_waited`.
+
+#### Scenario: Expected set absent, zero STUMPs — finalize without waiting
+
+- **WHEN** a BLOCK_PROCESSED message arrives with no `expectedSubtreeIndices` field and no STUMPs stored for the block
+- **THEN** the builder SHALL finalize the block immediately as an empty block (stamp `processed_at`, no BUMP, no grace-window wait), because an absent expected set means the block has no tracked transactions (merkle-service ≥ v0.4.5 emits the field whenever STUMPs are expected).
+
+#### Scenario: Expected set absent, STUMPs present — completeness unverifiable
+
+- **WHEN** a BLOCK_PROCESSED message arrives with no `expectedSubtreeIndices` field but one or more STUMPs are stored for the block
+- **THEN** the builder SHALL log a warning that completeness cannot be verified, wait the full grace window, re-read the STUMPs, and build from the post-window set, recording the build under outcome `grace_waited`.
+
+### Requirement: Build-outcome labels distinguish the grace dispositions
+
+The BUMP builder SHALL stamp every terminal disposition of a BLOCK_PROCESSED message onto `arcade_bump_builder_build_duration_seconds{outcome}` using a closed, pre-registered label set in which successful builds carry `finalized_complete_no_grace` (grace window skipped after completeness verification) or `grace_waited` (all other successful builds), and completeness deferrals carry `deferred_incomplete`. The labels `success` and `incomplete_stumps` SHALL NOT be emitted.
+
+#### Scenario: Deferral is stamped with the renamed failure label
+
+- **WHEN** a block is left un-finalized because expected STUMPs are still missing after the grace window
+- **THEN** the duration observation carries `outcome="deferred_incomplete"` and the `outcome="incomplete_stumps"` series is not emitted.
+
+#### Scenario: Pre-registration exports the new labels from the first scrape
+
+- **WHEN** the bump-builder service constructs and pre-registers its metrics
+- **THEN** child series for `finalized_complete_no_grace`, `grace_waited`, and `deferred_incomplete` exist at zero before any message is handled.

--- a/openspec/changes/skip-grace-when-complete/tasks.md
+++ b/openspec/changes/skip-grace-when-complete/tasks.md
@@ -1,0 +1,34 @@
+## 1. Tests first (RED against the wait-first ordering)
+
+- [x] 1.1 `TestBuilder_HandleMessage_CompleteExpectedSet_SkipsGraceWindow` — grace=5s, expected `{0}` satisfied pre-arrival; asserts handleMessage returns in <2s, BUMP stored, `MarkBlockProcessed` called. RED by timing on the old ordering.
+- [x] 1.2 `TestBuilder_HandleMessage_AbsentExpectedSet_ZeroStumps_SkipsGraceAndFinalizes` — grace=5s, field absent, no STUMPs; <2s, stamped, no BUMP. RED by timing.
+- [x] 1.3 `TestBumpOutcomesIncludeGraceDispositions` (metrics) — closed set carries `finalized_complete_no_grace`/`grace_waited`/`deferred_incomplete`, not `success`/`incomplete_stumps`. RED.
+- [x] 1.4 `TestBuilder_HandleMessage_DeferPath_StampsDeferredIncompleteOutcome` — defer path observed under `deferred_incomplete` on the duration histogram. RED.
+
+## 2. Regression pins (green before and after — guard the reorder)
+
+- [x] 2.1 `TestBuilder_HandleMessage_IncompleteExpectedSet_WaitsGraceThenDefers` — elapsed ≥ grace, no BUMP, no stamp.
+- [x] 2.2 `TestBuilder_HandleMessage_AbsentExpectedSet_WithStumps_WaitsGrace` — ambiguous set keeps the window; BUMP builds after it.
+- [x] 2.3 `TestBuilder_HandleMessage_IncompleteThenCompleteWithinGrace_Builds` — late STUMP lands mid-window; post-wait re-read builds.
+- [x] 2.4 `TestBuilder_HandleMessage_OutOfOrderStump_RecoveredOnRedelivery` — delivery 1 defers; STUMP lands; delivery 2 builds + stamps.
+- [x] 2.5 `TestBlockProcessing_ListStale_ExcludesFinalizedEmptyBlock` (store/postgres) — `MarkBlockProcessed(hash, 0, now)` removes the row from the stale scan and preserves the chaintracks height.
+- [x] 2.6 Existing builder suite kept green; `TestBuilder_LateSTUMP_ArrivesDuringGraceWindow` rewritten as `TestBuilder_LateSTUMP_AbsentExpectedSet_FinalizesWithoutWaiting` (its old expectation — absent+zero waits for a late STUMP — is exactly the behavior this change retires; mid-grace-arrival coverage moved to 2.3).
+
+## 3. Builder implementation
+
+- [x] 3.1 Extract `resolveStumps` (read → three-way dispatch → optional wait + re-read → completeness gate) returning `(stumps, disposition, done, err)`; `handleMessage` stamps `outcome` from the disposition on every terminal path.
+- [x] 3.2 Extract `finalizeEmptyBlock` (WARN text unchanged, `EmptyStumpBlocksTotal`, `markBlockProcessed(hash, 0)`) shared by the absent+zero and post-wait-zero paths.
+- [x] 3.3 `BumpBuilderStumpCount` observed once per message on the decision set; `GraceWaitTotal` only increments when the wait actually happens.
+
+## 4. Metric label migration (all four touch-points in sync)
+
+- [x] 4.1 `metrics/preregister.go` — `bumpBuildOutcomes` swaps `success` → `finalized_complete_no_grace` + `grace_waited`, `incomplete_stumps` → `deferred_incomplete`.
+- [x] 4.2 `metrics/metrics.go` — `BumpBuilderBuildDuration` doc contract, `BumpBuilderGraceWaitTotal` help/comment ("before re-reading STUMPs"), `BumpBuilderIncompleteStumpsTotal` rename mention.
+- [x] 4.3 `metrics/README.md` — failure regex and benign list updated; empty-stump recipe reads against the two build labels.
+
+## 5. Gates
+
+- [x] 5.1 `go build ./...`
+- [x] 5.2 `CGO_ENABLED=1 go test ./... -count=1`
+- [x] 5.3 `go test -race -count=1 ./services/bump_builder ./metrics ./store/postgres ./services/watchdog` (postgres also run with `-tags=postgres`)
+- [x] 5.4 `golangci-lint run`

--- a/services/bump_builder/builder.go
+++ b/services/bump_builder/builder.go
@@ -442,9 +442,14 @@ func (b *Builder) Stop() error {
 func (b *Builder) handleMessage(ctx context.Context, msg *kafka.Message) error {
 	overallStart := time.Now()
 	metrics.BumpBuilderBlocksProcessedTotal.Inc()
-	// outcome reflects the terminal disposition of this BLOCK_PROCESSED. Set
-	// before each return so the duration histogram lands in the right bucket.
-	outcome := "success"
+	// outcome reflects the terminal disposition of this BLOCK_PROCESSED. Every
+	// return path assigns it before returning so the duration histogram lands
+	// in the right bucket. There is no bare "success" label: a successful
+	// build lands as finalized_complete_no_grace (expected-STUMP set already
+	// complete on arrival, grace window skipped) or grace_waited (built after
+	// the grace-window path). The label set is closed — keep it in sync with
+	// metrics/preregister.go's bumpBuildOutcomes.
+	outcome := "grace_waited"
 	defer func() {
 		metrics.BumpBuilderBuildDuration.WithLabelValues(outcome).Observe(time.Since(overallStart).Seconds())
 	}()
@@ -471,71 +476,23 @@ func (b *Builder) handleMessage(ctx context.Context, msg *kafka.Message) error {
 		return nil
 	}
 
-	// Grace window: merkle-service's stumpGate only waits for the first HTTP attempt
-	// of each STUMP before releasing BLOCK_PROCESSED. STUMPs that got a 5xx on the
-	// first attempt retry asynchronously and may land after BLOCK_PROCESSED.
-	if grace := time.Duration(b.cfg.BumpBuilder.GraceWindowMs) * time.Millisecond; grace > 0 {
-		metrics.BumpBuilderGraceWaitTotal.Inc()
-		logger.Debug("waiting grace window", zap.Duration("duration", grace))
-		select {
-		case <-ctx.Done():
-			outcome = "context_canceled"
-			return ctx.Err()
-		case <-time.After(grace):
-		}
-	}
-
-	// 1. Get all STUMPs for this block
-	stumps, err := b.store.GetStumpsByBlockHash(ctx, blockHash)
+	// Resolve the STUMP set with completeness-first ordering: STUMPs are read
+	// BEFORE any grace-window wait, so a block whose expected-STUMP set is
+	// already complete (or provably empty) finalizes immediately instead of
+	// burning the window. Only an unverifiable set still waits + re-reads.
+	// See resolveStumps for the full contract.
+	stumps, disposition, done, err := b.resolveStumps(ctx, logger, &callback)
 	if err != nil {
-		outcome = "store_failed"
-		return fmt.Errorf("getting STUMPs for block: %w", err)
+		outcome = disposition
+		return err
 	}
-
-	metrics.BumpBuilderStumpCount.Observe(float64(len(stumps)))
-
-	// Completeness gate. merkle-service (PR #162) tells us exactly which subtree
-	// indices produced a STUMP for this block. If any are still missing once the
-	// grace window has elapsed, leave the block un-finalized: do NOT stamp
-	// processed_at, so ListStaleBlockProcessingStatus surfaces it and the
-	// watchdog re-drives it via /reprocess (which re-emits the missing STUMPs and
-	// BLOCK_PROCESSED). Returning nil — not an error — because a Kafka requeue
-	// would just replay against the same gap; only /reprocess can fill it, and
-	// the durable processed_at IS NULL is the recovery signal. An empty/absent
-	// expected set (pre-#162 merkle, or a block with no tracked txs) yields no
-	// missing indices and falls through to the existing behavior below.
-	if missing := missingStumpIndices(callback.ExpectedSubtreeIndices, stumps); len(missing) > 0 {
-		outcome = "incomplete_stumps"
-		metrics.BumpBuilderIncompleteStumpsTotal.Inc()
-		logger.Error(
-			"BLOCK_PROCESSED is missing expected STUMPs — deferring finalization so the watchdog can recover via /reprocess",
-			zap.Ints("missing_subtree_indices", missing),
-			zap.Int("expected_stumps", len(callback.ExpectedSubtreeIndices)),
-			zap.Int("received_stumps", len(stumps)),
-		)
+	if done {
+		outcome = disposition
 		return nil
 	}
-
-	if len(stumps) == 0 {
-		outcome = "no_stumps"
-		metrics.BumpBuilderEmptyStumpBlocksTotal.Inc()
-		// Warn — not Info — because the legitimate case (block contains no
-		// tracked txs) is indistinguishable from the silent-drop case
-		// (STUMP callbacks were dedup'd / DLQ'd / lost upstream). Operators
-		// need to see this rate in logs; a sustained stream while watched
-		// txs are in flight is the signal that merkle-service callbacks
-		// aren't landing.
-		//
-		// Reaching here means the expected set was empty (a non-empty set with
-		// zero received STUMPs would have been caught by the completeness gate
-		// above), so this block has no tracked txs and IS finalized — stamp
-		// processed_at so the watchdog doesn't keep re-driving a complete block.
-		// blockHeight is unknown on this path (no compound built); pass 0, which
-		// the upsert leaves the chaintracks-supplied height intact on conflict.
-		logger.Warn("BLOCK_PROCESSED arrived with zero STUMPs for this block — either no tracked txs in this block, or upstream STUMP callbacks were dropped (check merkle-service callback delivery)")
-		b.markBlockProcessed(ctx, logger, blockHash, 0)
-		return nil
-	}
+	// The build proceeds under its benign disposition; any later failure
+	// return overrides outcome with its failure label.
+	outcome = disposition
 
 	logger.Info("building compound BUMP", zap.Int("stump_count", len(stumps)))
 	logStumpInputs(logger, stumps)
@@ -655,6 +612,138 @@ func (b *Builder) handleMessage(ctx context.Context, msg *kafka.Message) error {
 		zap.Int("stumps_pruned", len(stumps)),
 	)
 	return nil
+}
+
+// resolveStumps decides which STUMP set handleMessage builds from and whether
+// the grace window has to be waited at all. Extracted from handleMessage to
+// keep its nesting under the lint bar (same motivation as tryShortCircuit).
+//
+// Completeness-first ordering: STUMPs are read BEFORE the grace window.
+// merkle-service (PR #162) tells us exactly which subtree indices produced a
+// STUMP for this block, and the grace window exists only to ride out STUMP
+// callbacks whose first HTTP attempt got a 5xx and are retrying
+// asynchronously (merkle's stumpGate only waits for the first attempt before
+// releasing BLOCK_PROCESSED). So:
+//
+//   - Expected set present and fully satisfied → nothing can still be in
+//     flight that we need; skip the window and build now
+//     (disposition finalized_complete_no_grace).
+//   - Expected set absent AND zero STUMPs stored → merkle ≥ v0.4.5 omits the
+//     field exactly when the block has no tracked txs, so "expect zero, have
+//     zero" is complete; finalize immediately (disposition no_stumps,
+//     done=true).
+//   - Anything else (expected set unsatisfied, or absent with STUMPs present
+//     — pre-#162 merkle, unverifiable) → wait the grace window, re-read, and
+//     re-run the completeness gate (disposition grace_waited on success).
+//
+// The returned disposition is always a valid outcome label for
+// BumpBuilderBuildDuration: on err it is the failure label to stamp; with
+// done=true it is the terminal benign/failure label and handleMessage must
+// return nil; otherwise it is the benign label the successful build lands
+// under. BumpBuilderStumpCount is observed exactly once per message, on the
+// STUMP set that reaches the decision.
+func (b *Builder) resolveStumps(ctx context.Context, logger *zap.Logger, callback *models.CallbackMessage) (stumps []*models.Stump, disposition string, done bool, err error) {
+	blockHash := callback.BlockHash
+	expected := callback.ExpectedSubtreeIndices
+
+	stumps, err = b.store.GetStumpsByBlockHash(ctx, blockHash)
+	if err != nil {
+		return nil, "store_failed", false, fmt.Errorf("getting STUMPs for block: %w", err)
+	}
+
+	switch {
+	case len(expected) > 0 && len(missingStumpIndices(expected, stumps)) == 0:
+		// Complete: every subtree index merkle told us to expect already has
+		// a stored STUMP — there is nothing left to wait for.
+		logger.Info(
+			"expected STUMP set complete — skipping grace window",
+			zap.Int("expected_stumps", len(expected)),
+			zap.Int("received_stumps", len(stumps)),
+		)
+		metrics.BumpBuilderStumpCount.Observe(float64(len(stumps)))
+		return stumps, "finalized_complete_no_grace", false, nil
+
+	case len(expected) == 0 && len(stumps) == 0:
+		// Absent + zero: complete by the absent-means-expect-zero contract —
+		// finalize now instead of burning the grace window first.
+		metrics.BumpBuilderStumpCount.Observe(0)
+		b.finalizeEmptyBlock(ctx, logger, blockHash)
+		return nil, "no_stumps", true, nil
+	}
+
+	// Incomplete (expected set not yet satisfied) or absent-with-STUMPs (no
+	// set to verify against): completeness cannot be established from the
+	// first read, so the grace window is still the only defense against late
+	// STUMP retries.
+	if len(expected) == 0 {
+		logger.Warn(
+			"BLOCK_PROCESSED lacks expected-STUMP set but STUMPs exist — cannot verify completeness; waiting grace window",
+			zap.Int("received_stumps", len(stumps)),
+		)
+	}
+	if grace := time.Duration(b.cfg.BumpBuilder.GraceWindowMs) * time.Millisecond; grace > 0 {
+		metrics.BumpBuilderGraceWaitTotal.Inc()
+		logger.Debug("waiting grace window", zap.Duration("duration", grace))
+		select {
+		case <-ctx.Done():
+			return nil, "context_canceled", false, ctx.Err()
+		case <-time.After(grace):
+		}
+		// Re-read: catching late arrivals is the whole point of the wait.
+		stumps, err = b.store.GetStumpsByBlockHash(ctx, blockHash)
+		if err != nil {
+			return nil, "store_failed", false, fmt.Errorf("getting STUMPs for block: %w", err)
+		}
+	}
+
+	metrics.BumpBuilderStumpCount.Observe(float64(len(stumps)))
+
+	// Completeness gate. If expected STUMPs are still missing once the grace
+	// window has elapsed, leave the block un-finalized: do NOT stamp
+	// processed_at, so ListStaleBlockProcessingStatus surfaces it and the
+	// watchdog re-drives it via /reprocess (which re-emits the missing STUMPs
+	// and BLOCK_PROCESSED). Returning done — not an error — because a Kafka
+	// requeue would just replay against the same gap; only /reprocess can fill
+	// it, and the durable processed_at IS NULL is the recovery signal.
+	if missing := missingStumpIndices(expected, stumps); len(missing) > 0 {
+		metrics.BumpBuilderIncompleteStumpsTotal.Inc()
+		logger.Error(
+			"BLOCK_PROCESSED is missing expected STUMPs — deferring finalization so the watchdog can recover via /reprocess",
+			zap.Ints("missing_subtree_indices", missing),
+			zap.Int("expected_stumps", len(expected)),
+			zap.Int("received_stumps", len(stumps)),
+		)
+		return nil, "deferred_incomplete", true, nil
+	}
+
+	// Zero STUMPs after the wait — only reachable with an absent expected set
+	// (a non-empty set with zero STUMPs is caught by the gate above): the
+	// pre-#162 no-tracked-tx block. Same empty-block finalize.
+	if len(stumps) == 0 {
+		b.finalizeEmptyBlock(ctx, logger, blockHash)
+		return nil, "no_stumps", true, nil
+	}
+
+	return stumps, "grace_waited", false, nil
+}
+
+// finalizeEmptyBlock finalizes a BLOCK_PROCESSED whose block has no stored
+// STUMPs and no unsatisfied expected set — a block with no tracked txs.
+//
+// Warn — not Info — because the legitimate case (block contains no tracked
+// txs) is indistinguishable from the silent-drop case (STUMP callbacks were
+// dedup'd / DLQ'd / lost upstream). Operators need to see this rate in logs;
+// a sustained stream while watched txs are in flight is the signal that
+// merkle-service callbacks aren't landing.
+//
+// The block IS finalized — stamp processed_at so the watchdog doesn't keep
+// re-driving a complete block. blockHeight is unknown on this path (no
+// compound built); pass 0, which the upsert leaves the chaintracks-supplied
+// height intact on conflict.
+func (b *Builder) finalizeEmptyBlock(ctx context.Context, logger *zap.Logger, blockHash string) {
+	metrics.BumpBuilderEmptyStumpBlocksTotal.Inc()
+	logger.Warn("BLOCK_PROCESSED arrived with zero STUMPs for this block — either no tracked txs in this block, or upstream STUMP callbacks were dropped (check merkle-service callback delivery)")
+	b.markBlockProcessed(ctx, logger, blockHash, 0)
 }
 
 // fetchBlockDataFromDatahub is the datahub fallback for block inputs: used when

--- a/services/bump_builder/builder_grace_test.go
+++ b/services/bump_builder/builder_grace_test.go
@@ -1,0 +1,332 @@
+package bump_builder
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// This file pins the completeness-first grace-window contract:
+//
+//   - When merkle's expected-STUMP set (CallbackMessage.ExpectedSubtreeIndices)
+//     is already fully satisfied by the stored STUMPs on arrival, the grace
+//     window is SKIPPED — it exists only to ride out late STUMP retries, so a
+//     verified-complete set has nothing to wait for.
+//   - An absent expected set with zero stored STUMPs finalizes immediately
+//     (merkle ≥ v0.4.5 omits the field exactly when the block has no tracked
+//     txs, so "expect zero, have zero" is complete).
+//   - Every other shape (incomplete set, or absent set with STUMPs present)
+//     keeps the grace window: wait, re-read, then decide.
+//
+// Wall-clock bounds use a 5s configured grace vs a <2s assertion so the tests
+// stay unambiguous under the race detector's slowdown.
+
+// bumpOutcomeSampleCount returns the cumulative sample count of the
+// arcade_bump_builder_build_duration_seconds child carrying the given outcome
+// label, or 0 when that series does not exist yet. The metric is global to
+// the process, so tests must compare before/after deltas rather than absolute
+// values.
+func bumpOutcomeSampleCount(t *testing.T, outcome string) uint64 {
+	t.Helper()
+	fams, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, f := range fams {
+		if f.GetName() != "arcade_bump_builder_build_duration_seconds" {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "outcome" && lp.GetValue() == outcome {
+					return m.GetHistogram().GetSampleCount()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// TestBuilder_HandleMessage_CompleteExpectedSet_SkipsGraceWindow: merkle says
+// subtree {0} should have a STUMP and it is already stored when
+// BLOCK_PROCESSED arrives, so handleMessage must build immediately instead of
+// burning the configured 5s grace window first. The wall-clock bound is the
+// assertion: on the old wait-first ordering this test times out past 2s.
+func TestBuilder_HandleMessage_CompleteExpectedSet_SkipsGraceWindow(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+	txidHex := testTxidHex
+
+	stumpData := makeMinimalSTUMP(txidHex)
+	ms.addStump(blockHash, 0, stumpData)
+
+	subtreeHash := mustHash(t, txidHex)
+	root := expectedCompoundRoot(t,
+		[]*models.Stump{{BlockHash: blockHash, SubtreeIndex: 0, StumpData: stumpData}},
+		[]chainhash.Hash{subtreeHash}, nil)
+	datahub := newDatahubServer(root, []chainhash.Hash{subtreeHash})
+	defer datahub.Close()
+
+	b := newTestBuilder(ms, datahub.URL)
+	b.cfg.BumpBuilder.GraceWindowMs = 5000
+
+	start := time.Now()
+	if err := b.handleMessage(context.Background(), makeBlockProcessedMsgWithExpected(blockHash, []int{0})); err != nil {
+		t.Fatalf("complete-set handleMessage returned error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= 2*time.Second {
+		t.Errorf("complete expected set must skip the grace window; handleMessage took %v (grace=5s)", elapsed)
+	}
+
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if _, ok := ms.bumps[blockHash]; !ok {
+		t.Error("expected BUMP to be stored for a complete block")
+	}
+	if len(ms.processedCalls) != 1 || ms.processedCalls[0].blockHash != blockHash {
+		t.Errorf("expected MarkBlockProcessed(%s) on a complete block, got %+v", blockHash, ms.processedCalls)
+	}
+}
+
+// TestBuilder_HandleMessage_AbsentExpectedSet_ZeroStumps_SkipsGraceAndFinalizes:
+// no expectedSubtreeIndices field and zero stored STUMPs means "expect zero,
+// have zero" — the block has no tracked txs and is complete on arrival, so it
+// must finalize (stamp processed_at) without waiting the 5s grace window.
+func TestBuilder_HandleMessage_AbsentExpectedSet_ZeroStumps_SkipsGraceAndFinalizes(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+
+	// No datahub, teranode nil: the empty-block path must return before any
+	// fetch; reaching the build path would crash the test.
+	b := &Builder{
+		cfg:    &config.Config{},
+		logger: zap.NewNop().Named("bump-builder"),
+		store:  ms,
+	}
+	b.cfg.BumpBuilder.GraceWindowMs = 5000
+
+	start := time.Now()
+	if err := b.handleMessage(context.Background(), makeBlockProcessedMsg(blockHash)); err != nil {
+		t.Fatalf("absent-set zero-stump handleMessage returned error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= 2*time.Second {
+		t.Errorf("absent set + zero STUMPs must finalize without the grace window; took %v (grace=5s)", elapsed)
+	}
+
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if len(ms.bumps) != 0 {
+		t.Errorf("no BUMP should be built with zero STUMPs, got %d", len(ms.bumps))
+	}
+	if len(ms.processedCalls) != 1 || ms.processedCalls[0].blockHash != blockHash {
+		t.Errorf("a no-tracked-tx block IS finalized — expected MarkBlockProcessed(%s), got %+v", blockHash, ms.processedCalls)
+	}
+}
+
+// TestBuilder_HandleMessage_DeferPath_StampsDeferredIncompleteOutcome pins the
+// outcome-label migration on the deferral path: a block missing expected
+// STUMPs after the grace window must land in the duration histogram as
+// outcome="deferred_incomplete" (renamed from "incomplete_stumps").
+func TestBuilder_HandleMessage_DeferPath_StampsDeferredIncompleteOutcome(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+	ms.addStump(blockHash, 0, makeMinimalSTUMP(testTxidHex))
+
+	b := &Builder{
+		cfg:    &config.Config{}, // grace 0: the defer decision is immediate
+		logger: zap.NewNop().Named("bump-builder"),
+		store:  ms,
+	}
+
+	before := bumpOutcomeSampleCount(t, "deferred_incomplete")
+	beforeOld := bumpOutcomeSampleCount(t, "incomplete_stumps")
+
+	if err := b.handleMessage(context.Background(), makeBlockProcessedMsgWithExpected(blockHash, []int{0, 1})); err != nil {
+		t.Fatalf("incomplete-set handleMessage must return nil, got: %v", err)
+	}
+
+	if after := bumpOutcomeSampleCount(t, "deferred_incomplete"); after != before+1 {
+		t.Errorf("outcome=deferred_incomplete sample count = %d, want %d", after, before+1)
+	}
+	if afterOld := bumpOutcomeSampleCount(t, "incomplete_stumps"); afterOld != beforeOld {
+		t.Errorf("retired outcome=incomplete_stumps must not be stamped; count went %d → %d", beforeOld, afterOld)
+	}
+}
+
+// TestBuilder_HandleMessage_IncompleteExpectedSet_WaitsGraceThenDefers pins
+// the fallback ordering: an expected set that is NOT yet satisfied must still
+// wait the full grace window (the late-STUMP-retry defense) before deferring.
+// Regression guard for the completeness-first reorder — skipping the wait
+// here would defer blocks whose STUMPs were still in flight.
+func TestBuilder_HandleMessage_IncompleteExpectedSet_WaitsGraceThenDefers(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+	ms.addStump(blockHash, 0, makeMinimalSTUMP(testTxidHex))
+
+	b := &Builder{
+		cfg:    &config.Config{},
+		logger: zap.NewNop().Named("bump-builder"),
+		store:  ms,
+	}
+	const graceMs = 150
+	b.cfg.BumpBuilder.GraceWindowMs = graceMs
+
+	start := time.Now()
+	if err := b.handleMessage(context.Background(), makeBlockProcessedMsgWithExpected(blockHash, []int{0, 1})); err != nil {
+		t.Fatalf("incomplete-set handleMessage must return nil (watchdog recovers), got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < graceMs*time.Millisecond {
+		t.Errorf("incomplete expected set must wait the grace window before deferring; took only %v", elapsed)
+	}
+
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if len(ms.bumps) != 0 {
+		t.Errorf("no BUMP should be built for an incomplete block, got %d", len(ms.bumps))
+	}
+	if len(ms.processedCalls) != 0 {
+		t.Errorf("processed_at must NOT be stamped for an incomplete block, got %+v", ms.processedCalls)
+	}
+}
+
+// TestBuilder_HandleMessage_AbsentExpectedSet_WithStumps_WaitsGrace pins the
+// ambiguous case: no expected set (pre-#162 merkle) but STUMPs exist, so
+// completeness cannot be verified up-front — the grace window must still be
+// waited before building.
+func TestBuilder_HandleMessage_AbsentExpectedSet_WithStumps_WaitsGrace(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+	txidHex := testTxidHex
+
+	stumpData := makeMinimalSTUMP(txidHex)
+	ms.addStump(blockHash, 0, stumpData)
+
+	subtreeHash := mustHash(t, txidHex)
+	root := expectedCompoundRoot(t,
+		[]*models.Stump{{BlockHash: blockHash, SubtreeIndex: 0, StumpData: stumpData}},
+		[]chainhash.Hash{subtreeHash}, nil)
+	datahub := newDatahubServer(root, []chainhash.Hash{subtreeHash})
+	defer datahub.Close()
+
+	b := newTestBuilder(ms, datahub.URL)
+	const graceMs = 150
+	b.cfg.BumpBuilder.GraceWindowMs = graceMs
+
+	start := time.Now()
+	if err := b.handleMessage(context.Background(), makeBlockProcessedMsg(blockHash)); err != nil {
+		t.Fatalf("absent-set-with-stumps handleMessage returned error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < graceMs*time.Millisecond {
+		t.Errorf("an unverifiable (absent) expected set must keep the grace window; took only %v", elapsed)
+	}
+
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if _, ok := ms.bumps[blockHash]; !ok {
+		t.Error("expected BUMP to be stored after the grace window")
+	}
+}
+
+// TestBuilder_HandleMessage_IncompleteThenCompleteWithinGrace_Builds covers
+// the late-STUMP retry the grace window exists for, under the modern (#162)
+// wire format: merkle expected {0}, the STUMP is not there on arrival but
+// lands mid-window, and the post-wait re-read must pick it up and build.
+func TestBuilder_HandleMessage_IncompleteThenCompleteWithinGrace_Builds(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+	txidHex := testTxidHex
+
+	lateStump := makeMinimalSTUMP(txidHex)
+	subtreeHash := mustHash(t, txidHex)
+	root := expectedCompoundRoot(t,
+		[]*models.Stump{{BlockHash: blockHash, SubtreeIndex: 0, StumpData: lateStump}},
+		[]chainhash.Hash{subtreeHash}, nil)
+	datahub := newDatahubServer(root, []chainhash.Hash{subtreeHash})
+	defer datahub.Close()
+
+	b := newTestBuilder(ms, datahub.URL)
+	b.cfg.BumpBuilder.GraceWindowMs = 150
+
+	// Insert the STUMP mid-grace-window from another goroutine.
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		_ = ms.InsertStump(context.Background(), &models.Stump{
+			BlockHash:    blockHash,
+			SubtreeIndex: 0,
+			StumpData:    lateStump,
+		})
+	}()
+
+	if err := b.handleMessage(context.Background(), makeBlockProcessedMsgWithExpected(blockHash, []int{0})); err != nil {
+		t.Fatalf("expected success after the late STUMP landed in the grace window, got: %v", err)
+	}
+
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if _, ok := ms.bumps[blockHash]; !ok {
+		t.Error("expected BUMP to be stored after late STUMP landed in grace window")
+	}
+	if len(ms.processedCalls) != 1 || ms.processedCalls[0].blockHash != blockHash {
+		t.Errorf("expected MarkBlockProcessed(%s) after the late STUMP completed the set, got %+v", blockHash, ms.processedCalls)
+	}
+}
+
+// TestBuilder_HandleMessage_OutOfOrderStump_RecoveredOnRedelivery pins the
+// watchdog-shaped recovery: delivery 1 arrives before its STUMP and defers
+// (no BUMP, no stamp); the STUMP lands afterwards; delivery 2 of the SAME
+// message finds the expected set complete and builds + finalizes via the
+// no-grace completeness path.
+func TestBuilder_HandleMessage_OutOfOrderStump_RecoveredOnRedelivery(t *testing.T) {
+	ms := newMockStore()
+	blockHash := testBlockHash
+	txidHex := testTxidHex
+
+	stumpData := makeMinimalSTUMP(txidHex)
+	subtreeHash := mustHash(t, txidHex)
+	root := expectedCompoundRoot(t,
+		[]*models.Stump{{BlockHash: blockHash, SubtreeIndex: 0, StumpData: stumpData}},
+		[]chainhash.Hash{subtreeHash}, nil)
+	datahub := newDatahubServer(root, []chainhash.Hash{subtreeHash})
+	defer datahub.Close()
+
+	b := newTestBuilder(ms, datahub.URL)
+	b.cfg.BumpBuilder.GraceWindowMs = 50
+
+	msg := makeBlockProcessedMsgWithExpected(blockHash, []int{0})
+
+	// Delivery 1: STUMP not yet stored → defer, leaving the block recoverable.
+	if err := b.handleMessage(context.Background(), msg); err != nil {
+		t.Fatalf("delivery 1 must return nil on deferral, got: %v", err)
+	}
+	ms.mu.Lock()
+	if len(ms.bumps) != 0 || len(ms.processedCalls) != 0 {
+		ms.mu.Unlock()
+		t.Fatalf("delivery 1 must defer: bumps=%d processed=%d", len(ms.bumps), len(ms.processedCalls))
+	}
+	ms.mu.Unlock()
+
+	// The out-of-order STUMP lands after the first delivery gave up.
+	ms.addStump(blockHash, 0, stumpData)
+
+	// Delivery 2 (watchdog /reprocess re-emits BLOCK_PROCESSED): the set is
+	// now complete, so the block builds and finalizes.
+	if err := b.handleMessage(context.Background(), msg); err != nil {
+		t.Fatalf("delivery 2 must build, got: %v", err)
+	}
+
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if _, ok := ms.bumps[blockHash]; !ok {
+		t.Error("expected BUMP to be stored on redelivery")
+	}
+	if len(ms.processedCalls) != 1 || ms.processedCalls[0].blockHash != blockHash {
+		t.Errorf("expected MarkBlockProcessed(%s) on redelivery, got %+v", blockHash, ms.processedCalls)
+	}
+}

--- a/services/bump_builder/builder_test.go
+++ b/services/bump_builder/builder_test.go
@@ -1020,29 +1020,35 @@ func TestBuilder_HandleMessage_InvalidJSON_ReturnsError(t *testing.T) {
 	}
 }
 
-// TestBuilder_LateSTUMP_ArrivesDuringGraceWindow simulates a late-retry STUMP that
-// lands after BLOCK_PROCESSED but within the grace window. The builder should wait
-// the grace window, then find the STUMP and build the BUMP successfully.
-func TestBuilder_LateSTUMP_ArrivesDuringGraceWindow(t *testing.T) {
+// TestBuilder_LateSTUMP_AbsentExpectedSet_FinalizesWithoutWaiting pins the
+// absent-means-expect-zero semantics of completeness-first grace handling: a
+// BLOCK_PROCESSED with NO expectedSubtreeIndices field and zero stored STUMPs
+// finalizes immediately as an empty block — it does NOT wait the grace window
+// for a STUMP that might land later. merkle ≥ v0.4.5 always sends the
+// expected set when the block has tracked txs, so a late STUMP is announced
+// by an (initially unsatisfied) expected set and rides the grace window via
+// that path — see TestBuilder_HandleMessage_IncompleteThenCompleteWithinGrace_Builds,
+// which took over the mid-grace-arrival coverage this test used to provide
+// under the wait-first ordering.
+func TestBuilder_LateSTUMP_AbsentExpectedSet_FinalizesWithoutWaiting(t *testing.T) {
 	ms := newMockStore()
 	blockHash := testBlockHash
 	txidHex := testTxidHex
 
-	// Compute what the late-arriving STUMP will produce so the datahub header
-	// merkle root set up ahead of time matches the compound the builder builds
-	// after the grace window.
 	lateStump := makeMinimalSTUMP(txidHex)
-	subtreeHash := mustHash(t, txidHex)
-	root := expectedCompoundRoot(t,
-		[]*models.Stump{{BlockHash: blockHash, SubtreeIndex: 0, StumpData: lateStump}},
-		[]chainhash.Hash{subtreeHash}, nil)
-	datahub := newDatahubServer(root, []chainhash.Hash{subtreeHash})
-	defer datahub.Close()
 
-	b := newTestBuilder(ms, datahub.URL)
-	b.cfg.BumpBuilder.GraceWindowMs = 100 // short grace for the test
+	// No datahub, teranode nil: the empty-block path must finalize before any
+	// build work; reaching the fetch path would crash the test.
+	b := &Builder{
+		cfg:    &config.Config{},
+		logger: zap.NewNop().Named("bump-builder"),
+		store:  ms,
+	}
+	b.cfg.BumpBuilder.GraceWindowMs = 100
 
-	// Insert STUMP mid-grace-window from another goroutine
+	// A STUMP shows up where the old wait-first ordering would still have been
+	// inside the grace window. Under absent-means-expect-zero it arrives after
+	// the block already finalized as empty.
 	go func() {
 		time.Sleep(30 * time.Millisecond)
 		_ = ms.InsertStump(context.Background(), &models.Stump{
@@ -1052,14 +1058,21 @@ func TestBuilder_LateSTUMP_ArrivesDuringGraceWindow(t *testing.T) {
 		})
 	}()
 
+	start := time.Now()
 	if err := b.handleMessage(context.Background(), makeBlockProcessedMsg(blockHash)); err != nil {
 		t.Fatalf("expected success, got: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= 100*time.Millisecond {
+		t.Errorf("absent set + zero STUMPs must not wait the grace window; took %v", elapsed)
 	}
 
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
-	if _, ok := ms.bumps[blockHash]; !ok {
-		t.Error("expected BUMP to be stored after late STUMP landed in grace window")
+	if len(ms.bumps) != 0 {
+		t.Errorf("no BUMP should be built on the empty-block finalize path, got %d", len(ms.bumps))
+	}
+	if len(ms.processedCalls) != 1 || ms.processedCalls[0].blockHash != blockHash {
+		t.Errorf("expected MarkBlockProcessed(%s) on the empty-block finalize path, got %+v", blockHash, ms.processedCalls)
 	}
 }
 

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -1300,6 +1300,57 @@ func TestBlockProcessing_ListStale_FiltersAndOrders(t *testing.T) {
 	}
 }
 
+// TestBlockProcessing_ListStale_ExcludesFinalizedEmptyBlock pins the
+// watchdog-interplay contract for empty-block finalization: bump-builder
+// finalizes a zero-STUMP block with MarkBlockProcessed(hash, 0, now) — height
+// 0 because no compound was built — and that exact call must (a) remove the
+// row from ListStaleBlockProcessingStatus (the stale predicate keys on
+// processed_at IS NULL, NOT on bump_built_at) so the watchdog never re-drives
+// a complete empty block, and (b) preserve the chaintracks-supplied height on
+// conflict. A future predicate change (e.g. adding bump_built_at IS NULL)
+// would silently resurrect the empty-block re-drive storm; this test makes
+// that loud.
+func TestBlockProcessing_ListStale_ExcludesFinalizedEmptyBlock(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	baseSeen := time.Unix(1700003000, 0).UTC()
+	threshold := baseSeen.Add(5 * time.Minute) // anything < threshold is stale
+
+	// Empty-block finalize: header seen, then the exact bump-builder call.
+	if err := s.UpsertBlockHeaderSeen(ctx, "empty-finalized", 300, baseSeen); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkBlockProcessed(ctx, "empty-finalized", 0, baseSeen.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Control: identical header-seen row without the stamp must still surface.
+	if err := s.UpsertBlockHeaderSeen(ctx, "still-stale", 310, baseSeen); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := s.ListStaleBlockProcessingStatus(ctx, threshold, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].BlockHash != "still-stale" {
+		t.Errorf("finalized empty block must be excluded from the stale scan, got %v", hashesOf(rows))
+	}
+
+	// The height-0 stamp must not clobber the chaintracks-supplied height:
+	// the upsert's conflict clause only writes processed_at.
+	all, err := s.ListBlockProcessingStatus(ctx, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range all {
+		if r.BlockHash == "empty-finalized" && r.BlockHeight != 300 {
+			t.Errorf("empty-block finalize clobbered block_height: got %d, want 300", r.BlockHeight)
+		}
+	}
+}
+
 func hashesOf(rows []*models.BlockProcessingStatus) []string {
 	out := make([]string, len(rows))
 	for i, r := range rows {


### PR DESCRIPTION
Implements the arcade half of `merkle-service/docs/block-processed-completeness.md`: BLOCK_PROCESSED already arrives with `expectedSubtreeIndices` (merkle ≥ v0.4.5), so the fixed 30s grace window — until now paid by **every** block before reading STUMPs — is only needed when completeness cannot be established.

## Behavior

| BLOCK_PROCESSED arrives with | Before | After |
|---|---|---|
| expected set, all STUMPs stored | 30s grace, then build | **build immediately** (INFO with expected/received counts) |
| absent set, zero STUMPs (empty/coinbase-only block) | 30s grace, then finalize | **finalize immediately** |
| absent set, STUMPs exist (unverifiable) | 30s grace | unchanged (WARN + grace) |
| expected set incomplete | 30s grace → defer to watchdog | unchanged (grace → re-read → defer) |

Impact: ~30s off every tx's MINED tail in steady state; reset-storm queues (each block serialized behind grace waits) drain roughly twice as fast — measured 2026-07-16: blocks 305/306/307 each burned the full window during recovery.

## Notes for reviewers

- **Dashboard-facing metric label migration** (threaded through all four #244 sync points): `success` → `finalized_complete_no_grace` | `grace_waited`; `incomplete_stumps` → `deferred_incomplete`. Update any dashboards/alerts keyed on the old labels.
- **Compatibility floor**: absent-means-expect-zero is safe against merkle ≥ v0.4.5 (attaches the field on all worker-path blocks); all current envs run v0.4.9.
- One existing test rewritten by necessity: the old `LateSTUMP_ArrivesDuringGraceWindow` pinned exactly the retired behavior (absent+zero waits for a late STUMP); mid-grace arrival coverage lives in `IncompleteThenCompleteWithinGrace_Builds`.
- Watchdog interplay: **no store change** — both stale predicates key on `processed_at`, which empty-block finalization already stamps (pinned by `TestBlockProcessing_ListStale_ExcludesFinalizedEmptyBlock`).

## Verification

`CGO_ENABLED=1 go test ./...` 30 packages ok; `-race` clean on bump_builder/metrics/postgres(-tags)/watchdog; `golangci-lint` 0 issues. TDD: 4 RED tests (two wall-clock skip bounds, metric labels, outcome stamp) + 6 behavior pins guarding the reorder. openspec change `skip-grace-when-complete` included.