### PR TITLE
feat(propagation): per-callback-host breakdown of the stuck-transient census

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -253,6 +253,21 @@ var OldestTransientTxAge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "Age of the oldest transaction stuck in each transient status (seconds; 0 when none). Leader-computed; aggregate with max().",
 }, []string{"status"})
 
+// StuckTransientTxsByCallback breaks the StuckTransientTxs census down by the
+// callback host of the submission(s) that registered each stuck tx, so an
+// operator can see WHICH client's transactions are stuck (e.g. one overlay
+// service dominating the ACCEPTED_BY_NETWORK backlog) rather than just the
+// aggregate. callback_host is the hostname of the submission's CallbackURL, or
+// "none" for txs submitted without a callback. Leader-computed and fully reset
+// each tick (so a host that drains stops reporting); aggregate with max() and
+// sum by (callback_host). Attribution is capped per tick
+// (stuckAttributionCap) to bound the per-tick submission lookups — the
+// uncapped totals stay on StuckTransientTxs.
+var StuckTransientTxsByCallback = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "arcade_stuck_transient_txs_by_callback",
+	Help: "Stuck transient txs (see arcade_stuck_transient_txs) attributed to the submitting client's callback host. Leader-computed, reset each tick; aggregate with max().",
+}, []string{"status", "callback_host"})
+
 // ---------------------------------------------------------------------------
 // bump_builder
 // ---------------------------------------------------------------------------

--- a/services/propagation/propagator_test.go
+++ b/services/propagation/propagator_test.go
@@ -121,6 +121,10 @@ type mockStore struct {
 	cleared        []clearedCall
 	// replayRows drives IterateStatusesSince for merkle-replay tests.
 	replayRows []*models.TransactionStatus
+	// submissionsByTxID drives GetSubmissionsByTxID, used by the reaper's
+	// stuck-by-callback attribution. Absent txids return no submissions
+	// (attributed to the "none" host).
+	submissionsByTxID map[string][]*models.Submission
 	// merkleMarks records every MarkMerkleRegisteredByTxIDs call as one
 	// slice per call. Lets tests assert how many flushes happened and
 	// which txids landed in each.
@@ -280,6 +284,12 @@ func (m *mockStore) ClearRetryState(_ context.Context, txid string, finalStatus 
 		Timestamp: time.Now(),
 	})
 	return nil
+}
+
+func (m *mockStore) GetSubmissionsByTxID(_ context.Context, txid string) ([]*models.Submission, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.submissionsByTxID[txid], nil
 }
 
 func (m *mockStore) IterateStatusesSince(_ context.Context, since time.Time, fn func(*models.TransactionStatus) error) error {

--- a/services/propagation/reaper.go
+++ b/services/propagation/reaper.go
@@ -3,6 +3,7 @@ package propagation
 import (
 	"context"
 	"errors"
+	"net/url"
 	"time"
 
 	"go.uber.org/zap"
@@ -69,6 +70,12 @@ var stuckTransientStatuses = []models.Status{
 	models.StatusAcceptedByNetwork,
 }
 
+// stuckAttributionCap bounds how many stuck txs one tick attributes to a
+// callback host. The uncapped totals live on StuckTransientTxs; the per-host
+// breakdown does one submission lookup per attributed tx, so cap it to keep
+// the leader tick cheap even when the stuck set is huge (a real incident).
+const stuckAttributionCap = 500
+
 // zeroStuckTransientGauges resets the leader-computed stuck gauges. Called on
 // non-leader ticks so a pod that lost the lease doesn't keep exporting its
 // last leader-era values (the current leader's values then win under max()).
@@ -77,6 +84,22 @@ func zeroStuckTransientGauges() {
 		metrics.StuckTransientTxs.WithLabelValues(string(st)).Set(0)
 		metrics.OldestTransientTxAge.WithLabelValues(string(st)).Set(0)
 	}
+	// The by-callback vec has dynamic host labels, so Reset (not per-label
+	// Set(0)) is the only way to drop hosts this pod is no longer leader for.
+	metrics.StuckTransientTxsByCallback.Reset()
+}
+
+// callbackHost extracts the hostname from a submission CallbackURL for the
+// per-client stuck breakdown, or "none" when there is no usable URL.
+func callbackHost(rawURL string) string {
+	if rawURL == "" {
+		return "none"
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Hostname() == "" {
+		return "unparsed"
+	}
+	return u.Hostname()
 }
 
 // reaperLeaseName is the well-known key every replica uses to coordinate
@@ -169,6 +192,14 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 	for _, s := range stuckTransientStatuses {
 		stuckTransient[s] = &transientStats{}
 	}
+	// txids of stuck rows to attribute to a callback host after the scan
+	// (bounded by stuckAttributionCap). Collected here — not looked up inline
+	// — so the scan itself stays free of per-row store calls.
+	type stuckRef struct {
+		txid   string
+		status models.Status
+	}
+	attrib := make([]stuckRef, 0, stuckAttributionCap)
 
 	stuck := make([]propagationMsg, 0, reaperRebroadcastBatch)
 	err := p.store.IterateStatusesSince(ctx, since, func(st *models.TransactionStatus) error {
@@ -180,6 +211,9 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 			ts.count++
 			if ts.oldest.IsZero() || st.Timestamp.Before(ts.oldest) {
 				ts.oldest = st.Timestamp
+			}
+			if len(attrib) < stuckAttributionCap {
+				attrib = append(attrib, stuckRef{txid: st.TxID, status: st.Status})
 			}
 		}
 
@@ -257,6 +291,45 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 				zap.Int("count", ts.count),
 				zap.Float64("oldest_age_seconds", age))
 		}
+	}
+
+	// Per-client breakdown of the stuck census: attribute each collected stuck
+	// tx to the callback host(s) of its submission(s), so an operator can see
+	// which client owns the backlog. One submission lookup per attributed tx
+	// (bounded by stuckAttributionCap). Reset the vec first so hosts that
+	// drained since the last tick stop reporting (dynamic host labels).
+	byCallback := make(map[models.Status]map[string]int)
+	for _, ref := range attrib {
+		if err := ctx.Err(); err != nil {
+			break
+		}
+		subs, subErr := p.store.GetSubmissionsByTxID(ctx, ref.txid)
+		if subErr != nil {
+			continue // best-effort: the uncapped totals are already published
+		}
+		hosts := map[string]struct{}{}
+		for _, sub := range subs {
+			hosts[callbackHost(sub.CallbackURL)] = struct{}{}
+		}
+		if len(hosts) == 0 {
+			hosts["none"] = struct{}{} // stuck tx with no registered callback
+		}
+		for h := range hosts {
+			if byCallback[ref.status] == nil {
+				byCallback[ref.status] = map[string]int{}
+			}
+			byCallback[ref.status][h]++
+		}
+	}
+	metrics.StuckTransientTxsByCallback.Reset()
+	for status, hosts := range byCallback {
+		for host, n := range hosts {
+			metrics.StuckTransientTxsByCallback.WithLabelValues(string(status), host).Set(float64(n))
+		}
+	}
+	if len(attrib) >= stuckAttributionCap {
+		p.logger.Warn("reaper: stuck-by-callback attribution capped",
+			zap.Int("cap", stuckAttributionCap))
 	}
 
 	if len(stuck) == 0 {

--- a/services/propagation/reaper_test.go
+++ b/services/propagation/reaper_test.go
@@ -103,6 +103,57 @@ func gaugeVal(t *testing.T, vec *prometheus.GaugeVec, label string) float64 {
 	return testutil.ToFloat64(vec.WithLabelValues(label))
 }
 
+// TestReapOnce_StuckByCallbackAttribution pins the per-client breakdown of the
+// stuck census: each stuck tx is attributed to its submission's callback host
+// (or "none" when it has no callback), so an operator can see which client
+// owns the ACCEPTED_BY_NETWORK backlog.
+func TestReapOnce_StuckByCallbackAttribution(t *testing.T) {
+	metrics.StuckTransientTxsByCallback.Reset()
+	stale := time.Now().Add(-2 * time.Hour)
+
+	log := &eventLog{}
+	ms := newMockStore()
+	ms.replayRows = []*models.TransactionStatus{
+		{TxID: "acc-a", Status: models.StatusAcceptedByNetwork, RawTx: []byte{0x01}, Timestamp: stale},
+		{TxID: "acc-b", Status: models.StatusAcceptedByNetwork, RawTx: []byte{0x02}, Timestamp: stale},
+		{TxID: "acc-c", Status: models.StatusAcceptedByNetwork, RawTx: []byte{0x03}, Timestamp: stale},
+		{TxID: "acc-nocb", Status: models.StatusAcceptedByNetwork, RawTx: []byte{0x04}, Timestamp: stale},
+	}
+	// Two txs from one overlay host, one from another, one with no callback.
+	ms.submissionsByTxID = map[string][]*models.Submission{
+		"acc-a": {{TxID: "acc-a", CallbackURL: "https://low-overlay.example/arc-ingest"}},
+		"acc-b": {{TxID: "acc-b", CallbackURL: "https://low-overlay.example/arc-ingest"}},
+		"acc-c": {{TxID: "acc-c", CallbackURL: "https://other-client.example/cb"}},
+		// acc-nocb: no submissions → "none"
+	}
+
+	merkleSrv := newMerkleServer(log, http.StatusOK)
+	defer merkleSrv.Close()
+	teranodeSrv := newTeranodeServer(log, http.StatusOK)
+	defer teranodeSrv.Close()
+
+	p := newPropagator(merkleSrv.URL, teranodeSrv.URL, ms)
+	p.reapOnce(context.Background())
+
+	acc := string(models.StatusAcceptedByNetwork)
+	byHost := func(host string) float64 {
+		return testutil.ToFloat64(metrics.StuckTransientTxsByCallback.WithLabelValues(acc, host))
+	}
+	if got := byHost("low-overlay.example"); got != 2 {
+		t.Errorf("low-overlay.example = %v, want 2", got)
+	}
+	if got := byHost("other-client.example"); got != 1 {
+		t.Errorf("other-client.example = %v, want 1", got)
+	}
+	if got := byHost("none"); got != 1 {
+		t.Errorf("none (no-callback) = %v, want 1", got)
+	}
+	// Aggregate by-callback must equal the uncapped census for ACCEPTED (4).
+	if got := gaugeVal(t, metrics.StuckTransientTxs, acc); got != 4 {
+		t.Errorf("uncapped ACCEPTED census = %v, want 4", got)
+	}
+}
+
 // TestReapOnce_StuckTransientCensus pins the stuck-transient gauges (issue:
 // alerting on txs whose SEEN state-transfer never arrived):
 //   - RECEIVED and ACCEPTED_BY_NETWORK rows older than stuckTransientAge are


### PR DESCRIPTION
## Summary

Answer the first triage question for CASE-26 — *which client* owns the stuck backlog — on the dashboard instead of only in ad-hoc log queries. Investigation of the stuck-ACCEPTED alert found one overlay client (`low-overlay.dev-a3e.workers.dev/arc-ingest`) generating ~70× the volume of any other and effectively the entire ACCEPTED_BY_NETWORK backlog; the existing `arcade_stuck_transient_txs` gauge only shows the aggregate count, not the submitter.

## Change

New gauge **`arcade_stuck_transient_txs_by_callback{status, callback_host}`**: the same stuck-transient census, attributed to the callback host of each stuck tx's submission(s) (or `"none"` when submitted without a callback). The existing `arcade_stuck_transient_txs` / `arcade_oldest_transient_tx_age_seconds` gauges — and the growth+floor alert keyed on them — are **untouched** (dedicated metric, not a new label on the existing one).

Semantics match the existing census: leader-computed, `Reset()` each tick so a drained host stops reporting; aggregate with `max()` across pods then `sum by (callback_host)`.

## Cost is bounded (safe on the reaper hot path)

- The `IterateStatusesSince` scan stays **lookup-free**: stuck txids are collected inline, capped at `stuckAttributionCap = 500`.
- Per-host attribution runs **after** the scan — one `GetSubmissionsByTxID` per collected tx — so even a huge stuck set during a real incident can't turn the census into thousands of store reads per tick.
- The **uncapped** totals stay on `arcade_stuck_transient_txs`; only the breakdown is capped (a warning logs when it is).
- Cardinality is the small set of registered callback hosts (URLs pass the intake SSRF guard); `Reset()` prevents stale host series lingering.

## Tests

`TestReapOnce_StuckByCallbackAttribution`: two txs from one overlay host, one from another, one with no callback → asserts the per-host gauge (2 / 1 / `none`=1) and that the by-callback total equals the uncapped ACCEPTED census (4). Existing census/rebroadcast tests updated (mockStore gains `GetSubmissionsByTxID`).

`go build`/`go vet`/`-race ./services/propagation/`/`magex lint` all clean.

## Follow-up

Once deployed, I'll add a `sum by (callback_host)(arcade_stuck_transient_txs_by_callback{status="ACCEPTED_BY_NETWORK"})` panel to the "Arcade + Merkle — Mainnet" dashboard (empty until the metric exists in prod). Interim, the same view is available live via DataPrime over webhook logs grouped by `callback_url`.

https://claude.ai/code/session_01Wct8fZwf557TsXtwLYDGpm
