### PR TITLE
feat(api,propagation): verdicts-vs-conditions rejection semantics, ARC codes, chain-freshness health

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,14 @@ When you provide `X-CallbackUrl`, Arcade will POST status updates:
 **Features:**
 - Automatic retries with linear backoff (1min, 2min, 3min, etc.)
 - Configurable max retries via `webhook.max_retries`
-- Delivery tracking
+- Every POST carries `User-Agent: arcade-webhook/<version>` — allowlist the
+  `arcade-webhook/` prefix at your edge so bot/WAF rules don't silently
+  reject deliveries
+- Delivery self-diagnosis: `GET /tx/{txid}?callbackToken=<token>` returns a
+  `callbacks` array with `attempts`, `lastAttemptAt`, and `lastResult`
+  (`"delivered"` or the last failure, e.g. `"status 403"`) for your
+  submissions — if `attempts` climbs while your endpoint sees nothing,
+  something in front of it is rejecting the POSTs
 
 </details>
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -223,6 +223,20 @@ After 100+ confirmations, `TxTracker.PruneConfirmed()` removes deeply confirmed 
 
 Transitions are guarded by `DisallowedPreviousStatuses()` in the SQL UPDATE query, preventing backward transitions — `MINED` cannot revert to `SEEN_ON_NETWORK` except through explicit reorg handling.
 
+### Rejection semantics: verdicts vs. conditions
+
+Arcade distinguishes two kinds of submit failure (issue #254):
+
+- **Verdicts about the transaction bytes** — validator failures (script, fee, size, malformation) and network rejections — are terminal: a `REJECTED` row is persisted with the reason in `extraInfo` and, when classifiable, the numeric ARC code (460-476) in `status`. `GET /tx/{txid}` serves the verdict indefinitely (there is no retention window).
+- **Conditions of arcade's chain view** are not verdicts and persist nothing. The intake nLockTime/BIP113 finality gate is the canonical case: arcade's view of the tip can trail the network, so a "not final yet" answer is a `400` with ARC code `476` and an actionable reason — but no `REJECTED` row, no status event. `GET /tx/{txid}` keeps returning `404` ("no verdict") for a first submission, so clients that resubmit on no-verdict recover automatically once the locktime expires, and a resubmission evaluated against a stale tip can never clobber an in-flight row.
+
+Recovery is client-driven by design — arcade keeps no rejected-tx tracker (a tx that mined before arcade ever saw it has no oracle to consult):
+
+- **Resubmitting a `REJECTED` transaction re-validates and re-broadcasts it.** If the original cause has cleared (e.g. a parent has since confirmed), the row advances through the normal `SEEN_ON_NETWORK → MINED` flow; the lattice permits every forward transition out of `REJECTED`.
+- **Cascade rejections are queue state, not verdicts about the child.** A child held behind a rejected ancestor gets `extraInfo` prefixed `parent rejected`, naming the ancestor — resubmit the child after the ancestor is accepted.
+
+Operators can detect the stale-chain-view condition before it causes non-final rejections: `GET /health` reports `blockHeight` (arcade's processed tip), and the `arcade_chain_tip_height` / `arcade_p2p_peer_best_height` gauges expose height lag between arcade and its datahub peers.
+
 ## Storage layout
 
 | Table | Primary key | Purpose |

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -650,6 +650,31 @@ var P2PEndpointDiscoveryTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "Datahub URL discovery outcomes from peer announcements.",
 }, []string{labelOutcome}) // registered, invalid, blocked, no_url, no_store, error
 
+// P2PPeerBestHeight reports the best block height each datahub peer
+// advertises in its node_status messages. Compared against
+// arcade_chain_tip_height (arcade's own processed tip) this is the
+// height-lag signal that was previously invisible: a reachable-but-stalled
+// peer showed healthy on every existing metric while its chain view froze
+// 50+ blocks behind (issue #254). Labelled by the peer's base_url — the
+// small, stable datahub set — and never by libp2p peer id, whose
+// restart-churn would grow the series set unboundedly; peers announcing no
+// base_url are skipped.
+var P2PPeerBestHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "arcade_p2p_peer_best_height",
+	Help: "Best block height advertised by a datahub peer via p2p node_status, by base_url.",
+}, []string{"base_url"})
+
+// ChainTipHeight reports arcade's own view of the active chain tip — the
+// highest block_processing row marked active. Refreshed by the api-server's
+// /health handler (which also returns it as blockHeight); alert on this
+// flatlining, or on arcade_p2p_peer_best_height pulling ahead of it, to
+// catch stale-chain-view conditions before they surface as non-final
+// rejections (issue #254).
+var ChainTipHeight = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "arcade_chain_tip_height",
+	Help: "Arcade's active processed chain-tip height (max active block_processing row).",
+})
+
 // ---------------------------------------------------------------------------
 // callback path — inbound merkle-service callbacks
 // ---------------------------------------------------------------------------

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -245,7 +245,10 @@ func (s Status) CanTransitionFrom(prev Status) bool {
 	return true
 }
 
-// Submission represents a client's submission and subscription preferences
+// Submission represents a client's submission and subscription preferences.
+// Deliberately carries no json tags: it is never serialized to clients
+// directly (CallbackToken must not leak) — the api-server maps it to a
+// response DTO where needed.
 type Submission struct {
 	SubmissionID        string
 	TxID                string
@@ -253,9 +256,22 @@ type Submission struct {
 	CallbackToken       string
 	FullStatusUpdates   bool
 	LastDeliveredStatus Status
-	RetryCount          int
-	NextRetryAt         *time.Time
-	CreatedAt           time.Time
+	// RetryCount and NextRetryAt are the webhook retry-scheduling state for
+	// the current transition: bumped by each failed POST, cleared by the CAS
+	// when the next transition is claimed.
+	RetryCount  int
+	NextRetryAt *time.Time
+	// Attempts, LastAttemptAt and LastResult are lifetime delivery
+	// bookkeeping, stamped after every POST regardless of outcome and never
+	// reset: Attempts counts every POST ever made for this submission,
+	// LastResult holds "delivered" or the last failure ("status 403", a
+	// transport error). Surfaced on GET /tx?callbackToken=… so receivers can
+	// self-diagnose delivery problems (issue #249: a WAF 403-ing every
+	// callback is invisible from the receiver's own logs).
+	Attempts      int
+	LastAttemptAt *time.Time
+	LastResult    string
+	CreatedAt     time.Time
 }
 
 // BlockReorg represents a notification that a block was orphaned due to a chain reorganization

--- a/openapi/arcade.openapi.yaml
+++ b/openapi/arcade.openapi.yaml
@@ -345,6 +345,17 @@ paths:
         prefixed `parent rejected` names the rejected ancestor and is
         retryable: resubmit after the ancestor is accepted (resubmitting a
         `REJECTED` transaction re-validates and re-broadcasts it).
+
+        With `?callbackToken=…` the response additionally carries a
+        `callbacks` array: the webhook delivery state of the submissions
+        registered under that token (and only that token — a txid can carry
+        subscriptions from multiple clients). `attempts`/`lastAttemptAt`/
+        `lastResult` are stamped on every POST arcade makes, so a receiver
+        whose edge is rejecting callbacks (e.g. a WAF answering 403) can
+        self-diagnose: `lastResult: "status 403"` with a climbing `attempts`
+        means arcade is delivering and the receiver's side is refusing. Note
+        the top-level `retryCount`/`nextRetryAt` fields are the transaction's
+        BROADCAST retry state — webhook retry state lives inside `callbacks`.
       parameters:
         - name: txid
           in: path
@@ -353,6 +364,16 @@ paths:
           schema:
             type: string
             example: "<hex>"
+        - name: callbackToken
+          in: query
+          required: false
+          description: >-
+            The X-CallbackToken supplied at submit time. Reveals the webhook
+            delivery state (`callbacks` array) of this token's submissions
+            for the txid. Same capability model as the SSE stream's
+            callbackToken.
+          schema:
+            type: string
       responses:
         "200":
           description: Current transaction status.
@@ -1042,6 +1063,12 @@ components:
         is a TransactionStatus; MINED/IMMUTABLE callbacks include blockHash,
         blockHeight, and merklePath (the tx's BUMP), so the proof arrives on the
         callback without a follow-up GET.
+
+        Every callback POST carries `User-Agent: arcade-webhook/<version>` —
+        allowlist the `arcade-webhook/` prefix at your edge so bot/WAF rules
+        for generic HTTP clients don't silently reject deliveries. Delivery
+        health per submission (attempts, last result) is inspectable via
+        `GET /tx/{txid}?callbackToken=…`.
       schema:
         type: string
         format: uri
@@ -1092,6 +1119,38 @@ components:
         - MINED
         - IMMUTABLE
 
+    CallbackDelivery:
+      type: object
+      description: >-
+        Webhook delivery state of one submission, for delivery
+        self-diagnosis. attempts/lastAttemptAt/lastResult are lifetime
+        bookkeeping stamped on every POST arcade makes (never reset);
+        nextRetryAt/lastDeliveredStatus reflect the current transition's
+        retry scheduling.
+      properties:
+        callbackUrl:
+          type: string
+        lastDeliveredStatus:
+          type: string
+          description: Last status transition claimed for delivery to this URL.
+        attempts:
+          type: integer
+          description: Total POSTs ever attempted for this submission.
+        lastAttemptAt:
+          type: string
+          format: date-time
+        lastResult:
+          type: string
+          description: >-
+            "delivered" on success, otherwise the last failure — an HTTP
+            outcome like "status 403" (the receiver or its edge answered
+            that code) or a transport error.
+          example: status 403
+        nextRetryAt:
+          type: string
+          format: date-time
+          description: When the webhook reaper will retry a failed delivery; absent when not in retry state.
+
     TransactionStatus:
       type: object
       properties:
@@ -1130,6 +1189,14 @@ components:
         extraInfo:
           type: string
           description: Free-form detail (e.g. rejection reason).
+        callbacks:
+          type: array
+          description: >-
+            Webhook delivery state of the requester's submissions. Present
+            only when the request carried a matching ?callbackToken=… —
+            scoped to that token's submissions.
+          items:
+            $ref: "#/components/schemas/CallbackDelivery"
         competingTxs:
           type: array
           items:

--- a/openapi/arcade.openapi.yaml
+++ b/openapi/arcade.openapi.yaml
@@ -86,6 +86,12 @@ paths:
       description: |
         Reports liveness of the API server process and the upstream Datahub
         endpoints it depends on. Suitable as a Kubernetes liveness probe.
+
+        `blockHeight` is this instance's own processed chain-tip height — a
+        freshness signal, not a liveness gate. `datahub_urls[].healthy` is
+        reachability-only, so an instance can report healthy while its chain
+        view is stale; clients that compare `blockHeight` against the real
+        network tip can detect a lagging instance and route around it.
       responses:
         "200":
           description: Process is live.
@@ -97,6 +103,7 @@ paths:
                 healthy: true
                 version: v0.8.0
                 status: ok
+                blockHeight: 958779
                 datahub_urls:
                   - url: https://datahub.example.com
                     healthy: true
@@ -200,15 +207,25 @@ paths:
         "400":
           description: |
             Malformed request, decode failure, empty transaction, validation
-            failure, or unsafe callback URL. On validation failure a terminal
-            `REJECTED` row is persisted so subscribers see the outcome.
+            failure, or unsafe callback URL. On a **validator** failure — a
+            verdict about the transaction bytes — a terminal `REJECTED` row is
+            persisted so subscribers see the outcome, carrying the numeric ARC
+            code as `status`.
 
-            Validation includes an nLockTime/BIP113 finality gate: a
-            transaction whose locktime is still ahead of the chain's
-            median-time-past (with a non-final input sequence) is rejected
-            with a reason stating when it becomes final. Resubmit the
-            identical transaction after that time and it re-enters the
-            broadcast pipeline.
+            The nLockTime/BIP113 finality gate is different: a transaction
+            whose locktime is still ahead of the chain's median-time-past
+            (with a non-final input sequence) gets a `400` with ARC code `476`
+            and a reason stating when it becomes final, but **no verdict is
+            persisted** — non-finality is a condition of this instance's chain
+            view, not a property of the transaction. `GET /tx/{txid}` keeps
+            returning its prior state (`404` for a first submission), so
+            resubmission policies keyed on "no verdict" work unchanged.
+            Resubmit the identical transaction once the locktime expires and
+            it enters the broadcast pipeline normally.
+
+            Validation-failure bodies carry the legacy `error`/`reason`/`txid`
+            fields plus the additive ARC error taxonomy (`status`, `title`,
+            `detail`, `type`) when the failure maps onto it.
           content:
             application/json:
               schema:
@@ -216,6 +233,11 @@ paths:
               example:
                 error: transaction failed validation
                 reason: "script evaluation failed"
+                txid: "<hex>"
+                status: 461
+                title: Malformed transaction
+                detail: Transaction unlocking scripts are invalid
+                type: "https://bitcoin-sv.github.io/arc/#/errors?id=_461"
         "503":
           description: |
             Broker is under backpressure; the transaction was not queued and a
@@ -245,7 +267,9 @@ paths:
 
         Bodies are capped at **256 MiB**. If any transaction in the batch fails
         validation the whole call returns `400` with the offending txid and
-        reason; the failed transaction is recorded as `REJECTED`.
+        reason; a validator failure records the transaction as `REJECTED`,
+        while a non-final (locktime) failure persists nothing — see `POST /tx`
+        for the verdict-vs-condition distinction and the additive ARC fields.
       parameters:
         - name: Content-Type
           in: header
@@ -306,6 +330,21 @@ paths:
       description: |
         Returns the current lifecycle state of a previously submitted
         transaction, including its merkle path once mined.
+
+        `404` means exactly "this instance has no verdict for this txid":
+        either it was never submitted here, or its only submissions were
+        answered with a non-persisting `400` (e.g. the non-final gate).
+        Status rows and mined proofs are retained indefinitely — there is no
+        retention window — so a previously returned verdict never expires
+        into a `404`. A mined transaction whose proof is temporarily
+        unretrievable still returns `200` with `txStatus: MINED` and block
+        fields, with `merklePath` omitted; retry the GET to recover the proof.
+
+        Terminal `REJECTED` rows include the rejection reason in `extraInfo`
+        and, when classifiable, the numeric ARC code in `status`. A reason
+        prefixed `parent rejected` names the rejected ancestor and is
+        retryable: resubmit after the ancestor is accepted (resubmitting a
+        `REJECTED` transaction re-validates and re-broadcasts it).
       parameters:
         - name: txid
           in: path
@@ -1063,7 +1102,10 @@ components:
           $ref: "#/components/schemas/Status"
         status:
           type: integer
-          description: Numeric status code (omitted when zero).
+          description: >-
+            Numeric ARC error code (460-476 taxonomy) recorded with a
+            REJECTED verdict when the failure is classifiable — e.g. 466
+            conflicting tx, 476 not final. Omitted when zero/unclassified.
         timestamp:
           type: string
           format: date-time
@@ -1289,6 +1331,14 @@ components:
         status:
           type: string
           example: ok
+        blockHeight:
+          type: integer
+          format: int64
+          description: >-
+            This instance's processed active chain-tip height. A freshness
+            signal (compare against the network tip to detect a stale chain
+            view); omitted when the height has never been readable.
+          example: 958779
         datahub_urls:
           type: array
           items:
@@ -1324,7 +1374,24 @@ components:
           description: Validation failure detail (present when a transaction fails validation).
         txid:
           type: string
-          description: The offending txid (present for batch validation failures).
+          description: The offending txid (present when a specific transaction failed).
+        status:
+          type: integer
+          description: >-
+            Numeric ARC error code (460-476 taxonomy) when the failure maps
+            onto it — e.g. 461 malformed unlocking scripts, 465 fee too low,
+            476 not final (retryable; resubmit after the locktime expires).
+            Absent for failures with no confident classification.
+          example: 476
+        title:
+          type: string
+          description: ARC error title for the status code.
+        detail:
+          type: string
+          description: ARC error detail for the status code.
+        type:
+          type: string
+          description: ARC error documentation URL for the status code.
       required:
         - error
 

--- a/services/api_server/arc_response_test.go
+++ b/services/api_server/arc_response_test.go
@@ -1,0 +1,76 @@
+package api_server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	arcerrors "github.com/bsv-blockchain/arcade/errors"
+)
+
+// TestRespondSubmitError_ARCFieldsAdditive pins the additive 400 body
+// contract (external feedback item 2): the legacy "error"/"reason" fields are
+// byte-compatible with what existing clients parse, and an ArcError in the
+// chain adds the machine-readable taxonomy alongside — numeric "status",
+// "title", "detail", "type" — without displacing anything. A plain error adds
+// no ARC fields.
+func TestRespondSubmitError_ARCFieldsAdditive(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	do := func(err error) map[string]any {
+		t.Helper()
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		respondSubmitError(c, "ab12", err)
+		var body map[string]any
+		if uErr := json.Unmarshal(w.Body.Bytes(), &body); uErr != nil {
+			t.Fatalf("decode body: %v (%s)", uErr, w.Body.String())
+		}
+		if w.Code != 400 {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+		return body
+	}
+
+	arcErr := arcerrors.NewArcError(errors.New("transaction is not final"), arcerrors.StatusNotFinal)
+	body := do(arcErr)
+	if body["error"] != "transaction failed validation" || body["txid"] != "ab12" {
+		t.Errorf("legacy fields wrong: %v", body)
+	}
+	if body["reason"] != arcErr.Error() {
+		t.Errorf("reason = %v, want %q", body["reason"], arcErr.Error())
+	}
+	if body["status"] != float64(476) {
+		t.Errorf("status = %v, want 476", body["status"])
+	}
+	if body["title"] != "Transaction not final" {
+		t.Errorf("title = %v", body["title"])
+	}
+	if body["detail"] == "" || body["type"] == "" {
+		t.Errorf("detail/type missing: %v", body)
+	}
+
+	plain := do(errors.New("failed to parse"))
+	if plain["reason"] != "failed to parse" {
+		t.Errorf("plain reason = %v", plain["reason"])
+	}
+	for _, k := range []string{"status", "title", "detail", "type"} {
+		if _, present := plain[k]; present {
+			t.Errorf("plain error must not add ARC field %q: %v", k, plain)
+		}
+	}
+}
+
+// TestArcStatusCodeOf pins the code extraction used to persist StatusCode on
+// intake-rejected rows.
+func TestArcStatusCodeOf(t *testing.T) {
+	if got := arcStatusCodeOf(arcerrors.NewArcError(errors.New("x"), arcerrors.StatusUnlockingScripts)); got != 461 {
+		t.Errorf("got %d, want 461", got)
+	}
+	if got := arcStatusCodeOf(errors.New("plain")); got != 0 {
+		t.Errorf("got %d, want 0 for a plain error", got)
+	}
+}

--- a/services/api_server/finality_handler_test.go
+++ b/services/api_server/finality_handler_test.go
@@ -81,13 +81,21 @@ func newFinalityTestServer(broker *kafka.RecordingBroker, ms *mockStore, pub *re
 	return srv, router
 }
 
-// TestHandleSubmitTransaction_NonFinal_RejectedWithReason pins the intake
-// finality gate (issue #245): a tx whose timestamp locktime is ahead of the
-// chain MTP with a non-final input sequence must be rejected synchronously
-// with an actionable reason, persist a REJECTED row with that reason, and
-// never reach the propagation topic.
-func TestHandleSubmitTransaction_NonFinal_RejectedWithReason(t *testing.T) {
+// TestHandleSubmitTransaction_NonFinal_NoVerdictPersisted pins the intake
+// finality gate's zero-state contract (issues #245/#254): a non-final tx is
+// answered with an actionable 400 carrying the ARC 476 code, but NOTHING is
+// persisted or published — no REJECTED row (GET /tx keeps returning 404,
+// "no verdict", so resubmission policies keyed on no-verdict work), no
+// status event, no Kafka publish. A non-final verdict reflects arcade's
+// current chain view, not the transaction bytes, so it must never become a
+// durable verdict that could stick after the tx mines elsewhere — nor
+// clobber an existing in-flight row on a resubmit under a stale tip.
+func TestHandleSubmitTransaction_NonFinal_NoVerdictPersisted(t *testing.T) {
 	ms := &mockStore{}
+	ms.getOrInsertFn = func(st *models.TransactionStatus) (*models.TransactionStatus, bool, error) {
+		t.Errorf("GetOrInsertStatus must not be called for a non-final tx, got %+v", st)
+		return nil, false, nil
+	}
 	pub := &recordingCallbackPub{}
 	broker := &kafka.RecordingBroker{}
 	_, router := newFinalityTestServer(broker, ms, pub)
@@ -104,36 +112,30 @@ func TestHandleSubmitTransaction_NonFinal_RejectedWithReason(t *testing.T) {
 	if !strings.Contains(w.Body.String(), "transaction is not final") {
 		t.Errorf("response %q missing finality reason", w.Body.String())
 	}
+	// The ARC taxonomy rides alongside the legacy reason (additive).
+	if !strings.Contains(w.Body.String(), `"status":476`) {
+		t.Errorf("response %q missing ARC 476 status code", w.Body.String())
+	}
 
 	// Nothing may reach Kafka — the tx must not be broadcast.
 	if got := totalMessages(broker); got != 0 {
 		t.Errorf("expected 0 published Kafka messages for non-final tx, got %d", got)
 	}
 
-	// A terminal REJECTED row with the finality reason must be persisted.
+	// Zero persistence: no status row writes of any kind...
 	ms.mu.Lock()
-	calls := append([]*models.TransactionStatus(nil), ms.updateStatusCalls...)
+	updates := append([]*models.TransactionStatus(nil), ms.updateStatusCalls...)
 	ms.mu.Unlock()
-	var sawReject bool
-	for _, c := range calls {
-		if c.Status == models.StatusRejected && strings.Contains(c.ExtraInfo, "transaction is not final") {
-			sawReject = true
-			break
-		}
+	if len(updates) != 0 {
+		t.Errorf("expected no status writes for non-final tx, got %v", updates)
 	}
-	if !sawReject {
-		t.Errorf("expected REJECTED row carrying the finality reason; UpdateStatus calls=%v", calls)
-	}
-
-	// Live subscribers must see the terminal outcome with the reason.
+	// ...and no status event for live subscribers: with no durable row a
+	// published REJECTED would be a verdict GET could never corroborate.
 	pub.mu.Lock()
 	publishes := append([]*models.TransactionStatus(nil), pub.publishes...)
 	pub.mu.Unlock()
-	if len(publishes) != 1 || publishes[0].Status != models.StatusRejected {
-		t.Fatalf("expected exactly 1 REJECTED publish, got %v", publishes)
-	}
-	if !strings.Contains(publishes[0].ExtraInfo, "transaction is not final") {
-		t.Errorf("publish ExtraInfo %q missing finality reason", publishes[0].ExtraInfo)
+	if len(publishes) != 0 {
+		t.Fatalf("expected no publishes for non-final tx, got %v", publishes)
 	}
 }
 
@@ -190,9 +192,14 @@ func TestHandleSubmitTransaction_NoFinalityChecker_Proceeds(t *testing.T) {
 
 // TestHandleSubmitTransactions_BatchNonFinal_AbortsWithTxid mirrors the
 // batch contract for validation failures: the offending txid is named and
-// the whole batch aborts before any publish.
+// the whole batch aborts before any publish — and, like the single-tx path,
+// a non-final verdict persists and publishes nothing (zero-state contract).
 func TestHandleSubmitTransactions_BatchNonFinal_AbortsWithTxid(t *testing.T) {
 	ms := &mockStore{}
+	ms.getOrInsertFn = func(st *models.TransactionStatus) (*models.TransactionStatus, bool, error) {
+		t.Errorf("GetOrInsertStatus must not be called for a non-final batch, got %+v", st)
+		return nil, false, nil
+	}
 	pub := &recordingCallbackPub{}
 	broker := &kafka.RecordingBroker{}
 	_, router := newFinalityTestServer(broker, ms, pub)
@@ -221,5 +228,17 @@ func TestHandleSubmitTransactions_BatchNonFinal_AbortsWithTxid(t *testing.T) {
 	}
 	if got := totalMessages(broker); got != 0 {
 		t.Errorf("expected 0 published Kafka messages for aborted batch, got %d", got)
+	}
+	ms.mu.Lock()
+	updates := len(ms.updateStatusCalls)
+	ms.mu.Unlock()
+	if updates != 0 {
+		t.Errorf("expected no status writes for non-final batch, got %d", updates)
+	}
+	pub.mu.Lock()
+	publishes := len(pub.publishes)
+	pub.mu.Unlock()
+	if publishes != 0 {
+		t.Errorf("expected no publishes for non-final batch, got %d", publishes)
 	}
 }

--- a/services/api_server/get_tx_callbacks_test.go
+++ b/services/api_server/get_tx_callbacks_test.go
@@ -1,0 +1,134 @@
+package api_server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// TestGetTransaction_CallbackStateTokenGated pins the delivery self-diagnosis
+// surface (issue #249): GET /tx/{txid}?callbackToken=… reveals the webhook
+// delivery state of the submissions registered under THAT token only. Without
+// the token — or with someone else's — the response is byte-identical to the
+// plain status read, and the CallbackToken itself never appears in any body.
+func TestGetTransaction_CallbackStateTokenGated(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		txid     = "aa11000000000000000000000000000000000000000000000000000000000000"
+		tokMine  = "tok-mine"
+		tokOther = "tok-other"
+	)
+	attemptAt := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	retryAt := attemptAt.Add(90 * time.Second)
+
+	ms := &mockStore{
+		subsByTxID: map[string][]*models.Submission{
+			txid: {
+				{
+					SubmissionID:        "sub-mine",
+					TxID:                txid,
+					CallbackURL:         "https://receiver.example/cb",
+					CallbackToken:       tokMine,
+					LastDeliveredStatus: models.StatusSeenOnNetwork,
+					RetryCount:          3,
+					NextRetryAt:         &retryAt,
+					Attempts:            14,
+					LastAttemptAt:       &attemptAt,
+					LastResult:          "status 403",
+				},
+				{
+					SubmissionID:  "sub-other",
+					TxID:          txid,
+					CallbackURL:   "https://someone-else.example/cb",
+					CallbackToken: tokOther,
+				},
+			},
+		},
+		getOrInsertFn: nil,
+	}
+	ms.getStatusFn = func(q string) *models.TransactionStatus {
+		if q != txid {
+			return nil
+		}
+		return &models.TransactionStatus{TxID: txid, Status: models.StatusSeenOnNetwork, Timestamp: attemptAt}
+	}
+
+	srv := &Server{
+		cfg:    &config.Config{},
+		logger: zap.NewNop(),
+		store:  ms,
+	}
+	router := gin.New()
+	srv.registerRoutes(router)
+
+	get := func(url string) (int, string) {
+		t.Helper()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w.Code, w.Body.String()
+	}
+
+	// With the matching token: base fields intact + this token's callback state.
+	code, body := get("/tx/" + txid + "?callbackToken=" + tokMine)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", code, body)
+	}
+	var resp struct {
+		TxID      string `json:"txid"`
+		TxStatus  string `json:"txStatus"`
+		Callbacks []struct {
+			CallbackURL         string     `json:"callbackUrl"`
+			LastDeliveredStatus string     `json:"lastDeliveredStatus"`
+			Attempts            int        `json:"attempts"`
+			LastAttemptAt       *time.Time `json:"lastAttemptAt"`
+			LastResult          string     `json:"lastResult"`
+			NextRetryAt         *time.Time `json:"nextRetryAt"`
+		} `json:"callbacks"`
+	}
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		t.Fatalf("decode: %v (%s)", err, body)
+	}
+	if resp.TxID != txid || resp.TxStatus != string(models.StatusSeenOnNetwork) {
+		t.Errorf("base status fields wrong: %s", body)
+	}
+	if len(resp.Callbacks) != 1 {
+		t.Fatalf("expected exactly 1 callback (token-scoped), got %d: %s", len(resp.Callbacks), body)
+	}
+	cb := resp.Callbacks[0]
+	if cb.CallbackURL != "https://receiver.example/cb" ||
+		cb.LastDeliveredStatus != string(models.StatusSeenOnNetwork) ||
+		cb.Attempts != 14 || cb.LastResult != "status 403" ||
+		cb.LastAttemptAt == nil || !cb.LastAttemptAt.Equal(attemptAt) ||
+		cb.NextRetryAt == nil || !cb.NextRetryAt.Equal(retryAt) {
+		t.Errorf("callback state wrong: %+v", cb)
+	}
+	// The other subscriber's URL must not leak, and no token ever appears.
+	for _, secret := range []string{"someone-else.example", tokMine, tokOther} {
+		if strings.Contains(body, secret) {
+			t.Errorf("response leaks %q: %s", secret, body)
+		}
+	}
+
+	// Without a token, and with a token that matches no submission: the
+	// response has no callbacks key at all (byte-identical to the plain read).
+	for _, url := range []string{"/tx/" + txid, "/tx/" + txid + "?callbackToken=stranger"} {
+		code, body := get(url)
+		if code != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d", url, code)
+		}
+		if strings.Contains(body, "callbacks") || strings.Contains(body, "callbackUrl") {
+			t.Errorf("%s: unexpected callback state in body: %s", url, body)
+		}
+	}
+}

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -181,11 +181,49 @@ func RenderDocs(w io.Writer) error {
 // per-endpoint Datahub health stays in datahub_urls[].healthy. Chaintracks moved
 // out of api-server in the microservice decomposition — its health is now
 // reported by the standalone chaintracks pod's /health endpoint.
+//
+// blockHeight is arcade's own processed active-tip height. It is a freshness
+// signal, not a liveness gate: datahub_urls[].healthy is reachability-only,
+// so this instance can look green while its chain view is stale — clients
+// comparing blockHeight against the real network tip can detect that and
+// route around it (issue #254). Omitted (0) when no store is wired or the
+// height has never been readable.
 type healthResponse struct {
 	Healthy     bool                      `json:"healthy"`
 	Version     string                    `json:"version"`
 	Status      string                    `json:"status"`
+	BlockHeight uint64                    `json:"blockHeight,omitempty"`
 	DatahubURLs []teranode.EndpointStatus `json:"datahub_urls"`
+}
+
+// healthTipTTL bounds how often /health re-reads the store's active tip
+// height. Probes arrive every few seconds per replica (kubelet, LBs, ARC
+// clients); one MAX-scan per TTL keeps the store cost flat regardless of
+// probe fan-in while staying far fresher than block cadence.
+const healthTipTTL = 5 * time.Second
+
+// activeTipHeight returns arcade's processed active-tip height for /health,
+// cached for healthTipTTL. Never fails the probe: on a store error it
+// serves the last known height (a frozen value reads as stale to clients —
+// which is exactly the signal — and the next probe retries the read).
+func (s *Server) activeTipHeight(ctx context.Context) uint64 {
+	if s.store == nil {
+		return 0
+	}
+	s.tipMu.Lock()
+	defer s.tipMu.Unlock()
+	if time.Since(s.tipFetchedAt) < healthTipTTL {
+		return s.tipHeight
+	}
+	h, err := s.store.GetActiveTipBlockHeight(ctx)
+	if err != nil {
+		s.logger.Debug("health tip-height read failed", zap.Error(err))
+		return s.tipHeight
+	}
+	s.tipHeight = h
+	s.tipFetchedAt = time.Now()
+	metrics.ChainTipHeight.Set(float64(h))
+	return h
 }
 
 func (s *Server) handleHealth(c *gin.Context) {
@@ -193,6 +231,7 @@ func (s *Server) handleHealth(c *gin.Context) {
 		Healthy:     true,
 		Version:     version.Version,
 		Status:      "ok",
+		BlockHeight: s.activeTipHeight(c.Request.Context()),
 		DatahubURLs: []teranode.EndpointStatus{},
 	}
 	if s.teranode != nil {
@@ -639,15 +678,13 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 	// BEEF parents are trusted (arcade doesn't own a chaintracker on the
 	// intake path); script execution against per-input source data still
 	// runs, which catches malformed unlocking scripts, bad signatures,
-	// and underpaid txs. Failures write a terminal REJECTED row and
-	// return 400 so the outcome is both durable and immediate.
+	// and underpaid txs. Failures are a verdict about the transaction
+	// bytes, so they write a terminal REJECTED row and return 400 —
+	// durable and immediate.
 	if s.validator != nil {
 		if err := s.validator.ValidateTransaction(c.Request.Context(), parsedTx, false); err != nil {
-			s.rejectAtIntake(c.Request.Context(), txid, err.Error(), opts)
-			c.JSON(http.StatusBadRequest, gin.H{
-				jsonKeyError: "transaction failed validation",
-				"reason":     err.Error(),
-			})
+			s.rejectAtIntake(c.Request.Context(), txid, err.Error(), arcStatusCodeOf(err), opts)
+			respondSubmitError(c, txid, err)
 			return
 		}
 	}
@@ -657,16 +694,26 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 	// wraps), so without this a non-final tx is broadcast and bounced by the
 	// network with an opaque generic error (issue #245). Runs after the
 	// validator so its fail-open behavior can never mask a validation error.
-	// The ArcError wrap attaches StatusNotFinal for structured consumers
-	// without changing the reason text (same pattern as mapTeranodeError).
+	//
+	// Unlike a validator failure, a non-final verdict reflects arcade's
+	// CURRENT CHAIN VIEW (which can trail the network's real tip), not the
+	// transaction bytes — a condition, not a verdict. So it is deliberately
+	// NOT persisted: no REJECTED row, no submission record, no status event
+	// (issue #254). The client gets the actionable 400 below; GET /tx keeps
+	// returning its prior state — 404 ("no verdict") for a fresh tx, so
+	// resubmission policies keyed on no-verdict work unchanged — and a
+	// resubmit evaluated against a stale tip can never clobber an existing
+	// in-flight row.
 	if fErr := s.finality.Check(c.Request.Context(), parsedTx); fErr != nil {
 		fErr = arcerrors.NewArcError(fErr, arcerrors.StatusNotFinal)
 		metrics.APIFinalityRejectionsTotal.WithLabelValues("/tx").Inc()
-		s.rejectAtIntake(c.Request.Context(), txid, fErr.Error(), opts)
-		c.JSON(http.StatusBadRequest, gin.H{
-			jsonKeyError: "transaction failed validation",
-			"reason":     fErr.Error(),
-		})
+		s.logger.Info(
+			"transaction not final at intake; no verdict persisted",
+			logfields.TxID(txid),
+			zap.String("reason", fErr.Error()),
+			logfields.Stage(logfields.StageIntake),
+		)
+		respondSubmitError(c, txid, fErr)
 		return
 	}
 
@@ -766,13 +813,51 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 	})
 }
 
+// arcStatusCodeOf extracts the numeric ARC status code (460-476 taxonomy,
+// errors/errors.go) from an error chain, or 0 when none is attached.
+func arcStatusCodeOf(err error) int {
+	if arcErr := arcerrors.GetArcError(err); arcErr != nil {
+		return int(arcErr.StatusCode)
+	}
+	return 0
+}
+
+// respondSubmitError writes the 400 for an intake validation or finality
+// failure. The legacy "error"/"reason" fields are unchanged so existing
+// clients keep parsing; "txid" and — when the error carries an ARC status
+// code — the ARC error taxonomy ("status", "title", "detail", "type") are
+// added alongside, so ARC-compatible clients can branch on the code (and
+// judge retryability, e.g. 476 non-final) without matching reason text.
+func respondSubmitError(c *gin.Context, txid string, err error) {
+	body := gin.H{
+		jsonKeyError: "transaction failed validation",
+		"txid":       txid,
+		"reason":     err.Error(),
+	}
+	if arcErr := arcerrors.GetArcError(err); arcErr != nil {
+		f := arcErr.ToErrorFields()
+		body["status"] = f.Status
+		body["title"] = f.Title
+		body["detail"] = f.Detail
+		body["type"] = f.Type
+	}
+	c.JSON(http.StatusBadRequest, body)
+}
+
 // rejectAtIntake is the terminal-rejection counterpart to the intake
-// success sequence. It persists a REJECTED row, records the submission
-// so SSE/webhook can resolve the callback URL+token on delivery, then
-// publishes the REJECTED status to TopicStatusUpdate so live
-// subscribers see the terminal outcome. Every step is best-effort —
+// success sequence, for VALIDATOR failures only — verdicts about the
+// transaction bytes. (Finality failures are conditions of arcade's chain
+// view and deliberately persist nothing; see the finality gate in
+// handleSubmitTransaction.) It persists a REJECTED row, records the
+// submission so SSE/webhook can resolve the callback URL+token on
+// delivery, then publishes the REJECTED status to TopicStatusUpdate so
+// live subscribers see the terminal outcome. Every step is best-effort —
 // the client has already received its 400 by the time this runs, so a
 // store or publish failure does not change the HTTP outcome.
+//
+// statusCode is the numeric ARC code (0 when unclassified) persisted and
+// published alongside the reason so consumers get a machine-readable
+// cause, not just prose.
 //
 // Order matches the success path: persist row, then queue submission,
 // then publish. Queuing the submission before the publish minimizes
@@ -780,23 +865,24 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 // without a matching submission row (the recorder pool is async, so
 // the window can't be eliminated entirely without making the row
 // write synchronous — a trade-off the success path also accepts).
-func (s *Server) rejectAtIntake(ctx context.Context, txid, reason string, opts submitOptions) {
+func (s *Server) rejectAtIntake(ctx context.Context, txid, reason string, statusCode int, opts submitOptions) {
 	s.logger.Info(
 		"transaction rejected",
 		logfields.TxID(txid),
 		zap.String("reason", reason),
 		logfields.Stage(logfields.StageIntake),
 	)
-	s.persistRejectedAtIntake(ctx, txid, reason)
+	s.persistRejectedAtIntake(ctx, txid, reason, statusCode)
 	s.recordSubmission(ctx, txid, opts)
 	if s.publisher == nil {
 		return
 	}
 	status := &models.TransactionStatus{
-		TxID:      txid,
-		Status:    models.StatusRejected,
-		ExtraInfo: reason,
-		Timestamp: time.Now(),
+		TxID:       txid,
+		Status:     models.StatusRejected,
+		StatusCode: statusCode,
+		ExtraInfo:  reason,
+		Timestamp:  time.Now(),
 	}
 	if err := s.publisher.Publish(ctx, status); err != nil {
 		s.logger.Warn(
@@ -812,15 +898,16 @@ func (s *Server) rejectAtIntake(ctx context.Context, txid, reason string, opts s
 // failure is logged but doesn't change the client response (the 400
 // has already told them the tx was rejected). When the store is nil
 // (test setups using struct-literal construction), this is a no-op.
-func (s *Server) persistRejectedAtIntake(ctx context.Context, txid, reason string) {
+func (s *Server) persistRejectedAtIntake(ctx context.Context, txid, reason string, statusCode int) {
 	if s.store == nil {
 		return
 	}
 	row := &models.TransactionStatus{
-		TxID:      txid,
-		Status:    models.StatusRejected,
-		ExtraInfo: reason,
-		Timestamp: time.Now(),
+		TxID:       txid,
+		Status:     models.StatusRejected,
+		StatusCode: statusCode,
+		ExtraInfo:  reason,
+		Timestamp:  time.Now(),
 	}
 	_, inserted, err := s.store.GetOrInsertStatus(ctx, row)
 	if err != nil {
@@ -921,30 +1008,29 @@ func (s *Server) handleSubmitTransactions(c *gin.Context) {
 		ctx := c.Request.Context()
 		for _, p := range parsed {
 			if vErr := s.validator.ValidateTransaction(ctx, p.tx, false); vErr != nil {
-				s.rejectAtIntake(ctx, p.txid, vErr.Error(), opts)
-				c.JSON(http.StatusBadRequest, gin.H{
-					jsonKeyError: "transaction failed validation",
-					"txid":       p.txid,
-					"reason":     vErr.Error(),
-				})
+				s.rejectAtIntake(ctx, p.txid, vErr.Error(), arcStatusCodeOf(vErr), opts)
+				respondSubmitError(c, p.txid, vErr)
 				return
 			}
 		}
 	}
 
 	// nLockTime/BIP113 finality gate per tx; see handleSubmitTransaction for
-	// the rationale. Aborts the whole batch naming the offending txid —
-	// matches the validation contract above.
+	// the rationale — including why a non-final verdict is NOT persisted
+	// (condition of arcade's chain view, not a verdict about the tx; issue
+	// #254). Aborts the whole batch naming the offending txid — matches the
+	// validation contract above.
 	for _, p := range parsed {
 		if fErr := s.finality.Check(c.Request.Context(), p.tx); fErr != nil {
 			fErr = arcerrors.NewArcError(fErr, arcerrors.StatusNotFinal)
 			metrics.APIFinalityRejectionsTotal.WithLabelValues("/txs").Inc()
-			s.rejectAtIntake(c.Request.Context(), p.txid, fErr.Error(), opts)
-			c.JSON(http.StatusBadRequest, gin.H{
-				jsonKeyError: "transaction failed validation",
-				"txid":       p.txid,
-				"reason":     fErr.Error(),
-			})
+			s.logger.Info(
+				"transaction not final at intake; no verdict persisted",
+				logfields.TxID(p.txid),
+				zap.String("reason", fErr.Error()),
+				logfields.Stage(logfields.StageIntake),
+			)
+			respondSubmitError(c, p.txid, fErr)
 			return
 		}
 	}

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -550,7 +550,37 @@ func (s *Server) handleBlockProcessed(c *gin.Context, msg models.CallbackMessage
 	c.Status(http.StatusOK)
 }
 
-// handleGetTransaction retrieves a transaction status by TXID.
+// callbackDelivery is the wire shape of one subscription's webhook delivery
+// state on GET /tx?callbackToken=… — the self-diagnosis surface for receivers
+// whose edge is rejecting arcade's POSTs (issue #249: a WAF 403'd 24k
+// callbacks while the receiver's own logs showed nothing). attempts /
+// lastAttemptAt / lastResult are lifetime bookkeeping stamped on every POST;
+// retry-scheduling state (nextRetryAt) is per-transition and cleared when the
+// next transition is claimed. Deliberately excludes CallbackToken.
+type callbackDelivery struct {
+	CallbackURL         string     `json:"callbackUrl,omitempty"`
+	LastDeliveredStatus string     `json:"lastDeliveredStatus,omitempty"`
+	Attempts            int        `json:"attempts"`
+	LastAttemptAt       *time.Time `json:"lastAttemptAt,omitempty"`
+	LastResult          string     `json:"lastResult,omitempty"`
+	NextRetryAt         *time.Time `json:"nextRetryAt,omitempty"`
+}
+
+// txStatusWithCallbacks embeds the plain status so the base response shape is
+// byte-identical to today's, plus the token-scoped callbacks array.
+type txStatusWithCallbacks struct {
+	*models.TransactionStatus
+
+	Callbacks []callbackDelivery `json:"callbacks,omitempty"`
+}
+
+// handleGetTransaction retrieves a transaction status by TXID. With an
+// optional ?callbackToken=… the response additionally carries the webhook
+// delivery state of the submissions registered under THAT token (capability
+// model — same scoping the SSE stream uses). Without the token, or when no
+// submission matches, the response is unchanged: a txid can carry
+// subscriptions from multiple unrelated clients, and their callback URLs and
+// delivery health are not each other's business.
 func (s *Server) handleGetTransaction(c *gin.Context) {
 	txid := c.Param("txid")
 	if txid == "" {
@@ -570,7 +600,41 @@ func (s *Server) handleGetTransaction(c *gin.Context) {
 		return
 	}
 
+	if callbacks := s.callbackDeliveries(c.Request.Context(), txid, c.Query("callbackToken")); len(callbacks) > 0 {
+		c.JSON(http.StatusOK, txStatusWithCallbacks{TransactionStatus: status, Callbacks: callbacks})
+		return
+	}
 	c.JSON(http.StatusOK, status)
+}
+
+// callbackDeliveries returns the delivery state of the txid's submissions
+// registered under token. Empty token or no match returns nil (never an
+// error to the client — the callbacks view is best-effort diagnostics and
+// must not break the status read).
+func (s *Server) callbackDeliveries(ctx context.Context, txid, token string) []callbackDelivery {
+	if token == "" || s.store == nil {
+		return nil
+	}
+	subs, err := s.store.GetSubmissionsByTxID(ctx, txid)
+	if err != nil {
+		s.logger.Warn("submission lookup for callback state failed", logfields.TxID(txid), zap.Error(err))
+		return nil
+	}
+	var out []callbackDelivery
+	for _, sub := range subs {
+		if sub.CallbackToken != token {
+			continue
+		}
+		out = append(out, callbackDelivery{
+			CallbackURL:         sub.CallbackURL,
+			LastDeliveredStatus: string(sub.LastDeliveredStatus),
+			Attempts:            sub.Attempts,
+			LastAttemptAt:       sub.LastAttemptAt,
+			LastResult:          sub.LastResult,
+			NextRetryAt:         sub.NextRetryAt,
+		})
+	}
+	return out
 }
 
 // Per-request body size caps for the submit endpoints. A BSV transaction can

--- a/services/api_server/handlers_health_test.go
+++ b/services/api_server/handlers_health_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ type healthResp struct {
 	Healthy     bool                      `json:"healthy"`
 	Version     string                    `json:"version"`
 	Status      string                    `json:"status"`
+	BlockHeight uint64                    `json:"blockHeight"`
 	DatahubURLs []teranode.EndpointStatus `json:"datahub_urls"`
 }
 
@@ -91,6 +93,48 @@ func TestHandleHealth_StructuredResponse(t *testing.T) {
 		if resp.DatahubURLs[i] != w {
 			t.Errorf("datahub_urls[%d] = %+v, want %+v", i, resp.DatahubURLs[i], w)
 		}
+	}
+}
+
+// TestHandleHealth_IncludesBlockHeight pins the chain-freshness field
+// (issue #254): /health reports arcade's own processed active-tip height so
+// clients can detect a stale chain view — datahub_urls[].healthy is
+// reachability-only and stays green through a chain stall. The store read
+// is TTL-cached (probes arrive every few seconds), and without a store the
+// field is omitted rather than reading as "height 0".
+func TestHandleHealth_IncludesBlockHeight(t *testing.T) {
+	ms := &mockStore{tipHeight: 958_779}
+	srv := &Server{
+		cfg:    &config.Config{},
+		logger: zap.NewNop(),
+		store:  ms,
+	}
+
+	code, resp, body := doHealth(t, srv)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%s)", code, string(body))
+	}
+	if resp.BlockHeight != 958_779 {
+		t.Errorf("expected blockHeight=958779, got %d (body=%s)", resp.BlockHeight, string(body))
+	}
+
+	// A second probe inside the TTL must serve the cached height.
+	_, resp, _ = doHealth(t, srv)
+	if resp.BlockHeight != 958_779 {
+		t.Errorf("cached probe: expected blockHeight=958779, got %d", resp.BlockHeight)
+	}
+	ms.mu.Lock()
+	calls := ms.tipCalls
+	ms.mu.Unlock()
+	if calls != 1 {
+		t.Errorf("expected 1 store tip read across 2 probes (TTL cache), got %d", calls)
+	}
+
+	// No store wired → the field is omitted entirely, not emitted as 0.
+	srvNoStore := &Server{cfg: &config.Config{}, logger: zap.NewNop()}
+	_, _, rawBody := doHealth(t, srvNoStore)
+	if strings.Contains(string(rawBody), "blockHeight") {
+		t.Errorf("expected blockHeight omitted without a store, body=%s", string(rawBody))
 	}
 }
 

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -63,6 +63,11 @@ type mockStore struct {
 	// used directly. Default behavior (nil hook) is the legacy "always
 	// fresh insert" stub: (nil, false, nil).
 	getOrInsertFn func(status *models.TransactionStatus) (*models.TransactionStatus, bool, error)
+	// tipHeight is served by GetActiveTipBlockHeight (the /health
+	// blockHeight source); tipCalls counts reads so tests can assert the
+	// handler's TTL cache actually coalesces probes.
+	tipHeight uint64
+	tipCalls  int
 }
 
 func (m *mockStore) UpdateStatus(_ context.Context, status *models.TransactionStatus) error {
@@ -265,7 +270,12 @@ func (m *mockStore) ListBlockProcessingStatus(context.Context, uint64, int) ([]*
 	return nil, nil
 }
 
-func (m *mockStore) GetActiveTipBlockHeight(context.Context) (uint64, error) { return 0, nil }
+func (m *mockStore) GetActiveTipBlockHeight(context.Context) (uint64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tipCalls++
+	return m.tipHeight, nil
+}
 
 func (m *mockStore) ListStaleBlockProcessingStatus(context.Context, time.Time, uint64, int) ([]*models.BlockProcessingStatus, error) {
 	return nil, nil

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -68,6 +68,10 @@ type mockStore struct {
 	// handler's TTL cache actually coalesces probes.
 	tipHeight uint64
 	tipCalls  int
+	// subsByTxID feeds GetSubmissionsByTxID and getStatusFn feeds GetStatus
+	// for the GET /tx callback-state tests.
+	subsByTxID  map[string][]*models.Submission
+	getStatusFn func(txid string) *models.TransactionStatus
 }
 
 func (m *mockStore) UpdateStatus(_ context.Context, status *models.TransactionStatus) error {
@@ -136,7 +140,10 @@ func (m *mockStore) BatchUpdateStatusReturning(_ context.Context, statuses []*mo
 	return out, nil
 }
 
-func (m *mockStore) GetStatus(context.Context, string) (*models.TransactionStatus, error) {
+func (m *mockStore) GetStatus(_ context.Context, txid string) (*models.TransactionStatus, error) {
+	if m.getStatusFn != nil {
+		return m.getStatusFn(txid), nil
+	}
 	return nil, nil
 }
 
@@ -170,8 +177,10 @@ func (m *mockStore) InsertSubmission(_ context.Context, sub *models.Submission) 
 	return nil
 }
 
-func (m *mockStore) GetSubmissionsByTxID(context.Context, string) ([]*models.Submission, error) {
-	return nil, nil
+func (m *mockStore) GetSubmissionsByTxID(_ context.Context, txid string) ([]*models.Submission, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.subsByTxID[txid], nil
 }
 
 func (m *mockStore) GetSubmissionsByToken(context.Context, string) ([]*models.Submission, error) {
@@ -187,6 +196,10 @@ func (m *mockStore) TokenHasSubmissionForTx(context.Context, string, string) (bo
 }
 
 func (m *mockStore) UpdateDeliveryStatus(context.Context, string, models.Status, int, *time.Time) error {
+	return nil
+}
+
+func (m *mockStore) RecordDeliveryAttempt(context.Context, string, time.Time, string) error {
 	return nil
 }
 

--- a/services/api_server/routes.go
+++ b/services/api_server/routes.go
@@ -67,9 +67,9 @@ var routeDocs = []RouteDoc{
 		Method:         "GET",
 		Path:           "/health",
 		Summary:        "Liveness probe",
-		Description:    "Reports liveness of the API server process and the upstream Datahub endpoints it depends on. Suitable as a Kubernetes liveness probe.",
+		Description:    "Reports liveness of the API server process and the upstream Datahub endpoints it depends on. Suitable as a Kubernetes liveness probe. blockHeight is this instance's processed chain-tip height — a freshness signal (datahub_urls[].healthy is reachability-only), letting clients detect a stale chain view and route around it.",
 		ResponseStatus: "200 OK",
-		ResponseBody:   "{\n  \"healthy\": true,\n  \"version\": \"v0.8.0\",\n  \"status\": \"ok\",\n  \"datahub_urls\": [\n    { \"url\": \"https://...\", \"healthy\": true }\n  ]\n}",
+		ResponseBody:   "{\n  \"healthy\": true,\n  \"version\": \"v0.8.0\",\n  \"status\": \"ok\",\n  \"blockHeight\": 958779,\n  \"datahub_urls\": [\n    { \"url\": \"https://...\", \"healthy\": true }\n  ]\n}",
 	},
 	{
 		Method:         "GET",

--- a/services/api_server/routes.go
+++ b/services/api_server/routes.go
@@ -48,7 +48,7 @@ var callbackSubscriptionHeaders = []RouteHeader{
 	{
 		Name:        "X-CallbackUrl",
 		Requirement: "Optional",
-		Description: "Webhook URL Arcade should POST status events to as this transaction progresses through the network. Must be a public HTTPS endpoint; private/loopback hosts are rejected unless the deployment is configured to allow them.",
+		Description: "Webhook URL Arcade should POST status events to as this transaction progresses through the network. Must be a public HTTPS endpoint; private/loopback hosts are rejected unless the deployment is configured to allow them. Every POST carries User-Agent: arcade-webhook/<version> — allowlist the arcade-webhook/ prefix so edge bot rules don't reject deliveries; per-submission delivery health is inspectable via GET /tx/:txid?callbackToken=<token>.",
 	},
 	{
 		Name:        "X-CallbackToken",
@@ -83,7 +83,7 @@ var routeDocs = []RouteDoc{
 		Method:      "GET",
 		Path:        "/tx/:txid",
 		Summary:     "Look up transaction status by txid",
-		Description: "Returns the current lifecycle state of a previously submitted transaction, including its merkle path once mined.",
+		Description: "Returns the current lifecycle state of a previously submitted transaction, including its merkle path once mined. With ?callbackToken=<token> the response adds a callbacks array: the webhook delivery state (attempts, lastAttemptAt, lastResult, nextRetryAt) of that token's submissions — lastResult \"status 403\" with climbing attempts means arcade is POSTing and the receiver's edge is refusing.",
 		Headers: []RouteHeader{
 			{
 				Name:        "Accept",
@@ -92,8 +92,8 @@ var routeDocs = []RouteDoc{
 			},
 		},
 		ResponseStatus: "200 OK",
-		ResponseBody:   "{\n  \"txid\": \"<hex>\",\n  \"txStatus\": \"SEEN_ON_NETWORK\",\n  \"status\": \"SEEN_ON_NETWORK\",\n  \"timestamp\": \"2026-05-20T12:00:00Z\",\n  \"blockHash\": \"<hex|null>\",\n  \"blockHeight\": 870123,\n  \"merklePath\": \"<BUMP hex|null>\",\n  \"extraInfo\": \"\",\n  \"competingTxs\": []\n}",
-		Notes:          "Returns 404 if the txid has never been submitted to this Arcade instance.",
+		ResponseBody:   "{\n  \"txid\": \"<hex>\",\n  \"txStatus\": \"SEEN_ON_NETWORK\",\n  \"status\": \"SEEN_ON_NETWORK\",\n  \"timestamp\": \"2026-05-20T12:00:00Z\",\n  \"blockHash\": \"<hex|null>\",\n  \"blockHeight\": 870123,\n  \"merklePath\": \"<BUMP hex|null>\",\n  \"extraInfo\": \"\",\n  \"competingTxs\": [],\n  \"callbacks\": [\n    {\n      \"callbackUrl\": \"https://...\",\n      \"lastDeliveredStatus\": \"SEEN_ON_NETWORK\",\n      \"attempts\": 14,\n      \"lastAttemptAt\": \"2026-05-20T12:00:00Z\",\n      \"lastResult\": \"status 403\",\n      \"nextRetryAt\": \"2026-05-20T12:05:00Z\"\n    }\n  ]\n}",
+		Notes:          "Returns 404 if the txid has never been submitted to this Arcade instance. The callbacks array appears only with a matching ?callbackToken= and covers only that token's submissions.",
 	},
 	{
 		Method:      "GET",

--- a/services/api_server/server.go
+++ b/services/api_server/server.go
@@ -68,6 +68,13 @@ type Server struct {
 	submissionCh   chan submissionRecord
 	submissionStop chan struct{}
 	stopOnce       sync.Once
+
+	// tipMu/tipHeight/tipFetchedAt cache the store's active-tip height for
+	// /health (see activeTipHeight): probes arrive every few seconds and
+	// the underlying read is a store scan we don't want to pay per probe.
+	tipMu        sync.Mutex
+	tipHeight    uint64
+	tipFetchedAt time.Time
 }
 
 // submissionRecord is the in-memory payload the async recorder consumes.

--- a/services/p2p_client/client.go
+++ b/services/p2p_client/client.go
@@ -240,6 +240,16 @@ func (c *Client) consume(ctx context.Context, msgs <-chan teranodep2p.NodeStatus
 func (c *Client) handleNodeStatus(ctx context.Context, msg teranodep2p.NodeStatusMessage) {
 	metrics.P2PNodeStatusMessagesTotal.Inc()
 
+	// Surface the peer's advertised tip height as a gauge instead of
+	// discarding it with the debug log below: alongside
+	// arcade_chain_tip_height it is the datahub height-lag signal operators
+	// alert on (issue #254 — peers chain-stalled 50+ blocks while every
+	// reachability probe stayed green). base_url-labelled only, so
+	// restart-churned peer ids can't grow the series set.
+	if msg.BaseURL != "" {
+		metrics.P2PPeerBestHeight.WithLabelValues(msg.BaseURL).Set(float64(msg.BestHeight))
+	}
+
 	if ce := c.logger.Check(zap.DebugLevel, "received node_status"); ce != nil {
 		fields := []zap.Field{
 			zap.String("peer_id", msg.PeerID),

--- a/services/propagation/classify_test.go
+++ b/services/propagation/classify_test.go
@@ -1,0 +1,70 @@
+package propagation
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestClassifyFailureLine pins the conservative Teranode-line → ARC-code map
+// (issue #254 / external feedback item 2). Invariants: the verbatim Teranode
+// line is always preserved in the message (the caller keeps every per-tx line
+// terminally rejected — the requeue signal is a body-less 5xx, decided
+// elsewhere); only confidently-mappable code prefixes gain an ARC status
+// code; and the non-final family carries an explicit retryable hint.
+func TestClassifyFailureLine(t *testing.T) {
+	cases := []struct {
+		name          string
+		line          string
+		wantCode      int
+		wantRetryHint bool
+	}{
+		{
+			name: "processing catch-all stays uncoded",
+			line: "PROCESSING (4): [ProcessTransaction][ab12] failed to validate transaction",
+		},
+		{
+			name:     "tx invalid maps to generic 467",
+			line:     "TX_INVALID (31): [ProcessTransaction][ab12] tx is invalid because fee too low",
+			wantCode: 467,
+		},
+		{
+			name:          "tx lock time maps to non-final 476 with retry hint",
+			line:          "TX_LOCK_TIME (35): [ProcessTransaction][ab12] Bad tx lock time",
+			wantCode:      476,
+			wantRetryHint: true,
+		},
+		{
+			name:          "utxo non-final maps to non-final 476 with retry hint",
+			line:          "UTXO_NON_FINAL (71): [ProcessTransaction][ab12] tx is non-final",
+			wantCode:      476,
+			wantRetryHint: true,
+		},
+		{
+			name:     "tx conflicting maps to conflict 466",
+			line:     "TX_CONFLICTING (36): [ProcessTransaction][ab12] tx conflicting",
+			wantCode: 466,
+		},
+		{
+			name: "unknown code name stays uncoded",
+			line: "SOME_FUTURE_CODE (99): [ProcessTransaction][ab12] who knows",
+		},
+		{
+			name: "line without code prefix stays uncoded",
+			line: "malformed line with no teranode code",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, code := classifyFailureLine(tc.line)
+			if code != tc.wantCode {
+				t.Errorf("code = %d, want %d", code, tc.wantCode)
+			}
+			if !strings.Contains(msg, tc.line) {
+				t.Errorf("message %q must preserve the Teranode line verbatim %q", msg, tc.line)
+			}
+			if got := strings.Contains(msg, "retryable"); got != tc.wantRetryHint {
+				t.Errorf("retryable hint present=%v, want %v (msg=%q)", got, tc.wantRetryHint, msg)
+			}
+		})
+	}
+}

--- a/services/propagation/depaware_test.go
+++ b/services/propagation/depaware_test.go
@@ -3,6 +3,7 @@ package propagation
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -191,8 +192,18 @@ func TestApplyTerminalStatuses_CascadesRejectedChildren(t *testing.T) {
 		t.Errorf("expected 2 cascade-rejection rows (child + grandchild), got %d: %v", len(rejected), rejected)
 	}
 	for txid, reason := range rejected {
-		if reason != "parent rejected" {
-			t.Errorf("%s ExtraInfo should be \"parent rejected\", got %q", txid, reason)
+		// The stable "parent rejected" prefix stays for existing consumers;
+		// the suffix must name the rejected ancestor and state the recovery
+		// path so a cascaded child reads as retryable queue state, not a
+		// verdict about its own bytes.
+		if !strings.HasPrefix(reason, "parent rejected") {
+			t.Errorf("%s ExtraInfo should keep the \"parent rejected\" prefix, got %q", txid, reason)
+		}
+		if !strings.Contains(reason, "ancestor parent") {
+			t.Errorf("%s ExtraInfo should name the rejected ancestor, got %q", txid, reason)
+		}
+		if !strings.Contains(reason, "resubmit") {
+			t.Errorf("%s ExtraInfo should state the resubmit recovery path, got %q", txid, reason)
 		}
 	}
 }

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/bsv-blockchain/arcade/config"
+	arcerrors "github.com/bsv-blockchain/arcade/errors"
 	"github.com/bsv-blockchain/arcade/events"
 	"github.com/bsv-blockchain/arcade/kafka"
 	"github.com/bsv-blockchain/arcade/logfields"
@@ -495,20 +496,30 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 	// releases waiters via the dispatcher itself (no caller action
 	// needed — released msgs are appended directly to the
 	// dispatcher's pendingMsgs). REJECTED returns cascaded
-	// descendants we write REJECTED rows for; the cascade reason is
-	// always "parent rejected" regardless of the parent's actual
-	// cause — see persistCascadeRejections.
-	var allCascaded []string
+	// descendants we write REJECTED rows for; the cascade reason names
+	// the rejected ancestor but never its cause — see
+	// persistCascadeRejections.
+	var allCascaded []cascadeRejection
 	for _, txid := range terminalAccepted {
 		p.notifyTerminalToDispatcher(ctx, txid, models.StatusAcceptedByNetwork)
 	}
 	for _, txid := range terminalRejected {
 		r := p.notifyTerminalToDispatcher(ctx, txid, models.StatusRejected)
-		allCascaded = append(allCascaded, r.cascaded...)
+		for _, child := range r.cascaded {
+			allCascaded = append(allCascaded, cascadeRejection{txid: child, ancestor: txid})
+		}
 	}
 	if len(allCascaded) > 0 {
 		p.persistCascadeRejections(ctx, allCascaded, now)
 	}
+}
+
+// cascadeRejection pairs a cascade-rejected tx with the terminal-rejected
+// ancestor whose verdict condemned it, so the persisted reason can name the
+// row a client should look at (and resubmit first).
+type cascadeRejection struct {
+	txid     string
+	ancestor string
 }
 
 // persistCascadeRejections writes terminal REJECTED rows for txs the
@@ -517,31 +528,40 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 // Best-effort: a store write failure is logged but doesn't undo the
 // in-memory cascade state (the dispatcher has already terminalized
 // them; we'd be reconciling at restart via Kafka replay anyway).
-func (p *Propagator) persistCascadeRejections(ctx context.Context, txids []string, now time.Time) {
-	statuses := make([]*models.TransactionStatus, len(txids))
-	for i, txid := range txids {
+func (p *Propagator) persistCascadeRejections(ctx context.Context, cascaded []cascadeRejection, now time.Time) {
+	statuses := make([]*models.TransactionStatus, len(cascaded))
+	txids := make([]string, len(cascaded))
+	for i, cr := range cascaded {
+		txids[i] = cr.txid
+		// "parent rejected" (kept as the stable prefix existing consumers
+		// match on) is the only structural reason that applies to a
+		// cascaded child — it didn't fail for any reason of its own. The
+		// suffix names the rejected ancestor whose row carries the actual
+		// cause, and states the recovery path: this rejection is a
+		// consequence of queue state, not a verdict about this tx's bytes,
+		// so once the ancestor is accepted a resubmission re-runs the
+		// pipeline (intake re-validates and re-broadcasts REJECTED rows).
+		reason := fmt.Sprintf(
+			"parent rejected (ancestor %s): retryable — resubmit after the ancestor is accepted",
+			cr.ancestor,
+		)
 		statuses[i] = &models.TransactionStatus{
-			TxID:      txid,
+			TxID:      cr.txid,
 			Status:    models.StatusRejected,
 			Timestamp: now,
-			// "parent rejected" is the only structural reason that
-			// applies to a cascaded child — it didn't fail for any
-			// reason of its own. The parent's actual cause lives on
-			// the parent's row; downstream consumers can correlate
-			// via the dep graph if they care.
-			ExtraInfo: "parent rejected",
+			ExtraInfo: reason,
 		}
 		p.logger.Info(
 			"transaction rejected",
-			logfields.TxID(txid),
-			zap.String("reason", "parent rejected"),
+			logfields.TxID(cr.txid),
+			zap.String("reason", reason),
 			logfields.Stage(logfields.StageCascade),
 		)
 	}
 	if _, err := p.store.BatchUpdateStatusReturning(ctx, statuses); err != nil {
 		p.logger.Warn(
 			"cascade rejection write failed",
-			zap.Int("count", len(txids)),
+			zap.Int("count", len(cascaded)),
 			zap.Error(err),
 		)
 	}
@@ -936,22 +956,55 @@ type txResult struct {
 	successEndpoint string
 }
 
-// classifyFailureLine maps one Teranode /txs failure line into a dispatcher
-// action bucket. The line is the full UserMessage produced by Teranode,
+// classifyFailureLine maps one Teranode /txs failure line into a client-
+// facing message and a machine-readable ARC status code (errors/errors.go
+// taxonomy; 0 when the line has no confident ARC equivalent). The line is
+// the full UserMessage produced by Teranode,
 // e.g. "PROCESSING (4): [ProcessTransaction][<txid>] failed to validate
 // transaction" or "TX_INVALID (31): [ProcessTransaction][<txid>] ...".
 //
-// Any per-txid line returned by Teranode is treated as terminally rejected.
-// Teranode wraps real validator failures with NewProcessingError (see
-// services/propagation/Server.go:1236), so PROCESSING is the catch-all
+// Any per-txid line returned by Teranode is still treated as terminally
+// rejected. Teranode wraps real validator failures with NewProcessingError
+// (see services/propagation/Server.go:1236), so PROCESSING is the catch-all
 // "this tx is bad" code in practice — we can't distinguish a transient
 // infra issue from a permanent validation failure by code alone. The
 // authoritative requeue signal is a 5xx batch response with no parseable
 // per-tx body (handled separately in broadcastBatchToEndpoints), which
-// reflects a true infra outage rather than a tx-level verdict. errMsg is
-// the line verbatim so wallet rows surface the actual Teranode message.
-func classifyFailureLine(line string) (txResultClass, string) {
-	return txResultClassRejected, line
+// reflects a true infra outage rather than a tx-level verdict.
+//
+// What the leading "NAME (n)" code DOES tell us confidently is mapped onto
+// the ARC taxonomy so consumers can branch on a number instead of prose
+// (issue #254 / external feedback item 2):
+//
+//	TX_LOCK_TIME (35), UTXO_NON_FINAL (71) → 476 StatusNotFinal. The peer's
+//	  view says the tx isn't final yet — a condition of that view, not a
+//	  verdict about the bytes; resubmitting after the lock expires (or the
+//	  peer's tip catches up) is expected to succeed, so the message gains an
+//	  explicit retryable hint. (Intake's finality gate catches most of these
+//	  against arcade's own tip; a line here means the peer's view trails.)
+//	TX_CONFLICTING (36) → 466 StatusConflict (double-spend attempt).
+//	TX_INVALID (31)     → 467 StatusGeneric (wraps fee/script/policy — the
+//	  name alone can't recover which).
+//	PROCESSING (4) and everything else → 0, message verbatim.
+//
+// errMsg preserves the Teranode line verbatim (plus the retryable suffix for
+// the non-final family) so wallet rows surface the actual message.
+func classifyFailureLine(line string) (errMsg string, arcCode int) {
+	name, _, found := strings.Cut(line, " (")
+	if !found {
+		return line, 0
+	}
+	switch name {
+	case "TX_LOCK_TIME", "UTXO_NON_FINAL":
+		return line + " — retryable: the transaction is not final against this peer's chain view; resubmit after the locktime expires",
+			int(arcerrors.StatusNotFinal)
+	case "TX_CONFLICTING":
+		return line, int(arcerrors.StatusConflict)
+	case "TX_INVALID":
+		return line, int(arcerrors.StatusGeneric)
+	default:
+		return line, 0
+	}
 }
 
 // startBroadcastSpan opens one "propagation.broadcast" span per flushed
@@ -1486,15 +1539,16 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 				successEndpoint: successEndpoint,
 			}
 		case rejectionLine[i] != "":
-			_, errMsg := classifyFailureLine(rejectionLine[i])
+			errMsg, arcCode := classifyFailureLine(rejectionLine[i])
 			results[i] = txResult{
 				class:  txResultClassRejected,
 				errMsg: errMsg,
 				status: &models.TransactionStatus{
-					TxID:      msg.TXID,
-					Status:    models.StatusRejected,
-					Timestamp: now,
-					ExtraInfo: errMsg,
+					TxID:       msg.TXID,
+					Status:     models.StatusRejected,
+					StatusCode: arcCode,
+					Timestamp:  now,
+					ExtraInfo:  errMsg,
 				},
 				rawTx: msg.RawTx,
 			}

--- a/services/webhook/service.go
+++ b/services/webhook/service.go
@@ -30,7 +30,14 @@ import (
 	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/store"
+	"github.com/bsv-blockchain/arcade/version"
 )
+
+// webhookUserAgent identifies arcade's callback POSTs. The "arcade-webhook/"
+// prefix is a documented, stable string receivers can allowlist at their
+// edge — Go's default Go-http-client UA is a common bot-rule target and got
+// every callback to one production receiver silently 403'd (issue #249).
+var webhookUserAgent = "arcade-webhook/" + version.Version
 
 // defaultMaxConcurrentDeliveries is the fallback pool size when
 // WebhookConfig.MaxConcurrentDeliveries is unset or non-positive.
@@ -386,31 +393,58 @@ func (s *Service) deliver(ctx context.Context, sub *models.Submission, status *m
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
+	// A distinctive UA (instead of Go's default Go-http-client/…) lets
+	// receivers allowlist arcade's callbacks explicitly — generic-Go-UA
+	// bot/WAF rules silently 403'd every POST to one production receiver
+	// while its origin saw nothing (issue #249).
+	req.Header.Set("User-Agent", webhookUserAgent)
 	if sub.CallbackToken != "" {
 		req.Header.Set("Authorization", "Bearer "+sub.CallbackToken)
 	}
 
 	resp, err := s.client.Do(req)
 	if err != nil {
+		s.recordAttempt(ctx, sub, logger, err.Error())
 		s.recordFailure(ctx, sub, status, logger, err.Error())
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		s.recordFailure(ctx, sub, status, logger, fmt.Sprintf("status %d", resp.StatusCode))
+		reason := fmt.Sprintf("status %d", resp.StatusCode)
+		s.recordAttempt(ctx, sub, logger, reason)
+		s.recordFailure(ctx, sub, status, logger, reason)
 		return
 	}
 
-	// CAS already advanced LastDeliveredStatus and cleared retry state, so
-	// there's no second store write on success. recordFailure remains the
-	// only post-claim writer. Info (not Debug): only subscribed txs reach
-	// here, so volume is bounded by callback subscriptions, not raw TPS —
-	// and this is the terminal-delivery lifecycle line for the
+	s.recordAttempt(ctx, sub, logger, deliveryResultDelivered)
+
+	// The CAS already advanced LastDeliveredStatus and cleared retry state,
+	// and recordAttempt above stamped the attempt bookkeeping — recordFailure
+	// remains the only retry-state writer. Info (not Debug): only subscribed
+	// txs reach here, so volume is bounded by callback subscriptions, not raw
+	// TPS — and this is the terminal-delivery lifecycle line for the
 	// txid/callback_url/status search story. No telemetry.LoggerWith here:
 	// deliver runs on the delivery worker pool from a Kafka-fed status
 	// event, not an HTTP request, so no per-request span ctx is plumbed in.
 	logger.Info("callback delivered")
+}
+
+// deliveryResultDelivered is the LastResult value recorded for a successful
+// POST; failures record the transport error or "status <code>" instead. The
+// exact string is part of the GET /tx `callbacks[].lastResult` surface.
+const deliveryResultDelivered = "delivered"
+
+// recordAttempt stamps the outcome of one POST attempt on the submission row
+// (attempts+1, lastAttemptAt, lastResult) so a client can self-diagnose
+// delivery problems from GET /tx?callbackToken=… — e.g. a WAF 403-ing every
+// callback looks like "arcade never called" from the receiver's side (issue
+// #249). Orthogonal to retry-state bookkeeping (CAS/recordFailure), and
+// best-effort: a write failure never changes the delivery outcome.
+func (s *Service) recordAttempt(ctx context.Context, sub *models.Submission, logger *zap.Logger, result string) {
+	if err := s.store.RecordDeliveryAttempt(ctx, sub.SubmissionID, time.Now(), result); err != nil {
+		logger.Warn("recording delivery attempt failed", zap.Error(err))
+	}
 }
 
 // recordFailure increments the submission's retry counter and computes the

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -28,6 +28,7 @@ type fakeStore struct {
 	subs map[string][]*models.Submission
 
 	deliveries []deliveryRecord
+	attempts   []attemptRecord
 }
 
 type deliveryRecord struct {
@@ -35,6 +36,11 @@ type deliveryRecord struct {
 	LastStatus   models.Status
 	RetryCount   int
 	NextRetryAt  *time.Time
+}
+
+type attemptRecord struct {
+	SubmissionID string
+	Result       string
 }
 
 func (s *fakeStore) GetSubmissionsByTxID(_ context.Context, txid string) ([]*models.Submission, error) {
@@ -70,6 +76,25 @@ func (s *fakeStore) UpdateDeliveryStatus(_ context.Context, id string, last mode
 				sub.LastDeliveredStatus = last
 				sub.RetryCount = retry
 				sub.NextRetryAt = nextRetry
+			}
+		}
+	}
+	return nil
+}
+
+// RecordDeliveryAttempt mirrors the real stores: attempts increments and the
+// last-attempt bookkeeping is overwritten, on every POST regardless of outcome.
+func (s *fakeStore) RecordDeliveryAttempt(_ context.Context, id string, at time.Time, result string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.attempts = append(s.attempts, attemptRecord{SubmissionID: id, Result: result})
+	for _, list := range s.subs {
+		for _, sub := range list {
+			if sub.SubmissionID == id {
+				sub.Attempts++
+				t := at
+				sub.LastAttemptAt = &t
+				sub.LastResult = result
 			}
 		}
 	}
@@ -269,12 +294,14 @@ func (p *scriptedPub) Close() error { return nil }
 // status, callback URL gets POSTed with the bearer token, store records
 // LastDeliveredStatus.
 func TestDeliverSuccess(t *testing.T) {
-	var receivedAuth string
+	var receivedAuth, receivedUA, receivedCT string
 	var receivedBody []byte
 	var hits atomic.Int32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAuth = r.Header.Get("Authorization")
+		receivedUA = r.Header.Get("User-Agent")
+		receivedCT = r.Header.Get("Content-Type")
 		body, _ := io.ReadAll(r.Body)
 		receivedBody = body
 		hits.Add(1)
@@ -312,6 +339,15 @@ func TestDeliverSuccess(t *testing.T) {
 	if receivedAuth != "Bearer tok-A" {
 		t.Errorf("Authorization = %q, want %q", receivedAuth, "Bearer tok-A")
 	}
+	// The documented allowlistable UA (issue #249) — receivers key WAF rules
+	// on the "arcade-webhook/" prefix, so it must never regress to Go's
+	// default UA. version.Version is "dev" outside ldflags builds.
+	if receivedUA != "arcade-webhook/dev" {
+		t.Errorf("User-Agent = %q, want %q", receivedUA, "arcade-webhook/dev")
+	}
+	if receivedCT != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", receivedCT)
+	}
 	var payload map[string]any
 	if err := json.Unmarshal(receivedBody, &payload); err != nil {
 		t.Fatalf("decoding callback body: %v", err)
@@ -321,6 +357,13 @@ func TestDeliverSuccess(t *testing.T) {
 	}
 	if len(st.deliveries) != 1 || st.deliveries[0].LastStatus != models.StatusMined {
 		t.Errorf("expected one MINED delivery record, got %+v", st.deliveries)
+	}
+	// Successful POST stamps the lifetime attempt bookkeeping.
+	if len(st.attempts) != 1 || st.attempts[0].Result != "delivered" {
+		t.Errorf("expected one delivered attempt record, got %+v", st.attempts)
+	}
+	if sub := st.subs[txA][0]; sub.Attempts != 1 || sub.LastResult != "delivered" || sub.LastAttemptAt == nil {
+		t.Errorf("submission attempt state not stamped: %+v", sub)
 	}
 }
 
@@ -400,6 +443,15 @@ func TestRetryOnFailure(t *testing.T) {
 	}
 	if d.NextRetryAt == nil || !d.NextRetryAt.After(before) {
 		t.Errorf("NextRetryAt = %v, expected after %v", d.NextRetryAt, before)
+	}
+	// The failed POST stamps the lifetime attempt bookkeeping with the same
+	// reason string the failure log carries — this is what GET /tx's
+	// callbacks[].lastResult surfaces for receiver self-diagnosis (#249).
+	if len(st.attempts) != 1 || st.attempts[0].Result != "status 500" {
+		t.Errorf("expected one 'status 500' attempt record, got %+v", st.attempts)
+	}
+	if sub := st.subs[txA][0]; sub.Attempts != 1 || sub.LastResult != "status 500" {
+		t.Errorf("submission attempt state not stamped on failure: %+v", sub)
 	}
 }
 

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -323,6 +323,14 @@ func (s *Store) GetOrInsertStatus(ctx context.Context, status *models.Transactio
 		"timestamp":  status.Timestamp.UnixMilli(),
 		"created_at": now.UnixMilli(),
 	}
+	// Rows can be born terminal (intake rejection): carry the machine-
+	// readable cause and code on the insert, matching the other backends.
+	if status.StatusCode != 0 {
+		bins["status_code"] = status.StatusCode
+	}
+	if status.ExtraInfo != "" {
+		bins["extra_info"] = status.ExtraInfo
+	}
 
 	policy := s.writePolicy(ctx)
 	policy.RecordExistsAction = aero.CREATE_ONLY
@@ -382,6 +390,9 @@ func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStat
 	bins := aero.BinMap{
 		"status":    string(status.Status),
 		"timestamp": status.Timestamp.UnixMilli(),
+	}
+	if status.StatusCode != 0 {
+		bins["status_code"] = status.StatusCode
 	}
 	if status.BlockHash != "" {
 		bins["block_hash"] = status.BlockHash
@@ -2264,6 +2275,11 @@ func recordToStatus(rec *aero.Record, txid string) *models.TransactionStatus {
 	if v, ok := rec.Bins["status"]; ok {
 		if s, ok := v.(string); ok {
 			status.Status = models.Status(s)
+		}
+	}
+	if v, ok := rec.Bins["status_code"]; ok {
+		if n, ok := v.(int); ok {
+			status.StatusCode = n
 		}
 	}
 	if v, ok := rec.Bins["block_hash"]; ok {

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -1677,6 +1677,29 @@ func (s *Store) UpdateDeliveryStatus(ctx context.Context, submissionID string, l
 	return s.client.Put(s.writePolicy(ctx), key, bins)
 }
 
+// RecordDeliveryAttempt implements store.Store. One Operate call: AddOp gives
+// a server-side atomic increment for the lifetime attempts counter (no
+// read-modify-write race across delivery workers); the puts overwrite the
+// last-attempt bookkeeping. Bin names must be <=15 chars ("last_attempt_at"
+// is exactly 15).
+func (s *Store) RecordDeliveryAttempt(ctx context.Context, submissionID string, at time.Time, result string) error {
+	key, err := s.key(setSubmissions, submissionID)
+	if err != nil {
+		return err
+	}
+	policy := s.writePolicy(ctx)
+	policy.RecordExistsAction = aero.UPDATE_ONLY // never create a phantom submission
+	_, err = s.client.Operate(policy, key,
+		aero.AddOp(aero.NewBin("attempts", 1)),
+		aero.PutOp(aero.NewBin("last_attempt_at", at.UnixMilli())),
+		aero.PutOp(aero.NewBin("last_result", result)),
+	)
+	if isKeyNotFound(err) {
+		return nil
+	}
+	return err
+}
+
 // UpdateDeliveryStatusCAS implements store.Store using a generation-match
 // CAS write — the same pattern TryAcquireOrRenew uses for the lease record.
 // Reading then writing with EXPECT_GEN_EQUAL guarantees we lose to any
@@ -2397,6 +2420,22 @@ func recordToSubmission(rec *aero.Record) *models.Submission {
 		if ms, ok := v.(int); ok {
 			t := time.UnixMilli(int64(ms))
 			sub.NextRetryAt = &t
+		}
+	}
+	if v, ok := rec.Bins["attempts"]; ok {
+		if n, ok := v.(int); ok {
+			sub.Attempts = n
+		}
+	}
+	if v, ok := rec.Bins["last_attempt_at"]; ok {
+		if ms, ok := v.(int); ok {
+			t := time.UnixMilli(int64(ms))
+			sub.LastAttemptAt = &t
+		}
+	}
+	if v, ok := rec.Bins["last_result"]; ok {
+		if s, ok := v.(string); ok {
+			sub.LastResult = s
 		}
 	}
 	return sub

--- a/store/pebble/delivery_attempt_test.go
+++ b/store/pebble/delivery_attempt_test.go
@@ -1,0 +1,60 @@
+package pebble
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// TestRecordDeliveryAttempt_RoundTrip pins the delivery-attempt bookkeeping
+// (issue #249): attempts accumulates across POSTs, last-attempt fields are
+// overwritten each time, the retry-scheduling fields are untouched, and an
+// unknown submission is a silent no-op (never a phantom row).
+func TestRecordDeliveryAttempt_RoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	sub := &models.Submission{
+		SubmissionID:  "sub-attempts",
+		TxID:          "aa11",
+		CallbackURL:   "https://receiver.example/cb",
+		CallbackToken: "tok",
+	}
+	if err := s.InsertSubmission(ctx, sub); err != nil {
+		t.Fatalf("InsertSubmission: %v", err)
+	}
+
+	t1 := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	if err := s.RecordDeliveryAttempt(ctx, sub.SubmissionID, t1, "status 403"); err != nil {
+		t.Fatalf("first attempt: %v", err)
+	}
+	t2 := t1.Add(time.Minute)
+	if err := s.RecordDeliveryAttempt(ctx, sub.SubmissionID, t2, "delivered"); err != nil {
+		t.Fatalf("second attempt: %v", err)
+	}
+
+	subs, err := s.GetSubmissionsByTxID(ctx, sub.TxID)
+	if err != nil || len(subs) != 1 {
+		t.Fatalf("GetSubmissionsByTxID: %v (%d subs)", err, len(subs))
+	}
+	got := subs[0]
+	if got.Attempts != 2 {
+		t.Errorf("Attempts = %d, want 2", got.Attempts)
+	}
+	if got.LastResult != "delivered" {
+		t.Errorf("LastResult = %q, want delivered", got.LastResult)
+	}
+	if got.LastAttemptAt == nil || !got.LastAttemptAt.Equal(t2) {
+		t.Errorf("LastAttemptAt = %v, want %v", got.LastAttemptAt, t2)
+	}
+	if got.RetryCount != 0 || got.NextRetryAt != nil {
+		t.Errorf("retry-scheduling state must be untouched: %+v", got)
+	}
+
+	// Unknown submission: no error, no phantom row.
+	if err := s.RecordDeliveryAttempt(ctx, "sub-missing", t1, "status 500"); err != nil {
+		t.Fatalf("missing submission should no-op, got %v", err)
+	}
+}

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -146,6 +146,9 @@ type storedSubmission struct {
 	LastDeliveredStatus string `json:"last_delivered_status,omitempty"`
 	RetryCount          int    `json:"retry_count,omitempty"`
 	NextRetryUnixNs     int64  `json:"next_retry_at,omitempty"`
+	Attempts            int    `json:"attempts,omitempty"`
+	LastAttemptUnixNs   int64  `json:"last_attempt_at,omitempty"`
+	LastResult          string `json:"last_result,omitempty"`
 	CreatedUnixNs       int64  `json:"created_at"`
 }
 
@@ -158,6 +161,8 @@ func (s storedSubmission) toModel() *models.Submission {
 		FullStatusUpdates:   s.FullStatusUpdates,
 		LastDeliveredStatus: models.Status(s.LastDeliveredStatus),
 		RetryCount:          s.RetryCount,
+		Attempts:            s.Attempts,
+		LastResult:          s.LastResult,
 	}
 	if s.CreatedUnixNs != 0 {
 		out.CreatedAt = time.Unix(0, s.CreatedUnixNs)
@@ -165,6 +170,10 @@ func (s storedSubmission) toModel() *models.Submission {
 	if s.NextRetryUnixNs != 0 {
 		t := time.Unix(0, s.NextRetryUnixNs)
 		out.NextRetryAt = &t
+	}
+	if s.LastAttemptUnixNs != 0 {
+		t := time.Unix(0, s.LastAttemptUnixNs)
+		out.LastAttemptAt = &t
 	}
 	return out
 }
@@ -1655,6 +1664,41 @@ func (s *Store) UpdateDeliveryStatus(ctx context.Context, submissionID string, l
 	} else {
 		ss.NextRetryUnixNs = 0
 	}
+
+	payload, err := json.Marshal(ss)
+	if err != nil {
+		return err
+	}
+	return s.db.Set(subKey(submissionID), payload, s.writeOpts)
+}
+
+// RecordDeliveryAttempt implements store.Store. The read-modify-write is
+// serialized via submissionMu so a concurrent CAS or retry-state write can't
+// lose the attempts increment.
+func (s *Store) RecordDeliveryAttempt(ctx context.Context, submissionID string, at time.Time, result string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.submissionMu.Lock()
+	defer s.submissionMu.Unlock()
+
+	v, closer, err := s.db.Get(subKey(submissionID))
+	if errors.Is(err, pebbledb.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var ss storedSubmission
+	if uErr := json.Unmarshal(v, &ss); uErr != nil {
+		_ = closer.Close()
+		return uErr
+	}
+	_ = closer.Close()
+
+	ss.Attempts++
+	ss.LastAttemptUnixNs = at.UnixNano()
+	ss.LastResult = result
 
 	payload, err := json.Marshal(ss)
 	if err != nil {

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -366,7 +366,7 @@ func (s *Store) batchUpdateStatusSQL(ctx context.Context, statuses []*models.Tra
 		return nil
 	}
 
-	const colsPerRow = 7 // txid, status, block_hash, block_height, extra_info, merkle_path, timestamp_at, disallowed_prev
+	const colsPerRow = 8 // txid, status, status_code, block_hash, block_height, extra_info, merkle_path, timestamp_at, disallowed_prev
 
 	args := make([]any, 0, len(statuses)*(colsPerRow+1))
 	now := time.Now()
@@ -391,6 +391,7 @@ func (s *Store) batchUpdateStatusSQL(ctx context.Context, statuses []*models.Tra
 			args,
 			st.TxID,
 			string(st.Status),
+			st.StatusCode,
 			st.BlockHash,
 			int64(st.BlockHeight), /* #nosec G115 */
 			st.ExtraInfo,
@@ -410,8 +411,8 @@ func (s *Store) batchUpdateStatusSQL(ctx context.Context, statuses []*models.Tra
 		// right types for the VALUES alias columns.
 		fmt.Fprintf(
 			&values,
-			"($%d::text,$%d::text,$%d::text,$%d::bigint,$%d::text,$%d::bytea,$%d::timestamptz,$%d::text[])",
-			base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8,
+			"($%d::text,$%d::text,$%d::int,$%d::text,$%d::bigint,$%d::text,$%d::bytea,$%d::timestamptz,$%d::text[])",
+			base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9,
 		)
 	}
 
@@ -422,12 +423,13 @@ func (s *Store) batchUpdateStatusSQL(ctx context.Context, statuses []*models.Tra
 	q := `
 UPDATE transactions t SET
     status       = v.status,
+    status_code  = COALESCE(NULLIF(v.status_code, 0),     t.status_code),
     block_hash   = COALESCE(NULLIF(v.block_hash, ''),     t.block_hash),
     block_height = COALESCE(NULLIF(v.block_height, 0),    t.block_height),
     extra_info   = COALESCE(NULLIF(v.extra_info, ''),     t.extra_info),
     merkle_path  = COALESCE(v.merkle_path,                t.merkle_path),
     timestamp_at = v.timestamp_at
-FROM (VALUES ` + values.String() + `) AS v(txid, status, block_hash, block_height, extra_info, merkle_path, timestamp_at, disallowed_prev)
+FROM (VALUES ` + values.String() + `) AS v(txid, status, status_code, block_hash, block_height, extra_info, merkle_path, timestamp_at, disallowed_prev)
 WHERE t.txid = v.txid AND t.status <> ALL(v.disallowed_prev)`
 
 	if _, err := s.pool.Exec(ctx, q, args...); err != nil {
@@ -467,6 +469,11 @@ func (s *Store) UpdateStatus(ctx context.Context, status *models.TransactionStat
 	if status.ExtraInfo != "" {
 		sets = append(sets, fmt.Sprintf("extra_info = $%d", idx))
 		args = append(args, status.ExtraInfo)
+		idx++
+	}
+	if status.StatusCode != 0 {
+		sets = append(sets, fmt.Sprintf("status_code = $%d", idx))
+		args = append(args, status.StatusCode)
 		idx++
 	}
 	if len(status.MerklePath) > 0 {

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -1174,7 +1174,8 @@ WHERE t.txid IN (SELECT DISTINCT txid FROM submissions WHERE callback_token = $1
 func (s *Store) submissions(ctx context.Context, where string, arg any) ([]*models.Submission, error) {
 	q := `
 SELECT submission_id, txid, callback_url, callback_token, full_status_updates,
-       last_delivered_status, retry_count, next_retry_at, created_at
+       last_delivered_status, retry_count, next_retry_at, attempts,
+       last_attempt_at, last_result, created_at
 FROM submissions WHERE ` + where
 	rows, err := s.pool.Query(ctx, q, arg)
 	if err != nil {
@@ -1184,26 +1185,43 @@ FROM submissions WHERE ` + where
 
 	var out []*models.Submission
 	for rows.Next() {
-		sub := &models.Submission{}
-		var lastStatus *string
-		var nextRetry *time.Time
-		if err := rows.Scan(
-			&sub.SubmissionID, &sub.TxID, &sub.CallbackURL, &sub.CallbackToken,
-			&sub.FullStatusUpdates, &lastStatus, &sub.RetryCount, &nextRetry,
-			&sub.CreatedAt,
-		); err != nil {
+		sub, err := scanSubmission(rows)
+		if err != nil {
 			return out, err
-		}
-		if lastStatus != nil {
-			sub.LastDeliveredStatus = models.Status(*lastStatus)
-		}
-		if nextRetry != nil {
-			t := *nextRetry
-			sub.NextRetryAt = &t
 		}
 		out = append(out, sub)
 	}
 	return out, rows.Err()
+}
+
+// scanSubmission reads one submissions row in the canonical column order
+// (shared by submissions and ListSubmissionsReadyForRetry).
+func scanSubmission(row rowScanner) (*models.Submission, error) {
+	sub := &models.Submission{}
+	var lastStatus, lastResult *string
+	var nextRetry, lastAttempt *time.Time
+	if err := row.Scan(
+		&sub.SubmissionID, &sub.TxID, &sub.CallbackURL, &sub.CallbackToken,
+		&sub.FullStatusUpdates, &lastStatus, &sub.RetryCount, &nextRetry,
+		&sub.Attempts, &lastAttempt, &lastResult, &sub.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if lastStatus != nil {
+		sub.LastDeliveredStatus = models.Status(*lastStatus)
+	}
+	if nextRetry != nil {
+		t := *nextRetry
+		sub.NextRetryAt = &t
+	}
+	if lastAttempt != nil {
+		t := *lastAttempt
+		sub.LastAttemptAt = &t
+	}
+	if lastResult != nil {
+		sub.LastResult = *lastResult
+	}
+	return sub, nil
 }
 
 func (s *Store) UpdateDeliveryStatus(ctx context.Context, submissionID string, lastStatus models.Status, retryCount int, nextRetry *time.Time) error {
@@ -1248,7 +1266,8 @@ func (s *Store) ListSubmissionsReadyForRetry(ctx context.Context, now time.Time,
 	}
 	const q = `
 SELECT submission_id, txid, callback_url, callback_token, full_status_updates,
-       last_delivered_status, retry_count, next_retry_at, created_at
+       last_delivered_status, retry_count, next_retry_at, attempts,
+       last_attempt_at, last_result, created_at
 FROM submissions
 WHERE retry_count > 0
   AND next_retry_at IS NOT NULL
@@ -1263,26 +1282,25 @@ LIMIT $2`
 
 	var out []*models.Submission
 	for rows.Next() {
-		sub := &models.Submission{}
-		var lastStatus *string
-		var nextRetry *time.Time
-		if err := rows.Scan(
-			&sub.SubmissionID, &sub.TxID, &sub.CallbackURL, &sub.CallbackToken,
-			&sub.FullStatusUpdates, &lastStatus, &sub.RetryCount, &nextRetry,
-			&sub.CreatedAt,
-		); err != nil {
+		sub, err := scanSubmission(rows)
+		if err != nil {
 			return out, err
-		}
-		if lastStatus != nil {
-			sub.LastDeliveredStatus = models.Status(*lastStatus)
-		}
-		if nextRetry != nil {
-			t := *nextRetry
-			sub.NextRetryAt = &t
 		}
 		out = append(out, sub)
 	}
 	return out, rows.Err()
+}
+
+// RecordDeliveryAttempt implements store.Store: one atomic in-place update —
+// attempts increments server-side so concurrent workers can't lose counts.
+func (s *Store) RecordDeliveryAttempt(ctx context.Context, submissionID string, at time.Time, result string) error {
+	const q = `
+UPDATE submissions SET attempts = attempts + 1, last_attempt_at=$2, last_result=$3
+WHERE submission_id=$1`
+	if _, err := s.pool.Exec(ctx, q, submissionID, at, result); err != nil {
+		return fmt.Errorf("record delivery attempt: %w", err)
+	}
+	return nil
 }
 
 // --- Leaser ---

--- a/store/postgres/schema.sql
+++ b/store/postgres/schema.sql
@@ -79,6 +79,9 @@ CREATE TABLE IF NOT EXISTS submissions (
     last_delivered_status TEXT,
     retry_count           INT NOT NULL DEFAULT 0,
     next_retry_at         TIMESTAMPTZ,
+    attempts              INT NOT NULL DEFAULT 0,
+    last_attempt_at       TIMESTAMPTZ,
+    last_result           TEXT,
     created_at            TIMESTAMPTZ NOT NULL
 );
 -- Idempotent column adds for stores created before the exactly-once webhook
@@ -89,6 +92,12 @@ CREATE TABLE IF NOT EXISTS submissions (
 ALTER TABLE submissions ADD COLUMN IF NOT EXISTS last_delivered_status TEXT;
 ALTER TABLE submissions ADD COLUMN IF NOT EXISTS retry_count           INT NOT NULL DEFAULT 0;
 ALTER TABLE submissions ADD COLUMN IF NOT EXISTS next_retry_at         TIMESTAMPTZ;
+-- Delivery-attempt bookkeeping (issue #249): lifetime attempt counter plus
+-- the last attempt's time and outcome, surfaced on GET /tx?callbackToken=…
+-- so receivers can self-diagnose callbacks their edge is rejecting.
+ALTER TABLE submissions ADD COLUMN IF NOT EXISTS attempts              INT NOT NULL DEFAULT 0;
+ALTER TABLE submissions ADD COLUMN IF NOT EXISTS last_attempt_at       TIMESTAMPTZ;
+ALTER TABLE submissions ADD COLUMN IF NOT EXISTS last_result           TEXT;
 CREATE INDEX IF NOT EXISTS idx_sub_txid   ON submissions(txid);
 CREATE INDEX IF NOT EXISTS idx_sub_token  ON submissions(callback_token);
 -- Partial index keyed off the webhook reaper's scan predicate; stays

--- a/store/store.go
+++ b/store/store.go
@@ -256,6 +256,16 @@ type Store interface {
 	// UpdateDeliveryStatus updates the delivery tracking for a submission
 	UpdateDeliveryStatus(ctx context.Context, submissionID string, lastStatus models.Status, retryCount int, nextRetry *time.Time) error
 
+	// RecordDeliveryAttempt stamps the outcome of one webhook POST attempt on
+	// the submission row: Attempts is incremented and LastAttemptAt/LastResult
+	// are overwritten (result is "delivered" or the failure reason, e.g.
+	// "status 403"). Deliberately orthogonal to UpdateDeliveryStatus /
+	// UpdateDeliveryStatusCAS: those manage the per-transition retry state the
+	// CAS resets (issue #166), while this is monotonic lifetime bookkeeping
+	// surfaced to clients via GET /tx?callbackToken=… for delivery
+	// self-diagnosis (issue #249).
+	RecordDeliveryAttempt(ctx context.Context, submissionID string, at time.Time, result string) error
+
 	// UpdateDeliveryStatusCAS atomically advances LastDeliveredStatus from
 	// `expected` to `next` for the given submission. Returns true iff a row
 	// was updated; false means another replica has already advanced this

--- a/tests/smoke/nonfinal_tx_test.go
+++ b/tests/smoke/nonfinal_tx_test.go
@@ -104,11 +104,14 @@ func getTxStatus(rt *arcadeRuntime, txid string) (int, string, error) {
 }
 
 // TestSmoke_NonFinalTxRejectedAtIntake exercises the nLockTime/BIP113
-// finality gate end-to-end through the real boot path (issue #245): arcade
-// boots with chaintracks.mode=remote pointed at a stub chain, a non-final
-// tx is rejected synchronously with an actionable reason (never reaching
-// teranode), the reason is durable on GET /tx/{txid}, and an
-// otherwise-identical final tx broadcasts normally.
+// finality gate end-to-end through the real boot path (issues #245/#254):
+// arcade boots with chaintracks.mode=remote pointed at a stub chain, a
+// non-final tx is answered synchronously with an actionable 400 carrying
+// ARC code 476 (never reaching teranode) — but NO verdict is persisted:
+// non-finality is a condition of arcade's chain view, so GET /tx/{txid}
+// keeps returning 404 ("no verdict") and resubmission policies keyed on
+// no-verdict recover once the locktime expires. An otherwise-identical
+// final tx broadcasts normally.
 func TestSmoke_NonFinalTxRejectedAtIntake(t *testing.T) {
 	recorder := newRecordingTeranode(t)
 	stub := newStubChaintracks(t)
@@ -130,17 +133,18 @@ func TestSmoke_NonFinalTxRejectedAtIntake(t *testing.T) {
 	if !strings.Contains(body, "transaction is not final") {
 		t.Errorf("response %q missing finality reason", body)
 	}
+	if !strings.Contains(body, `"status":476`) {
+		t.Errorf("response %q missing ARC 476 status code", body)
+	}
 
-	// The rejection must be durable and carry the reason for late readers.
+	// Zero-state contract: no verdict is persisted for a non-final tx, so
+	// GET stays 404 — the "no verdict" answer resubmission policies key on.
 	code, body, err = getTxStatus(rt, nonFinal.TxID())
 	if err != nil {
 		t.Fatalf("get non-final tx status: %v", err)
 	}
-	if code != http.StatusOK {
-		t.Fatalf("GET /tx/%s: expected 200, got %d: %s", nonFinal.TxID(), code, body)
-	}
-	if !strings.Contains(body, "REJECTED") || !strings.Contains(body, "transaction is not final") {
-		t.Errorf("status body %q missing REJECTED + finality reason", body)
+	if code != http.StatusNotFound {
+		t.Fatalf("GET /tx/%s: expected 404 (no verdict persisted), got %d: %s", nonFinal.TxID(), code, body)
 	}
 
 	// Final: locktime already below the MTP — must broadcast normally.


### PR DESCRIPTION
## Summary

Implements the actionable half of the external feedback bundle (issue #254 + the five-item feedback doc from the chained-covenant production user), drawing the line agreed in the follow-up discussion: **verdicts about a transaction's bytes are terminal; conditions of arcade's chain view are not.** Fixes #254's three asks; the remaining feedback items are answered without code (rationale below).

## Changes

- **Non-final intake persists nothing** (the sticky-REJECTED root case). The nLockTime/BIP113 gate keeps its actionable 400 — now carrying ARC `476` — but writes no REJECTED row, records no submission, publishes no event. A fresh tx's `GET /tx/{txid}` stays `404` ("no verdict"), so clients that resubmit on no-verdict recover automatically once the locktime expires or the chain view catches up; a resubmit evaluated against a stale tip can no longer clobber an in-flight (e.g. SEEN) row. Validator failures — verdicts about the bytes — keep the durable REJECTED contract.
- **ARC codes end-to-end** (`460-476` taxonomy, `errors/errors.go` — previously fully built but unused in production paths):
  - intake rejections persist the code in the pre-existing `StatusCode` column (`status` in JSON); postgres/aerospike writers now actually persist it (pebble already merged it) and aerospike additionally persists `extra_info` on born-terminal inserts;
  - submit 400 bodies additively gain `status`/`title`/`detail`/`type` alongside the untouched legacy `error`/`reason`;
  - the propagation path's `classifyFailureLine` (previously a no-op) conservatively parses Teranode's line prefix: `TX_LOCK_TIME`/`UTXO_NON_FINAL`→476 + explicit "retryable" hint, `TX_CONFLICTING`→466, `TX_INVALID`→467, everything else uncoded with the line verbatim. Per-tx lines remain terminal — the requeue signal stays the body-less 5xx.
- **Cascade rejections are labeled as queue state**: `parent rejected (ancestor <txid>): retryable — resubmit after the ancestor is accepted` (stable `parent rejected` prefix kept for existing matchers).
- **Chain-freshness signal**: `GET /health` gains `blockHeight` (arcade's processed active tip, TTL-cached store read), and two gauges close the height-lag blind spot — `arcade_chain_tip_height` and `arcade_p2p_peer_best_height` (the p2p `node_status.BestHeight` was previously discarded at debug level). `datahub_urls[].healthy` is reachability-only and stays green through a chain stall; `blockHeight` is what clients compare and route on.
- **Allowlistable webhook User-Agent** (#249 follow-up): every callback POST now carries `User-Agent: arcade-webhook/<version>` — receivers can allowlist the stable `arcade-webhook/` prefix, and generic-Go-UA bot/WAF rules (which silently 403'd 24k POSTs to one production receiver) stop matching.
- **Self-diagnosable delivery state** (#249 follow-up): every POST stamps lifetime bookkeeping on the submission row via new store method `RecordDeliveryAttempt` — `attempts` (atomic server-side increment), `lastAttemptAt`, `lastResult` (`"delivered"` | `"status 403"` | transport error) — orthogonal to the CAS/retry-state writers (#166 untouched). `GET /tx/{txid}?callbackToken=…` returns a `callbacks` array scoped to that token's submissions (same capability model as SSE; no token → response byte-identical to before, and one client can never see another's callback URLs or delivery health). "Your edge is 403-ing us" is now visible from the receiver's side: `lastResult: "status 403"` with climbing `attempts`.
- **Docs**: "verdicts vs. conditions" section in `docs/overview.md`; OpenAPI + served route docs for the non-final 400 contract, the additive ARC fields, `GET /tx` 404 semantics and the no-retention guarantee, the webhook UA, the `CallbackDelivery` schema + `callbackToken` query param; README webhook section.

## Feedback items answered without code

- **REJECTED→MINED reconciliation/tracker**: declined per the discussion thread — arcade has no historical oracle for a tx mined in an already-processed block. Recovery stays client-driven: resubmitting a REJECTED tx re-validates and re-broadcasts (shipped in v0.10.0, #176/#246); this PR removes the case where there was a false verdict to recover *from*.
- **"Resubmission doesn't re-validate"**: outdated — true of v0.9.10 (the hosted deployment), fixed since v0.10.0.
- **Webhook empty-CallbackURL skip**: by-design SSE-only (token-only) subscriptions; no code path persists a blanked URL (queue-fullness drops whole records with a metric, never corrupts them). The hosted zero-webhook symptom (#249) is a deployment-side investigation; #259 separately adds `merklePath` to callbacks.
- **"GET must never 404 for a mined tx"**: impossible for never-submitted txs (same no-oracle constraint); for known txs GET already never 404s and has no retention window — now documented.
- **"Stricter-than-consensus validation"**: the divergence was Teranode's own finality rule evaluated on a lagging view (#245, closed via #246); arcade mirrors the node's mempool rule, and this PR makes the lagging-view case non-sticky. Inner-error opacity remains upstream (teranode#1272); we now classify what the line does carry.

## Tests

- Intake: non-final single+batch → 400 with ARC 476, zero store writes, zero publishes (rewritten to pin the zero-state contract); additive 400 body shape; `arcStatusCodeOf` extraction.
- Propagation: `classifyFailureLine` table test (code map, verbatim-line preservation, retryable hint); cascade test extended for the ancestor-naming reason.
- Health: `blockHeight` presence, TTL-cache coalescing (1 store read across 2 probes), omission without a store.
- Webhook: `User-Agent`/`Content-Type` asserted on the outgoing POST; attempt bookkeeping stamped on success (`delivered`) and failure (`status 500`) paths.
- GET /tx callbacks: token-scoped array with full state; wrong/absent token → byte-identical response; other subscribers' URLs and all tokens never appear in any body. Pebble round-trip: attempts accumulate, retry-state untouched, unknown submission no-ops.

Verification: `gofmt`/`go build`/`go vet`/`magex lint` clean; full `go test ./...` + smoke suite green; `-race` clean on api_server/propagation/webhook/p2p_client/store.

Fixes #254.


https://claude.ai/code/session_01Wct8fZwf557TsXtwLYDGpm
