### PR TITLE
feat(push): deliver merkle proof on MINED SSE frames and webhook callbacks

### DIFF
--- a/bump/bump.go
+++ b/bump/bump.go
@@ -3,8 +3,10 @@
 package bump
 
 import (
+	"cmp"
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/transaction"
@@ -391,28 +393,109 @@ func ExtractMinimalPathForTx(bumpData []byte, txid string) []byte {
 	return minimal.Bytes()
 }
 
-// IndexCompound parses a compound BUMP and returns it alongside a level-0
-// txid→offset index. Callers that need per-tx minimal paths for many txs of the
-// same block (e.g. SSE/webhook fan-out enrichment) parse+index once via this,
-// cache the result, then call ExtractMinimalPath(compound, offset) per tx —
-// avoiding both a re-parse and the O(level-0) hash scan that finding a tx's
-// offset would otherwise cost on every extraction. Returns an error if the BUMP
-// cannot be parsed.
-func IndexCompound(bumpData []byte) (*transaction.MerklePath, map[chainhash.Hash]uint64, error) {
+// CompoundIndex is a compound BUMP parsed and indexed for repeated per-tx
+// minimal-path extraction: a level-0 txid→offset map plus every level's
+// elements sorted by offset for binary search. Callers that need minimal paths
+// for many txs of the same block (e.g. SSE/webhook fan-out enrichment) build
+// one index via IndexCompound, cache it, and call MinimalPathBytes per tx —
+// O(depth·log level-size) each, instead of a re-parse plus the O(level-size)
+// linear scans that ExtractMinimalPath's findLeafByOffset walk costs.
+//
+// The index shares the parsed PathElements and is read-only after
+// construction, so a cached CompoundIndex is safe for concurrent use.
+type CompoundIndex struct {
+	blockHeight uint32
+	// txOffsets maps each level-0 leaf hash to its offset (duplicate-flag
+	// leaves carry no hash and are reachable only as siblings via levels).
+	txOffsets map[chainhash.Hash]uint64
+	// levels holds every PathElement of the compound per level, sorted by
+	// Offset so leafAt can binary-search. Chosen over per-level maps: ~8B
+	// per element instead of ~50B, and the resident set is what the store's
+	// bump cache has to budget for.
+	levels [][]*transaction.PathElement
+	leaves int
+}
+
+// IndexCompound parses a compound BUMP and indexes it for per-tx extraction.
+// Returns an error if the BUMP cannot be parsed.
+func IndexCompound(bumpData []byte) (*CompoundIndex, error) {
 	compound, err := transaction.NewMerklePathFromBinary(bumpData)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	var offsets map[chainhash.Hash]uint64
+	ci := &CompoundIndex{
+		blockHeight: compound.BlockHeight,
+		levels:      make([][]*transaction.PathElement, len(compound.Path)),
+	}
 	if len(compound.Path) > 0 {
-		offsets = make(map[chainhash.Hash]uint64, len(compound.Path[0]))
+		ci.txOffsets = make(map[chainhash.Hash]uint64, len(compound.Path[0]))
 		for _, leaf := range compound.Path[0] {
 			if leaf.Hash != nil {
-				offsets[*leaf.Hash] = leaf.Offset
+				ci.txOffsets[*leaf.Hash] = leaf.Offset
 			}
 		}
 	}
-	return compound, offsets, nil
+	for level, elems := range compound.Path {
+		sorted := make([]*transaction.PathElement, len(elems))
+		copy(sorted, elems)
+		slices.SortFunc(sorted, func(a, b *transaction.PathElement) int {
+			return cmp.Compare(a.Offset, b.Offset)
+		})
+		ci.levels[level] = sorted
+		ci.leaves += len(sorted)
+	}
+	return ci, nil
+}
+
+// Leaves reports the total PathElement count across all levels — the size
+// proxy cache implementations use to budget resident memory.
+func (ci *CompoundIndex) Leaves() int { return ci.leaves }
+
+// leafAt returns the element at (level, offset), or nil when absent.
+func (ci *CompoundIndex) leafAt(level int, offset uint64) *transaction.PathElement {
+	if level >= len(ci.levels) {
+		return nil
+	}
+	elems := ci.levels[level]
+	i, ok := slices.BinarySearchFunc(elems, offset, func(e *transaction.PathElement, off uint64) int {
+		return cmp.Compare(e.Offset, off)
+	})
+	if !ok {
+		return nil
+	}
+	return elems[i]
+}
+
+// MinimalPathBytes returns the BRC-74 serialized minimal path for txid, or nil
+// when the txid is unparseable or not a level-0 leaf of the compound. The walk
+// mirrors ExtractMinimalPath (level-0 leaf + sibling, then one sibling per
+// upper level, absent nodes skipped) with indexed lookups in place of scans.
+func (ci *CompoundIndex) MinimalPathBytes(txid string) []byte {
+	txHash, err := chainhash.NewHashFromHex(txid)
+	if err != nil {
+		return nil
+	}
+	txOffset, ok := ci.txOffsets[*txHash]
+	if !ok {
+		return nil
+	}
+	mp := &transaction.MerklePath{
+		BlockHeight: ci.blockHeight,
+		Path:        make([][]*transaction.PathElement, len(ci.levels)),
+	}
+	offset := txOffset
+	for level := range ci.levels {
+		if level == 0 {
+			if leaf := ci.leafAt(0, offset); leaf != nil {
+				addLeaf(mp, 0, leaf)
+			}
+		}
+		if sibling := ci.leafAt(level, offset^1); sibling != nil {
+			addLeaf(mp, level, sibling)
+		}
+		offset >>= 1
+	}
+	return mp.Bytes()
 }
 
 // ExtractLevel0Hashes parses a BRC-74 STUMP binary and returns all level-0 hashes.

--- a/bump/bump.go
+++ b/bump/bump.go
@@ -391,6 +391,30 @@ func ExtractMinimalPathForTx(bumpData []byte, txid string) []byte {
 	return minimal.Bytes()
 }
 
+// IndexCompound parses a compound BUMP and returns it alongside a level-0
+// txid→offset index. Callers that need per-tx minimal paths for many txs of the
+// same block (e.g. SSE/webhook fan-out enrichment) parse+index once via this,
+// cache the result, then call ExtractMinimalPath(compound, offset) per tx —
+// avoiding both a re-parse and the O(level-0) hash scan that finding a tx's
+// offset would otherwise cost on every extraction. Returns an error if the BUMP
+// cannot be parsed.
+func IndexCompound(bumpData []byte) (*transaction.MerklePath, map[chainhash.Hash]uint64, error) {
+	compound, err := transaction.NewMerklePathFromBinary(bumpData)
+	if err != nil {
+		return nil, nil, err
+	}
+	var offsets map[chainhash.Hash]uint64
+	if len(compound.Path) > 0 {
+		offsets = make(map[chainhash.Hash]uint64, len(compound.Path[0]))
+		for _, leaf := range compound.Path[0] {
+			if leaf.Hash != nil {
+				offsets[*leaf.Hash] = leaf.Offset
+			}
+		}
+	}
+	return compound, offsets, nil
+}
+
 // ExtractLevel0Hashes parses a BRC-74 STUMP binary and returns all level-0 hashes.
 func ExtractLevel0Hashes(stumpData []byte) []chainhash.Hash {
 	mp, err := transaction.NewMerklePathFromBinary(stumpData)

--- a/docs/sse.md
+++ b/docs/sse.md
@@ -45,8 +45,24 @@ data: {"txid":"abc...","txStatus":"SEEN_ON_NETWORK","timestamp":"2026-04-28T18:2
 
 - `id` is a Unix nanosecond timestamp. Clients should remember the most recent `id` and send it back as `Last-Event-ID` on reconnect (browser `EventSource` does this automatically).
 - `event: status` is the only event type emitted for transaction updates.
-- `data` is one JSON object per frame with three fields: `txid`, `txStatus`, `timestamp` (RFC 3339).
+- `data` is one JSON object per frame. Every frame carries `txid`, `txStatus`, and `timestamp` (RFC 3339).
 - A blank line terminates each frame.
+
+### Mined frames carry the merkle proof
+
+When `txStatus` is `MINED` (or `IMMUTABLE`), the frame additionally carries the block context and the transaction's merkle proof — the same fields the webhook callback and `GET /tx/:txid` return, so a push-only client never has to poll for the proof:
+
+```
+id: 1745870512987654321
+event: status
+data: {"txid":"abc...","txStatus":"MINED","timestamp":"2026-04-28T18:21:52Z","blockHash":"0000...","blockHeight":870123,"merklePath":"<BUMP hex>"}
+
+```
+
+- `blockHash` / `blockHeight` — the block the transaction was mined into.
+- `merklePath` — the transaction's minimal [BUMP](https://github.com/bitcoin-sv/BRCs/blob/master/transactions/0074.md) (Bitcoin Unified Merkle Path), hex-encoded. Verify it by recomputing the block merkle root from the txid.
+
+These three fields are omitted from non-mined frames, so pre-`MINED` frames keep the original three-field shape. On a `Last-Event-ID` reconnect, replayed `MINED` frames are enriched with `merklePath` best-effort: to keep the replay path bounded, a single reconnect enriches at most a fixed number of distinct blocks, after which replayed `MINED` frames still carry `blockHash`/`blockHeight` but omit `merklePath` — recover it with `GET /tx/:txid`.
 
 Every ~15 seconds the server emits a `: keepalive` comment frame so idle proxies don't kill the connection. Comment frames have no `event:` and should be ignored by clients.
 

--- a/docs/sse.md
+++ b/docs/sse.md
@@ -50,7 +50,7 @@ data: {"txid":"abc...","txStatus":"SEEN_ON_NETWORK","timestamp":"2026-04-28T18:2
 
 ### Mined frames carry the merkle proof
 
-When `txStatus` is `MINED` (or `IMMUTABLE`), the frame additionally carries the block context and the transaction's merkle proof — the same fields the webhook callback and `GET /tx/:txid` return, so a push-only client never has to poll for the proof:
+When `txStatus` is `MINED` (or `IMMUTABLE`), the frame additionally carries the block context and the transaction's merkle proof — the same fields the webhook callback and `GET /tx/{txid}` return, so a push-only client never has to poll for the proof:
 
 ```
 id: 1745870512987654321
@@ -62,7 +62,7 @@ data: {"txid":"abc...","txStatus":"MINED","timestamp":"2026-04-28T18:21:52Z","bl
 - `blockHash` / `blockHeight` — the block the transaction was mined into.
 - `merklePath` — the transaction's minimal [BUMP](https://github.com/bitcoin-sv/BRCs/blob/master/transactions/0074.md) (Bitcoin Unified Merkle Path), hex-encoded. Verify it by recomputing the block merkle root from the txid.
 
-These three fields are omitted from non-mined frames, so pre-`MINED` frames keep the original three-field shape. On a `Last-Event-ID` reconnect, replayed `MINED` frames are enriched with `merklePath` best-effort: to keep the replay path bounded, a single reconnect enriches at most a fixed number of distinct blocks, after which replayed `MINED` frames still carry `blockHash`/`blockHeight` but omit `merklePath` — recover it with `GET /tx/:txid`.
+These three fields are omitted from non-mined frames, so pre-`MINED` frames keep the original three-field shape. On a `Last-Event-ID` reconnect, replayed `MINED` frames are enriched with `merklePath` best-effort: to keep the replay path bounded, a single reconnect enriches at most a fixed number of distinct blocks, after which replayed `MINED` frames still carry `blockHash`/`blockHeight` but omit `merklePath` — recover it with `GET /tx/{txid}`.
 
 Every ~15 seconds the server emits a `: keepalive` comment frame so idle proxies don't kill the connection. Comment frames have no `event:` and should be ignored by clients.
 

--- a/internal/synthblock/synthblock.go
+++ b/internal/synthblock/synthblock.go
@@ -39,13 +39,16 @@ func Build(numTxs int, height uint64) (Block, error) {
 		return Block{}, fmt.Errorf("synthblock: numTxs must be a power of two ≥ 1, got %d", numTxs)
 	}
 
-	// Level 0: deterministic, distinct leaf hashes.
+	// Level 0: deterministic, distinct leaf hashes. The counter is 32-bit so
+	// leaf seeds stay unique for any block size a test could realistically
+	// build (a 16-bit counter would silently wrap past 65 535 leaves and
+	// produce duplicate txids).
 	leaves := make([]*chainhash.Hash, numTxs)
 	txids := make([]string, numTxs)
 	for i := range leaves {
-		var seed [12]byte
+		var seed [14]byte
 		copy(seed[:], "synthblock")
-		binary.BigEndian.PutUint16(seed[10:], uint16(i))
+		binary.BigEndian.PutUint32(seed[10:], uint32(i))
 		h := chainhash.DoubleHashH(seed[:])
 		leaves[i] = &h
 		txids[i] = h.String()

--- a/internal/synthblock/synthblock.go
+++ b/internal/synthblock/synthblock.go
@@ -45,7 +45,7 @@ func Build(numTxs int, height uint64) (Block, error) {
 	for i := range leaves {
 		var seed [12]byte
 		copy(seed[:], "synthblock")
-		binary.BigEndian.PutUint16(seed[10:], uint16(i)) //nolint:gosec // test data
+		binary.BigEndian.PutUint16(seed[10:], uint16(i))
 		h := chainhash.DoubleHashH(seed[:])
 		leaves[i] = &h
 		txids[i] = h.String()

--- a/internal/synthblock/synthblock.go
+++ b/internal/synthblock/synthblock.go
@@ -1,0 +1,144 @@
+// Package synthblock builds synthetic mined blocks for tests: a full compound
+// BUMP over a set of deterministic txids whose merkle root is known. It exists
+// so tests in different packages (webhook, sse, store) can share one importable
+// block builder + proof verifier — the equivalent helpers in bump/bump_test.go
+// are package-private and unreachable from other packages.
+//
+// A "full" compound holds every node at every tree level, so bump.ExtractMinimalPath
+// (the same extractor the store uses for per-tx enrichment) can pull a valid
+// minimal path for any of the block's txids.
+package synthblock
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math/bits"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+)
+
+// Block is a synthetic mined block.
+type Block struct {
+	// BumpBytes is the compound BUMP, ready to pass to store.InsertBUMP.
+	BumpBytes []byte
+	// Txids are the block's level-0 transaction ids, display-order hex.
+	Txids []string
+	// Root is the block's merkle root, display-order hex (as in a header).
+	Root string
+	// Height is the block height encoded in the compound BUMP.
+	Height uint64
+}
+
+// Build constructs a Block with numTxs leaves. numTxs must be a power of two
+// (1, 2, 4, 8, …) so the tree is perfectly balanced and every internal node is
+// present — keeping the builder small and the extracted paths unambiguous.
+func Build(numTxs int, height uint64) (Block, error) {
+	if numTxs < 1 || numTxs&(numTxs-1) != 0 {
+		return Block{}, fmt.Errorf("synthblock: numTxs must be a power of two ≥ 1, got %d", numTxs)
+	}
+
+	// Level 0: deterministic, distinct leaf hashes.
+	leaves := make([]*chainhash.Hash, numTxs)
+	txids := make([]string, numTxs)
+	for i := range leaves {
+		var seed [12]byte
+		copy(seed[:], "synthblock")
+		binary.BigEndian.PutUint16(seed[10:], uint16(i)) //nolint:gosec // test data
+		h := chainhash.DoubleHashH(seed[:])
+		leaves[i] = &h
+		txids[i] = h.String()
+	}
+
+	// treeHeight is the number of BUMP levels: log2(numTxs), but at least 1 so a
+	// single-tx block still carries its lone txid leaf in Path[0] (ComputeRoot
+	// then returns that txid as the root).
+	treeHeight := bits.Len64(uint64(numTxs)) - 1
+	if treeHeight < 1 {
+		treeHeight = 1
+	}
+
+	path := make([][]*transaction.PathElement, treeHeight)
+	txidFlag := true
+
+	// Level 0 holds every leaf, flagged as a txid.
+	path[0] = make([]*transaction.PathElement, numTxs)
+	for i, leaf := range leaves {
+		path[0][i] = &transaction.PathElement{
+			Offset: uint64(i),
+			Hash:   leaf,
+			Txid:   &txidFlag,
+		}
+	}
+
+	// Build each higher level from the one below, keeping the running hashes so
+	// we can also compute the root. cur starts at the leaf level.
+	cur := leaves
+	for level := 1; level < treeHeight; level++ {
+		next := make([]*chainhash.Hash, len(cur)/2)
+		path[level] = make([]*transaction.PathElement, len(next))
+		for i := range next {
+			parent := transaction.MerkleTreeParent(cur[2*i], cur[2*i+1])
+			next[i] = parent
+			path[level][i] = &transaction.PathElement{
+				Offset: uint64(i),
+				Hash:   parent,
+			}
+		}
+		cur = next
+	}
+
+	// The root is the parent of the final pair (or the sole txid for a 1-tx block).
+	var root *chainhash.Hash
+	switch {
+	case len(cur) == 1:
+		root = cur[0]
+	default:
+		root = transaction.MerkleTreeParent(cur[0], cur[1])
+	}
+
+	mp := &transaction.MerklePath{BlockHeight: uint32(height), Path: path} //nolint:gosec // test data
+	return Block{
+		BumpBytes: mp.Bytes(),
+		Txids:     txids,
+		Root:      root.String(),
+		Height:    height,
+	}, nil
+}
+
+// VerifyMerklePathHex parses a hex-encoded BUMP (a per-tx minimal path or a
+// compound) and checks that it proves txid against wantRoot. Both txid and
+// wantRoot are display-order hex; ComputeRoot's output is compared in the same
+// order, so no manual byte reversal is needed. Returns a descriptive error on
+// any parse/compute/mismatch failure.
+func VerifyMerklePathHex(merklePathHex, txid, wantRoot string) error {
+	raw, err := hex.DecodeString(merklePathHex)
+	if err != nil {
+		return fmt.Errorf("decode merklePath hex: %w", err)
+	}
+	return VerifyMerklePath(raw, txid, wantRoot)
+}
+
+// VerifyMerklePath is VerifyMerklePathHex for raw BUMP bytes.
+func VerifyMerklePath(bumpBytes []byte, txid, wantRoot string) error {
+	if len(bumpBytes) == 0 {
+		return fmt.Errorf("empty merklePath")
+	}
+	mp, err := transaction.NewMerklePathFromBinary(bumpBytes)
+	if err != nil {
+		return fmt.Errorf("parse merklePath: %w", err)
+	}
+	txHash, err := chainhash.NewHashFromHex(txid)
+	if err != nil {
+		return fmt.Errorf("parse txid %q: %w", txid, err)
+	}
+	root, err := mp.ComputeRoot(txHash)
+	if err != nil {
+		return fmt.Errorf("compute root for %s: %w", txid, err)
+	}
+	if root.String() != wantRoot {
+		return fmt.Errorf("merkle root mismatch for %s: got %s want %s", txid, root.String(), wantRoot)
+	}
+	return nil
+}

--- a/internal/synthblock/synthblock_test.go
+++ b/internal/synthblock/synthblock_test.go
@@ -1,0 +1,70 @@
+package synthblock
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+
+	"github.com/bsv-blockchain/arcade/bump"
+)
+
+// TestBuild_MinimalPathsVerify is the load-bearing sanity check: for a range of
+// block sizes, every txid's minimal path extracted from the compound (via the
+// SAME bump.ExtractMinimalPath the store uses) must recompute the block root.
+func TestBuild_MinimalPathsVerify(t *testing.T) {
+	for _, numTxs := range []int{1, 2, 4, 8, 16} {
+		blk, err := Build(numTxs, 870123)
+		if err != nil {
+			t.Fatalf("Build(%d): %v", numTxs, err)
+		}
+		if len(blk.Txids) != numTxs {
+			t.Fatalf("Build(%d): got %d txids", numTxs, len(blk.Txids))
+		}
+
+		// Whole-compound proof for each tx.
+		for _, txid := range blk.Txids {
+			if err := VerifyMerklePath(blk.BumpBytes, txid, blk.Root); err != nil {
+				t.Errorf("compound verify numTxs=%d: %v", numTxs, err)
+			}
+		}
+
+		// Per-tx minimal path, mirroring store enrichment: index once, extract per tx.
+		compound, offsets, err := bump.IndexCompound(blk.BumpBytes)
+		if err != nil {
+			t.Fatalf("IndexCompound(%d): %v", numTxs, err)
+		}
+		for _, txid := range blk.Txids {
+			th, err := chainhash.NewHashFromHex(txid)
+			if err != nil {
+				t.Fatalf("parse txid %s: %v", txid, err)
+			}
+			off, ok := offsets[*th]
+			if !ok {
+				t.Fatalf("numTxs=%d: txid %s missing from offset index", numTxs, txid)
+			}
+			minimal := bump.ExtractMinimalPath(compound, off).Bytes()
+			if err := VerifyMerklePath(minimal, txid, blk.Root); err != nil {
+				t.Errorf("minimal verify numTxs=%d txid=%s: %v", numTxs, txid, err)
+			}
+		}
+	}
+}
+
+func TestBuild_RejectsNonPowerOfTwo(t *testing.T) {
+	for _, n := range []int{0, 3, 5, 6, 7, 100} {
+		if _, err := Build(n, 1); err == nil {
+			t.Errorf("Build(%d) should have failed", n)
+		}
+	}
+}
+
+func TestVerify_DetectsWrongRoot(t *testing.T) {
+	blk, err := Build(8, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad := "00" + blk.Root[2:]
+	if err := VerifyMerklePath(blk.BumpBytes, blk.Txids[0], bad); err == nil {
+		t.Fatal("expected root mismatch to be detected")
+	}
+}

--- a/internal/synthblock/synthblock_test.go
+++ b/internal/synthblock/synthblock_test.go
@@ -1,16 +1,16 @@
 package synthblock
 
 import (
+	"bytes"
 	"testing"
-
-	"github.com/bsv-blockchain/go-sdk/chainhash"
 
 	"github.com/bsv-blockchain/arcade/bump"
 )
 
 // TestBuild_MinimalPathsVerify is the load-bearing sanity check: for a range of
 // block sizes, every txid's minimal path extracted from the compound (via the
-// SAME bump.ExtractMinimalPath the store uses) must recompute the block root.
+// SAME bump.CompoundIndex walk the store enrichment uses) must recompute the
+// block root and match the unindexed extractor byte-for-byte.
 func TestBuild_MinimalPathsVerify(t *testing.T) {
 	for _, numTxs := range []int{1, 2, 4, 8, 16} {
 		blk, err := Build(numTxs, 870123)
@@ -23,28 +23,27 @@ func TestBuild_MinimalPathsVerify(t *testing.T) {
 
 		// Whole-compound proof for each tx.
 		for _, txid := range blk.Txids {
-			if err := VerifyMerklePath(blk.BumpBytes, txid, blk.Root); err != nil {
-				t.Errorf("compound verify numTxs=%d: %v", numTxs, err)
+			if vErr := VerifyMerklePath(blk.BumpBytes, txid, blk.Root); vErr != nil {
+				t.Errorf("compound verify numTxs=%d: %v", numTxs, vErr)
 			}
 		}
 
 		// Per-tx minimal path, mirroring store enrichment: index once, extract per tx.
-		compound, offsets, err := bump.IndexCompound(blk.BumpBytes)
+		idx, err := bump.IndexCompound(blk.BumpBytes)
 		if err != nil {
 			t.Fatalf("IndexCompound(%d): %v", numTxs, err)
 		}
 		for _, txid := range blk.Txids {
-			th, err := chainhash.NewHashFromHex(txid)
-			if err != nil {
-				t.Fatalf("parse txid %s: %v", txid, err)
+			minimal := idx.MinimalPathBytes(txid)
+			if len(minimal) == 0 {
+				t.Fatalf("numTxs=%d: no minimal path for txid %s", numTxs, txid)
 			}
-			off, ok := offsets[*th]
-			if !ok {
-				t.Fatalf("numTxs=%d: txid %s missing from offset index", numTxs, txid)
+			// The indexed walk must be byte-identical to the unindexed extractor.
+			if legacy := bump.ExtractMinimalPathForTx(blk.BumpBytes, txid); !bytes.Equal(minimal, legacy) {
+				t.Errorf("numTxs=%d txid=%s: indexed path differs from ExtractMinimalPathForTx", numTxs, txid)
 			}
-			minimal := bump.ExtractMinimalPath(compound, off).Bytes()
-			if err := VerifyMerklePath(minimal, txid, blk.Root); err != nil {
-				t.Errorf("minimal verify numTxs=%d txid=%s: %v", numTxs, txid, err)
+			if vErr := VerifyMerklePath(minimal, txid, blk.Root); vErr != nil {
+				t.Errorf("minimal verify numTxs=%d txid=%s: %v", numTxs, txid, vErr)
 			}
 		}
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -506,6 +506,17 @@ var WebhookCASLostTotal = promauto.NewCounter(prometheus.CounterOpts{
 	Help: "Webhook deliveries skipped because another replica won the LastDeliveredStatus CAS.",
 })
 
+// MinedPushWithoutMerklePathTotal counts MINED (or IMMUTABLE) statuses pushed
+// on a channel ("webhook" | "sse") whose body/frame went out without a
+// merklePath despite enrichment being attempted. Because the compound BUMP is
+// persisted before the MINED event is published, a nonzero value points to a
+// cache-eviction/reorg race or a missing/unparseable BUMP — the proof is still
+// recoverable via GET /tx/:txid, but a sustained rate warrants investigation.
+var MinedPushWithoutMerklePathTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_mined_push_without_merkle_path_total",
+	Help: "MINED/IMMUTABLE statuses pushed without a merklePath after enrichment, by channel.",
+}, []string{"channel"})
+
 // WebhookCASErrorTotal counts CAS attempts that failed with a real infra
 // error rather than a generation mismatch — surfaced separately so a flat
 // WebhookCASLostTotal can't mask a backend that's silently failing every

--- a/openapi/arcade.openapi.yaml
+++ b/openapi/arcade.openapi.yaml
@@ -556,11 +556,11 @@ paths:
             An event stream of status updates. Every frame carries
             txid/txStatus/timestamp. MINED (and IMMUTABLE) frames additionally
             carry blockHash, blockHeight, and merklePath (the transaction's BUMP,
-            hex-encoded) — the same proof GET /tx/:txid and the webhook callback
+            hex-encoded) — the same proof GET /tx/{txid} and the webhook callback
             return, so push-only clients need not poll. Those three fields are
             omitted from earlier frames. On a Last-Event-ID reconnect, replayed
             MINED frames include merklePath best-effort (bounded per reconnect);
-            when omitted, recover it via GET /tx/:txid.
+            when omitted, recover it via GET /tx/{txid}.
           content:
             text/event-stream:
               schema:
@@ -1082,7 +1082,7 @@ components:
           nullable: true
           description: >-
             BUMP merkle path, hex-encoded. Null/absent until mined. On and after
-            MINED it is returned by GET /tx/:txid, pushed on the webhook callback
+            MINED it is returned by GET /tx/{txid}, pushed on the webhook callback
             body, and included in the SSE MINED frame (best-effort on catchup
             replay).
         extraInfo:

--- a/openapi/arcade.openapi.yaml
+++ b/openapi/arcade.openapi.yaml
@@ -552,7 +552,15 @@ paths:
             example: "1716205200123456789"
       responses:
         "200":
-          description: An event stream of status updates.
+          description: |
+            An event stream of status updates. Every frame carries
+            txid/txStatus/timestamp. MINED (and IMMUTABLE) frames additionally
+            carry blockHash, blockHeight, and merklePath (the transaction's BUMP,
+            hex-encoded) — the same proof GET /tx/:txid and the webhook callback
+            return, so push-only clients need not poll. Those three fields are
+            omitted from earlier frames. On a Last-Event-ID reconnect, replayed
+            MINED frames include merklePath best-effort (bounded per reconnect);
+            when omitted, recover it via GET /tx/:txid.
           content:
             text/event-stream:
               schema:
@@ -564,7 +572,7 @@ paths:
 
                 id: 1716205260987654321
                 event: status
-                data: {"txid":"<hex>","txStatus":"MINED","timestamp":"2026-05-20T12:01:00Z"}
+                data: {"txid":"<hex>","txStatus":"MINED","timestamp":"2026-05-20T12:01:00Z","blockHash":"<hex>","blockHeight":870123,"merklePath":"<BUMP hex>"}
 
                 : keepalive
 
@@ -991,7 +999,10 @@ components:
       description: |
         Webhook URL Arcade should POST status events to as this transaction
         progresses. Must be a public HTTPS endpoint; private/loopback hosts are
-        rejected unless the deployment is configured to allow them.
+        rejected unless the deployment is configured to allow them. The POST body
+        is a TransactionStatus; MINED/IMMUTABLE callbacks include blockHash,
+        blockHeight, and merklePath (the tx's BUMP), so the proof arrives on the
+        callback without a follow-up GET.
       schema:
         type: string
         format: uri
@@ -1069,7 +1080,11 @@ components:
         merklePath:
           type: string
           nullable: true
-          description: BUMP merkle path, hex-encoded. Null/absent until mined.
+          description: >-
+            BUMP merkle path, hex-encoded. Null/absent until mined. On and after
+            MINED it is returned by GET /tx/:txid, pushed on the webhook callback
+            body, and included in the SSE MINED frame (best-effort on catchup
+            replay).
         extraInfo:
           type: string
           description: Free-form detail (e.g. rejection reason).

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -135,6 +135,8 @@ func (m *mockStore) GetStatus(context.Context, string) (*models.TransactionStatu
 	return nil, nil
 }
 
+func (m *mockStore) EnrichMerklePath(context.Context, *models.TransactionStatus) {}
+
 func (m *mockStore) GetStatusesSince(context.Context, time.Time) ([]*models.TransactionStatus, error) {
 	return nil, nil
 }

--- a/services/sse/manager.go
+++ b/services/sse/manager.go
@@ -152,6 +152,11 @@ func (m *Manager) fanOut(ctx context.Context, status *models.TransactionStatus) 
 	}
 	m.mu.RUnlock()
 
+	if len(clients) == 0 {
+		return // nobody listening — skip the token probes and enrichment
+	}
+
+	enriched := false
 	for _, c := range clients {
 		if c.Ctx.Err() != nil {
 			metrics.APISSEDroppedTotal.WithLabelValues("client_gone").Inc()
@@ -159,6 +164,17 @@ func (m *Manager) fanOut(ctx context.Context, status *models.TransactionStatus) 
 		}
 		if c.Token != "" && !m.txBelongsToToken(ctx, status.TxID, c.Token) {
 			continue
+		}
+		// This client will receive the frame, so attach the merkle proof — once
+		// per event (the status pointer is shared across the sends below) and
+		// lazily after the token match, so we only pay for txids a connected
+		// client actually wants. Safe on this single fan-out goroutine: the
+		// mutation completes before any c.Ch <- status send establishes
+		// happens-before with the client's read-only writeStatus. No-op for
+		// non-mined statuses.
+		if !enriched {
+			m.enrichMerklePath(ctx, status)
+			enriched = true
 		}
 		select {
 		case c.Ch <- status:
@@ -311,6 +327,17 @@ func (s *Service) handleEvents(c *gin.Context) {
 // of frames used to OOM the whole pod, killing every connected client.
 const catchupMaxFrames = 10_000
 
+// catchupBlockBudget bounds how many DISTINCT blocks a single catchup replay
+// will enrich with merkle paths. Enrichment parses (and caches) a block's
+// compound BUMP; within one replay the LRU keeps recent blocks hot, but a
+// pathological reconnect window spanning many distinct blocks would otherwise
+// re-parse a large BUMP per block. Capping distinct blocks bounds that CPU to
+// at most catchupBlockBudget parses per replay, independent of frame count —
+// the memory ceiling is already the store's bump-cache size. Over-budget MINED
+// frames still ship with blockHash/blockHeight; the proof stays recoverable via
+// GET /tx/:id.
+const catchupBlockBudget = 64
+
 // errCatchupCapped stops the catchup iteration at catchupMaxFrames.
 // Internal sentinel, never surfaced to the client.
 var errCatchupCapped = errors.New("sse catchup frame cap reached")
@@ -327,18 +354,33 @@ var errCatchupCapped = errors.New("sse catchup frame cap reached")
 //
 // The store streams a projection (no raw tx, no merkle-path enrichment) in
 // ascending timestamp order, so replayed event ids stay monotonic for
-// Last-Event-ID resume.
+// Last-Event-ID resume. Merkle-path enrichment is layered on HERE (not inside
+// the iterator, which must stay a pure projection per its contract): terminal
+// frames on a Last-Event-ID reconnect are enriched best-effort, bounded by
+// catchupBlockBudget distinct blocks. Fresh connects replay only non-terminal
+// statuses, so the enrichment branch never fires there.
 func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, since time.Time) {
 	var only []models.Status
 	if since.IsZero() {
 		only = models.NonTerminalStatuses()
 	}
 	frames := 0
+	enrichedBlocks := make(map[string]struct{})
 	err := s.store.IterateStatusesByToken(ctx, token, since, only, func(status *models.TransactionStatus) error {
 		if frames >= catchupMaxFrames {
 			return errCatchupCapped
 		}
 		frames++
+		if status.Status == models.StatusMined || status.Status == models.StatusImmutable {
+			_, seen := enrichedBlocks[status.BlockHash]
+			if status.BlockHash != "" && (seen || len(enrichedBlocks) < catchupBlockBudget) {
+				enrichedBlocks[status.BlockHash] = struct{}{}
+				s.store.EnrichMerklePath(ctx, status)
+				if len(status.MerklePath) == 0 {
+					metrics.MinedPushWithoutMerklePathTotal.WithLabelValues("sse").Inc()
+				}
+			}
+		}
 		return writeStatus(w, status)
 	})
 	if errors.Is(err, errCatchupCapped) {
@@ -348,13 +390,31 @@ func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, s
 	}
 }
 
+// enrichMerklePath attaches the merkle proof to a mined/immutable status before
+// it is framed to clients. No-op for other statuses, when there is no store, or
+// when the block's BUMP isn't retrievable — best-effort, so it never blocks a
+// frame. Records a metric when a mined frame still lacks a proof so operators
+// can spot BUMP-availability gaps.
+func (m *Manager) enrichMerklePath(ctx context.Context, status *models.TransactionStatus) {
+	if m.store == nil {
+		return
+	}
+	m.store.EnrichMerklePath(ctx, status)
+	if (status.Status == models.StatusMined || status.Status == models.StatusImmutable) && len(status.MerklePath) == 0 {
+		metrics.MinedPushWithoutMerklePathTotal.WithLabelValues("sse").Inc()
+	}
+}
+
 // writeStatus emits one status frame. Event id is the timestamp in
 // nanoseconds so clients can use it as Last-Event-ID on reconnect.
 func writeStatus(w *sseWriter, status *models.TransactionStatus) error {
 	data, err := json.Marshal(statusPayload{
-		TxID:      status.TxID,
-		TxStatus:  string(status.Status),
-		Timestamp: status.Timestamp.UTC().Format(time.RFC3339),
+		TxID:        status.TxID,
+		TxStatus:    string(status.Status),
+		Timestamp:   status.Timestamp.UTC().Format(time.RFC3339),
+		BlockHash:   status.BlockHash,
+		BlockHeight: status.BlockHeight,
+		MerklePath:  status.MerklePath,
 	})
 	if err != nil {
 		return err
@@ -363,10 +423,15 @@ func writeStatus(w *sseWriter, status *models.TransactionStatus) error {
 	return w.write(frame)
 }
 
-// statusPayload is the JSON shape inside a `data:` field. Field order
-// and names mirror the legacy wire format: txid, txStatus, timestamp.
+// statusPayload is the JSON shape inside a `data:` field. txid/txStatus/timestamp
+// are the always-present legacy fields; blockHash/blockHeight/merklePath are
+// added for mined/immutable frames (omitempty keeps every other frame at the
+// original three-field shape). merklePath is a BUMP, hex-encoded like GET /tx.
 type statusPayload struct {
-	TxID      string `json:"txid"`
-	TxStatus  string `json:"txStatus"`
-	Timestamp string `json:"timestamp"`
+	TxID        string          `json:"txid"`
+	TxStatus    string          `json:"txStatus"`
+	Timestamp   string          `json:"timestamp"`
+	BlockHash   string          `json:"blockHash,omitempty"`
+	BlockHeight uint64          `json:"blockHeight,omitempty"`
+	MerklePath  models.HexBytes `json:"merklePath,omitempty"`
 }

--- a/services/sse/merklepath_e2e_test.go
+++ b/services/sse/merklepath_e2e_test.go
@@ -62,22 +62,22 @@ func newMerkleSSEHarness(t *testing.T, token string, subIdx int) *merkleSSEHarne
 		t.Fatalf("synthblock.Build: %v", err)
 	}
 	for _, txid := range blk.Txids {
-		if _, _, err := st.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		if _, _, sErr := st.GetOrInsertStatus(ctx, &models.TransactionStatus{
 			TxID: txid, Status: models.StatusSeenOnNetwork, Timestamp: time.Now().UTC(),
-		}); err != nil {
-			t.Fatalf("seed row: %v", err)
+		}); sErr != nil {
+			t.Fatalf("seed row: %v", sErr)
 		}
 	}
-	if _, _, err := st.SetMinedByTxIDs(ctx, sseBlockHash, sseHeight, blk.Txids); err != nil {
-		t.Fatalf("SetMinedByTxIDs: %v", err)
+	if _, _, mErr := st.SetMinedByTxIDs(ctx, sseBlockHash, sseHeight, blk.Txids); mErr != nil {
+		t.Fatalf("SetMinedByTxIDs: %v", mErr)
 	}
-	if err := st.InsertBUMP(ctx, sseBlockHash, sseHeight, blk.BumpBytes); err != nil {
-		t.Fatalf("InsertBUMP: %v", err)
+	if bErr := st.InsertBUMP(ctx, sseBlockHash, sseHeight, blk.BumpBytes); bErr != nil {
+		t.Fatalf("InsertBUMP: %v", bErr)
 	}
-	if err := st.InsertSubmission(ctx, &models.Submission{
+	if subErr := st.InsertSubmission(ctx, &models.Submission{
 		SubmissionID: "sub-" + token, TxID: blk.Txids[subIdx], CallbackToken: token,
-	}); err != nil {
-		t.Fatalf("InsertSubmission: %v", err)
+	}); subErr != nil {
+		t.Fatalf("InsertSubmission: %v", subErr)
 	}
 
 	broker := kafka.NewMemoryBroker(64)
@@ -140,15 +140,15 @@ func assertMinedFrameCarriesProof(t *testing.T, frame, txid, root string) {
 }
 
 func TestSSE_E2E_MinedLiveFrameCarriesProof(t *testing.T) {
-	const token = "tok-sse-live"
-	h := newMerkleSSEHarness(t, token, 3)
+	const liveTok = "tok-sse-live"
+	h := newMerkleSSEHarness(t, liveTok, 3)
 	defer h.Close()
 	waitForSubscriberReady()
 
 	subTxid := h.block.Txids[3]
 
 	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet,
-		h.httpSrv.URL+"/events?callbackToken="+token, nil)
+		h.httpSrv.URL+"/events?callbackToken="+liveTok, nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET /events: %v", err)
@@ -157,14 +157,14 @@ func TestSSE_E2E_MinedLiveFrameCarriesProof(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// The bulk MINED event bump_builder publishes: block fields + all txids, no path.
-	if err := h.pub.PublishBulk(t.Context(), &models.TransactionStatus{
+	if pErr := h.pub.PublishBulk(t.Context(), &models.TransactionStatus{
 		Status:      models.StatusMined,
 		BlockHash:   sseBlockHash,
 		BlockHeight: sseHeight,
 		Timestamp:   time.Now().UTC(),
 		TxIDs:       h.block.Txids,
-	}); err != nil {
-		t.Fatalf("PublishBulk: %v", err)
+	}); pErr != nil {
+		t.Fatalf("PublishBulk: %v", pErr)
 	}
 
 	frame, err := readNextSSEFrame(resp.Body, 3*time.Second)
@@ -175,8 +175,8 @@ func TestSSE_E2E_MinedLiveFrameCarriesProof(t *testing.T) {
 }
 
 func TestSSE_E2E_MinedCatchupFrameCarriesProof(t *testing.T) {
-	const token = "tok-sse-catchup"
-	h := newMerkleSSEHarness(t, token, 5)
+	const catchupTok = "tok-sse-catchup"
+	h := newMerkleSSEHarness(t, catchupTok, 5)
 	defer h.Close()
 	waitForSubscriberReady()
 
@@ -186,7 +186,7 @@ func TestSSE_E2E_MinedCatchupFrameCarriesProof(t *testing.T) {
 	// the catchup replay emits the terminal MINED frame.
 	since := time.Now().Add(-time.Hour)
 	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet,
-		h.httpSrv.URL+"/events?callbackToken="+token, nil)
+		h.httpSrv.URL+"/events?callbackToken="+catchupTok, nil)
 	req.Header.Set("Last-Event-ID", fmt.Sprintf("%d", since.UnixNano()))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/services/sse/merklepath_e2e_test.go
+++ b/services/sse/merklepath_e2e_test.go
@@ -1,0 +1,202 @@
+package sse
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/events"
+	"github.com/bsv-blockchain/arcade/internal/synthblock"
+	"github.com/bsv-blockchain/arcade/kafka"
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store/pebble"
+)
+
+// These tests wire the SSE service against a REAL pebble store (not the stub)
+// so merkle-path enrichment actually runs, and verify the proof in the emitted
+// frame recomputes the block merkle root.
+
+const (
+	sseBlockHash = "000000000000000000000000000000000000000000000000000000000000cafe"
+	sseHeight    = 880456
+)
+
+type merkleSSEHarness struct {
+	store   *pebble.Store
+	pub     *events.KafkaPublisher
+	broker  kafka.Broker
+	httpSrv *httptest.Server
+	block   synthblock.Block
+}
+
+func (h *merkleSSEHarness) Close() {
+	h.httpSrv.Close()
+	_ = h.broker.Close()
+}
+
+// newMerkleSSEHarness builds a pebble store holding one mined block's compound
+// BUMP, wires the SSE service over the in-memory broker, and registers a
+// submission for block.Txids[idx] under the given token.
+func newMerkleSSEHarness(t *testing.T, token string, subIdx int) *merkleSSEHarness {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ctx := context.Background()
+
+	st, err := pebble.New(config.Pebble{Path: t.TempDir(), MemTableSizeMB: 4, L0CompactionThreshold: 2})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	blk, err := synthblock.Build(8, sseHeight)
+	if err != nil {
+		t.Fatalf("synthblock.Build: %v", err)
+	}
+	for _, txid := range blk.Txids {
+		if _, _, err := st.GetOrInsertStatus(ctx, &models.TransactionStatus{
+			TxID: txid, Status: models.StatusSeenOnNetwork, Timestamp: time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("seed row: %v", err)
+		}
+	}
+	if _, _, err := st.SetMinedByTxIDs(ctx, sseBlockHash, sseHeight, blk.Txids); err != nil {
+		t.Fatalf("SetMinedByTxIDs: %v", err)
+	}
+	if err := st.InsertBUMP(ctx, sseBlockHash, sseHeight, blk.BumpBytes); err != nil {
+		t.Fatalf("InsertBUMP: %v", err)
+	}
+	if err := st.InsertSubmission(ctx, &models.Submission{
+		SubmissionID: "sub-" + token, TxID: blk.Txids[subIdx], CallbackToken: token,
+	}); err != nil {
+		t.Fatalf("InsertSubmission: %v", err)
+	}
+
+	broker := kafka.NewMemoryBroker(64)
+	pub := events.NewKafkaPublisher(kafka.NewProducer(broker), zap.NewNop(), 0)
+
+	svc := &Service{
+		cfg:       &config.Config{SSE: config.SSEConfig{Enabled: true}},
+		logger:    zap.NewNop(),
+		store:     st,
+		publisher: pub,
+	}
+	mgr, err := newManager(t.Context(), pub, st, zap.NewNop())
+	if err != nil {
+		_ = broker.Close()
+		t.Fatalf("newManager: %v", err)
+	}
+	svc.manager = mgr
+
+	router := gin.New()
+	router.GET("/events", svc.handleEvents)
+
+	return &merkleSSEHarness{store: st, pub: pub, broker: broker, httpSrv: httptest.NewServer(router), block: blk}
+}
+
+// frameData extracts and decodes the JSON object from a `data:` line of an SSE frame.
+func frameData(t *testing.T, frame string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(frame, "\n") {
+		if data, ok := strings.CutPrefix(line, "data: "); ok {
+			var m map[string]any
+			if err := json.Unmarshal([]byte(data), &m); err != nil {
+				t.Fatalf("decode SSE data %q: %v", data, err)
+			}
+			return m
+		}
+	}
+	t.Fatalf("no data line in frame %q", frame)
+	return nil
+}
+
+func assertMinedFrameCarriesProof(t *testing.T, frame, txid, root string) {
+	t.Helper()
+	m := frameData(t, frame)
+	if m["txid"] != txid || m["txStatus"] != string(models.StatusMined) {
+		t.Fatalf("unexpected frame for %s: %v", txid, m)
+	}
+	if m["blockHash"] != sseBlockHash {
+		t.Fatalf("frame missing blockHash: %v", m["blockHash"])
+	}
+	if _, ok := m["blockHeight"]; !ok {
+		t.Fatalf("frame missing blockHeight: %v", m)
+	}
+	mp, ok := m["merklePath"].(string)
+	if !ok || mp == "" {
+		t.Fatalf("frame missing merklePath: %v", m["merklePath"])
+	}
+	if err := synthblock.VerifyMerklePathHex(mp, txid, root); err != nil {
+		t.Fatalf("SSE frame merklePath does not verify: %v", err)
+	}
+}
+
+func TestSSE_E2E_MinedLiveFrameCarriesProof(t *testing.T) {
+	const token = "tok-sse-live"
+	h := newMerkleSSEHarness(t, token, 3)
+	defer h.Close()
+	waitForSubscriberReady()
+
+	subTxid := h.block.Txids[3]
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		h.httpSrv.URL+"/events?callbackToken="+token, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /events: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	time.Sleep(100 * time.Millisecond)
+
+	// The bulk MINED event bump_builder publishes: block fields + all txids, no path.
+	if err := h.pub.PublishBulk(t.Context(), &models.TransactionStatus{
+		Status:      models.StatusMined,
+		BlockHash:   sseBlockHash,
+		BlockHeight: sseHeight,
+		Timestamp:   time.Now().UTC(),
+		TxIDs:       h.block.Txids,
+	}); err != nil {
+		t.Fatalf("PublishBulk: %v", err)
+	}
+
+	frame, err := readNextSSEFrame(resp.Body, 3*time.Second)
+	if err != nil {
+		t.Fatalf("read frame: %v", err)
+	}
+	assertMinedFrameCarriesProof(t, frame, subTxid, h.block.Root)
+}
+
+func TestSSE_E2E_MinedCatchupFrameCarriesProof(t *testing.T) {
+	const token = "tok-sse-catchup"
+	h := newMerkleSSEHarness(t, token, 5)
+	defer h.Close()
+	waitForSubscriberReady()
+
+	subTxid := h.block.Txids[5]
+
+	// Reconnect with a Last-Event-ID well before the mined row's timestamp, so
+	// the catchup replay emits the terminal MINED frame.
+	since := time.Now().Add(-time.Hour)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		h.httpSrv.URL+"/events?callbackToken="+token, nil)
+	req.Header.Set("Last-Event-ID", fmt.Sprintf("%d", since.UnixNano()))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /events: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	frame, err := readNextSSEFrame(resp.Body, 3*time.Second)
+	if err != nil {
+		t.Fatalf("read catchup frame: %v", err)
+	}
+	assertMinedFrameCarriesProof(t, frame, subTxid, h.block.Root)
+}

--- a/services/sse/sse_test.go
+++ b/services/sse/sse_test.go
@@ -89,6 +89,12 @@ func (s *sseStoreStub) GetStatus(_ context.Context, txid string) (*models.Transa
 	return s.statusByTx[txid], nil
 }
 
+// EnrichMerklePath is a no-op for this stub: these tests don't exercise the
+// compound-BUMP extraction (the dedicated pebble-backed e2e tests do). It must
+// still exist so fan-out/catchup enrichment doesn't dereference the nil
+// embedded store.Store.
+func (s *sseStoreStub) EnrichMerklePath(_ context.Context, _ *models.TransactionStatus) {}
+
 // IterateStatusesByToken mirrors the real backends: distinct txids under
 // the token, current status projection, since/only filters, ascending
 // timestamp order.

--- a/services/webhook/merklepath_e2e_test.go
+++ b/services/webhook/merklepath_e2e_test.go
@@ -48,20 +48,20 @@ func mineBlock(t *testing.T, st *pebble.Store, insertBump bool) synthblock.Block
 		t.Fatalf("synthblock.Build: %v", err)
 	}
 	for _, txid := range blk.Txids {
-		if _, _, err := st.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		if _, _, sErr := st.GetOrInsertStatus(ctx, &models.TransactionStatus{
 			TxID:      txid,
 			Status:    models.StatusSeenOnNetwork,
 			Timestamp: time.Now().UTC(),
-		}); err != nil {
-			t.Fatalf("seed row %s: %v", txid, err)
+		}); sErr != nil {
+			t.Fatalf("seed row %s: %v", txid, sErr)
 		}
 	}
-	if _, _, err := st.SetMinedByTxIDs(ctx, e2eBlockHash, e2eHeight, blk.Txids); err != nil {
-		t.Fatalf("SetMinedByTxIDs: %v", err)
+	if _, _, mErr := st.SetMinedByTxIDs(ctx, e2eBlockHash, e2eHeight, blk.Txids); mErr != nil {
+		t.Fatalf("SetMinedByTxIDs: %v", mErr)
 	}
 	if insertBump {
-		if err := st.InsertBUMP(ctx, e2eBlockHash, e2eHeight, blk.BumpBytes); err != nil {
-			t.Fatalf("InsertBUMP: %v", err)
+		if bErr := st.InsertBUMP(ctx, e2eBlockHash, e2eHeight, blk.BumpBytes); bErr != nil {
+			t.Fatalf("InsertBUMP: %v", bErr)
 		}
 	}
 	return blk

--- a/services/webhook/merklepath_e2e_test.go
+++ b/services/webhook/merklepath_e2e_test.go
@@ -1,0 +1,216 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/internal/synthblock"
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store/pebble"
+)
+
+// These tests exercise the real push path end to end: a real pebble store holds
+// a mined block's compound BUMP, and the webhook dispatch/reaper code enriches
+// the outgoing callback body with the per-tx merkle proof. Verification is
+// cryptographic — the received merklePath must recompute the block's merkle
+// root for the delivered txid (synthblock.VerifyMerklePathHex).
+
+const (
+	e2eBlockHash = "000000000000000000000000000000000000000000000000000000000000beef"
+	e2eHeight    = 870123
+)
+
+func newWebhookPebble(t *testing.T) *pebble.Store {
+	t.Helper()
+	st, err := pebble.New(config.Pebble{Path: t.TempDir(), MemTableSizeMB: 4, L0CompactionThreshold: 2})
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+// mineBlock seeds numTxs rows, transitions them to MINED under blockHash, and
+// (when insertBump) stores the block's compound BUMP so enrichment can find it.
+func mineBlock(t *testing.T, st *pebble.Store, insertBump bool) synthblock.Block {
+	t.Helper()
+	ctx := context.Background()
+	blk, err := synthblock.Build(8, e2eHeight)
+	if err != nil {
+		t.Fatalf("synthblock.Build: %v", err)
+	}
+	for _, txid := range blk.Txids {
+		if _, _, err := st.GetOrInsertStatus(ctx, &models.TransactionStatus{
+			TxID:      txid,
+			Status:    models.StatusSeenOnNetwork,
+			Timestamp: time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("seed row %s: %v", txid, err)
+		}
+	}
+	if _, _, err := st.SetMinedByTxIDs(ctx, e2eBlockHash, e2eHeight, blk.Txids); err != nil {
+		t.Fatalf("SetMinedByTxIDs: %v", err)
+	}
+	if insertBump {
+		if err := st.InsertBUMP(ctx, e2eBlockHash, e2eHeight, blk.BumpBytes); err != nil {
+			t.Fatalf("InsertBUMP: %v", err)
+		}
+	}
+	return blk
+}
+
+// captureReceiver is an httptest callback endpoint that decodes each POST body
+// and forwards it on a channel.
+func captureReceiver(t *testing.T) (*httptest.Server, <-chan map[string]any) {
+	t.Helper()
+	bodies := make(chan map[string]any, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		_ = json.Unmarshal(raw, &body)
+		bodies <- body
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, bodies
+}
+
+func recvBody(t *testing.T, bodies <-chan map[string]any) map[string]any {
+	t.Helper()
+	select {
+	case b := <-bodies:
+		return b
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for webhook POST")
+		return nil
+	}
+}
+
+func TestWebhook_E2E_MinedDeliversMerklePath(t *testing.T) {
+	st := newWebhookPebble(t)
+	blk := mineBlock(t, st, true)
+	srv, bodies := captureReceiver(t)
+
+	subTxid := blk.Txids[3]
+	if err := st.InsertSubmission(context.Background(), &models.Submission{
+		SubmissionID:  "sub-live",
+		TxID:          subTxid,
+		CallbackURL:   srv.URL,
+		CallbackToken: "tok-live",
+	}); err != nil {
+		t.Fatalf("InsertSubmission: %v", err)
+	}
+
+	svc := New(config.WebhookConfig{}, config.CallbackConfig{AllowPrivateIPs: true},
+		zap.NewNop(), recordingPub{}, st, nil)
+
+	// Drive the exact bulk MINED event bump_builder publishes.
+	svc.handleUpdate(context.Background(), &models.TransactionStatus{
+		Status:      models.StatusMined,
+		BlockHash:   e2eBlockHash,
+		BlockHeight: e2eHeight,
+		Timestamp:   time.Now().UTC(),
+		TxIDs:       blk.Txids,
+	})
+
+	body := recvBody(t, bodies)
+	if body["txid"] != subTxid {
+		t.Fatalf("txid: got %v want %s", body["txid"], subTxid)
+	}
+	if body["txStatus"] != string(models.StatusMined) {
+		t.Fatalf("txStatus: got %v want MINED", body["txStatus"])
+	}
+	if body["blockHash"] != e2eBlockHash {
+		t.Fatalf("blockHash: got %v want %s", body["blockHash"], e2eBlockHash)
+	}
+	mp, ok := body["merklePath"].(string)
+	if !ok || mp == "" {
+		t.Fatalf("merklePath missing from webhook body: %v", body["merklePath"])
+	}
+	if err := synthblock.VerifyMerklePathHex(mp, subTxid, blk.Root); err != nil {
+		t.Fatalf("delivered merklePath does not verify: %v", err)
+	}
+}
+
+func TestWebhook_E2E_ReaperRedeliversMerklePath(t *testing.T) {
+	st := newWebhookPebble(t)
+	blk := mineBlock(t, st, true)
+	srv, bodies := captureReceiver(t)
+
+	subTxid := blk.Txids[1]
+	if err := st.InsertSubmission(context.Background(), &models.Submission{
+		SubmissionID:  "sub-reaper",
+		TxID:          subTxid,
+		CallbackURL:   srv.URL,
+		CallbackToken: "tok-reaper",
+	}); err != nil {
+		t.Fatalf("InsertSubmission: %v", err)
+	}
+	// Put the submission in ready-for-retry state at MINED: LastDeliveredStatus
+	// already advanced, NextRetryAt in the past.
+	past := time.Now().Add(-time.Minute)
+	if err := st.UpdateDeliveryStatus(context.Background(), "sub-reaper", models.StatusMined, 1, &past); err != nil {
+		t.Fatalf("UpdateDeliveryStatus: %v", err)
+	}
+
+	svc := New(config.WebhookConfig{}, config.CallbackConfig{AllowPrivateIPs: true},
+		zap.NewNop(), recordingPub{}, st, nil)
+
+	svc.reapOnce(context.Background())
+
+	body := recvBody(t, bodies)
+	if body["txStatus"] != string(models.StatusMined) {
+		t.Fatalf("redelivery must keep LastDeliveredStatus MINED, got %v", body["txStatus"])
+	}
+	mp, ok := body["merklePath"].(string)
+	if !ok || mp == "" {
+		t.Fatalf("reaper redelivery missing merklePath: %v", body["merklePath"])
+	}
+	if err := synthblock.VerifyMerklePathHex(mp, subTxid, blk.Root); err != nil {
+		t.Fatalf("redelivered merklePath does not verify: %v", err)
+	}
+}
+
+func TestWebhook_E2E_MissingBUMPStillDelivers(t *testing.T) {
+	st := newWebhookPebble(t)
+	blk := mineBlock(t, st, false) // rows MINED, but no compound BUMP stored
+	srv, bodies := captureReceiver(t)
+
+	subTxid := blk.Txids[2]
+	if err := st.InsertSubmission(context.Background(), &models.Submission{
+		SubmissionID:  "sub-nobump",
+		TxID:          subTxid,
+		CallbackURL:   srv.URL,
+		CallbackToken: "tok-nobump",
+	}); err != nil {
+		t.Fatalf("InsertSubmission: %v", err)
+	}
+
+	svc := New(config.WebhookConfig{}, config.CallbackConfig{AllowPrivateIPs: true},
+		zap.NewNop(), recordingPub{}, st, nil)
+
+	svc.handleUpdate(context.Background(), &models.TransactionStatus{
+		Status:      models.StatusMined,
+		BlockHash:   e2eBlockHash,
+		BlockHeight: e2eHeight,
+		Timestamp:   time.Now().UTC(),
+		TxIDs:       blk.Txids,
+	})
+
+	body := recvBody(t, bodies)
+	// Delivery must still happen (best-effort proof), just without merklePath.
+	if body["txid"] != subTxid || body["txStatus"] != string(models.StatusMined) {
+		t.Fatalf("expected MINED delivery for %s, got %v", subTxid, body)
+	}
+	if mp, present := body["merklePath"]; present {
+		t.Fatalf("merklePath should be absent when the BUMP is missing, got %v", mp)
+	}
+}

--- a/services/webhook/reaper.go
+++ b/services/webhook/reaper.go
@@ -113,6 +113,21 @@ func (s *Service) reapOnce(ctx context.Context) {
 			Status:    sub.LastDeliveredStatus,
 			Timestamp: time.Now(),
 		}
+		// Redeliver the exact transition we failed on: Status stays
+		// LastDeliveredStatus so deliver()'s CAS (expected=LastDeliveredStatus →
+		// next=status.Status) is a no-op advance that clears retry state. For a
+		// mined/immutable redelivery, graft the block context + merkle proof
+		// from the stored row (GetStatus enriches merklePath) so retried
+		// callbacks match the shape of a first-attempt delivery. The lean status
+		// has no BlockHash, so EnrichMerklePath alone would no-op here — GetStatus
+		// supplies both. Best-effort: on any error, redeliver without the proof.
+		if status.Status == models.StatusMined || status.Status == models.StatusImmutable {
+			if full, err := s.store.GetStatus(ctx, sub.TxID); err == nil && full != nil {
+				status.BlockHash = full.BlockHash
+				status.BlockHeight = full.BlockHeight
+				status.MerklePath = full.MerklePath
+			}
+		}
 		s.deliver(ctx, sub, status)
 	}
 }

--- a/services/webhook/service.go
+++ b/services/webhook/service.go
@@ -293,12 +293,24 @@ func (s *Service) dispatchOne(ctx context.Context, status *models.TransactionSta
 		)
 		return
 	}
+	enriched := false
 	for _, sub := range subs {
 		if sub.CallbackURL == "" {
 			continue // SSE-only subscription; no webhook to send
 		}
 		if !shouldDeliver(sub, status) {
 			continue
+		}
+		// Attach the merkle proof to MINED/IMMUTABLE deliveries. Done lazily on
+		// the first deliverable subscriber (not for SSE-only txids) and only
+		// once — the status pointer is shared across every deliver() below, so
+		// all subscribers of this txid get the same enriched body. Best-effort:
+		// a no-op for non-mined statuses or when the BUMP isn't retrievable, so
+		// it never blocks delivery. deliver() emits the metric when a MINED body
+		// still lacks a path.
+		if !enriched {
+			s.store.EnrichMerklePath(ctx, status)
+			enriched = true
 		}
 		s.deliver(ctx, sub, status)
 	}
@@ -357,6 +369,10 @@ func (s *Service) deliver(ctx context.Context, sub *models.Submission, status *m
 	if !claimed {
 		metrics.WebhookCASLostTotal.Inc()
 		return
+	}
+
+	if (status.Status == models.StatusMined || status.Status == models.StatusImmutable) && len(status.MerklePath) == 0 {
+		metrics.MinedPushWithoutMerklePathTotal.WithLabelValues("webhook").Inc()
 	}
 
 	body, err := json.Marshal(status)

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -126,6 +126,8 @@ func (s *fakeStore) GetStatus(context.Context, string) (*models.TransactionStatu
 	return nil, nil
 }
 
+func (s *fakeStore) EnrichMerklePath(context.Context, *models.TransactionStatus) {}
+
 func (s *fakeStore) GetStatusesSince(context.Context, time.Time) ([]*models.TransactionStatus, error) {
 	return nil, nil
 }

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -15,7 +15,9 @@ import (
 	"github.com/aerospike/aerospike-client-go/v7/types"
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/transaction"
+	lru "github.com/hashicorp/golang-lru/v2"
 
+	"github.com/bsv-blockchain/arcade/bump"
 	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
@@ -76,6 +78,23 @@ var (
 )
 
 // Store is the Aerospike-backed implementation of store.Store and store.Leaser.
+// bumpCacheSize bounds how many parsed+indexed compound BUMPs the store keeps
+// resident for merkle-path enrichment. enrichMerklePath runs on every GetStatus
+// of a mined tx and once per subscribed tx during a MINED fan-out; without a
+// cache each call reassembles the chunked BUMP from Aerospike and re-parses it
+// — expensive. Lookups and fan-out cluster on the few recently-mined blocks in
+// flight, so a small LRU gives a high hit rate while bounding the resident set
+// to bumpCacheSize sparse compounds plus their level-0 offset indexes.
+const bumpCacheSize = 16
+
+// cachedBUMP is one block's parsed compound BUMP plus its level-0 txid→offset
+// index, so per-tx path extraction is a map lookup + ExtractMinimalPath rather
+// than a reassemble+re-parse and a level-0 hash scan.
+type cachedBUMP struct {
+	compound *transaction.MerklePath
+	offsets  map[chainhash.Hash]uint64
+}
+
 type Store struct {
 	client        *aero.Client
 	namespace     string
@@ -84,6 +103,7 @@ type Store struct {
 	opTimeout     time.Duration
 	socketTimeout time.Duration
 	bumpChunkSize int
+	bumpCache     *lru.Cache[string, *cachedBUMP]
 }
 
 // New creates an Aerospike-backed Store connected to the configured cluster.
@@ -145,6 +165,12 @@ func New(cfg config.Aero) (*Store, error) {
 		bumpChunkSize = bumpDefaultChunkSizeBytes
 	}
 
+	bumpCache, cacheErr := lru.New[string, *cachedBUMP](bumpCacheSize)
+	if cacheErr != nil {
+		client.Close()
+		return nil, fmt.Errorf("init bump cache: %w", cacheErr)
+	}
+
 	s := &Store{
 		client:        client,
 		namespace:     cfg.Namespace,
@@ -153,6 +179,7 @@ func New(cfg config.Aero) (*Store, error) {
 		opTimeout:     time.Duration(cfg.OpTimeoutMs) * time.Millisecond,
 		socketTimeout: time.Duration(cfg.SocketTimeoutMs) * time.Millisecond,
 		bumpChunkSize: bumpChunkSize,
+		bumpCache:     bumpCache,
 	}
 
 	if err := s.EnsureIndexes(); err != nil {
@@ -928,6 +955,10 @@ func (s *Store) InsertBUMP(ctx context.Context, blockHash string, blockHeight ui
 			_ = err
 		}
 	}
+	// A rebuild can overwrite the compound for an existing block (e.g. late
+	// STUMP callbacks). Drop any cached parse so the next enrichment reassembles
+	// and re-parses the current stored BUMP.
+	s.bumpCache.Remove(blockHash)
 	return nil
 }
 
@@ -2303,8 +2334,17 @@ func recordToStatus(rec *aero.Record, txid string) *models.TransactionStatus {
 	return status
 }
 
+// EnrichMerklePath implements store.Store: it populates status.MerklePath in
+// place for a mined/immutable status carrying a BlockHash, extracting the tx's
+// minimal path from the block's compound BUMP. Best-effort — see the interface
+// doc. Delegates to the same enrichMerklePath used by GetStatus.
+func (s *Store) EnrichMerklePath(ctx context.Context, status *models.TransactionStatus) {
+	s.enrichMerklePath(ctx, status)
+}
+
 // enrichMerklePath fetches the compound BUMP for a mined/immutable transaction
-// and extracts the per-tx minimal merkle path if not already present.
+// and extracts the per-tx minimal merkle path if not already present, reusing
+// the block's cached, indexed compound.
 func (s *Store) enrichMerklePath(ctx context.Context, status *models.TransactionStatus) {
 	if status == nil || len(status.MerklePath) > 0 || status.BlockHash == "" {
 		return
@@ -2312,63 +2352,40 @@ func (s *Store) enrichMerklePath(ctx context.Context, status *models.Transaction
 	if status.Status != models.StatusMined && status.Status != models.StatusImmutable {
 		return
 	}
-	_, bumpData, err := s.GetBUMP(ctx, status.BlockHash)
-	if err != nil || len(bumpData) == 0 {
+	entry := s.compoundBUMP(ctx, status.BlockHash)
+	if entry == nil {
 		return
 	}
-	status.MerklePath = extractMinimalPathForTx(bumpData, status.TxID)
+	txHash, err := chainhash.NewHashFromHex(status.TxID)
+	if err != nil {
+		return
+	}
+	offset, ok := entry.offsets[*txHash]
+	if !ok {
+		return
+	}
+	status.MerklePath = bump.ExtractMinimalPath(entry.compound, offset).Bytes()
 }
 
-// extractMinimalPathForTx extracts a per-tx minimal merkle path from a compound BUMP.
-func extractMinimalPathForTx(bumpData []byte, txid string) []byte {
-	compound, err := transaction.NewMerklePathFromBinary(bumpData)
+// compoundBUMP returns the parsed+indexed compound BUMP for a block, caching it
+// so repeated enrichment for txs in the same block reuses the chunk reassembly,
+// the parse, and the level-0 offset index. The returned value is shared and
+// read-only.
+func (s *Store) compoundBUMP(ctx context.Context, blockHash string) *cachedBUMP {
+	if c, ok := s.bumpCache.Get(blockHash); ok {
+		return c
+	}
+	_, bumpData, err := s.GetBUMP(ctx, blockHash)
+	if err != nil || len(bumpData) == 0 {
+		return nil
+	}
+	compound, offsets, err := bump.IndexCompound(bumpData)
 	if err != nil {
 		return nil
 	}
-	txHash, err := chainhash.NewHashFromHex(txid)
-	if err != nil {
-		return nil
-	}
-
-	var txOffset uint64
-	found := false
-	if len(compound.Path) > 0 {
-		for _, leaf := range compound.Path[0] {
-			if leaf.Hash != nil && *leaf.Hash == *txHash {
-				txOffset = leaf.Offset
-				found = true
-				break
-			}
-		}
-	}
-	if !found {
-		return nil
-	}
-
-	mp := &transaction.MerklePath{
-		BlockHeight: compound.BlockHeight,
-		Path:        make([][]*transaction.PathElement, len(compound.Path)),
-	}
-	offset := txOffset
-	for level := 0; level < len(compound.Path); level++ {
-		if level == 0 {
-			for _, leaf := range compound.Path[level] {
-				if leaf.Offset == offset {
-					mp.Path[level] = append(mp.Path[level], leaf)
-					break
-				}
-			}
-		}
-		sibOffset := offset ^ 1
-		for _, leaf := range compound.Path[level] {
-			if leaf.Offset == sibOffset {
-				mp.Path[level] = append(mp.Path[level], leaf)
-				break
-			}
-		}
-		offset = offset >> 1
-	}
-	return mp.Bytes()
+	entry := &cachedBUMP{compound: compound, offsets: offsets}
+	s.bumpCache.Add(blockHash, entry)
+	return entry
 }
 
 func recordToSubmission(rec *aero.Record) *models.Submission {

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -13,15 +13,12 @@ import (
 
 	aero "github.com/aerospike/aerospike-client-go/v7"
 	"github.com/aerospike/aerospike-client-go/v7/types"
-	"github.com/bsv-blockchain/go-sdk/chainhash"
-	"github.com/bsv-blockchain/go-sdk/transaction"
-	lru "github.com/hashicorp/golang-lru/v2"
 
-	"github.com/bsv-blockchain/arcade/bump"
 	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/store"
+	"github.com/bsv-blockchain/arcade/store/bumpcache"
 )
 
 func isKeyNotFound(err error) bool {
@@ -78,23 +75,6 @@ var (
 )
 
 // Store is the Aerospike-backed implementation of store.Store and store.Leaser.
-// bumpCacheSize bounds how many parsed+indexed compound BUMPs the store keeps
-// resident for merkle-path enrichment. enrichMerklePath runs on every GetStatus
-// of a mined tx and once per subscribed tx during a MINED fan-out; without a
-// cache each call reassembles the chunked BUMP from Aerospike and re-parses it
-// — expensive. Lookups and fan-out cluster on the few recently-mined blocks in
-// flight, so a small LRU gives a high hit rate while bounding the resident set
-// to bumpCacheSize sparse compounds plus their level-0 offset indexes.
-const bumpCacheSize = 16
-
-// cachedBUMP is one block's parsed compound BUMP plus its level-0 txid→offset
-// index, so per-tx path extraction is a map lookup + ExtractMinimalPath rather
-// than a reassemble+re-parse and a level-0 hash scan.
-type cachedBUMP struct {
-	compound *transaction.MerklePath
-	offsets  map[chainhash.Hash]uint64
-}
-
 type Store struct {
 	client        *aero.Client
 	namespace     string
@@ -103,7 +83,11 @@ type Store struct {
 	opTimeout     time.Duration
 	socketTimeout time.Duration
 	bumpChunkSize int
-	bumpCache     *lru.Cache[string, *cachedBUMP]
+	// bumpCache holds parsed+indexed compound BUMPs for merkle-path
+	// enrichment — sizing, budget, and singleflight live in bumpcache.
+	// Especially valuable here: a miss reassembles the chunked BUMP from
+	// Aerospike before parsing.
+	bumpCache *bumpcache.Cache
 }
 
 // New creates an Aerospike-backed Store connected to the configured cluster.
@@ -165,12 +149,6 @@ func New(cfg config.Aero) (*Store, error) {
 		bumpChunkSize = bumpDefaultChunkSizeBytes
 	}
 
-	bumpCache, cacheErr := lru.New[string, *cachedBUMP](bumpCacheSize)
-	if cacheErr != nil {
-		client.Close()
-		return nil, fmt.Errorf("init bump cache: %w", cacheErr)
-	}
-
 	s := &Store{
 		client:        client,
 		namespace:     cfg.Namespace,
@@ -179,7 +157,7 @@ func New(cfg config.Aero) (*Store, error) {
 		opTimeout:     time.Duration(cfg.OpTimeoutMs) * time.Millisecond,
 		socketTimeout: time.Duration(cfg.SocketTimeoutMs) * time.Millisecond,
 		bumpChunkSize: bumpChunkSize,
-		bumpCache:     bumpCache,
+		bumpCache:     bumpcache.New(),
 	}
 
 	if err := s.EnsureIndexes(); err != nil {
@@ -2346,46 +2324,10 @@ func (s *Store) EnrichMerklePath(ctx context.Context, status *models.Transaction
 // and extracts the per-tx minimal merkle path if not already present, reusing
 // the block's cached, indexed compound.
 func (s *Store) enrichMerklePath(ctx context.Context, status *models.TransactionStatus) {
-	if status == nil || len(status.MerklePath) > 0 || status.BlockHash == "" {
-		return
-	}
-	if status.Status != models.StatusMined && status.Status != models.StatusImmutable {
-		return
-	}
-	entry := s.compoundBUMP(ctx, status.BlockHash)
-	if entry == nil {
-		return
-	}
-	txHash, err := chainhash.NewHashFromHex(status.TxID)
-	if err != nil {
-		return
-	}
-	offset, ok := entry.offsets[*txHash]
-	if !ok {
-		return
-	}
-	status.MerklePath = bump.ExtractMinimalPath(entry.compound, offset).Bytes()
-}
-
-// compoundBUMP returns the parsed+indexed compound BUMP for a block, caching it
-// so repeated enrichment for txs in the same block reuses the chunk reassembly,
-// the parse, and the level-0 offset index. The returned value is shared and
-// read-only.
-func (s *Store) compoundBUMP(ctx context.Context, blockHash string) *cachedBUMP {
-	if c, ok := s.bumpCache.Get(blockHash); ok {
-		return c
-	}
-	_, bumpData, err := s.GetBUMP(ctx, blockHash)
-	if err != nil || len(bumpData) == 0 {
-		return nil
-	}
-	compound, offsets, err := bump.IndexCompound(bumpData)
-	if err != nil {
-		return nil
-	}
-	entry := &cachedBUMP{compound: compound, offsets: offsets}
-	s.bumpCache.Add(blockHash, entry)
-	return entry
+	s.bumpCache.Enrich(status, func() ([]byte, error) {
+		_, bumpData, err := s.GetBUMP(ctx, status.BlockHash)
+		return bumpData, err
+	})
 }
 
 func recordToSubmission(rec *aero.Record) *models.Submission {

--- a/store/bumpcache/bumpcache.go
+++ b/store/bumpcache/bumpcache.go
@@ -1,0 +1,163 @@
+// Package bumpcache is the shared parsed-BUMP cache behind every store
+// backend's EnrichMerklePath. Enrichment runs on every GetStatus of a mined tx
+// and once per subscribed tx during a MINED SSE/webhook fan-out; without a
+// cache each call would re-fetch and re-parse the whole block BUMP — the
+// dominant heap consumer under sustained load. Lookups and fan-out cluster on
+// the few recently-mined blocks in flight, so a small LRU gives a high hit
+// rate. The cache bounds its resident set two ways: an entry cap AND a total
+// PathElement budget, because a single mega-block compound can dwarf any
+// count-based limit (this service has OOM'd inside a 512Mi pod before —
+// #237/#238). Concurrent misses for one block collapse onto a single
+// fetch+parse via singleflight, so a MINED burst hitting the SSE fan-out,
+// webhook workers, and GET /tx handlers at once pays for one parse, not three.
+package bumpcache
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/bsv-blockchain/arcade/bump"
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// maxEntries bounds how many blocks' parsed+indexed compound BUMPs stay
+// resident at once.
+const maxEntries = 16
+
+// maxTotalLeaves bounds the summed PathElement count across every cached
+// entry (~100B resident per element → a ceiling in the tens of MB). When an
+// insert pushes the sum over budget, oldest entries are evicted until it
+// fits — but the newest entry always stays, even alone over budget: a block's
+// fan-out must be able to reuse one parse, and one resident compound is the
+// floor the process pays anyway while serving it.
+const maxTotalLeaves = 512 * 1024
+
+// Cache is a bounded, singleflight-guarded cache of bump.CompoundIndex per
+// block hash. The zero value is not usable; construct with New.
+type Cache struct {
+	group     singleflight.Group
+	maxLeaves int
+
+	// mu guards lru and totalLeaves. The LRU's evict callback adjusts
+	// totalLeaves and runs synchronously inside mutations, so it MUST NOT
+	// take mu itself — every lru call site below already holds it.
+	mu          sync.Mutex
+	lru         *simplelru.LRU[string, *bump.CompoundIndex]
+	totalLeaves int
+}
+
+// New constructs an empty cache with the package's production bounds.
+func New() *Cache {
+	return newWithLimits(maxEntries, maxTotalLeaves)
+}
+
+// newWithLimits is the constructor proper, split out so tests can exercise
+// eviction without building half-million-leaf compounds.
+func newWithLimits(entries, leaves int) *Cache {
+	c := &Cache{maxLeaves: leaves}
+	l, err := simplelru.NewLRU(entries, func(_ string, v *bump.CompoundIndex) {
+		c.totalLeaves -= v.Leaves()
+	})
+	if err != nil {
+		// Unreachable: NewLRU only fails for a non-positive size and every
+		// caller passes a positive constant.
+		panic(err)
+	}
+	c.lru = l
+	return c
+}
+
+// Enrich populates status.MerklePath in place for a MINED/IMMUTABLE status
+// that already carries a BlockHash, extracting the tx's minimal path from the
+// block's cached compound index. It is a no-op when the status is nil, already
+// has a MerklePath, has no BlockHash, is not MINED/IMMUTABLE, or the BUMP
+// cannot be fetched/parsed — best-effort, never a delivery gate. fetch is only
+// invoked on a cache miss and must return the block's raw compound BUMP.
+func (c *Cache) Enrich(status *models.TransactionStatus, fetch func() ([]byte, error)) {
+	if status == nil || len(status.MerklePath) > 0 || status.BlockHash == "" {
+		return
+	}
+	if status.Status != models.StatusMined && status.Status != models.StatusImmutable {
+		return
+	}
+	idx := c.index(status.BlockHash, fetch)
+	if idx == nil {
+		return
+	}
+	status.MerklePath = idx.MinimalPathBytes(status.TxID)
+}
+
+// Remove invalidates a block's cached index. Called by InsertBUMP: a rebuild
+// can overwrite the stored compound for an existing block (e.g. late STUMP
+// callbacks), so the next enrichment must re-fetch and re-parse.
+func (c *Cache) Remove(blockHash string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lru.Remove(blockHash)
+}
+
+// Contains reports whether a block's index is currently cached, without
+// updating recency. Exposed for tests.
+func (c *Cache) Contains(blockHash string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lru.Contains(blockHash)
+}
+
+// index returns the block's compound index, loading it via fetch on a miss.
+// Concurrent misses for the same block share one fetch+parse; every caller
+// gets the same shared, read-only index. Returns nil when the BUMP is
+// unavailable or unparseable (the error is not cached — the next call
+// retries).
+func (c *Cache) index(blockHash string, fetch func() ([]byte, error)) *bump.CompoundIndex {
+	if idx, ok := c.lookup(blockHash); ok {
+		return idx
+	}
+	v, err, _ := c.group.Do(blockHash, func() (any, error) {
+		// Re-check under the flight: a previous leader may have populated
+		// the cache between our miss and joining the group.
+		if idx, ok := c.lookup(blockHash); ok {
+			return idx, nil
+		}
+		data, err := fetch()
+		if err != nil {
+			return nil, err
+		}
+		if len(data) == 0 {
+			return (*bump.CompoundIndex)(nil), nil
+		}
+		idx, err := bump.IndexCompound(data)
+		if err != nil {
+			return nil, err
+		}
+		c.add(blockHash, idx)
+		return idx, nil
+	})
+	if err != nil {
+		return nil
+	}
+	idx, _ := v.(*bump.CompoundIndex)
+	return idx
+}
+
+func (c *Cache) lookup(blockHash string) (*bump.CompoundIndex, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lru.Get(blockHash)
+}
+
+// add inserts an entry and enforces the leaf budget. Replacing an existing
+// key removes it first so the evict callback keeps totalLeaves exact (the
+// LRU's in-place update path skips the callback).
+func (c *Cache) add(blockHash string, idx *bump.CompoundIndex) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lru.Remove(blockHash)
+	c.lru.Add(blockHash, idx)
+	c.totalLeaves += idx.Leaves()
+	for c.totalLeaves > c.maxLeaves && c.lru.Len() > 1 {
+		c.lru.RemoveOldest()
+	}
+}

--- a/store/bumpcache/bumpcache_test.go
+++ b/store/bumpcache/bumpcache_test.go
@@ -1,0 +1,242 @@
+package bumpcache
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bsv-blockchain/arcade/bump"
+	"github.com/bsv-blockchain/arcade/internal/synthblock"
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+const testBlockHash = "0000000000000000000000000000000000000000000000000000000000000abc"
+
+// countingFetch returns a fetch func serving the given BUMP and a counter of
+// how many times it was invoked.
+func countingFetch(data []byte) (func() ([]byte, error), *atomic.Int64) {
+	var calls atomic.Int64
+	return func() ([]byte, error) {
+		calls.Add(1)
+		return data, nil
+	}, &calls
+}
+
+func minedStatus(txid string) *models.TransactionStatus {
+	return &models.TransactionStatus{TxID: txid, Status: models.StatusMined, BlockHash: testBlockHash}
+}
+
+func TestEnrich_PopulatesVerifyingPathAndCaches(t *testing.T) {
+	blk, err := synthblock.Build(8, 900100)
+	if err != nil {
+		t.Fatalf("synthblock.Build: %v", err)
+	}
+	c := New()
+	fetch, calls := countingFetch(blk.BumpBytes)
+
+	for _, txid := range blk.Txids {
+		st := minedStatus(txid)
+		c.Enrich(st, fetch)
+		if len(st.MerklePath) == 0 {
+			t.Fatalf("no merklePath for %s", txid)
+		}
+		if vErr := synthblock.VerifyMerklePath(st.MerklePath, txid, blk.Root); vErr != nil {
+			t.Fatalf("merklePath does not verify for %s: %v", txid, vErr)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("fetch called %d times for one block, want 1", got)
+	}
+	if !c.Contains(testBlockHash) {
+		t.Fatal("block should be cached after enrichment")
+	}
+
+	// Remove invalidates: the next enrichment re-fetches.
+	c.Remove(testBlockHash)
+	if c.Contains(testBlockHash) {
+		t.Fatal("Remove must drop the cached entry")
+	}
+	c.Enrich(minedStatus(blk.Txids[0]), fetch)
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("fetch called %d times after Remove, want 2", got)
+	}
+}
+
+func TestEnrich_GuardsAreNoOps(t *testing.T) {
+	c := New()
+	fetch := func() ([]byte, error) {
+		t.Fatal("fetch must not be called for guarded statuses")
+		return nil, nil
+	}
+
+	c.Enrich(nil, fetch)
+	c.Enrich(&models.TransactionStatus{TxID: "a", Status: models.StatusMined}, fetch) // no BlockHash
+	c.Enrich(&models.TransactionStatus{TxID: "a", Status: models.StatusSeenOnNetwork, BlockHash: testBlockHash}, fetch)
+	c.Enrich(&models.TransactionStatus{TxID: "a", Status: models.StatusMined, BlockHash: testBlockHash, MerklePath: []byte{1}}, fetch)
+}
+
+func TestEnrich_FetchErrorIsBestEffortAndRetried(t *testing.T) {
+	blk, err := synthblock.Build(4, 900101)
+	if err != nil {
+		t.Fatalf("synthblock.Build: %v", err)
+	}
+	c := New()
+	var calls atomic.Int64
+	fail := errors.New("backend down")
+	fetch := func() ([]byte, error) {
+		if calls.Add(1) == 1 {
+			return nil, fail
+		}
+		return blk.BumpBytes, nil
+	}
+
+	st := minedStatus(blk.Txids[0])
+	c.Enrich(st, fetch)
+	if len(st.MerklePath) != 0 {
+		t.Fatal("failed fetch must leave the status unenriched")
+	}
+	if c.Contains(testBlockHash) {
+		t.Fatal("errors must not be cached")
+	}
+
+	c.Enrich(st, fetch)
+	if len(st.MerklePath) == 0 {
+		t.Fatal("second enrichment should succeed once the backend recovers")
+	}
+}
+
+func TestEnrich_ConcurrentMissesShareOneFetch(t *testing.T) {
+	blk, err := synthblock.Build(16, 900102)
+	if err != nil {
+		t.Fatalf("synthblock.Build: %v", err)
+	}
+	c := New()
+
+	var calls atomic.Int64
+	gate := make(chan struct{})
+	fetch := func() ([]byte, error) {
+		calls.Add(1)
+		<-gate // hold the flight open until every goroutine has joined
+		return blk.BumpBytes, nil
+	}
+
+	const workers = 16
+	var started, done sync.WaitGroup
+	started.Add(workers)
+	done.Add(workers)
+	statuses := make([]*models.TransactionStatus, workers)
+	for i := 0; i < workers; i++ {
+		statuses[i] = minedStatus(blk.Txids[i])
+		go func(st *models.TransactionStatus) {
+			defer done.Done()
+			started.Done()
+			c.Enrich(st, fetch)
+		}(statuses[i])
+	}
+	started.Wait()
+	close(gate)
+	done.Wait()
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("fetch called %d times under concurrent misses, want 1 (singleflight)", got)
+	}
+	for i, st := range statuses {
+		if len(st.MerklePath) == 0 {
+			t.Fatalf("worker %d not enriched", i)
+		}
+		if vErr := synthblock.VerifyMerklePath(st.MerklePath, blk.Txids[i], blk.Root); vErr != nil {
+			t.Fatalf("worker %d path does not verify: %v", i, vErr)
+		}
+	}
+}
+
+func TestLeafBudget_EvictsOldestButKeepsNewest(t *testing.T) {
+	// Three 8-tx blocks; budget only fits one block's leaves, so each insert
+	// evicts the previous entry but the newest always stays resident.
+	blkA, err := synthblock.Build(8, 900103)
+	if err != nil {
+		t.Fatalf("Build A: %v", err)
+	}
+	blkB, err := synthblock.Build(8, 900104)
+	if err != nil {
+		t.Fatalf("Build B: %v", err)
+	}
+
+	hashA := "00000000000000000000000000000000000000000000000000000000000000aa"
+	hashB := "00000000000000000000000000000000000000000000000000000000000000bb"
+
+	c := newWithLimits(16, 1) // 1-leaf budget: any real compound exceeds it alone
+
+	stA := &models.TransactionStatus{TxID: blkA.Txids[0], Status: models.StatusMined, BlockHash: hashA}
+	fetchA, _ := countingFetch(blkA.BumpBytes)
+	c.Enrich(stA, fetchA)
+	if len(stA.MerklePath) == 0 {
+		t.Fatal("A not enriched")
+	}
+	if !c.Contains(hashA) {
+		t.Fatal("newest entry must stay cached even when alone over budget")
+	}
+
+	stB := &models.TransactionStatus{TxID: blkB.Txids[0], Status: models.StatusMined, BlockHash: hashB}
+	fetchB, _ := countingFetch(blkB.BumpBytes)
+	c.Enrich(stB, fetchB)
+	if c.Contains(hashA) {
+		t.Fatal("over-budget insert must evict the older entry")
+	}
+	if !c.Contains(hashB) {
+		t.Fatal("newest entry must survive the budget sweep")
+	}
+
+	c.mu.Lock()
+	total, entries := c.totalLeaves, c.lru.Len()
+	c.mu.Unlock()
+	if entries != 1 {
+		t.Fatalf("want 1 resident entry, got %d", entries)
+	}
+	if want := idxLeaves(t, blkB.BumpBytes); total != want {
+		t.Fatalf("leaf accounting drifted: total=%d want=%d", total, want)
+	}
+}
+
+func TestEntryCap_EvictsAndKeepsAccountingExact(t *testing.T) {
+	c := newWithLimits(2, 1<<20)
+	hashes := []string{
+		"0000000000000000000000000000000000000000000000000000000000000001",
+		"0000000000000000000000000000000000000000000000000000000000000002",
+		"0000000000000000000000000000000000000000000000000000000000000003",
+	}
+	var perBlockLeaves int
+	for i, h := range hashes {
+		blk, err := synthblock.Build(4, uint64(900110+i))
+		if err != nil {
+			t.Fatalf("Build %d: %v", i, err)
+		}
+		perBlockLeaves = idxLeaves(t, blk.BumpBytes)
+		st := &models.TransactionStatus{TxID: blk.Txids[0], Status: models.StatusMined, BlockHash: h}
+		fetch, _ := countingFetch(blk.BumpBytes)
+		c.Enrich(st, fetch)
+	}
+	if c.Contains(hashes[0]) {
+		t.Fatal("entry cap must evict the oldest block")
+	}
+	if !c.Contains(hashes[1]) || !c.Contains(hashes[2]) {
+		t.Fatal("newer blocks must remain")
+	}
+	c.mu.Lock()
+	total := c.totalLeaves
+	c.mu.Unlock()
+	if want := 2 * perBlockLeaves; total != want {
+		t.Fatalf("leaf accounting drifted after cap eviction: total=%d want=%d", total, want)
+	}
+}
+
+// idxLeaves parses a BUMP and reports its indexed leaf count.
+func idxLeaves(t *testing.T, bumpBytes []byte) int {
+	t.Helper()
+	idx, err := bump.IndexCompound(bumpBytes)
+	if err != nil {
+		t.Fatalf("IndexCompound: %v", err)
+	}
+	return idx.Leaves()
+}

--- a/store/pebble/merklepath_test.go
+++ b/store/pebble/merklepath_test.go
@@ -1,0 +1,77 @@
+package pebble
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/arcade/internal/synthblock"
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+const mpTestBlockHash = "00000000000000000000000000000000000000000000000000000000000000ff"
+
+// TestEnrichMerklePath_VerifiesAndCaches exercises the push-path enrichment
+// primitive: every mined tx gets a merkle proof that recomputes the block root,
+// repeated enrichment for one block is served from the parsed-BUMP cache, and
+// InsertBUMP invalidates that cache. Guards also confirm the best-effort no-ops.
+func TestEnrichMerklePath_VerifiesAndCaches(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	blk, err := synthblock.Build(8, 900001)
+	if err != nil {
+		t.Fatalf("synthblock.Build: %v", err)
+	}
+	for _, txid := range blk.Txids {
+		if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+			TxID: txid, Status: models.StatusSeenOnNetwork, Timestamp: time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("seed %s: %v", txid, err)
+		}
+	}
+	if _, _, err := s.SetMinedByTxIDs(ctx, mpTestBlockHash, 900001, blk.Txids); err != nil {
+		t.Fatalf("SetMinedByTxIDs: %v", err)
+	}
+	if err := s.InsertBUMP(ctx, mpTestBlockHash, 900001, blk.BumpBytes); err != nil {
+		t.Fatalf("InsertBUMP: %v", err)
+	}
+
+	// Every mined tx enriches to a verifying proof.
+	for _, txid := range blk.Txids {
+		st := &models.TransactionStatus{TxID: txid, Status: models.StatusMined, BlockHash: mpTestBlockHash}
+		s.EnrichMerklePath(ctx, st)
+		if len(st.MerklePath) == 0 {
+			t.Fatalf("no merklePath for %s", txid)
+		}
+		if err := synthblock.VerifyMerklePath(st.MerklePath, txid, blk.Root); err != nil {
+			t.Fatalf("enriched merklePath does not verify for %s: %v", txid, err)
+		}
+	}
+
+	// The block's parsed compound is cached after enrichment...
+	if !s.bumpCache.Contains(mpTestBlockHash) {
+		t.Fatal("expected block to be cached after enrichment")
+	}
+	// ...and re-inserting the BUMP invalidates it.
+	if err := s.InsertBUMP(ctx, mpTestBlockHash, 900001, blk.BumpBytes); err != nil {
+		t.Fatalf("re-InsertBUMP: %v", err)
+	}
+	if s.bumpCache.Contains(mpTestBlockHash) {
+		t.Fatal("InsertBUMP must invalidate the cached compound")
+	}
+
+	// Guard: non-mined status is a no-op.
+	seen := &models.TransactionStatus{TxID: blk.Txids[0], Status: models.StatusSeenOnNetwork, BlockHash: mpTestBlockHash}
+	s.EnrichMerklePath(ctx, seen)
+	if len(seen.MerklePath) != 0 {
+		t.Fatal("non-mined status must not be enriched")
+	}
+
+	// Guard: unknown block is a best-effort no-op (no panic, no path).
+	missing := &models.TransactionStatus{TxID: blk.Txids[0], Status: models.StatusMined, BlockHash: "00000000000000000000000000000000000000000000000000000000deadbeef"}
+	s.EnrichMerklePath(ctx, missing)
+	if len(missing.MerklePath) != 0 {
+		t.Fatal("unknown block must yield no merklePath")
+	}
+}

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -23,16 +23,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bsv-blockchain/go-sdk/chainhash"
-	"github.com/bsv-blockchain/go-sdk/transaction"
 	pebbledb "github.com/cockroachdb/pebble"
-	lru "github.com/hashicorp/golang-lru/v2"
 
-	"github.com/bsv-blockchain/arcade/bump"
 	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/store"
+	"github.com/bsv-blockchain/arcade/store/bumpcache"
 )
 
 // getOrInsertShards serializes GetOrInsertStatus per-txid so concurrent
@@ -41,34 +38,19 @@ import (
 // contention cheap.
 const getOrInsertShards = 64
 
-// bumpCacheSize bounds how many parsed+indexed compound BUMPs the store keeps
-// resident for merkle-path enrichment. enrichMerklePath runs on every GetStatus
-// of a mined tx and once per subscribed tx during a MINED fan-out; without a
-// cache each call re-fetches and re-parses the whole block BUMP. Lookups and
-// fan-out cluster on the few recently-mined blocks in flight, so a small LRU
-// gives a high hit rate while bounding the resident set to bumpCacheSize sparse
-// compounds plus their level-0 offset indexes.
-const bumpCacheSize = 16
-
 var (
 	_ store.Store  = (*Store)(nil)
 	_ store.Leaser = (*Store)(nil)
 )
-
-// cachedBUMP is one block's parsed compound BUMP plus its level-0 txid→offset
-// index, so per-tx path extraction is a map lookup + ExtractMinimalPath rather
-// than a re-parse and a level-0 hash scan.
-type cachedBUMP struct {
-	compound *transaction.MerklePath
-	offsets  map[chainhash.Hash]uint64
-}
 
 // Store is a Pebble-backed implementation of store.Store and store.Leaser.
 type Store struct {
 	db        *pebbledb.DB
 	writeOpts *pebbledb.WriteOptions
 	cfg       config.Pebble
-	bumpCache *lru.Cache[string, *cachedBUMP]
+	// bumpCache holds parsed+indexed compound BUMPs for merkle-path
+	// enrichment — sizing, budget, and singleflight live in bumpcache.
+	bumpCache *bumpcache.Cache
 	insertMu  [getOrInsertShards]sync.Mutex
 	leaseMu   sync.Mutex
 	// submissionMu serializes the read-modify-write sequence in
@@ -221,17 +203,11 @@ func New(cfg config.Pebble) (*Store, error) {
 		return nil, fmt.Errorf("open pebble at %s: %w", cfg.Path, err)
 	}
 
-	bumpCache, err := lru.New[string, *cachedBUMP](bumpCacheSize)
-	if err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("init bump cache: %w", err)
-	}
-
 	return &Store{
 		db:        db,
 		writeOpts: &pebbledb.WriteOptions{Sync: cfg.SyncWrites},
 		cfg:       cfg,
-		bumpCache: bumpCache,
+		bumpCache: bumpcache.New(),
 	}, nil
 }
 
@@ -1927,43 +1903,8 @@ func (s *Store) EnrichMerklePath(ctx context.Context, status *models.Transaction
 // enrichMerklePath attaches the per-tx minimal merkle path for mined/immutable
 // rows, extracting it from the block's cached, indexed compound BUMP.
 func (s *Store) enrichMerklePath(ctx context.Context, status *models.TransactionStatus) {
-	if status == nil || len(status.MerklePath) > 0 || status.BlockHash == "" {
-		return
-	}
-	if status.Status != models.StatusMined && status.Status != models.StatusImmutable {
-		return
-	}
-	entry := s.compoundBUMP(ctx, status.BlockHash)
-	if entry == nil {
-		return
-	}
-	txHash, err := chainhash.NewHashFromHex(status.TxID)
-	if err != nil {
-		return
-	}
-	offset, ok := entry.offsets[*txHash]
-	if !ok {
-		return
-	}
-	status.MerklePath = bump.ExtractMinimalPath(entry.compound, offset).Bytes()
-}
-
-// compoundBUMP returns the parsed+indexed compound BUMP for a block, caching it
-// so repeated enrichment for txs in the same block reuses the parse and the
-// level-0 offset index. The returned value is shared and read-only.
-func (s *Store) compoundBUMP(ctx context.Context, blockHash string) *cachedBUMP {
-	if c, ok := s.bumpCache.Get(blockHash); ok {
-		return c
-	}
-	_, bumpData, err := s.GetBUMP(ctx, blockHash)
-	if err != nil || len(bumpData) == 0 {
-		return nil
-	}
-	compound, offsets, err := bump.IndexCompound(bumpData)
-	if err != nil {
-		return nil
-	}
-	entry := &cachedBUMP{compound: compound, offsets: offsets}
-	s.bumpCache.Add(blockHash, entry)
-	return entry
+	s.bumpCache.Enrich(status, func() ([]byte, error) {
+		_, bumpData, err := s.GetBUMP(ctx, status.BlockHash)
+		return bumpData, err
+	})
 }

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -26,7 +26,9 @@ import (
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/transaction"
 	pebbledb "github.com/cockroachdb/pebble"
+	lru "github.com/hashicorp/golang-lru/v2"
 
+	"github.com/bsv-blockchain/arcade/bump"
 	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
@@ -39,16 +41,34 @@ import (
 // contention cheap.
 const getOrInsertShards = 64
 
+// bumpCacheSize bounds how many parsed+indexed compound BUMPs the store keeps
+// resident for merkle-path enrichment. enrichMerklePath runs on every GetStatus
+// of a mined tx and once per subscribed tx during a MINED fan-out; without a
+// cache each call re-fetches and re-parses the whole block BUMP. Lookups and
+// fan-out cluster on the few recently-mined blocks in flight, so a small LRU
+// gives a high hit rate while bounding the resident set to bumpCacheSize sparse
+// compounds plus their level-0 offset indexes.
+const bumpCacheSize = 16
+
 var (
 	_ store.Store  = (*Store)(nil)
 	_ store.Leaser = (*Store)(nil)
 )
+
+// cachedBUMP is one block's parsed compound BUMP plus its level-0 txid→offset
+// index, so per-tx path extraction is a map lookup + ExtractMinimalPath rather
+// than a re-parse and a level-0 hash scan.
+type cachedBUMP struct {
+	compound *transaction.MerklePath
+	offsets  map[chainhash.Hash]uint64
+}
 
 // Store is a Pebble-backed implementation of store.Store and store.Leaser.
 type Store struct {
 	db        *pebbledb.DB
 	writeOpts *pebbledb.WriteOptions
 	cfg       config.Pebble
+	bumpCache *lru.Cache[string, *cachedBUMP]
 	insertMu  [getOrInsertShards]sync.Mutex
 	leaseMu   sync.Mutex
 	// submissionMu serializes the read-modify-write sequence in
@@ -201,10 +221,17 @@ func New(cfg config.Pebble) (*Store, error) {
 		return nil, fmt.Errorf("open pebble at %s: %w", cfg.Path, err)
 	}
 
+	bumpCache, err := lru.New[string, *cachedBUMP](bumpCacheSize)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("init bump cache: %w", err)
+	}
+
 	return &Store{
 		db:        db,
 		writeOpts: &pebbledb.WriteOptions{Sync: cfg.SyncWrites},
 		cfg:       cfg,
+		bumpCache: bumpCache,
 	}, nil
 }
 
@@ -978,7 +1005,14 @@ func (s *Store) InsertBUMP(ctx context.Context, blockHash string, blockHeight ui
 	if err != nil {
 		return err
 	}
-	return s.db.Set(bumpKey(blockHash), payload, s.writeOpts)
+	if err := s.db.Set(bumpKey(blockHash), payload, s.writeOpts); err != nil {
+		return err
+	}
+	// A rebuild can overwrite bump_data for an existing block (e.g. late STUMP
+	// callbacks produce a more complete sparse compound). Drop any cached parse
+	// so the next enrichment re-fetches the current stored BUMP.
+	s.bumpCache.Remove(blockHash)
+	return nil
 }
 
 func (s *Store) GetBUMP(ctx context.Context, blockHash string) (uint64, []byte, error) {
@@ -1882,8 +1916,16 @@ func (s *Store) ListDatahubEndpoints(ctx context.Context, network string) ([]sto
 
 // --- Helpers ---
 
+// EnrichMerklePath implements store.Store: it populates status.MerklePath in
+// place for a mined/immutable status carrying a BlockHash, extracting the tx's
+// minimal path from the block's compound BUMP. Best-effort — see the interface
+// doc. Delegates to the same enrichMerklePath used by GetStatus.
+func (s *Store) EnrichMerklePath(ctx context.Context, status *models.TransactionStatus) {
+	s.enrichMerklePath(ctx, status)
+}
+
 // enrichMerklePath attaches the per-tx minimal merkle path for mined/immutable
-// rows, extracting it from the compound BUMP. Matches the Aerospike behavior.
+// rows, extracting it from the block's cached, indexed compound BUMP.
 func (s *Store) enrichMerklePath(ctx context.Context, status *models.TransactionStatus) {
 	if status == nil || len(status.MerklePath) > 0 || status.BlockHash == "" {
 		return
@@ -1891,60 +1933,37 @@ func (s *Store) enrichMerklePath(ctx context.Context, status *models.Transaction
 	if status.Status != models.StatusMined && status.Status != models.StatusImmutable {
 		return
 	}
-	_, bumpData, err := s.GetBUMP(ctx, status.BlockHash)
-	if err != nil || len(bumpData) == 0 {
+	entry := s.compoundBUMP(ctx, status.BlockHash)
+	if entry == nil {
 		return
 	}
-	status.MerklePath = extractMinimalPathForTx(bumpData, status.TxID)
+	txHash, err := chainhash.NewHashFromHex(status.TxID)
+	if err != nil {
+		return
+	}
+	offset, ok := entry.offsets[*txHash]
+	if !ok {
+		return
+	}
+	status.MerklePath = bump.ExtractMinimalPath(entry.compound, offset).Bytes()
 }
 
-func extractMinimalPathForTx(bumpData []byte, txid string) []byte {
-	compound, err := transaction.NewMerklePathFromBinary(bumpData)
+// compoundBUMP returns the parsed+indexed compound BUMP for a block, caching it
+// so repeated enrichment for txs in the same block reuses the parse and the
+// level-0 offset index. The returned value is shared and read-only.
+func (s *Store) compoundBUMP(ctx context.Context, blockHash string) *cachedBUMP {
+	if c, ok := s.bumpCache.Get(blockHash); ok {
+		return c
+	}
+	_, bumpData, err := s.GetBUMP(ctx, blockHash)
+	if err != nil || len(bumpData) == 0 {
+		return nil
+	}
+	compound, offsets, err := bump.IndexCompound(bumpData)
 	if err != nil {
 		return nil
 	}
-	txHash, err := chainhash.NewHashFromHex(txid)
-	if err != nil {
-		return nil
-	}
-
-	var txOffset uint64
-	found := false
-	if len(compound.Path) > 0 {
-		for _, leaf := range compound.Path[0] {
-			if leaf.Hash != nil && *leaf.Hash == *txHash {
-				txOffset = leaf.Offset
-				found = true
-				break
-			}
-		}
-	}
-	if !found {
-		return nil
-	}
-
-	mp := &transaction.MerklePath{
-		BlockHeight: compound.BlockHeight,
-		Path:        make([][]*transaction.PathElement, len(compound.Path)),
-	}
-	offset := txOffset
-	for level := 0; level < len(compound.Path); level++ {
-		if level == 0 {
-			for _, leaf := range compound.Path[level] {
-				if leaf.Offset == offset {
-					mp.Path[level] = append(mp.Path[level], leaf)
-					break
-				}
-			}
-		}
-		sibOffset := offset ^ 1
-		for _, leaf := range compound.Path[level] {
-			if leaf.Offset == sibOffset {
-				mp.Path[level] = append(mp.Path[level], leaf)
-				break
-			}
-		}
-		offset = offset >> 1
-	}
-	return mp.Bytes()
+	entry := &cachedBUMP{compound: compound, offsets: offsets}
+	s.bumpCache.Add(blockHash, entry)
+	return entry
 }

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/bsv-blockchain/arcade/bump"
 	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/store"
@@ -42,17 +43,27 @@ var (
 // Store is the Postgres-backed implementation of the store interfaces.
 // bumpCacheSize bounds how many parsed compound BUMPs the store keeps
 // resident for merkle-path enrichment. enrichMerklePath runs on every
-// GetStatus of a mined tx and would otherwise re-fetch and re-parse the
-// whole block BUMP on each call — the dominant heap consumer under
-// sustained status-lookup load. Status lookups cluster on recently-mined
-// blocks, so a small LRU gives a
-// high hit rate while keeping the resident set bounded.
-const bumpCacheSize = 8
+// GetStatus of a mined tx — and, since push-path enrichment was added, once
+// per subscribed tx during a MINED fan-out — and would otherwise re-fetch and
+// re-parse the whole block BUMP on each call, the dominant heap consumer under
+// sustained load. Status lookups and fan-out both cluster on the handful of
+// recently-mined blocks in flight, so a small LRU gives a high hit rate while
+// keeping the resident set bounded to bumpCacheSize sparse compounds (tracked
+// txs only) plus their level-0 offset indexes.
+const bumpCacheSize = 16
+
+// cachedBUMP is one block's parsed compound BUMP plus its level-0 txid→offset
+// index, so per-tx path extraction is a map lookup + ExtractMinimalPath rather
+// than a re-parse and a level-0 hash scan.
+type cachedBUMP struct {
+	compound *transaction.MerklePath
+	offsets  map[chainhash.Hash]uint64
+}
 
 type Store struct {
 	pool      *pgxpool.Pool
 	stopEmb   func() error
-	bumpCache *lru.Cache[string, *transaction.MerklePath]
+	bumpCache *lru.Cache[string, *cachedBUMP]
 }
 
 // New connects to Postgres (optionally starting the embedded-postgres process
@@ -89,7 +100,7 @@ func New(ctx context.Context, cfg config.Postgres) (*Store, error) {
 		return nil, fmt.Errorf("connect postgres: %w", err)
 	}
 
-	bumpCache, err := lru.New[string, *transaction.MerklePath](bumpCacheSize)
+	bumpCache, err := lru.New[string, *cachedBUMP](bumpCacheSize)
 	if err != nil {
 		pool.Close()
 		if stopEmbedded != nil {
@@ -1484,10 +1495,16 @@ func scanStatus(row rowScanner) (*models.TransactionStatus, error) {
 	return &st, nil
 }
 
+// EnrichMerklePath implements store.Store: it populates status.MerklePath in
+// place for a mined/immutable status carrying a BlockHash, extracting the tx's
+// minimal path from the block's compound BUMP. Best-effort — see the interface
+// doc. Delegates to the same enrichMerklePath used by GetStatus.
+func (s *Store) EnrichMerklePath(ctx context.Context, status *models.TransactionStatus) {
+	s.enrichMerklePath(ctx, status)
+}
+
 // enrichMerklePath attaches the per-tx minimal merkle path for mined/immutable
-// rows, extracting it from the compound BUMP. Matches aerospike/pebble — the
-// extraction is duplicated across backends so each store package stays
-// self-contained.
+// rows, extracting it from the block's cached, indexed compound BUMP.
 func (s *Store) enrichMerklePath(ctx context.Context, status *models.TransactionStatus) {
 	if status == nil || len(status.MerklePath) > 0 || status.BlockHash == "" {
 		return
@@ -1495,18 +1512,26 @@ func (s *Store) enrichMerklePath(ctx context.Context, status *models.Transaction
 	if status.Status != models.StatusMined && status.Status != models.StatusImmutable {
 		return
 	}
-	compound := s.compoundBUMP(ctx, status.BlockHash)
-	if compound == nil {
+	entry := s.compoundBUMP(ctx, status.BlockHash)
+	if entry == nil {
 		return
 	}
-	status.MerklePath = extractMinimalPathForTx(compound, status.TxID)
+	txHash, err := chainhash.NewHashFromHex(status.TxID)
+	if err != nil {
+		return
+	}
+	offset, ok := entry.offsets[*txHash]
+	if !ok {
+		return
+	}
+	status.MerklePath = bump.ExtractMinimalPath(entry.compound, offset).Bytes()
 }
 
-// compoundBUMP returns the parsed compound BUMP for a block, caching the
-// parsed form so repeated status lookups for txs in the same block reuse
-// it instead of re-fetching and re-parsing the (potentially large) BUMP.
-// The returned value is shared and must be treated as read-only.
-func (s *Store) compoundBUMP(ctx context.Context, blockHash string) *transaction.MerklePath {
+// compoundBUMP returns the parsed+indexed compound BUMP for a block, caching it
+// so repeated enrichment for txs in the same block reuses the parse and the
+// level-0 offset index instead of re-fetching, re-parsing, and rescanning the
+// (potentially large) BUMP. The returned value is shared and read-only.
+func (s *Store) compoundBUMP(ctx context.Context, blockHash string) *cachedBUMP {
 	if c, ok := s.bumpCache.Get(blockHash); ok {
 		return c
 	}
@@ -1514,60 +1539,11 @@ func (s *Store) compoundBUMP(ctx context.Context, blockHash string) *transaction
 	if err != nil || len(bumpData) == 0 {
 		return nil
 	}
-	compound, err := transaction.NewMerklePathFromBinary(bumpData)
+	compound, offsets, err := bump.IndexCompound(bumpData)
 	if err != nil {
 		return nil
 	}
-	s.bumpCache.Add(blockHash, compound)
-	return compound
-}
-
-// extractMinimalPathForTx extracts a per-tx minimal merkle path from an
-// already-parsed compound BUMP. compound is shared via the store's bump
-// cache, so this only reads from it and builds a fresh MerklePath result.
-func extractMinimalPathForTx(compound *transaction.MerklePath, txid string) []byte {
-	txHash, err := chainhash.NewHashFromHex(txid)
-	if err != nil {
-		return nil
-	}
-
-	var txOffset uint64
-	found := false
-	if len(compound.Path) > 0 {
-		for _, leaf := range compound.Path[0] {
-			if leaf.Hash != nil && *leaf.Hash == *txHash {
-				txOffset = leaf.Offset
-				found = true
-				break
-			}
-		}
-	}
-	if !found {
-		return nil
-	}
-
-	mp := &transaction.MerklePath{
-		BlockHeight: compound.BlockHeight,
-		Path:        make([][]*transaction.PathElement, len(compound.Path)),
-	}
-	offset := txOffset
-	for level := 0; level < len(compound.Path); level++ {
-		if level == 0 {
-			for _, leaf := range compound.Path[level] {
-				if leaf.Offset == offset {
-					mp.Path[level] = append(mp.Path[level], leaf)
-					break
-				}
-			}
-		}
-		sibOffset := offset ^ 1
-		for _, leaf := range compound.Path[level] {
-			if leaf.Offset == sibOffset {
-				mp.Path[level] = append(mp.Path[level], leaf)
-				break
-			}
-		}
-		offset = offset >> 1
-	}
-	return mp.Bytes()
+	entry := &cachedBUMP{compound: compound, offsets: offsets}
+	s.bumpCache.Add(blockHash, entry)
+	return entry
 }

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -20,16 +20,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bsv-blockchain/go-sdk/chainhash"
-	"github.com/bsv-blockchain/go-sdk/transaction"
-	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"github.com/bsv-blockchain/arcade/bump"
 	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/store"
+	"github.com/bsv-blockchain/arcade/store/bumpcache"
 )
 
 //go:embed schema.sql
@@ -41,29 +38,12 @@ var (
 )
 
 // Store is the Postgres-backed implementation of the store interfaces.
-// bumpCacheSize bounds how many parsed compound BUMPs the store keeps
-// resident for merkle-path enrichment. enrichMerklePath runs on every
-// GetStatus of a mined tx — and, since push-path enrichment was added, once
-// per subscribed tx during a MINED fan-out — and would otherwise re-fetch and
-// re-parse the whole block BUMP on each call, the dominant heap consumer under
-// sustained load. Status lookups and fan-out both cluster on the handful of
-// recently-mined blocks in flight, so a small LRU gives a high hit rate while
-// keeping the resident set bounded to bumpCacheSize sparse compounds (tracked
-// txs only) plus their level-0 offset indexes.
-const bumpCacheSize = 16
-
-// cachedBUMP is one block's parsed compound BUMP plus its level-0 txid→offset
-// index, so per-tx path extraction is a map lookup + ExtractMinimalPath rather
-// than a re-parse and a level-0 hash scan.
-type cachedBUMP struct {
-	compound *transaction.MerklePath
-	offsets  map[chainhash.Hash]uint64
-}
-
 type Store struct {
-	pool      *pgxpool.Pool
-	stopEmb   func() error
-	bumpCache *lru.Cache[string, *cachedBUMP]
+	pool    *pgxpool.Pool
+	stopEmb func() error
+	// bumpCache holds parsed+indexed compound BUMPs for merkle-path
+	// enrichment — sizing, budget, and singleflight live in bumpcache.
+	bumpCache *bumpcache.Cache
 }
 
 // New connects to Postgres (optionally starting the embedded-postgres process
@@ -100,16 +80,7 @@ func New(ctx context.Context, cfg config.Postgres) (*Store, error) {
 		return nil, fmt.Errorf("connect postgres: %w", err)
 	}
 
-	bumpCache, err := lru.New[string, *cachedBUMP](bumpCacheSize)
-	if err != nil {
-		pool.Close()
-		if stopEmbedded != nil {
-			_ = stopEmbedded()
-		}
-		return nil, fmt.Errorf("init bump cache: %w", err)
-	}
-
-	return &Store{pool: pool, stopEmb: stopEmbedded, bumpCache: bumpCache}, nil
+	return &Store{pool: pool, stopEmb: stopEmbedded, bumpCache: bumpcache.New()}, nil
 }
 
 // EnsureIndexes applies the schema. Safe to call repeatedly — every CREATE
@@ -1506,44 +1477,8 @@ func (s *Store) EnrichMerklePath(ctx context.Context, status *models.Transaction
 // enrichMerklePath attaches the per-tx minimal merkle path for mined/immutable
 // rows, extracting it from the block's cached, indexed compound BUMP.
 func (s *Store) enrichMerklePath(ctx context.Context, status *models.TransactionStatus) {
-	if status == nil || len(status.MerklePath) > 0 || status.BlockHash == "" {
-		return
-	}
-	if status.Status != models.StatusMined && status.Status != models.StatusImmutable {
-		return
-	}
-	entry := s.compoundBUMP(ctx, status.BlockHash)
-	if entry == nil {
-		return
-	}
-	txHash, err := chainhash.NewHashFromHex(status.TxID)
-	if err != nil {
-		return
-	}
-	offset, ok := entry.offsets[*txHash]
-	if !ok {
-		return
-	}
-	status.MerklePath = bump.ExtractMinimalPath(entry.compound, offset).Bytes()
-}
-
-// compoundBUMP returns the parsed+indexed compound BUMP for a block, caching it
-// so repeated enrichment for txs in the same block reuses the parse and the
-// level-0 offset index instead of re-fetching, re-parsing, and rescanning the
-// (potentially large) BUMP. The returned value is shared and read-only.
-func (s *Store) compoundBUMP(ctx context.Context, blockHash string) *cachedBUMP {
-	if c, ok := s.bumpCache.Get(blockHash); ok {
-		return c
-	}
-	_, bumpData, err := s.GetBUMP(ctx, blockHash)
-	if err != nil || len(bumpData) == 0 {
-		return nil
-	}
-	compound, offsets, err := bump.IndexCompound(bumpData)
-	if err != nil {
-		return nil
-	}
-	entry := &cachedBUMP{compound: compound, offsets: offsets}
-	s.bumpCache.Add(blockHash, entry)
-	return entry
+	s.bumpCache.Enrich(status, func() ([]byte, error) {
+		_, bumpData, err := s.GetBUMP(ctx, status.BlockHash)
+		return bumpData, err
+	})
 }

--- a/store/store.go
+++ b/store/store.go
@@ -101,6 +101,19 @@ type Store interface {
 	// GetStatus retrieves the status for a transaction
 	GetStatus(ctx context.Context, txid string) (*models.TransactionStatus, error)
 
+	// EnrichMerklePath populates status.MerklePath in place for a MINED/IMMUTABLE
+	// status that already carries a BlockHash, extracting the transaction's
+	// minimal merkle path from the block's compound BUMP. It is a no-op when the
+	// status is nil, already has a MerklePath, has no BlockHash, is not
+	// MINED/IMMUTABLE, or the block's BUMP cannot be retrieved/parsed — so callers
+	// on push paths can invoke it unconditionally and treat the proof as
+	// best-effort (never a delivery gate). Safe to call repeatedly across all the
+	// txids of one block: implementations cache the parsed compound BUMP and its
+	// txid→offset index per block, so per-tx enrichment is O(tree depth), not a
+	// re-parse. Unlike GetStatus this does not read the full row (no RawTx), which
+	// keeps it cheap enough for the SSE/webhook fan-out hot path.
+	EnrichMerklePath(ctx context.Context, status *models.TransactionStatus)
+
 	// GetStatusesSince retrieves all transactions updated since a given timestamp
 	GetStatusesSince(ctx context.Context, since time.Time) ([]*models.TransactionStatus, error)
 

--- a/store/store.go
+++ b/store/store.go
@@ -108,10 +108,11 @@ type Store interface {
 	// MINED/IMMUTABLE, or the block's BUMP cannot be retrieved/parsed — so callers
 	// on push paths can invoke it unconditionally and treat the proof as
 	// best-effort (never a delivery gate). Safe to call repeatedly across all the
-	// txids of one block: implementations cache the parsed compound BUMP and its
-	// txid→offset index per block, so per-tx enrichment is O(tree depth), not a
-	// re-parse. Unlike GetStatus this does not read the full row (no RawTx), which
-	// keeps it cheap enough for the SSE/webhook fan-out hot path.
+	// txids of one block: implementations share the bounded bumpcache of parsed,
+	// indexed compound BUMPs (see store/bumpcache), so per-tx enrichment is
+	// O(tree depth · log level-size), not a re-parse. Unlike GetStatus this does
+	// not read the full row (no RawTx), which keeps it cheap enough for the
+	// SSE/webhook fan-out hot path.
 	EnrichMerklePath(ctx context.Context, status *models.TransactionStatus)
 
 	// GetStatusesSince retrieves all transactions updated since a given timestamp


### PR DESCRIPTION
## Summary

The merkle proof (`merklePath`) was retrievable **only** via `GET /tx/:txid` — neither push channel delivered it. The bulk MINED event `bump_builder` publishes carries no per-tx path, the webhook forwarded it as-is (blockHash/blockHeight but no proof), and SSE hard-projected frames to `txid`/`txStatus`/`timestamp`. Push-only clients — and ARC migrators, whose callbacks embedded the proof — had to poll `GET` to recover it.

This delivers the proof on **all** MINED (and IMMUTABLE) push updates: live webhook callbacks, live SSE frames, webhook redeliveries, and SSE reconnect replays — matching `GET /tx/:txid`. Fixes #258.

Enrichment happens lazily at each consuming service, reusing the compound BUMP the store already persists, so the Kafka event stays small.

## Changes

- **store**: new `EnrichMerklePath` on the `Store` interface — best-effort, in-place, a no-op unless MINED/IMMUTABLE with a `BlockHash` and a retrievable BUMP (so it never gates delivery). All three backends delegate to one shared cache, new package `store/bumpcache` (replaces Postgres's private parse cache; invalidated on `InsertBUMP`), which holds a `bump.CompoundIndex` per block: level-0 txid→offset map plus every level offset-sorted for binary search, so per-tx extraction is O(depth·log level-size) — genuinely so, not the O(level-size) linear `findLeafByOffset` scans (65k-tx block: 2.6s → 86ms to enrich the whole fan-out; the gap grows 4× per block-size doubling). The cache is bounded two ways (16 entries **and** a total-leaf budget, since one mega-block compound can dwarf any entry count — this service has OOM'd in 512Mi before) and misses are singleflight-deduped: at MINED time the SSE fan-out, webhook workers, and `GET /tx` handlers would otherwise race to fetch+parse the same block's multi-MB compound. The three divergent private extractors collapse onto `bump.CompoundIndex.MinimalPathBytes`, parity-tested byte-for-byte against `bump.ExtractMinimalPathForTx`.
- **webhook**: enrich once per txid in `dispatchOne` (shared across subscribers); reaper redelivery keeps `Status = LastDeliveredStatus` (CAS-safe) and grafts block/merkle fields from `GetStatus`.
- **sse**: `statusPayload` gains `blockHash`/`blockHeight`/`merklePath` (`omitempty`, so non-mined frames are unchanged — full parity with the webhook body); enrich lazily in `fanOut` after the token match (single fan-out goroutine, before any send); catchup replay enriches best-effort, bounded by a per-reconnect distinct-block budget (the catchup path is historically OOM-sensitive).
- **observability**: `arcade_mined_push_without_merkle_path_total{channel}` counter for best-effort misses (BUMP eviction/reorg races).
- **docs**: `docs/sse.md` frame format and `openapi/arcade.openapi.yaml` (SSE example, `merklePath` schema note, `X-CallbackUrl` description) describe the enriched shape.

## Failure modes (intended)

- Missing/unparseable BUMP → enrich no-ops, status still delivered without `merklePath` (+ metric). Since `InsertBUMP` precedes the MINED publish, this only occurs on cache-eviction/reorg races.
- Over-budget catchup replays ship `blockHash`/`blockHeight` without `merklePath`; recover via `GET /tx/:txid`.

## Tests

New importable `internal/synthblock` builds a synthetic block with a known merkle root and **cryptographically verifies** each proof (`ComputeRoot(txid) == root`), not just field presence:

- webhook: live delivery, reaper redelivery, missing-BUMP negative (delivers without a proof, never drops)
- sse: live frame, catchup-on-reconnect
- store: pebble enrichment + cache-hit + `InsertBUMP` invalidation + guard no-ops
- bumpcache: singleflight dedup under concurrent misses, fetch-error retry (errors never cached), leaf-budget and entry-cap eviction with exact accounting, guard no-ops

Verification: `gofmt`/`go build`/`go vet`/`magex lint` clean; full `go test ./...` green; `go test -race` on sse/webhook/pebble/bumpcache/synthblock clean.
