### PR TITLE
fix(propagation): reaper rebroadcasts stuck ACCEPTED_BY_NETWORK txs to drain the stuck gauge

### DIFF
--- a/services/propagation/reaper.go
+++ b/services/propagation/reaper.go
@@ -30,15 +30,27 @@ import (
 // that the normal intake→ACCEPTED path (seconds) and the 2s in-memory requeue
 // are never pre-empted by the reaper.
 //
+// staleAcceptedByNetworkAge: a row at ACCEPTED_BY_NETWORK older than this was
+// accepted into a mempool but never advanced to SEEN — the merkle-service
+// state-transfer that drives SEEN never arrived (the /watch registration was
+// lost, or the tx propagated too narrowly for merkle-service's p2p to observe
+// it). Rebroadcast to nudge it: re-registering gives merkle-service another
+// chance to watch and detect the tx, and re-broadcasting pushes it to more
+// peers so it can propagate wider. Safe to repeat every tick — the lattice
+// forbids ACCEPTED_BY_NETWORK → ACCEPTED_BY_NETWORK
+// (models.Status.DisallowedPreviousStatuses), so a still-accepted rebroadcast
+// result is a store no-op: the stuck gauge drains only when the tx genuinely
+// reaches SEEN/MINED/REJECTED, never via a spurious timestamp refresh.
+//
 // staleScanLookback bounds how far back IterateStatusesSince walks. Rows
 // older than this are assumed permanently stuck and outside the reaper's
-// responsibility — the operator surfaces them with `arcade tools surface
-// stuck` if a deeper sweep is needed.
+// responsibility.
 const (
-	staleSeenOnNetworkAge  = time.Hour
-	staleReceivedAge       = time.Hour
-	staleScanLookback      = 24 * time.Hour
-	reaperRebroadcastBatch = 200
+	staleSeenOnNetworkAge     = time.Hour
+	staleReceivedAge          = time.Hour
+	staleAcceptedByNetworkAge = time.Hour
+	staleScanLookback         = 24 * time.Hour
+	reaperRebroadcastBatch    = 200
 
 	// stuckTransientAge is the threshold for the StuckTransientTxs /
 	// OldestTransientTxAge gauges: a tx sitting in RECEIVED or
@@ -49,9 +61,9 @@ const (
 )
 
 // stuckTransientStatuses are the transient statuses the stuck gauges track.
-// RECEIVED is partially self-healed by the rebroadcast arm below;
-// ACCEPTED_BY_NETWORK has no self-heal path, which is exactly why it needs
-// the visibility.
+// Both are now nudged by the rebroadcast arm below (RECEIVED past
+// staleReceivedAge, ACCEPTED_BY_NETWORK past staleAcceptedByNetworkAge); the
+// gauges stay as the census of what's still stuck after those nudges.
 var stuckTransientStatuses = []models.Status{
 	models.StatusReceived,
 	models.StatusAcceptedByNetwork,
@@ -123,13 +135,15 @@ func (p *Propagator) tryReap(ctx context.Context) {
 
 // reapOnce rebroadcasts rows stuck past their stale-age threshold:
 // SEEN_ON_NETWORK / SEEN_MULTIPLE_NODES past staleSeenOnNetworkAge (peer
-// mempool eviction, dropped BLOCK_PROCESSED callback, fee bump needed), and
+// mempool eviction, dropped BLOCK_PROCESSED callback, fee bump needed),
 // RECEIVED past staleReceivedAge (a no-verdict broadcast whose in-memory
 // requeue was lost, or an intake Kafka-publish failure the submitter never
-// retried). Both carry RawTx and are validated txs we accepted responsibility
-// to propagate, so rebroadcasting self-heals a transient downstream outage.
-// Recent RECEIVED rows (still in the normal intake/requeue path) and body-less
-// rows are left alone.
+// retried), and ACCEPTED_BY_NETWORK past staleAcceptedByNetworkAge (accepted
+// into a mempool but the SEEN state-transfer from merkle-service never
+// arrived — re-register + re-broadcast to nudge it toward SEEN). All carry
+// RawTx and are validated txs we accepted responsibility to propagate, so
+// rebroadcasting self-heals a transient downstream outage. Recent rows (still
+// in the normal intake/requeue path) and body-less rows are left alone.
 //
 // Rebroadcasts go through the same registerBatch + broadcastInChunks +
 // applyTerminalStatuses pipeline as processBatch but bypass the
@@ -144,6 +158,7 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 	since := now.Add(-staleScanLookback)
 	seenDeadline := now.Add(-staleSeenOnNetworkAge)
 	receivedDeadline := now.Add(-staleReceivedAge)
+	acceptedDeadline := now.Add(-staleAcceptedByNetworkAge)
 
 	stuckTransientDeadline := now.Add(-stuckTransientAge)
 	type transientStats struct {
@@ -191,6 +206,19 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 			// retried. Rebroadcast to self-heal. Recent rows are still in
 			// the normal intake/requeue path, so leave them alone.
 			if !st.Timestamp.Before(receivedDeadline) {
+				return nil
+			}
+		case models.StatusAcceptedByNetwork:
+			// Accepted into a mempool but never advanced to SEEN past
+			// staleAcceptedByNetworkAge — the merkle-service SEEN
+			// state-transfer never arrived. Rebroadcast re-registers the tx
+			// with merkle-service (another chance to watch + detect) and
+			// re-broadcasts to more peers (wider propagation). If it stays
+			// ACCEPTED the lattice makes the resulting write a no-op, so this
+			// only ever helps drain the stuck gauge, never masks it. Recent
+			// rows are still in the normal ACCEPTED→SEEN window, so leave
+			// them alone.
+			if !st.Timestamp.Before(acceptedDeadline) {
 				return nil
 			}
 		default:

--- a/services/propagation/reaper_test.go
+++ b/services/propagation/reaper_test.go
@@ -107,7 +107,6 @@ func gaugeVal(t *testing.T, vec *prometheus.GaugeVec, label string) float64 {
 // alerting on txs whose SEEN state-transfer never arrived):
 //   - RECEIVED and ACCEPTED_BY_NETWORK rows older than stuckTransientAge are
 //     counted — INCLUDING body-less rows the rebroadcast arm skips;
-//   - ACCEPTED_BY_NETWORK is counted but NOT rebroadcast (no behavior change);
 //   - fresh transient rows and terminal rows are not counted;
 //   - the oldest-age gauge reflects the oldest stuck row per status.
 func TestReapOnce_StuckTransientCensus(t *testing.T) {
@@ -150,13 +149,60 @@ func TestReapOnce_StuckTransientCensus(t *testing.T) {
 	if got := gaugeVal(t, metrics.OldestTransientTxAge, string(models.StatusReceived)); got < 2.5*3600 {
 		t.Errorf("oldest RECEIVED age = %vs, want > 9000s", got)
 	}
-	// ACCEPTED_BY_NETWORK must NOT be rebroadcast (census only).
-	if got := log.count("register:acc-stale"); got != 0 {
-		t.Errorf("ACCEPTED_BY_NETWORK row was rebroadcast; census must not change rebroadcast behavior")
+	// Stale ACCEPTED_BY_NETWORK with a body is now nudged by the rebroadcast
+	// arm (see TestReapOnce_RebroadcastsStaleAccepted); the census still
+	// counts it regardless.
+	if got := log.count("register:acc-stale"); got != 1 {
+		t.Errorf("stale ACCEPTED_BY_NETWORK with body should be rebroadcast; events=%v", log.all())
 	}
 	// Rebroadcast arm unchanged: stale RECEIVED with body + stale SEEN.
 	if got := log.count("register:recv-stale-body"); got != 1 {
 		t.Errorf("stale RECEIVED with body not rebroadcast; events=%v", log.all())
+	}
+}
+
+// TestReapOnce_RebroadcastsStaleAccepted pins the ACCEPTED_BY_NETWORK
+// self-heal arm (the stuck-at-ACCEPTED drain, CASE-26): a validated tx that
+// reached ACCEPTED_BY_NETWORK but never advanced to SEEN past
+// staleAcceptedByNetworkAge is re-registered with merkle-service and
+// re-broadcast. Recent ACCEPTED rows (still in the normal ACCEPTED→SEEN
+// window) and body-less rows are left alone.
+func TestReapOnce_RebroadcastsStaleAccepted(t *testing.T) {
+	now := time.Now()
+	stale := now.Add(-2 * time.Hour)    // > staleAcceptedByNetworkAge, < staleScanLookback
+	recent := now.Add(-1 * time.Minute) // < staleAcceptedByNetworkAge
+
+	log := &eventLog{}
+	ms := newMockStore()
+	ms.replayRows = []*models.TransactionStatus{
+		{TxID: "acc-stale", Status: models.StatusAcceptedByNetwork, RawTx: []byte{0x0a}, Timestamp: stale},
+		{TxID: "acc-recent", Status: models.StatusAcceptedByNetwork, RawTx: []byte{0x0b}, Timestamp: recent},
+		{TxID: "acc-nobody", Status: models.StatusAcceptedByNetwork, Timestamp: stale}, // no RawTx → skip
+	}
+
+	merkleSrv := newMerkleServer(log, http.StatusOK)
+	defer merkleSrv.Close()
+	teranodeSrv := newTeranodeServer(log, http.StatusOK)
+	defer teranodeSrv.Close()
+
+	p := newPropagator(merkleSrv.URL, teranodeSrv.URL, ms)
+	p.reapOnce(context.Background())
+
+	want := map[string]int{
+		"register:acc-stale":  1, // stale ACCEPTED with body → rebroadcast
+		"register:acc-recent": 0, // still in the normal ACCEPTED→SEEN window
+		"register:acc-nobody": 0, // no RawTx to rebroadcast
+	}
+	for prefix, exp := range want {
+		if got := log.count(prefix); got != exp {
+			t.Errorf("%q count = %d, want %d; events=%v", prefix, got, exp, log.all())
+		}
+	}
+	if got := log.count("register:"); got != 1 {
+		t.Errorf("total register count = %d, want 1; events=%v", got, log.all())
+	}
+	if got := log.count("broadcast"); got != 1 {
+		t.Errorf("broadcast count = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Transactions that reach `ACCEPTED_BY_NETWORK` but never get the merkle-service SEEN callback had **no self-heal path** — the propagation reaper rebroadcast `RECEIVED` and `SEEN_*` rows but explicitly skipped `ACCEPTED_BY_NETWORK` (its `default` branch even carried a comment saying it "has no self-heal path"). Those txs accumulate indefinitely, and because `arcade_oldest_transient_tx_age_seconds{status="ACCEPTED_BY_NETWORK"}` climbs without bound, the stuck-transient alert (CASE-26) fires continuously with no way to drain.

Observed live on `arcade-v2` mainnet: **22 txs stuck at ACCEPTED_BY_NETWORK, oldest ~24h**, keeping the alert red while submission/mine throughput was healthy (the alert is a level, not a rate).

## Change

Bring `ACCEPTED_BY_NETWORK` into the reaper's rebroadcast arm past a new `staleAcceptedByNetworkAge` (1h, matching the stuck-gauge threshold so "stuck" means the same thing everywhere):

- **re-register** with merkle-service → another chance to watch + detect the tx and issue the SEEN callback (the real drain lever);
- **re-broadcast** to more peers → wider propagation for txs that only reached one mempool.

## Why it's safe (can't mask the gauge)

`models.Status.DisallowedPreviousStatuses(ACCEPTED_BY_NETWORK)` includes `ACCEPTED_BY_NETWORK` itself, so a rebroadcast that stays accepted is a **store no-op** — no timestamp refresh. The gauge falls only on a genuine advance to SEEN/MINED/REJECTED, never cosmetically. Reuses the existing `registerBatch → broadcastInChunks → applyTerminalStatuses` pipeline, bounded by `reaperRebroadcastBatch` (200/tick), and covers reaper redeliveries.

**Operational note:** this re-POSTs to the teranode datahub cluster, which was throwing 500/502s during the incident — so the drain may be slow until that upstream recovers, but it's harmless (bounded, idempotent, lattice-guarded).

## Tests

- `TestReapOnce_RebroadcastsStaleAccepted` — stale-with-body ACCEPTED is rebroadcast; recent (still in the normal ACCEPTED→SEEN window) and body-less rows are left alone.
- Updated `TestReapOnce_StuckTransientCensus`, which previously asserted ACCEPTED is never rebroadcast.

`go build` / `go vet` / `-race ./services/propagation/` / `magex lint` all clean.

## Context

Follow-up from a production incident (CASE-26). The exact stuck txids can't be pulled from Coralogix (INFO logs are TCO-sampled and bulk-event txid arrays are chunk-lossy); they're read from the store with `SELECT txid FROM transactions WHERE status='ACCEPTED_BY_NETWORK' AND timestamp_at < now()-interval '1 hour'`. Related lifecycle work: #260 (verdicts-vs-conditions, ARC codes, /health freshness).

https://claude.ai/code/session_01Wct8fZwf557TsXtwLYDGpm
