### PR TITLE
feat(api): add GET /policy with dynamic network-enforced mining fee (#212)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -310,22 +310,31 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *zap.Logger) (*De
 }
 
 // validatorPolicyFromConfig builds the validator.Policy from cfg.Validator.
-// Returns nil when no operator-facing fields are set so NewValidator's
-// built-in defaults apply unchanged. When AcceptZeroFee is set, returns
-// a policy with an explicit pointer-to-zero MinFeePerKB so that
-// NewValidator preserves it (its nil-check is on the pointer, not the
-// value) and ValidateTransaction feeds Satoshis=0 to spv.Verify, which
-// accepts any non-negative fee — including fee=0.
+// The size/sigop fields carry their (defaulted) config values through so the
+// GET /policy endpoint and intake validation agree on the advertised limits;
+// a zero there falls back to the validator's canonical teranode default.
+//
+// Fee handling preserves the original semantics: AcceptZeroFee returns an
+// explicit pointer-to-zero MinFeePerKB so NewValidator preserves it (its
+// nil-check is on the pointer, not the value) and ValidateTransaction feeds
+// Satoshis=0 to spv.Verify, which accepts any non-negative fee — including
+// fee=0. A zero MinFeePerKB with AcceptZeroFee=false leaves the pointer nil so
+// the validator's DefaultMinFeePerKB applies.
 func validatorPolicyFromConfig(cfg *config.Config) *validator.Policy {
-	if cfg.Validator.AcceptZeroFee {
+	p := &validator.Policy{
+		MaxTxSizePolicy:         int(cfg.Validator.MaxTxSizePolicy),     //nolint:gosec // policy size in bytes, bounded far below int max
+		MaxScriptSizePolicy:     int(cfg.Validator.MaxScriptSizePolicy), //nolint:gosec // policy size in bytes, bounded far below int max
+		MaxTxSigopsCountsPolicy: cfg.Validator.MaxTxSigopsCountsPolicy,
+	}
+	switch {
+	case cfg.Validator.AcceptZeroFee:
 		zero := uint64(0)
-		return &validator.Policy{MinFeePerKB: &zero}
+		p.MinFeePerKB = &zero
+	case cfg.Validator.MinFeePerKB != 0:
+		minFee := cfg.Validator.MinFeePerKB
+		p.MinFeePerKB = &minFee
 	}
-	if cfg.Validator.MinFeePerKB == 0 {
-		return nil
-	}
-	minFee := cfg.Validator.MinFeePerKB
-	return &validator.Policy{MinFeePerKB: &minFee}
+	return p
 }
 
 // modeNeedsChaintracks reports whether the configured service mode constructs

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -85,16 +85,19 @@ func TestModeNeedsValidator(t *testing.T) {
 }
 
 func TestValidatorPolicyFromConfig(t *testing.T) {
+	// The policy is always non-nil now that the size/sigop fields thread
+	// through (issue #212); wantFeeNil asserts only the MinFeePerKB pointer,
+	// which drives the validator's DefaultMinFeePerKB fallback when nil.
 	cases := []struct {
 		name        string
 		acceptZero  bool
 		minFeePerKB uint64
-		wantNil     bool
+		wantFeeNil  bool
 		wantFee     uint64
 	}{
 		{
-			name:    "unset config returns nil so NewValidator applies its default",
-			wantNil: true,
+			name:       "unset fee leaves MinFeePerKB nil so NewValidator applies its default",
+			wantFeeNil: true,
 		},
 		{
 			name:        "explicit min_fee_per_kb threads through",
@@ -102,9 +105,9 @@ func TestValidatorPolicyFromConfig(t *testing.T) {
 			wantFee:     50,
 		},
 		{
-			name:        "min_fee_per_kb=0 without flag still falls back to default",
+			name:        "min_fee_per_kb=0 without flag leaves MinFeePerKB nil (default floor)",
 			minFeePerKB: 0,
-			wantNil:     true,
+			wantFeeNil:  true,
 		},
 		{
 			name:       "accept_zero_fee pins fee to zero",
@@ -126,14 +129,17 @@ func TestValidatorPolicyFromConfig(t *testing.T) {
 			cfg.Validator.MinFeePerKB = tc.minFeePerKB
 
 			got := validatorPolicyFromConfig(cfg)
-			if tc.wantNil {
-				if got != nil {
-					t.Fatalf("expected nil policy, got %+v", got)
+			if got == nil {
+				t.Fatalf("expected non-nil policy, got nil")
+			}
+			if tc.wantFeeNil {
+				if got.MinFeePerKB != nil {
+					t.Fatalf("expected nil MinFeePerKB, got %d", *got.MinFeePerKB)
 				}
 				return
 			}
-			if got == nil || got.MinFeePerKB == nil {
-				t.Fatalf("expected non-nil policy with MinFeePerKB set, got %+v", got)
+			if got.MinFeePerKB == nil {
+				t.Fatalf("expected non-nil MinFeePerKB, got nil")
 			}
 			if *got.MinFeePerKB != tc.wantFee {
 				t.Errorf("MinFeePerKB = %d, want %d", *got.MinFeePerKB, tc.wantFee)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -151,15 +151,37 @@ health:
 #   sample_ratio: 1.0            # ParentBased(TraceIDRatioBased) sampler ratio, 0.0-1.0
 #   export_timeout_ms: 10000
 
-# Intake-time transaction validator. The default rejects txs whose
-# fee rate is below the BSV miner policy minimum of 100 sat/kB.
+# Intake-time transaction validator. Also backs the ARC-compatible
+# GET /policy endpoint (issue #212): the size/sigop limits below are what
+# intake enforces and what /policy advertises.
 # validator:
-#   min_fee_per_kb: 100
+#   # min_fee_per_kb is the intake fee floor in satoshis/kB. Default 0 means
+#   # "not operator-configured": arcade then dynamically tracks the lowest fee
+#   # the network will accept — the minimum advertised across peer node_status
+#   # announcements — and BOTH enforces it at intake and advertises it via
+#   # GET /policy (issue #212). Until a peer is heard it uses the built-in
+#   # 100 sat/kB floor. Set a non-zero value to pin and enforce an exact floor.
+#   min_fee_per_kb: 0
 #   # accept_zero_fee, when true, pins the floor to 0 sat/kB so any tx
-#   # (including fee=0) is accepted at intake. Intended for
-#   # teratestnet/regtest where the upstream Teranode is also configured
-#   # to accept zero-fee txs. Leave false on mainnet and testnet.
+#   # (including fee=0) is accepted at intake, and /policy advertises 0.
+#   # Intended for teratestnet/regtest where the upstream Teranode is also
+#   # configured to accept zero-fee txs. Leave false on mainnet and testnet.
 #   # accept_zero_fee: false
+#   # GET /policy size/format limits. Left unset (or 0), they fall back to
+#   # teranode's canonical policy defaults shown here. max_tx_sigops_counts_policy
+#   # of 0 means unlimited (the BSV post-Genesis default).
+#   # max_tx_size_policy: 10485760
+#   # max_script_size_policy: 500000
+#   # max_tx_sigops_counts_policy: 0
+#   # standard_format_supported: true
+#   # observed_fee_ttl_ms bounds how long a peer's node_status-advertised fee
+#   # stays eligible for the network-minimum (default 15 min). A peer not
+#   # re-heard within this window is dropped from the minimum.
+#   # observed_fee_ttl_ms: 900000
+#   # observed_fee_refresh_ms is how often the api-server recomputes the
+#   # network-minimum fee and updates the intake floor (default 30 s). Only
+#   # active when min_fee_per_kb=0 and accept_zero_fee=false.
+#   # observed_fee_refresh_ms: 30000
 #   # disable_finality_check turns off the nLockTime/BIP113 intake gate
 #   # that rejects provably non-final txs with an actionable reason
 #   # (issue #245). The gate needs a chain source: the embedded

--- a/config/config.go
+++ b/config/config.go
@@ -923,8 +923,15 @@ const (
 type ValidatorConfig struct {
 	// MinFeePerKB is the network's minimum acceptable fee rate in
 	// satoshis per kilobyte. Transactions below this rate are rejected
-	// at intake. Zero falls back to DefaultValidatorMinFeePerKB unless
-	// AcceptZeroFee is true (which forces a zero floor regardless).
+	// at intake. Zero (the default) falls back to DefaultValidatorMinFeePerKB
+	// at intake unless AcceptZeroFee is true (which forces a zero floor
+	// regardless).
+	//
+	// Zero additionally signals "not operator-configured" to the GET /policy
+	// endpoint (issue #212): the advertised miningFee then becomes the lowest
+	// fee observed from peer node_status announcements, falling back to
+	// DefaultValidatorMinFeePerKB when no peer has been heard. A non-zero value
+	// (or AcceptZeroFee) is reported verbatim.
 	MinFeePerKB uint64 `mapstructure:"min_fee_per_kb"`
 
 	// AcceptZeroFee, when true, pins the validator's fee floor to exactly
@@ -940,6 +947,42 @@ type ValidatorConfig struct {
 	// authoritative and the check fails open when chain state is
 	// unavailable — so this exists purely as an emergency escape hatch.
 	DisableFinalityCheck bool `mapstructure:"disable_finality_check"`
+
+	// The fields below back the ARC-compatible GET /policy endpoint
+	// (issue #212). Each is the policy value arcade advertises and, for
+	// the size/sigop fields, enforces. Left at zero, they fall back to
+	// teranode's canonical policy defaults (see validator.defaultPolicySettings).
+
+	// MaxTxSizePolicy caps accepted transaction size in bytes. 0 =>
+	// DefaultValidatorMaxTxSizePolicy.
+	MaxTxSizePolicy uint64 `mapstructure:"max_tx_size_policy"`
+
+	// MaxScriptSizePolicy caps accepted script size in bytes. 0 =>
+	// DefaultValidatorMaxScriptSizePolicy.
+	MaxScriptSizePolicy uint64 `mapstructure:"max_script_size_policy"`
+
+	// MaxTxSigopsCountsPolicy caps sigops per transaction. 0 => unlimited,
+	// the BSV post-Genesis default, and is reported verbatim in /policy.
+	MaxTxSigopsCountsPolicy int64 `mapstructure:"max_tx_sigops_counts_policy"`
+
+	// StandardFormatSupported reports whether standard (non-EF) transaction
+	// format is accepted at intake. Arcade parses standard raw txs (see
+	// handleSubmitTransaction), so this defaults to true.
+	StandardFormatSupported bool `mapstructure:"standard_format_supported"`
+
+	// ObservedFeeTTLMs bounds how long a mining fee observed from a peer's
+	// node_status announcement stays eligible for the network-minimum
+	// computation. A peer not re-heard within this window is dropped from the
+	// minimum so a departed cheap node can't pin the fee low forever.
+	// 0 => DefaultValidatorObservedFeeTTLMs.
+	ObservedFeeTTLMs uint64 `mapstructure:"observed_fee_ttl_ms"`
+
+	// ObservedFeeRefreshMs is how often the api-server recomputes the
+	// network-minimum fee from observed peer policies and pushes it into the
+	// intake validator (issue #212). Only active when the operator has NOT
+	// pinned a fee (min_fee_per_kb=0 and accept_zero_fee=false).
+	// 0 => DefaultValidatorObservedFeeRefreshMs.
+	ObservedFeeRefreshMs uint64 `mapstructure:"observed_fee_refresh_ms"`
 }
 
 // DefaultValidatorMinFeePerKB is the production fee floor in satoshis
@@ -947,6 +990,23 @@ type ValidatorConfig struct {
 // Tests and ad-hoc deployments may set ValidatorConfig.MinFeePerKB to
 // a lower value to accept older or non-standard txs.
 const DefaultValidatorMinFeePerKB = 100
+
+// Default policy values for the GET /policy endpoint. They mirror teranode's
+// canonical BSV policy defaults (validator.defaultPolicySettings) so arcade
+// advertises the same limits the upstream node enforces when the operator
+// leaves them unset.
+const (
+	// DefaultValidatorMaxTxSizePolicy is the max accepted tx size in bytes (10 MiB).
+	DefaultValidatorMaxTxSizePolicy = 10485760
+	// DefaultValidatorMaxScriptSizePolicy is the max accepted script size in bytes.
+	DefaultValidatorMaxScriptSizePolicy = 500000
+	// DefaultValidatorObservedFeeTTLMs is how long (15 min) a peer's observed
+	// mining fee remains eligible for the network-minimum.
+	DefaultValidatorObservedFeeTTLMs = 900000
+	// DefaultValidatorObservedFeeRefreshMs is how often (30 s) the api-server
+	// recomputes the network-minimum fee and updates the intake validator.
+	DefaultValidatorObservedFeeRefreshMs = 30000
+)
 
 func BindFlags(cmd *cobra.Command) {
 	cmd.Flags().String("mode", "all", "Service mode: all, api-server, bump-builder, propagation, p2p-client")
@@ -1203,9 +1263,23 @@ func setDefaults() {
 	viper.SetDefault("chaintracks_server.tie_scan_depth", 20)
 	viper.SetDefault("chaintracks_server.tie_scan_min_interval_ms", 5000)
 
-	// Intake validator fee floor in satoshis per KB. Matches the
-	// current BSV miner policy minimum.
-	viper.SetDefault("validator.min_fee_per_kb", DefaultValidatorMinFeePerKB)
+	// Intake validator fee floor in satoshis per KB. Default 0 means "not
+	// operator-configured": intake still enforces DefaultValidatorMinFeePerKB
+	// (the validator's built-in floor), while GET /policy advertises the
+	// network-observed minimum (issue #212). SetDefault is required even at 0
+	// so AutomaticEnv honors the ARCADE_VALIDATOR_MIN_FEE_PER_KB override.
+	viper.SetDefault("validator.min_fee_per_kb", 0)
+
+	// ARC-compatible GET /policy fields (issue #212). Defaults mirror
+	// teranode's canonical policy so the advertised limits match the
+	// upstream node. Every key needs an explicit SetDefault for AutomaticEnv
+	// to honour its ARCADE_VALIDATOR_* override (same reasoning as above).
+	viper.SetDefault("validator.max_tx_size_policy", DefaultValidatorMaxTxSizePolicy)
+	viper.SetDefault("validator.max_script_size_policy", DefaultValidatorMaxScriptSizePolicy)
+	viper.SetDefault("validator.max_tx_sigops_counts_policy", 0)
+	viper.SetDefault("validator.standard_format_supported", true)
+	viper.SetDefault("validator.observed_fee_ttl_ms", DefaultValidatorObservedFeeTTLMs)
+	viper.SetDefault("validator.observed_fee_refresh_ms", DefaultValidatorObservedFeeRefreshMs)
 }
 
 func validate(cfg *Config) error {

--- a/config/config_policy_test.go
+++ b/config/config_policy_test.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// loadValidatorDefaults exercises the real setDefaults + env wiring (minus the
+// config file and validate step) so the /policy config surface is tested the
+// way Load actually resolves it.
+func loadValidatorDefaults(t *testing.T) ValidatorConfig {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.SetEnvPrefix("ARCADE")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+	setDefaults()
+
+	var cfg Config
+	if err := viper.Unmarshal(&cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	return cfg.Validator
+}
+
+func TestPolicyConfigDefaults(t *testing.T) {
+	v := loadValidatorDefaults(t)
+
+	// min_fee_per_kb defaults to 0 ("not operator-configured") so /policy can
+	// fall back to the network-observed minimum (issue #212).
+	if v.MinFeePerKB != 0 {
+		t.Errorf("MinFeePerKB default = %d, want 0", v.MinFeePerKB)
+	}
+	if v.MaxTxSizePolicy != DefaultValidatorMaxTxSizePolicy {
+		t.Errorf("MaxTxSizePolicy default = %d, want %d", v.MaxTxSizePolicy, DefaultValidatorMaxTxSizePolicy)
+	}
+	if v.MaxScriptSizePolicy != DefaultValidatorMaxScriptSizePolicy {
+		t.Errorf("MaxScriptSizePolicy default = %d, want %d", v.MaxScriptSizePolicy, DefaultValidatorMaxScriptSizePolicy)
+	}
+	if v.MaxTxSigopsCountsPolicy != 0 {
+		t.Errorf("MaxTxSigopsCountsPolicy default = %d, want 0", v.MaxTxSigopsCountsPolicy)
+	}
+	if !v.StandardFormatSupported {
+		t.Errorf("StandardFormatSupported default = false, want true")
+	}
+	if v.ObservedFeeTTLMs != DefaultValidatorObservedFeeTTLMs {
+		t.Errorf("ObservedFeeTTLMs default = %d, want %d", v.ObservedFeeTTLMs, DefaultValidatorObservedFeeTTLMs)
+	}
+	if v.ObservedFeeRefreshMs != DefaultValidatorObservedFeeRefreshMs {
+		t.Errorf("ObservedFeeRefreshMs default = %d, want %d", v.ObservedFeeRefreshMs, DefaultValidatorObservedFeeRefreshMs)
+	}
+}
+
+func TestPolicyConfigEnvOverrides(t *testing.T) {
+	t.Setenv("ARCADE_VALIDATOR_MIN_FEE_PER_KB", "250")
+	t.Setenv("ARCADE_VALIDATOR_MAX_TX_SIZE_POLICY", "7777")
+	t.Setenv("ARCADE_VALIDATOR_MAX_SCRIPT_SIZE_POLICY", "8888")
+	t.Setenv("ARCADE_VALIDATOR_MAX_TX_SIGOPS_COUNTS_POLICY", "99")
+	t.Setenv("ARCADE_VALIDATOR_STANDARD_FORMAT_SUPPORTED", "false")
+	t.Setenv("ARCADE_VALIDATOR_OBSERVED_FEE_TTL_MS", "60000")
+	t.Setenv("ARCADE_VALIDATOR_OBSERVED_FEE_REFRESH_MS", "5000")
+
+	v := loadValidatorDefaults(t)
+
+	if v.MinFeePerKB != 250 {
+		t.Errorf("MinFeePerKB = %d, want 250", v.MinFeePerKB)
+	}
+	if v.MaxTxSizePolicy != 7777 {
+		t.Errorf("MaxTxSizePolicy = %d, want 7777", v.MaxTxSizePolicy)
+	}
+	if v.MaxScriptSizePolicy != 8888 {
+		t.Errorf("MaxScriptSizePolicy = %d, want 8888", v.MaxScriptSizePolicy)
+	}
+	if v.MaxTxSigopsCountsPolicy != 99 {
+		t.Errorf("MaxTxSigopsCountsPolicy = %d, want 99", v.MaxTxSigopsCountsPolicy)
+	}
+	if v.StandardFormatSupported {
+		t.Errorf("StandardFormatSupported = true, want false (env override)")
+	}
+	if v.ObservedFeeTTLMs != 60000 {
+		t.Errorf("ObservedFeeTTLMs = %d, want 60000", v.ObservedFeeTTLMs)
+	}
+	if v.ObservedFeeRefreshMs != 5000 {
+		t.Errorf("ObservedFeeRefreshMs = %d, want 5000", v.ObservedFeeRefreshMs)
+	}
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -998,6 +998,17 @@ var P2PPeerBestHeight = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "Best block height advertised by a datahub peer via p2p node_status, by base_url.",
 }, []string{"base_url"})
 
+// P2PPeerMinMiningFee reports the minimum mining fee (satoshis per 1000 bytes)
+// each peer advertises in its node_status FeePolicy. The GET /policy endpoint
+// advertises the network-wide minimum of these (issue #212); this gauge makes
+// the per-peer inputs visible. Labelled by base_url for the same
+// bounded-cardinality reason as P2PPeerBestHeight; peers with no base_url are
+// still persisted for the minimum but not surfaced here.
+var P2PPeerMinMiningFee = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "arcade_p2p_peer_min_mining_fee",
+	Help: "Minimum mining fee (satoshis per 1000 bytes) advertised by a peer via p2p node_status, by base_url.",
+}, []string{"base_url"})
+
 // ChainTipHeight reports arcade's own view of the active chain tip — the
 // highest block_processing row marked active. Refreshed by the api-server's
 // /health handler (which also returns it as blockHeight); alert on this

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -364,11 +364,28 @@ type SubmitOptions struct {
 	SkipScriptValidation bool   // Skip script validation
 }
 
-// Policy represents the transaction policy configuration
+// FeeAmount is the ARC mining-fee rate expressed as a number of satoshis per
+// a number of bytes, e.g. {Satoshis: 100, Bytes: 1000} == 100 sat/kB.
+type FeeAmount struct {
+	Satoshis uint64 `json:"satoshis"`
+	Bytes    uint64 `json:"bytes"`
+}
+
+// Policy is the ARC-compatible transaction policy document returned by
+// GET /policy (issue #212). Field names and JSON tags match the ARC contract
+// so arcade is a drop-in target for clients that discover fee/size limits
+// before building transactions.
 type Policy struct {
-	MaxScriptSizePolicy     uint64 `json:"maxscriptsizepolicy"`
-	MaxTxSigOpsCountsPolicy uint64 `json:"maxtxsigopscountspolicy"`
-	MaxTxSizePolicy         uint64 `json:"maxtxsizepolicy"`
-	MiningFeeBytes          uint64 `json:"miningFeeBytes"`
-	MiningFeeSatoshis       uint64 `json:"miningFeeSatoshis"`
+	MiningFee               FeeAmount `json:"miningFee"`
+	MaxTxSizePolicy         uint64    `json:"maxtxsizepolicy"`
+	MaxScriptSizePolicy     uint64    `json:"maxscriptsizepolicy"`
+	MaxTxSigopsCountsPolicy int64     `json:"maxtxsigopscountspolicy"`
+	StandardFormatSupported bool      `json:"standardFormatSupported"`
+}
+
+// PolicyResponse wraps Policy in the ARC response envelope with a policy
+// timestamp (RFC 3339).
+type PolicyResponse struct {
+	Policy    Policy    `json:"policy"`
+	Timestamp time.Time `json:"timestamp"`
 }

--- a/openapi/arcade.openapi.yaml
+++ b/openapi/arcade.openapi.yaml
@@ -128,6 +128,56 @@ paths:
                     type: string
                     example: ready
 
+  /policy:
+    get:
+      operationId: getPolicy
+      tags: [Operations]
+      summary: Discover the current fee and size policy (ARC-compatible)
+      description: |
+        Returns Arcade's effective transaction policy in the ARC schema so
+        clients can discover the fee rate and size limits before building
+        transactions. Every value reflects exactly what intake enforces.
+
+        When the operator hasn't pinned a fee, `miningFee` tracks the lowest fee
+        the network will accept — the minimum advertised across peer
+        `node_status` announcements — and Arcade enforces that same floor at
+        intake, falling back to the built-in default until a peer is heard.
+        `maxtxsigopscountspolicy` of `0` means unlimited (the BSV post-Genesis
+        default). Also served at `/v1/policy`. Always returns 200.
+      responses:
+        "200":
+          description: Current transaction policy.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyResponse"
+              example:
+                policy:
+                  miningFee:
+                    satoshis: 100
+                    bytes: 1000
+                  maxtxsizepolicy: 10485760
+                  maxscriptsizepolicy: 500000
+                  maxtxsigopscountspolicy: 0
+                  standardFormatSupported: true
+                timestamp: "2026-08-07T12:00:00Z"
+
+  /v1/policy:
+    get:
+      operationId: getPolicyV1
+      tags: [Operations]
+      summary: Discover the current fee and size policy (ARC alias)
+      description: |
+        Alias of `GET /policy` matching the ARC specification path. Returns the
+        identical response.
+      responses:
+        "200":
+          description: Current transaction policy.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyResponse"
+
   /metrics:
     get:
       operationId: getMetrics
@@ -1437,6 +1487,68 @@ components:
           type: string
         healthy:
           type: boolean
+
+    FeeAmount:
+      type: object
+      description: Mining-fee rate expressed as satoshis per a number of bytes.
+      properties:
+        satoshis:
+          type: integer
+          format: int64
+          example: 100
+        bytes:
+          type: integer
+          format: int64
+          example: 1000
+      required:
+        - satoshis
+        - bytes
+
+    Policy:
+      type: object
+      description: ARC-compatible transaction policy.
+      properties:
+        miningFee:
+          $ref: "#/components/schemas/FeeAmount"
+        maxtxsizepolicy:
+          type: integer
+          format: int64
+          description: Maximum accepted transaction size in bytes.
+          example: 10485760
+        maxscriptsizepolicy:
+          type: integer
+          format: int64
+          description: Maximum accepted script size in bytes.
+          example: 500000
+        maxtxsigopscountspolicy:
+          type: integer
+          format: int64
+          description: Maximum sigops per transaction; 0 means unlimited (BSV post-Genesis).
+          example: 0
+        standardFormatSupported:
+          type: boolean
+          description: Whether standard (non-EF) transaction format is accepted at intake.
+          example: true
+      required:
+        - miningFee
+        - maxtxsizepolicy
+        - maxscriptsizepolicy
+        - maxtxsigopscountspolicy
+        - standardFormatSupported
+
+    PolicyResponse:
+      type: object
+      properties:
+        policy:
+          $ref: "#/components/schemas/Policy"
+        timestamp:
+          type: string
+          format: date-time
+          description: Policy timestamp (RFC 3339).
+          example: "2026-08-07T12:00:00Z"
+      required:
+        - policy
+        - timestamp
 
     ErrorResponse:
       type: object

--- a/openapi/arcade.openapi.yaml
+++ b/openapi/arcade.openapi.yaml
@@ -142,8 +142,9 @@ paths:
         the network will accept — the minimum advertised across peer
         `node_status` announcements — and Arcade enforces that same floor at
         intake, falling back to the built-in default until a peer is heard.
-        `maxtxsigopscountspolicy` of `0` means unlimited (the BSV post-Genesis
-        default). Also served at `/v1/policy`. Always returns 200.
+        `maxtxsigopscountspolicy` of `4294967295` means unlimited (the BSV
+        post-Genesis default), matching the ARC convention. Also served at
+        `/v1/policy`. Always returns 200.
       responses:
         "200":
           description: Current transaction policy.
@@ -158,7 +159,7 @@ paths:
                     bytes: 1000
                   maxtxsizepolicy: 10485760
                   maxscriptsizepolicy: 500000
-                  maxtxsigopscountspolicy: 0
+                  maxtxsigopscountspolicy: 4294967295
                   standardFormatSupported: true
                 timestamp: "2026-08-07T12:00:00Z"
 
@@ -1523,8 +1524,8 @@ components:
         maxtxsigopscountspolicy:
           type: integer
           format: int64
-          description: Maximum sigops per transaction; 0 means unlimited (BSV post-Genesis).
-          example: 0
+          description: Maximum sigops per transaction; 4294967295 means unlimited (BSV post-Genesis), the ARC convention.
+          example: 4294967295
         standardFormatSupported:
           type: boolean
           description: Whether standard (non-EF) transaction format is accepted at intake.

--- a/services/api_server/fee_refresher.go
+++ b/services/api_server/fee_refresher.go
@@ -1,0 +1,108 @@
+package api_server
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/store"
+)
+
+// feePinned reports whether the operator has fixed the intake fee floor. When
+// pinned, arcade enforces (and /policy advertises) that exact value and the
+// fee refresher does not run. When unpinned (min_fee_per_kb=0 and
+// accept_zero_fee=false), arcade tracks the network-observed minimum instead.
+func (s *Server) feePinned() bool {
+	return s.cfg.Validator.AcceptZeroFee || s.cfg.Validator.MinFeePerKB != 0
+}
+
+func (s *Server) observedFeeTTLMs() uint64 {
+	if s.cfg.Validator.ObservedFeeTTLMs == 0 {
+		return config.DefaultValidatorObservedFeeTTLMs
+	}
+	return s.cfg.Validator.ObservedFeeTTLMs
+}
+
+func (s *Server) observedFeeRefreshMs() uint64 {
+	if s.cfg.Validator.ObservedFeeRefreshMs == 0 {
+		return config.DefaultValidatorObservedFeeRefreshMs
+	}
+	return s.cfg.Validator.ObservedFeeRefreshMs
+}
+
+// runFeeRefresher periodically recomputes the lowest mining fee the network
+// will accept — the minimum advertised across peer node_status announcements
+// within the observed-fee TTL — and pushes it into the validator so intake
+// enforces it (issue #212). It runs only when the operator has not pinned a
+// fee. Bound to the server lifetime ctx; returns when it is cancelled.
+func (s *Server) runFeeRefresher(ctx context.Context) {
+	s.refreshFeeOnce(ctx) // seed immediately so intake reacts before the first tick
+
+	ticker := time.NewTicker(time.Duration(s.observedFeeRefreshMs()) * time.Millisecond) //nolint:gosec // refresh interval in ms fits int64
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.refreshFeeOnce(ctx)
+		}
+	}
+}
+
+// refreshFeeOnce reads the observed peer policies and updates the validator's
+// fee floor to the network minimum, or to the built-in default when nothing
+// fresh has been observed. A store read failure leaves the current floor
+// unchanged rather than dropping it to the default.
+func (s *Server) refreshFeeOnce(ctx context.Context) {
+	rctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	peers, err := s.store.ListPeerPolicies(rctx, s.cfg.Network)
+	if err != nil {
+		s.logger.Warn("fee refresher: list peer policies failed, keeping current floor", zap.Error(err))
+		return
+	}
+
+	floor := uint64(config.DefaultValidatorMinFeePerKB)
+	if observed, ok := lowestObservedFeePerKB(peers, time.Duration(s.observedFeeTTLMs())*time.Millisecond, time.Now()); ok { //nolint:gosec // TTL in ms fits int64
+		floor = observed
+	}
+
+	prev := s.validator.MinFeePerKB()
+	s.validator.SetMinFeePerKB(floor)
+	if floor != prev {
+		s.logger.Info("intake fee floor updated from network observations",
+			zap.Uint64("prev_sat_per_kb", prev),
+			zap.Uint64("new_sat_per_kb", floor),
+			zap.Int("observed_peers", len(peers)))
+	}
+}
+
+// lowestObservedFeePerKB returns the minimum mining fee rate (in satoshis per
+// 1000 bytes) advertised by peers re-heard within ttl. ok is false when no
+// fresh observation exists. A peer's rate is normalized to sat/kB so
+// observations with a non-1000 byte basis compare correctly.
+func lowestObservedFeePerKB(peers []store.PeerPolicy, ttl time.Duration, now time.Time) (uint64, bool) {
+	cutoff := now.Add(-ttl)
+	var (
+		best  uint64
+		found bool
+	)
+	for _, p := range peers {
+		if p.MiningFeeBytes == 0 {
+			continue // avoid divide-by-zero on a malformed row
+		}
+		if !p.LastSeen.IsZero() && p.LastSeen.Before(cutoff) {
+			continue // peer not re-heard within TTL
+		}
+		perKB := p.MiningFeeSatoshis * 1000 / p.MiningFeeBytes
+		if !found || perKB < best {
+			best = perKB
+			found = true
+		}
+	}
+	return best, found
+}

--- a/services/api_server/fee_refresher.go
+++ b/services/api_server/fee_refresher.go
@@ -2,6 +2,7 @@ package api_server
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"go.uber.org/zap"
@@ -83,8 +84,10 @@ func (s *Server) refreshFeeOnce(ctx context.Context) {
 
 // lowestObservedFeePerKB returns the minimum mining fee rate (in satoshis per
 // 1000 bytes) advertised by peers re-heard within ttl. ok is false when no
-// fresh observation exists. A peer's rate is normalized to sat/kB so
-// observations with a non-1000 byte basis compare correctly.
+// fresh observation exists. A peer's rate is normalized to sat/kB using ceil
+// division so a non-1000 byte basis never rounds the enforced floor *below*
+// what the peer requires (e.g. 1 sat / 1001 bytes must map to 1 sat/kB, not 0,
+// or arcade would accept fee=0 that no node would).
 func lowestObservedFeePerKB(peers []store.PeerPolicy, ttl time.Duration, now time.Time) (uint64, bool) {
 	cutoff := now.Add(-ttl)
 	var (
@@ -98,11 +101,35 @@ func lowestObservedFeePerKB(peers []store.PeerPolicy, ttl time.Duration, now tim
 		if !p.LastSeen.IsZero() && p.LastSeen.Before(cutoff) {
 			continue // peer not re-heard within TTL
 		}
-		perKB := p.MiningFeeSatoshis * 1000 / p.MiningFeeBytes
+		perKB := ceilFeePerKB(p.MiningFeeSatoshis, p.MiningFeeBytes)
 		if !found || perKB < best {
 			best = perKB
 			found = true
 		}
 	}
 	return best, found
+}
+
+// ceilFeePerKB computes ceil(satoshis*1000 / bytes), rounding up so the derived
+// sat/kB floor is never lower than the peer's advertised rate. It is
+// overflow-safe for any input: an absurdly large advertised fee saturates to
+// MaxUint64, so it reads as "very high" and can never be wrongly selected as
+// the network minimum. bytes must be non-zero (checked by callers).
+func ceilFeePerKB(satoshis, bytes uint64) uint64 {
+	const scale = 1000
+	whole := satoshis / bytes
+	rem := satoshis % bytes // < bytes
+	if whole > math.MaxUint64/scale || rem > math.MaxUint64/scale {
+		return math.MaxUint64
+	}
+	base := whole * scale
+	remScaled := rem * scale
+	add := remScaled / bytes
+	if remScaled%bytes != 0 {
+		add++ // round up
+	}
+	if base > math.MaxUint64-add {
+		return math.MaxUint64
+	}
+	return base + add
 }

--- a/services/api_server/fee_refresher_test.go
+++ b/services/api_server/fee_refresher_test.go
@@ -1,0 +1,134 @@
+package api_server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/store"
+	"github.com/bsv-blockchain/arcade/validator"
+)
+
+func newFeeServer(ms *mockStore) *Server {
+	return &Server{
+		cfg:       &config.Config{Network: "mainnet"},
+		logger:    zap.NewNop(),
+		store:     ms,
+		validator: validator.NewValidator(nil), // starts at DefaultMinFeePerKB (100)
+	}
+}
+
+func TestLowestObservedFeePerKB(t *testing.T) {
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+	ttl := 15 * time.Minute
+
+	t.Run("min over fresh peers, stale excluded", func(t *testing.T) {
+		peers := []store.PeerPolicy{
+			{PeerID: "p1", MiningFeeSatoshis: 500, MiningFeeBytes: 1000, LastSeen: now},
+			{PeerID: "p2", MiningFeeSatoshis: 100, MiningFeeBytes: 1000, LastSeen: now.Add(-time.Minute)},
+			// stale cheapest — must be excluded
+			{PeerID: "p3", MiningFeeSatoshis: 1, MiningFeeBytes: 1000, LastSeen: now.Add(-24 * time.Hour)},
+		}
+		got, ok := lowestObservedFeePerKB(peers, ttl, now)
+		if !ok || got != 100 {
+			t.Fatalf("got (%d,%v), want (100,true)", got, ok)
+		}
+	})
+
+	t.Run("no fresh peers", func(t *testing.T) {
+		peers := []store.PeerPolicy{
+			{PeerID: "p1", MiningFeeSatoshis: 1, MiningFeeBytes: 1000, LastSeen: now.Add(-24 * time.Hour)},
+		}
+		if _, ok := lowestObservedFeePerKB(peers, ttl, now); ok {
+			t.Fatal("expected ok=false when all peers stale")
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		if _, ok := lowestObservedFeePerKB(nil, ttl, now); ok {
+			t.Fatal("expected ok=false for empty input")
+		}
+	})
+
+	t.Run("non-1000 byte basis normalized to sat/kB", func(t *testing.T) {
+		// 250 sat per 500 bytes == 500 sat/kB; 100 sat per 1000 bytes == 100 sat/kB.
+		peers := []store.PeerPolicy{
+			{PeerID: "p1", MiningFeeSatoshis: 250, MiningFeeBytes: 500, LastSeen: now},
+			{PeerID: "p2", MiningFeeSatoshis: 100, MiningFeeBytes: 1000, LastSeen: now},
+		}
+		got, ok := lowestObservedFeePerKB(peers, ttl, now)
+		if !ok || got != 100 {
+			t.Fatalf("got (%d,%v), want (100,true)", got, ok)
+		}
+	})
+
+	t.Run("zero-byte row skipped", func(t *testing.T) {
+		peers := []store.PeerPolicy{
+			{PeerID: "bad", MiningFeeSatoshis: 5, MiningFeeBytes: 0, LastSeen: now},
+			{PeerID: "ok", MiningFeeSatoshis: 80, MiningFeeBytes: 1000, LastSeen: now},
+		}
+		got, ok := lowestObservedFeePerKB(peers, ttl, now)
+		if !ok || got != 80 {
+			t.Fatalf("got (%d,%v), want (80,true)", got, ok)
+		}
+	})
+}
+
+func TestRefreshFeeOnce_UpdatesValidatorToObservedMin(t *testing.T) {
+	ms := &mockStore{peerPolicies: []store.PeerPolicy{
+		{PeerID: "p1", MiningFeeSatoshis: 500, MiningFeeBytes: 1000, LastSeen: time.Now()},
+		{PeerID: "p2", MiningFeeSatoshis: 50, MiningFeeBytes: 1000, LastSeen: time.Now()},
+	}}
+	s := newFeeServer(ms)
+
+	s.refreshFeeOnce(context.Background())
+
+	if got := s.validator.MinFeePerKB(); got != 50 {
+		t.Errorf("validator floor = %d, want 50 (network minimum)", got)
+	}
+}
+
+func TestRefreshFeeOnce_NoObservationsUsesDefault(t *testing.T) {
+	s := newFeeServer(&mockStore{})
+	s.validator.SetMinFeePerKB(7) // pretend a prior observation had set it low
+
+	s.refreshFeeOnce(context.Background())
+
+	if got := s.validator.MinFeePerKB(); got != config.DefaultValidatorMinFeePerKB {
+		t.Errorf("validator floor = %d, want %d (default when nothing observed)", got, config.DefaultValidatorMinFeePerKB)
+	}
+}
+
+func TestRefreshFeeOnce_StoreErrorKeepsCurrentFloor(t *testing.T) {
+	s := newFeeServer(&mockStore{listPeerPoliciesErr: errTest})
+	s.validator.SetMinFeePerKB(42)
+
+	s.refreshFeeOnce(context.Background())
+
+	if got := s.validator.MinFeePerKB(); got != 42 {
+		t.Errorf("validator floor = %d, want 42 (unchanged on store error)", got)
+	}
+}
+
+func TestFeePinned(t *testing.T) {
+	cases := []struct {
+		name string
+		vcfg config.ValidatorConfig
+		want bool
+	}{
+		{"unset", config.ValidatorConfig{}, false},
+		{"accept zero fee", config.ValidatorConfig{AcceptZeroFee: true}, true},
+		{"explicit min fee", config.ValidatorConfig{MinFeePerKB: 100}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{cfg: &config.Config{Validator: tc.vcfg}}
+			if got := s.feePinned(); got != tc.want {
+				t.Errorf("feePinned() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/services/api_server/fee_refresher_test.go
+++ b/services/api_server/fee_refresher_test.go
@@ -65,6 +65,29 @@ func TestLowestObservedFeePerKB(t *testing.T) {
 		}
 	})
 
+	t.Run("rounds up, never below the peer rate", func(t *testing.T) {
+		// 1 sat / 1001 bytes is ~0.999 sat/kB; must round UP to 1, not down to
+		// 0 (which would let arcade accept fee=0 that the peer would reject).
+		peers := []store.PeerPolicy{
+			{PeerID: "p1", MiningFeeSatoshis: 1, MiningFeeBytes: 1001, LastSeen: now},
+		}
+		got, ok := lowestObservedFeePerKB(peers, ttl, now)
+		if !ok || got != 1 {
+			t.Fatalf("got (%d,%v), want (1,true) — ceil, not floor", got, ok)
+		}
+	})
+
+	t.Run("absurd fee saturates and is never the minimum", func(t *testing.T) {
+		peers := []store.PeerPolicy{
+			{PeerID: "huge", MiningFeeSatoshis: 1 << 60, MiningFeeBytes: 1, LastSeen: now},
+			{PeerID: "sane", MiningFeeSatoshis: 20, MiningFeeBytes: 1000, LastSeen: now},
+		}
+		got, ok := lowestObservedFeePerKB(peers, ttl, now)
+		if !ok || got != 20 {
+			t.Fatalf("got (%d,%v), want (20,true) — huge fee must not wrap into the minimum", got, ok)
+		}
+	})
+
 	t.Run("zero-byte row skipped", func(t *testing.T) {
 		peers := []store.PeerPolicy{
 			{PeerID: "bad", MiningFeeSatoshis: 5, MiningFeeBytes: 0, LastSeen: now},

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -72,6 +72,10 @@ type mockStore struct {
 	// for the GET /tx callback-state tests.
 	subsByTxID  map[string][]*models.Submission
 	getStatusFn func(txid string) *models.TransactionStatus
+	// peerPolicies feeds ListPeerPolicies for the GET /policy tests;
+	// listPeerPoliciesErr injects a store failure.
+	peerPolicies        []store.PeerPolicy
+	listPeerPoliciesErr error
 }
 
 func (m *mockStore) UpdateStatus(_ context.Context, status *models.TransactionStatus) error {
@@ -271,6 +275,17 @@ func (m *mockStore) UpsertDatahubEndpoint(context.Context, store.DatahubEndpoint
 
 func (m *mockStore) ListDatahubEndpoints(context.Context, string) ([]store.DatahubEndpoint, error) {
 	return nil, nil
+}
+
+func (m *mockStore) UpsertPeerPolicy(context.Context, store.PeerPolicy) error {
+	return nil
+}
+
+func (m *mockStore) ListPeerPolicies(context.Context, string) ([]store.PeerPolicy, error) {
+	if m.listPeerPoliciesErr != nil {
+		return nil, m.listPeerPoliciesErr
+	}
+	return m.peerPolicies, nil
 }
 
 func (m *mockStore) UpsertBlockHeaderSeen(context.Context, string, uint64, time.Time) error {

--- a/services/api_server/policy_routes.go
+++ b/services/api_server/policy_routes.go
@@ -15,6 +15,30 @@ import (
 // FeePolicy.MiningFee convention.
 const miningFeeBytesBasis = 1000
 
+// arcUnlimitedSigops is the value ARC uses in maxtxsigopscountspolicy to mean
+// "unlimited" (max uint32). Arcade/teranode represent unlimited internally as
+// 0; the /policy response maps 0 to this so ARC clients don't read it as
+// "zero sigops allowed".
+const arcUnlimitedSigops = 4294967295
+
+// arcSigops maps arcade's internal sigop cap to the ARC wire convention: an
+// internal 0 (unlimited, BSV post-Genesis) becomes ARC's unlimited sentinel; a
+// real cap is reported verbatim.
+func arcSigops(internal int64) int64 {
+	if internal == 0 {
+		return arcUnlimitedSigops
+	}
+	return internal
+}
+
+// firstNonZero returns v, or fallback when v is 0.
+func firstNonZero(v, fallback uint64) uint64 {
+	if v == 0 {
+		return fallback
+	}
+	return v
+}
+
 // handlePolicy serves the ARC-compatible GET /policy document (issue #212).
 // It reports arcade's effective transaction policy: the size/sigop limits and
 // mining fee floor the validator actually enforces, plus the standard-format
@@ -30,15 +54,17 @@ func (s *Server) handlePolicy(c *gin.Context) {
 
 	// Size/sigop limits: prefer the validator's resolved values so /policy
 	// advertises exactly what intake enforces. Fall back to config when the
-	// validator is unset (struct-literal test servers).
+	// validator is unset (struct-literal test servers), and to the canonical
+	// teranode defaults when the config value is 0, so the document is never
+	// meaningless (e.g. maxtxsizepolicy: 0).
 	if s.validator != nil {
 		pol.MaxTxSizePolicy = uint64(s.validator.MaxTxSizePolicy())         //nolint:gosec // validator returns a non-negative byte size
 		pol.MaxScriptSizePolicy = uint64(s.validator.MaxScriptSizePolicy()) //nolint:gosec // validator returns a non-negative byte size
-		pol.MaxTxSigopsCountsPolicy = s.validator.MaxTxSigopsCountsPolicy()
+		pol.MaxTxSigopsCountsPolicy = arcSigops(s.validator.MaxTxSigopsCountsPolicy())
 	} else {
-		pol.MaxTxSizePolicy = s.cfg.Validator.MaxTxSizePolicy
-		pol.MaxScriptSizePolicy = s.cfg.Validator.MaxScriptSizePolicy
-		pol.MaxTxSigopsCountsPolicy = s.cfg.Validator.MaxTxSigopsCountsPolicy
+		pol.MaxTxSizePolicy = firstNonZero(s.cfg.Validator.MaxTxSizePolicy, config.DefaultValidatorMaxTxSizePolicy)
+		pol.MaxScriptSizePolicy = firstNonZero(s.cfg.Validator.MaxScriptSizePolicy, config.DefaultValidatorMaxScriptSizePolicy)
+		pol.MaxTxSigopsCountsPolicy = arcSigops(s.cfg.Validator.MaxTxSigopsCountsPolicy)
 	}
 
 	c.JSON(http.StatusOK, models.PolicyResponse{

--- a/services/api_server/policy_routes.go
+++ b/services/api_server/policy_routes.go
@@ -1,0 +1,65 @@
+package api_server
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// miningFeeBytesBasis is the byte basis arcade advertises fee rates against:
+// satoshis per 1000 bytes (== satoshis/kB), matching the node_status
+// FeePolicy.MiningFee convention.
+const miningFeeBytesBasis = 1000
+
+// handlePolicy serves the ARC-compatible GET /policy document (issue #212).
+// It reports arcade's effective transaction policy: the size/sigop limits and
+// mining fee floor the validator actually enforces, plus the standard-format
+// flag from config. The mining fee is read straight off the validator
+// (MinFeePerKB), which the fee refresher keeps in step with the lowest fee the
+// network will accept — so /policy always advertises exactly what intake
+// enforces. Read-only; always returns 200.
+func (s *Server) handlePolicy(c *gin.Context) {
+	pol := models.Policy{
+		StandardFormatSupported: s.cfg.Validator.StandardFormatSupported,
+		MiningFee:               s.resolveMiningFee(),
+	}
+
+	// Size/sigop limits: prefer the validator's resolved values so /policy
+	// advertises exactly what intake enforces. Fall back to config when the
+	// validator is unset (struct-literal test servers).
+	if s.validator != nil {
+		pol.MaxTxSizePolicy = uint64(s.validator.MaxTxSizePolicy())         //nolint:gosec // validator returns a non-negative byte size
+		pol.MaxScriptSizePolicy = uint64(s.validator.MaxScriptSizePolicy()) //nolint:gosec // validator returns a non-negative byte size
+		pol.MaxTxSigopsCountsPolicy = s.validator.MaxTxSigopsCountsPolicy()
+	} else {
+		pol.MaxTxSizePolicy = s.cfg.Validator.MaxTxSizePolicy
+		pol.MaxScriptSizePolicy = s.cfg.Validator.MaxScriptSizePolicy
+		pol.MaxTxSigopsCountsPolicy = s.cfg.Validator.MaxTxSigopsCountsPolicy
+	}
+
+	c.JSON(http.StatusOK, models.PolicyResponse{
+		Policy:    pol,
+		Timestamp: time.Now().UTC(),
+	})
+}
+
+// resolveMiningFee reports the fee floor the validator currently enforces. When
+// the validator is present (production), that is authoritative — the refresher
+// keeps it equal to the network minimum when the operator hasn't pinned a fee.
+// The config fallback covers struct-literal test servers with no validator.
+func (s *Server) resolveMiningFee() models.FeeAmount {
+	if s.validator != nil {
+		return models.FeeAmount{Satoshis: s.validator.MinFeePerKB(), Bytes: miningFeeBytesBasis}
+	}
+	if s.cfg.Validator.AcceptZeroFee {
+		return models.FeeAmount{Satoshis: 0, Bytes: miningFeeBytesBasis}
+	}
+	if s.cfg.Validator.MinFeePerKB != 0 {
+		return models.FeeAmount{Satoshis: s.cfg.Validator.MinFeePerKB, Bytes: miningFeeBytesBasis}
+	}
+	return models.FeeAmount{Satoshis: config.DefaultValidatorMinFeePerKB, Bytes: miningFeeBytesBasis}
+}

--- a/services/api_server/policy_routes_test.go
+++ b/services/api_server/policy_routes_test.go
@@ -60,8 +60,9 @@ func TestHandlePolicy_ReportsValidatorFloor(t *testing.T) {
 		t.Errorf("size fields = {%d %d}, want validator defaults {10485760 500000}",
 			resp.Policy.MaxTxSizePolicy, resp.Policy.MaxScriptSizePolicy)
 	}
-	if resp.Policy.MaxTxSigopsCountsPolicy != 0 {
-		t.Errorf("maxtxsigopscountspolicy = %d, want 0", resp.Policy.MaxTxSigopsCountsPolicy)
+	// Internal 0 (unlimited) is reported as ARC's unlimited sentinel.
+	if resp.Policy.MaxTxSigopsCountsPolicy != arcUnlimitedSigops {
+		t.Errorf("maxtxsigopscountspolicy = %d, want %d (ARC unlimited)", resp.Policy.MaxTxSigopsCountsPolicy, arcUnlimitedSigops)
 	}
 	if !resp.Policy.StandardFormatSupported {
 		t.Errorf("standardFormatSupported = false, want true")
@@ -119,6 +120,24 @@ func TestHandlePolicy_SizeAndFormatFieldsFromConfig(t *testing.T) {
 	}
 	if !resp.Policy.StandardFormatSupported {
 		t.Errorf("standardFormatSupported = false, want true")
+	}
+}
+
+// TestHandlePolicy_ZeroConfigFallsBackToDefaults covers the no-validator path
+// with an all-zero validator config: size fields must fall back to the
+// canonical teranode defaults rather than emitting a meaningless 0, and sigops
+// must report the ARC unlimited sentinel.
+func TestHandlePolicy_ZeroConfigFallsBackToDefaults(t *testing.T) {
+	_, router := setupPolicyServer(&mockStore{}, config.ValidatorConfig{}, nil)
+	resp := getPolicy(t, router, "/policy")
+	if resp.Policy.MaxTxSizePolicy != config.DefaultValidatorMaxTxSizePolicy {
+		t.Errorf("maxtxsizepolicy = %d, want %d", resp.Policy.MaxTxSizePolicy, config.DefaultValidatorMaxTxSizePolicy)
+	}
+	if resp.Policy.MaxScriptSizePolicy != config.DefaultValidatorMaxScriptSizePolicy {
+		t.Errorf("maxscriptsizepolicy = %d, want %d", resp.Policy.MaxScriptSizePolicy, config.DefaultValidatorMaxScriptSizePolicy)
+	}
+	if resp.Policy.MaxTxSigopsCountsPolicy != arcUnlimitedSigops {
+		t.Errorf("maxtxsigopscountspolicy = %d, want %d", resp.Policy.MaxTxSigopsCountsPolicy, arcUnlimitedSigops)
 	}
 }
 

--- a/services/api_server/policy_routes_test.go
+++ b/services/api_server/policy_routes_test.go
@@ -1,0 +1,131 @@
+package api_server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/validator"
+)
+
+var errTest = errors.New("policy test: store failure")
+
+func setupPolicyServer(ms *mockStore, vcfg config.ValidatorConfig, val *validator.Validator) (*Server, *gin.Engine) {
+	gin.SetMode(gin.TestMode)
+	srv := &Server{
+		cfg:       &config.Config{Network: "mainnet", Validator: vcfg},
+		logger:    zap.NewNop(),
+		store:     ms,
+		validator: val,
+	}
+	router := gin.New()
+	srv.registerRoutes(router)
+	return srv, router
+}
+
+func getPolicy(t *testing.T, router http.Handler, path string) models.PolicyResponse {
+	t.Helper()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET %s: status = %d, want 200; body=%s", path, w.Code, w.Body.String())
+	}
+	var resp models.PolicyResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode policy response: %v; body=%s", err, w.Body.String())
+	}
+	return resp
+}
+
+// TestHandlePolicy_ReportsValidatorFloor is the production path: /policy
+// advertises exactly the fee floor and size limits the validator enforces.
+func TestHandlePolicy_ReportsValidatorFloor(t *testing.T) {
+	v := validator.NewValidator(nil) // starts at DefaultMinFeePerKB (100)
+	v.SetMinFeePerKB(37)             // as the fee refresher would after observing the network
+	_, router := setupPolicyServer(&mockStore{}, config.ValidatorConfig{StandardFormatSupported: true}, v)
+
+	resp := getPolicy(t, router, "/policy")
+	if resp.Policy.MiningFee != (models.FeeAmount{Satoshis: 37, Bytes: 1000}) {
+		t.Errorf("miningFee = %+v, want {37 1000} (validator floor)", resp.Policy.MiningFee)
+	}
+	if resp.Policy.MaxTxSizePolicy != 10485760 || resp.Policy.MaxScriptSizePolicy != 500000 {
+		t.Errorf("size fields = {%d %d}, want validator defaults {10485760 500000}",
+			resp.Policy.MaxTxSizePolicy, resp.Policy.MaxScriptSizePolicy)
+	}
+	if resp.Policy.MaxTxSigopsCountsPolicy != 0 {
+		t.Errorf("maxtxsigopscountspolicy = %d, want 0", resp.Policy.MaxTxSigopsCountsPolicy)
+	}
+	if !resp.Policy.StandardFormatSupported {
+		t.Errorf("standardFormatSupported = false, want true")
+	}
+	if resp.Timestamp.IsZero() {
+		t.Errorf("timestamp is zero, want an RFC3339 time")
+	}
+}
+
+// The remaining cases exercise the no-validator fallback (struct-literal test
+// servers): the reported fee comes from config, else the built-in default.
+func TestHandlePolicy_ConfiguredFeeFallback(t *testing.T) {
+	_, router := setupPolicyServer(&mockStore{}, config.ValidatorConfig{MinFeePerKB: 250}, nil)
+	resp := getPolicy(t, router, "/policy")
+	if resp.Policy.MiningFee != (models.FeeAmount{Satoshis: 250, Bytes: 1000}) {
+		t.Errorf("miningFee = %+v, want {250 1000}", resp.Policy.MiningFee)
+	}
+}
+
+func TestHandlePolicy_AcceptZeroFeeFallback(t *testing.T) {
+	_, router := setupPolicyServer(&mockStore{}, config.ValidatorConfig{AcceptZeroFee: true, MinFeePerKB: 250}, nil)
+	resp := getPolicy(t, router, "/policy")
+	if resp.Policy.MiningFee != (models.FeeAmount{Satoshis: 0, Bytes: 1000}) {
+		t.Errorf("miningFee = %+v, want {0 1000}", resp.Policy.MiningFee)
+	}
+}
+
+func TestHandlePolicy_DefaultFeeFallback(t *testing.T) {
+	_, router := setupPolicyServer(&mockStore{}, config.ValidatorConfig{MinFeePerKB: 0}, nil)
+	resp := getPolicy(t, router, "/policy")
+	want := models.FeeAmount{Satoshis: config.DefaultValidatorMinFeePerKB, Bytes: 1000}
+	if resp.Policy.MiningFee != want {
+		t.Errorf("miningFee = %+v, want %+v", resp.Policy.MiningFee, want)
+	}
+}
+
+func TestHandlePolicy_SizeAndFormatFieldsFromConfig(t *testing.T) {
+	vcfg := config.ValidatorConfig{
+		MaxTxSizePolicy:         12345678,
+		MaxScriptSizePolicy:     4242,
+		MaxTxSigopsCountsPolicy: 99,
+		StandardFormatSupported: true,
+	}
+	_, router := setupPolicyServer(&mockStore{}, vcfg, nil)
+
+	resp := getPolicy(t, router, "/policy")
+	if resp.Policy.MaxTxSizePolicy != 12345678 {
+		t.Errorf("maxtxsizepolicy = %d, want 12345678", resp.Policy.MaxTxSizePolicy)
+	}
+	if resp.Policy.MaxScriptSizePolicy != 4242 {
+		t.Errorf("maxscriptsizepolicy = %d, want 4242", resp.Policy.MaxScriptSizePolicy)
+	}
+	if resp.Policy.MaxTxSigopsCountsPolicy != 99 {
+		t.Errorf("maxtxsigopscountspolicy = %d, want 99", resp.Policy.MaxTxSigopsCountsPolicy)
+	}
+	if !resp.Policy.StandardFormatSupported {
+		t.Errorf("standardFormatSupported = false, want true")
+	}
+}
+
+func TestHandlePolicy_V1Alias(t *testing.T) {
+	_, router := setupPolicyServer(&mockStore{}, config.ValidatorConfig{MinFeePerKB: 300}, nil)
+	resp := getPolicy(t, router, "/v1/policy")
+	if resp.Policy.MiningFee.Satoshis != 300 {
+		t.Errorf("/v1/policy miningFee.satoshis = %d, want 300", resp.Policy.MiningFee.Satoshis)
+	}
+}

--- a/services/api_server/routes.go
+++ b/services/api_server/routes.go
@@ -80,6 +80,15 @@ var routeDocs = []RouteDoc{
 		ResponseBody:   "{\n  \"status\": \"ready\"\n}",
 	},
 	{
+		Method:         "GET",
+		Path:           "/policy",
+		Summary:        "Discover the current fee and size policy (ARC-compatible)",
+		Description:    "Returns Arcade's effective transaction policy in the ARC schema so clients can discover the fee rate and size limits before building transactions. Every value reflects exactly what intake enforces. When the operator hasn't pinned a fee, miningFee tracks the lowest fee the network will accept — the minimum advertised across peer node_status announcements — and Arcade enforces that same floor at intake; it falls back to the built-in default until a peer is heard. Also served at /v1/policy.",
+		ResponseStatus: "200 OK",
+		ResponseBody:   "{\n  \"policy\": {\n    \"miningFee\": { \"satoshis\": 100, \"bytes\": 1000 },\n    \"maxtxsizepolicy\": 10485760,\n    \"maxscriptsizepolicy\": 500000,\n    \"maxtxsigopscountspolicy\": 0,\n    \"standardFormatSupported\": true\n  },\n  \"timestamp\": \"2026-08-07T12:00:00Z\"\n}",
+		Notes:          "maxtxsigopscountspolicy of 0 means unlimited (the BSV post-Genesis default). Always returns 200 — a transient store error falls back to the default fee.",
+	},
+	{
 		Method:      "GET",
 		Path:        "/tx/:txid",
 		Summary:     "Look up transaction status by txid",
@@ -282,4 +291,8 @@ func (s *Server) registerRoutes(r *gin.Engine) {
 	r.GET("/tx/:txid", s.handleGetTransaction)
 	r.POST("/tx", s.handleSubmitTransaction)
 	r.POST("/txs", s.handleSubmitTransactions)
+	// ARC-compatible policy discovery (issue #212). Bare /policy matches the
+	// path clients 404'd on; /v1/policy is the alias used by the ARC spec.
+	r.GET("/policy", s.handlePolicy)
+	r.GET("/v1/policy", s.handlePolicy)
 }

--- a/services/api_server/routes.go
+++ b/services/api_server/routes.go
@@ -85,8 +85,8 @@ var routeDocs = []RouteDoc{
 		Summary:        "Discover the current fee and size policy (ARC-compatible)",
 		Description:    "Returns Arcade's effective transaction policy in the ARC schema so clients can discover the fee rate and size limits before building transactions. Every value reflects exactly what intake enforces. When the operator hasn't pinned a fee, miningFee tracks the lowest fee the network will accept — the minimum advertised across peer node_status announcements — and Arcade enforces that same floor at intake; it falls back to the built-in default until a peer is heard. Also served at /v1/policy.",
 		ResponseStatus: "200 OK",
-		ResponseBody:   "{\n  \"policy\": {\n    \"miningFee\": { \"satoshis\": 100, \"bytes\": 1000 },\n    \"maxtxsizepolicy\": 10485760,\n    \"maxscriptsizepolicy\": 500000,\n    \"maxtxsigopscountspolicy\": 0,\n    \"standardFormatSupported\": true\n  },\n  \"timestamp\": \"2026-08-07T12:00:00Z\"\n}",
-		Notes:          "maxtxsigopscountspolicy of 0 means unlimited (the BSV post-Genesis default). Always returns 200 — a transient store error falls back to the default fee.",
+		ResponseBody:   "{\n  \"policy\": {\n    \"miningFee\": { \"satoshis\": 100, \"bytes\": 1000 },\n    \"maxtxsizepolicy\": 10485760,\n    \"maxscriptsizepolicy\": 500000,\n    \"maxtxsigopscountspolicy\": 4294967295,\n    \"standardFormatSupported\": true\n  },\n  \"timestamp\": \"2026-08-07T12:00:00Z\"\n}",
+		Notes:          "maxtxsigopscountspolicy of 4294967295 means unlimited (the BSV post-Genesis default), matching the ARC convention. Always returns 200.",
 	},
 	{
 		Method:      "GET",

--- a/services/api_server/server.go
+++ b/services/api_server/server.go
@@ -167,6 +167,17 @@ func (s *Server) Start(ctx context.Context) error {
 		go s.runSubmissionRecorder(ctx, &recorderWG)
 	}
 
+	// When the operator hasn't pinned a fee, track the lowest fee the network
+	// will accept (from peer node_status observations) and push it into the
+	// validator so intake enforces it (issue #212). Bound to ctx; no drain
+	// needed, so it isn't part of recorderWG.
+	if s.validator != nil && !s.feePinned() {
+		s.logger.Info("starting dynamic intake fee tracking from network observations",
+			zap.Uint64("refresh_ms", s.observedFeeRefreshMs()),
+			zap.Uint64("ttl_ms", s.observedFeeTTLMs()))
+		go s.runFeeRefresher(ctx)
+	}
+
 	addr := fmt.Sprintf("%s:%d", s.cfg.APIServer.Host, s.cfg.APIServer.Port)
 	s.server = &http.Server{
 		Addr:              addr,

--- a/services/p2p_client/client.go
+++ b/services/p2p_client/client.go
@@ -392,6 +392,20 @@ func (c *Client) recordPeerFee(ctx context.Context, msg teranodep2p.NodeStatusMe
 		MiningFeeBytes:    byts,
 		LastSeen:          time.Now(),
 	}); err != nil {
+		// An implausible advertisement is the peer's fault, not ours: node_status
+		// is unauthenticated gossip and a peer may announce a fee too large to
+		// store. Log it as a dropped advertisement rather than a store failure,
+		// so a hostile peer cannot fill the operator's warning stream.
+		if errors.Is(err, store.ErrInvalidPeerPolicy) {
+			c.logger.Debug(
+				"ignoring implausible peer mining fee",
+				zap.String("peer_id", msg.PeerID),
+				zap.Uint64("mining_fee_satoshis", sats),
+				zap.Uint64("mining_fee_bytes", byts),
+				zap.Error(err),
+			)
+			return
+		}
 		c.logger.Warn(
 			"failed to persist peer mining fee",
 			zap.String("peer_id", msg.PeerID),

--- a/services/p2p_client/client.go
+++ b/services/p2p_client/client.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"sync"
 	"time"
@@ -56,10 +57,13 @@ type teraClient interface {
 
 // EndpointWriter is the narrow store contract p2p_client needs: persist a
 // discovered datahub URL so other pods (propagation, bump-builder) can pick
-// it up via their teranode.Client refresh loop. Defined as an interface here
-// rather than taking *store.Store directly so tests can pass a fake.
+// it up via their teranode.Client refresh loop, and persist a peer's observed
+// mining fee so api-server pods can serve the network-minimum fee in GET
+// /policy (issue #212). Defined as an interface here rather than taking
+// *store.Store directly so tests can pass a fake.
 type EndpointWriter interface {
 	UpsertDatahubEndpoint(ctx context.Context, ep store.DatahubEndpoint) error
+	UpsertPeerPolicy(ctx context.Context, pp store.PeerPolicy) error
 }
 
 // clientFactory is overridable in tests to avoid starting a real libp2p host.
@@ -282,6 +286,11 @@ func (c *Client) handleNodeStatus(ctx context.Context, msg teranodep2p.NodeStatu
 		ce.Write(fields...)
 	}
 
+	// Record the peer's advertised mining fee before the datahub-URL gate
+	// below, so a peer that exposes a fee but no datahub URL still counts
+	// toward the GET /policy network-minimum (issue #212).
+	c.recordPeerFee(ctx, msg)
+
 	raw := pickDatahubURL(msg)
 	if raw == "" {
 		metrics.P2PEndpointDiscoveryTotal.WithLabelValues("no_url").Inc()
@@ -332,6 +341,51 @@ func (c *Client) handleNodeStatus(ctx context.Context, msg teranodep2p.NodeStatu
 		zap.String("peer_id", msg.PeerID),
 		zap.String("url", normalized),
 	)
+}
+
+// recordPeerFee extracts the peer's advertised minimum mining fee from a
+// node_status announcement and persists it to the shared store so api-server
+// pods can compute the network-minimum fee for GET /policy. It prefers the
+// structured FeePolicy.MiningFee (satoshis per Bytes) and falls back to the
+// legacy MinMiningTxFee (*float64 in BSV/kB). Peers advertising neither (older
+// nodes) are skipped.
+func (c *Client) recordPeerFee(ctx context.Context, msg teranodep2p.NodeStatusMessage) {
+	var sats, byts uint64
+	switch {
+	case msg.FeePolicy != nil && msg.FeePolicy.MiningFee.Bytes > 0:
+		sats = msg.FeePolicy.MiningFee.Satoshis
+		byts = msg.FeePolicy.MiningFee.Bytes
+	case msg.MinMiningTxFee != nil:
+		// BSV/kB -> satoshis per 1000 bytes (1 BSV = 1e8 satoshis).
+		sats = uint64(math.Round(*msg.MinMiningTxFee * 1e8))
+		byts = 1000
+	default:
+		return
+	}
+
+	if msg.BaseURL != "" {
+		// Normalize to satoshis per 1000 bytes for a comparable gauge.
+		metrics.P2PPeerMinMiningFee.WithLabelValues(msg.BaseURL).Set(float64(sats) * 1000 / float64(byts))
+	}
+
+	if c.store == nil || msg.PeerID == "" {
+		return
+	}
+	upsertCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := c.store.UpsertPeerPolicy(upsertCtx, store.PeerPolicy{
+		PeerID:            msg.PeerID,
+		Network:           c.cfg.Network,
+		MiningFeeSatoshis: sats,
+		MiningFeeBytes:    byts,
+		LastSeen:          time.Now(),
+	}); err != nil {
+		c.logger.Warn(
+			"failed to persist peer mining fee",
+			zap.String("peer_id", msg.PeerID),
+			zap.Error(err),
+		)
+	}
 }
 
 // validateDatahubURL runs the full discovered-URL validation (scheme, SSRF

--- a/services/p2p_client/client.go
+++ b/services/p2p_client/client.go
@@ -356,8 +356,20 @@ func (c *Client) recordPeerFee(ctx context.Context, msg teranodep2p.NodeStatusMe
 		sats = msg.FeePolicy.MiningFee.Satoshis
 		byts = msg.FeePolicy.MiningFee.Bytes
 	case msg.MinMiningTxFee != nil:
-		// BSV/kB -> satoshis per 1000 bytes (1 BSV = 1e8 satoshis).
-		sats = uint64(math.Round(*msg.MinMiningTxFee * 1e8))
+		// BSV/kB -> satoshis per 1000 bytes (1 BSV = 1e8 satoshis). Validate the
+		// untrusted float before converting: a malformed/malicious node_status
+		// could carry NaN/Inf/negative or an absurd magnitude, which uint64()
+		// would turn into a wrapped garbage value that pollutes metrics and the
+		// int64-backed store columns. Drop such advertisements.
+		f := *msg.MinMiningTxFee
+		v := math.Round(f * 1e8)
+		if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 || v > math.MaxInt64 {
+			c.logger.Debug("ignoring implausible peer MinMiningTxFee",
+				zap.String("peer_id", msg.PeerID),
+				zap.Float64("min_mining_tx_fee", f))
+			return
+		}
+		sats = uint64(v)
 		byts = 1000
 	default:
 		return

--- a/services/p2p_client/client_test.go
+++ b/services/p2p_client/client_test.go
@@ -23,8 +23,9 @@ import (
 // store is now the only sink — the in-process teranode.Client AddEndpoints
 // path was removed when p2p_client was decoupled from the propagation pod.
 type fakeEndpointWriter struct {
-	mu    sync.Mutex
-	calls []store.DatahubEndpoint
+	mu       sync.Mutex
+	calls    []store.DatahubEndpoint
+	feeCalls []store.PeerPolicy
 }
 
 func (f *fakeEndpointWriter) UpsertDatahubEndpoint(_ context.Context, ep store.DatahubEndpoint) error {
@@ -34,11 +35,26 @@ func (f *fakeEndpointWriter) UpsertDatahubEndpoint(_ context.Context, ep store.D
 	return nil
 }
 
+func (f *fakeEndpointWriter) UpsertPeerPolicy(_ context.Context, pp store.PeerPolicy) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.feeCalls = append(f.feeCalls, pp)
+	return nil
+}
+
 func (f *fakeEndpointWriter) snapshot() []store.DatahubEndpoint {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	out := make([]store.DatahubEndpoint, len(f.calls))
 	copy(out, f.calls)
+	return out
+}
+
+func (f *fakeEndpointWriter) feeSnapshot() []store.PeerPolicy {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]store.PeerPolicy, len(f.feeCalls))
+	copy(out, f.feeCalls)
 	return out
 }
 
@@ -406,5 +422,69 @@ func TestClient_ValidationCacheSkipsRepeatLookups(t *testing.T) {
 	waitForUpserts(t, w, 3)
 	if got := lookups.Load(); got != 1 {
 		t.Errorf("expected exactly 1 DNS lookup across 3 announcements, got %d", got)
+	}
+}
+
+// TestRecordPeerFee_FeePolicy verifies the structured FeePolicy.MiningFee is
+// persisted verbatim as the peer's observed fee.
+func TestRecordPeerFee_FeePolicy(t *testing.T) {
+	c, w := newTestClient(t, newFakeTeraClient("sender"))
+	c.recordPeerFee(context.Background(), teranodep2p.NodeStatusMessage{
+		PeerID:    "peer-1",
+		BaseURL:   "https://peer.example",
+		FeePolicy: &teranodep2p.FeePolicy{MiningFee: teranodep2p.FeeAmount{Satoshis: 75, Bytes: 1000}},
+	})
+
+	fees := w.feeSnapshot()
+	if len(fees) != 1 {
+		t.Fatalf("expected 1 fee upsert, got %d: %+v", len(fees), fees)
+	}
+	if fees[0].PeerID != "peer-1" || fees[0].MiningFeeSatoshis != 75 || fees[0].MiningFeeBytes != 1000 {
+		t.Errorf("fee = %+v, want {peer-1 75 1000 ...}", fees[0])
+	}
+	if fees[0].Network != config.NetworkMainnet {
+		t.Errorf("network = %q, want %q", fees[0].Network, config.NetworkMainnet)
+	}
+}
+
+// TestRecordPeerFee_LegacyMinMiningTxFee verifies the BSV/kB fallback is
+// converted to satoshis-per-1000-bytes when no structured FeePolicy is present.
+func TestRecordPeerFee_LegacyMinMiningTxFee(t *testing.T) {
+	c, w := newTestClient(t, newFakeTeraClient("sender"))
+	fee := 0.0000005 // BSV/kB -> 50 sat per 1000 bytes
+	c.recordPeerFee(context.Background(), teranodep2p.NodeStatusMessage{
+		PeerID:         "peer-2",
+		MinMiningTxFee: &fee,
+	})
+
+	fees := w.feeSnapshot()
+	if len(fees) != 1 {
+		t.Fatalf("expected 1 fee upsert, got %d: %+v", len(fees), fees)
+	}
+	if fees[0].MiningFeeSatoshis != 50 || fees[0].MiningFeeBytes != 1000 {
+		t.Errorf("fee = {%d %d}, want {50 1000}", fees[0].MiningFeeSatoshis, fees[0].MiningFeeBytes)
+	}
+}
+
+// TestRecordPeerFee_URLlessPeerStillRecorded verifies a peer that advertises a
+// fee but no datahub URL is still counted toward the /policy network-minimum.
+func TestRecordPeerFee_URLlessPeerStillRecorded(t *testing.T) {
+	c, w := newTestClient(t, newFakeTeraClient("sender"))
+	c.recordPeerFee(context.Background(), teranodep2p.NodeStatusMessage{
+		PeerID:    "peer-3",
+		FeePolicy: &teranodep2p.FeePolicy{MiningFee: teranodep2p.FeeAmount{Satoshis: 10, Bytes: 1000}},
+	})
+	if fees := w.feeSnapshot(); len(fees) != 1 || fees[0].PeerID != "peer-3" {
+		t.Fatalf("expected URL-less peer fee recorded, got %+v", fees)
+	}
+}
+
+// TestRecordPeerFee_NoFeeAdvertised verifies peers advertising no fee (old
+// nodes) are skipped rather than recorded with a zero fee.
+func TestRecordPeerFee_NoFeeAdvertised(t *testing.T) {
+	c, w := newTestClient(t, newFakeTeraClient("sender"))
+	c.recordPeerFee(context.Background(), teranodep2p.NodeStatusMessage{PeerID: "peer-4"})
+	if fees := w.feeSnapshot(); len(fees) != 0 {
+		t.Fatalf("expected no fee upsert for feeless peer, got %+v", fees)
 	}
 }

--- a/services/p2p_client/client_test.go
+++ b/services/p2p_client/client_test.go
@@ -2,6 +2,7 @@ package p2p_client
 
 import (
 	"context"
+	"math"
 	"net"
 	"strings"
 	"sync"
@@ -486,5 +487,23 @@ func TestRecordPeerFee_NoFeeAdvertised(t *testing.T) {
 	c.recordPeerFee(context.Background(), teranodep2p.NodeStatusMessage{PeerID: "peer-4"})
 	if fees := w.feeSnapshot(); len(fees) != 0 {
 		t.Fatalf("expected no fee upsert for feeless peer, got %+v", fees)
+	}
+}
+
+// TestRecordPeerFee_RejectsMalformedLegacyFee verifies that a malformed or
+// malicious legacy MinMiningTxFee (NaN, Inf, negative, or absurdly large) is
+// dropped rather than converted into a wrapped uint64 that would pollute the
+// store and metrics.
+func TestRecordPeerFee_RejectsMalformedLegacyFee(t *testing.T) {
+	bad := []float64{math.NaN(), math.Inf(1), -0.0001, 1e30}
+	for _, f := range bad {
+		c, w := newTestClient(t, newFakeTeraClient("sender"))
+		c.recordPeerFee(context.Background(), teranodep2p.NodeStatusMessage{
+			PeerID:         "peer-bad",
+			MinMiningTxFee: &f,
+		})
+		if fees := w.feeSnapshot(); len(fees) != 0 {
+			t.Errorf("fee=%v: expected no upsert for malformed fee, got %+v", f, fees)
+		}
 	}
 }

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -250,6 +250,14 @@ func (s *fakeStore) ListDatahubEndpoints(context.Context, string) ([]store.Datah
 	return nil, nil
 }
 
+func (s *fakeStore) UpsertPeerPolicy(context.Context, store.PeerPolicy) error {
+	return nil
+}
+
+func (s *fakeStore) ListPeerPolicies(context.Context, string) ([]store.PeerPolicy, error) {
+	return nil, nil
+}
+
 func (s *fakeStore) UpsertBlockHeaderSeen(context.Context, string, uint64, time.Time) error {
 	return nil
 }

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -43,6 +43,7 @@ const (
 	setBlockProcessing  = "arcade_block_processing"
 	setLeases           = "arcade_leases"
 	setDatahubEndpoints = "arcade_datahub_endpoints"
+	setPeerPolicies     = "arcade_peer_policies"
 )
 
 // BUMP chunking — large compound BUMPs (scaling networks with millions of
@@ -2894,6 +2895,78 @@ loop:
 			}
 			if ep.URL != "" && ep.Network == network {
 				out = append(out, ep)
+			}
+		}
+	}
+	if loopErr != nil {
+		return nil, loopErr
+	}
+	return out, nil
+}
+
+func (s *Store) UpsertPeerPolicy(ctx context.Context, pp store.PeerPolicy) error {
+	if pp.PeerID == "" {
+		return fmt.Errorf("upsert peer policy: empty peer id")
+	}
+	key, err := s.key(setPeerPolicies, pp.PeerID)
+	if err != nil {
+		return err
+	}
+	bins := aero.BinMap{
+		"peer_id":   pp.PeerID,
+		"network":   pp.Network,
+		"fee_sats":  int64(pp.MiningFeeSatoshis), //nolint:gosec // fee in satoshis, non-negative and bounded
+		"fee_bytes": int64(pp.MiningFeeBytes),    //nolint:gosec // fee byte basis, non-negative and bounded
+		"last_seen": pp.LastSeen.UnixMilli(),
+	}
+	return s.client.Put(s.writePolicy(ctx), key, bins)
+}
+
+// ListPeerPolicies scans every recorded peer policy, filtering to entries
+// scoped to the given network. Cardinality tracks the peer count (dozens to
+// low hundreds) — no pagination needed.
+func (s *Store) ListPeerPolicies(ctx context.Context, network string) ([]store.PeerPolicy, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	stmt := aero.NewStatement(s.namespace, setPeerPolicies)
+	rs, err := s.client.Query(s.queryPolicy(ctx), stmt)
+	if rs != nil {
+		defer func() { _ = rs.Close() }()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query peer policies: %w", err)
+	}
+
+	var (
+		out     []store.PeerPolicy
+		loopErr error
+	)
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			loopErr = ctx.Err()
+			break loop
+		case rec, ok := <-rs.Results():
+			if !ok {
+				break loop
+			}
+			if rec.Err != nil {
+				loopErr = rec.Err
+				break loop
+			}
+			pp := store.PeerPolicy{
+				PeerID:            getString(rec.Record, "peer_id"),
+				Network:           getString(rec.Record, "network"),
+				MiningFeeSatoshis: uint64(getInt64(rec.Record, "fee_sats")),  //nolint:gosec // stored non-negative
+				MiningFeeBytes:    uint64(getInt64(rec.Record, "fee_bytes")), //nolint:gosec // stored non-negative
+			}
+			if ms := getInt64(rec.Record, "last_seen"); ms > 0 {
+				pp.LastSeen = time.UnixMilli(ms)
+			}
+			if pp.PeerID != "" && pp.Network == network {
+				out = append(out, pp)
 			}
 		}
 	}

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -2905,18 +2905,21 @@ loop:
 }
 
 func (s *Store) UpsertPeerPolicy(ctx context.Context, pp store.PeerPolicy) error {
-	if pp.PeerID == "" {
-		return fmt.Errorf("upsert peer policy: empty peer id")
+	if err := pp.Validate(); err != nil {
+		return err
 	}
 	key, err := s.key(setPeerPolicies, pp.PeerID)
 	if err != nil {
 		return err
 	}
 	bins := aero.BinMap{
-		"peer_id":   pp.PeerID,
-		"network":   pp.Network,
-		"fee_sats":  int64(pp.MiningFeeSatoshis), //nolint:gosec // fee in satoshis, non-negative and bounded
-		"fee_bytes": int64(pp.MiningFeeBytes),    //nolint:gosec // fee byte basis, non-negative and bounded
+		"peer_id": pp.PeerID,
+		"network": pp.Network,
+		// Both narrowings are bounded by PeerPolicy.Validate above; without it a
+		// peer-supplied value over MaxInt64 would wrap negative into the bin and
+		// read back as an astronomical fee.
+		"fee_sats":  int64(pp.MiningFeeSatoshis), //nolint:gosec // bounded by PeerPolicy.Validate
+		"fee_bytes": int64(pp.MiningFeeBytes),    //nolint:gosec // bounded by PeerPolicy.Validate
 		"last_seen": pp.LastSeen.UnixMilli(),
 	}
 	return s.client.Put(s.writePolicy(ctx), key, bins)

--- a/store/pebble/keys.go
+++ b/store/pebble/keys.go
@@ -14,12 +14,13 @@ import (
 // the referenced txid/id off the end of the key. This keeps index writes
 // to a single Set() per index and avoids a second lookup round-trip.
 const (
-	prefixTx      = "tx:"
-	prefixBump    = "bump:"
-	prefixStump   = "stump:"
-	prefixSub     = "sub:"
-	prefixLease   = "lease:"
-	prefixDatahub = "dh:"
+	prefixTx         = "tx:"
+	prefixBump       = "bump:"
+	prefixStump      = "stump:"
+	prefixSub        = "sub:"
+	prefixLease      = "lease:"
+	prefixDatahub    = "dh:"
+	prefixPeerPolicy = "pp:"
 
 	prefixIdxTxStatus        = "idx:tx:status:"
 	prefixIdxTxBlock         = "idx:tx:block:"
@@ -38,6 +39,9 @@ func subKey(id string) []byte              { return []byte(prefixSub + id) }
 func leaseKey(name string) []byte          { return []byte(prefixLease + name) }
 func datahubEndpointKey(url string) []byte { return []byte(prefixDatahub + url) }
 func datahubEndpointPrefix() []byte        { return []byte(prefixDatahub) }
+
+func peerPolicyKey(peerID string) []byte { return []byte(prefixPeerPolicy + peerID) }
+func peerPolicyPrefix() []byte           { return []byte(prefixPeerPolicy) }
 
 func stumpKey(blockHash string, idx int) []byte {
 	return []byte(fmt.Sprintf("%s%s:%010d", prefixStump, blockHash, idx))

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -2293,8 +2293,12 @@ func (s *Store) UpsertPeerPolicy(ctx context.Context, pp store.PeerPolicy) error
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if pp.PeerID == "" {
-		return fmt.Errorf("upsert peer policy: empty peer id")
+	// Pebble stores the fees as JSON uint64 and so cannot lose precision, but it
+	// validates on the same terms as the other backends: a zero byte basis is
+	// meaningless everywhere, and one backend silently accepting what the others
+	// reject would make the store's contract depend on its deployment.
+	if err := pp.Validate(); err != nil {
+		return err
 	}
 	stored := storedPeerPolicy{
 		PeerID:            pp.PeerID,

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -241,6 +241,14 @@ type storedDatahubEndpoint struct {
 	LastSeenUnixNs int64  `json:"last_seen"`
 }
 
+type storedPeerPolicy struct {
+	PeerID            string `json:"peer_id"`
+	Network           string `json:"network"`
+	MiningFeeSatoshis uint64 `json:"mining_fee_satoshis"`
+	MiningFeeBytes    uint64 `json:"mining_fee_bytes"`
+	LastSeenUnixNs    int64  `json:"last_seen"`
+}
+
 // New opens a Pebble database at cfg.Path and returns a Store ready to use.
 // If the directory does not exist it's created. The returned Store takes an
 // exclusive file lock on the directory — closing the Store releases it.
@@ -2277,6 +2285,69 @@ func (s *Store) ListDatahubEndpoints(ctx context.Context, network string) ([]sto
 			ep.LastSeen = time.Unix(0, row.LastSeenUnixNs)
 		}
 		out = append(out, ep)
+	}
+	return out, nil
+}
+
+func (s *Store) UpsertPeerPolicy(ctx context.Context, pp store.PeerPolicy) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if pp.PeerID == "" {
+		return fmt.Errorf("upsert peer policy: empty peer id")
+	}
+	stored := storedPeerPolicy{
+		PeerID:            pp.PeerID,
+		Network:           pp.Network,
+		MiningFeeSatoshis: pp.MiningFeeSatoshis,
+		MiningFeeBytes:    pp.MiningFeeBytes,
+	}
+	if !pp.LastSeen.IsZero() {
+		stored.LastSeenUnixNs = pp.LastSeen.UnixNano()
+	}
+	payload, err := json.Marshal(stored)
+	if err != nil {
+		return err
+	}
+	return s.db.Set(peerPolicyKey(pp.PeerID), payload, s.writeOpts)
+}
+
+func (s *Store) ListPeerPolicies(ctx context.Context, network string) ([]store.PeerPolicy, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	prefix := peerPolicyPrefix()
+	iter, err := s.db.NewIter(&pebbledb.IterOptions{
+		LowerBound: prefix,
+		UpperBound: endOfPrefix(prefix),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = iter.Close() }()
+
+	var out []store.PeerPolicy
+	for iter.First(); iter.Valid(); iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return out, err
+		}
+		var row storedPeerPolicy
+		if err := json.Unmarshal(iter.Value(), &row); err != nil {
+			continue
+		}
+		if row.Network != network {
+			continue
+		}
+		pp := store.PeerPolicy{
+			PeerID:            row.PeerID,
+			Network:           row.Network,
+			MiningFeeSatoshis: row.MiningFeeSatoshis,
+			MiningFeeBytes:    row.MiningFeeBytes,
+		}
+		if row.LastSeenUnixNs != 0 {
+			pp.LastSeen = time.Unix(0, row.LastSeenUnixNs)
+		}
+		out = append(out, pp)
 	}
 	return out, nil
 }

--- a/store/pebble/peer_policies_test.go
+++ b/store/pebble/peer_policies_test.go
@@ -1,0 +1,96 @@
+package pebble
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/arcade/store"
+)
+
+const ppNetMainnet = "mainnet"
+
+func TestPeerPolicies_UpsertAndList(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+
+	in := []store.PeerPolicy{
+		{PeerID: "peer-a", Network: ppNetMainnet, MiningFeeSatoshis: 100, MiningFeeBytes: 1000, LastSeen: now},
+		{PeerID: "peer-b", Network: ppNetMainnet, MiningFeeSatoshis: 50, MiningFeeBytes: 1000, LastSeen: now.Add(time.Minute)},
+	}
+	for _, pp := range in {
+		if err := s.UpsertPeerPolicy(ctx, pp); err != nil {
+			t.Fatalf("upsert %s: %v", pp.PeerID, err)
+		}
+	}
+
+	out, err := s.ListPeerPolicies(ctx, ppNetMainnet)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 policies, got %d: %+v", len(out), out)
+	}
+	got := map[string]store.PeerPolicy{}
+	for _, pp := range out {
+		got[pp.PeerID] = pp
+	}
+	for _, want := range in {
+		g, ok := got[want.PeerID]
+		if !ok {
+			t.Fatalf("missing peer %s", want.PeerID)
+		}
+		if g.MiningFeeSatoshis != want.MiningFeeSatoshis || g.MiningFeeBytes != want.MiningFeeBytes {
+			t.Errorf("%s fee: got {%d %d} want {%d %d}", want.PeerID,
+				g.MiningFeeSatoshis, g.MiningFeeBytes, want.MiningFeeSatoshis, want.MiningFeeBytes)
+		}
+		if !g.LastSeen.Equal(want.LastSeen) {
+			t.Errorf("%s last_seen: got %v want %v", want.PeerID, g.LastSeen, want.LastSeen)
+		}
+	}
+}
+
+func TestPeerPolicies_NetworkScopedAndOverwrite(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+
+	for _, pp := range []store.PeerPolicy{
+		{PeerID: "m1", Network: ppNetMainnet, MiningFeeSatoshis: 100, MiningFeeBytes: 1000, LastSeen: now},
+		{PeerID: "r1", Network: "regtest", MiningFeeSatoshis: 1, MiningFeeBytes: 1000, LastSeen: now},
+	} {
+		if err := s.UpsertPeerPolicy(ctx, pp); err != nil {
+			t.Fatalf("upsert %s: %v", pp.PeerID, err)
+		}
+	}
+
+	regtest, err := s.ListPeerPolicies(ctx, "regtest")
+	if err != nil {
+		t.Fatalf("list regtest: %v", err)
+	}
+	if len(regtest) != 1 || regtest[0].PeerID != "r1" {
+		t.Fatalf("regtest list: got %+v", regtest)
+	}
+
+	// Upsert on the same peer id overwrites the prior fee.
+	if upErr := s.UpsertPeerPolicy(ctx, store.PeerPolicy{
+		PeerID: "m1", Network: ppNetMainnet, MiningFeeSatoshis: 42, MiningFeeBytes: 1000, LastSeen: now.Add(time.Hour),
+	}); upErr != nil {
+		t.Fatalf("overwrite upsert: %v", upErr)
+	}
+	mainnet, err := s.ListPeerPolicies(ctx, ppNetMainnet)
+	if err != nil {
+		t.Fatalf("list mainnet: %v", err)
+	}
+	if len(mainnet) != 1 || mainnet[0].MiningFeeSatoshis != 42 {
+		t.Fatalf("mainnet list after overwrite: got %+v", mainnet)
+	}
+}
+
+func TestPeerPolicies_RejectsEmptyPeerID(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.UpsertPeerPolicy(context.Background(), store.PeerPolicy{Network: ppNetMainnet}); err == nil {
+		t.Fatal("expected error upserting peer policy with empty peer id")
+	}
+}

--- a/store/pebble/peer_policies_test.go
+++ b/store/pebble/peer_policies_test.go
@@ -2,6 +2,8 @@ package pebble
 
 import (
 	"context"
+	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -92,5 +94,44 @@ func TestPeerPolicies_RejectsEmptyPeerID(t *testing.T) {
 	s := newTestStore(t)
 	if err := s.UpsertPeerPolicy(context.Background(), store.PeerPolicy{Network: ppNetMainnet}); err == nil {
 		t.Fatal("expected error upserting peer policy with empty peer id")
+	}
+}
+
+// TestPeerPolicies_RejectsUnstorableFee proves the backend actually consults
+// PeerPolicy.Validate rather than trusting its caller. Pebble stores the fees
+// as JSON uint64 and so could hold these values, but it refuses them anyway:
+// the Postgres and Aerospike backends narrow to int64, and a store whose
+// contract varied by deployment would let a value round-trip in testing and
+// corrupt in production.
+func TestPeerPolicies_RejectsUnstorableFee(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name string
+		pp   store.PeerPolicy
+	}{
+		{
+			name: "zero byte basis",
+			pp:   store.PeerPolicy{PeerID: "peer-a", Network: ppNetMainnet, MiningFeeSatoshis: 100, MiningFeeBytes: 0},
+		},
+		{
+			name: "satoshis above the signed-64-bit ceiling",
+			pp:   store.PeerPolicy{PeerID: "peer-a", Network: ppNetMainnet, MiningFeeSatoshis: math.MaxInt64 + 1, MiningFeeBytes: 1000},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := s.UpsertPeerPolicy(ctx, tc.pp)
+			if !errors.Is(err, store.ErrInvalidPeerPolicy) {
+				t.Fatalf("UpsertPeerPolicy err = %v, want ErrInvalidPeerPolicy", err)
+			}
+			got, listErr := s.ListPeerPolicies(ctx, ppNetMainnet)
+			if listErr != nil {
+				t.Fatalf("ListPeerPolicies: %v", listErr)
+			}
+			if len(got) != 0 {
+				t.Errorf("a refused advertisement must not be persisted, got %+v", got)
+			}
+		})
 	}
 }

--- a/store/peer_policy_test.go
+++ b/store/peer_policy_test.go
@@ -1,0 +1,111 @@
+package store
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"testing"
+)
+
+// TestPeerPolicyValidate pins what a backend is allowed to persist.
+//
+// The fee originates in node_status gossip, which is unauthenticated: the peer
+// chooses the number. The Postgres and Aerospike backends store it in signed
+// 64-bit columns, so an unchecked value above MaxInt64 wraps negative on write
+// and reads back as an astronomical uint64 — which GET /policy would then
+// advertise as the network's minimum fee. Validate is what makes the narrowing
+// in those backends safe, so it is tested on the type rather than once per
+// backend.
+// testPeerID is the subject of the peer-policy validation tests; file-scoped
+// so both tests below can name the same peer.
+const testPeerID = "peer-a"
+
+func TestPeerPolicyValidate(t *testing.T) {
+	const (
+		okSats  = uint64(100)
+		okBytes = uint64(1000)
+	)
+
+	cases := []struct {
+		name    string
+		pp      PeerPolicy
+		wantErr bool
+		// mustSay is a fragment the message has to carry, so an operator
+		// reading the log learns which peer and which value were refused.
+		mustSay string
+	}{
+		{
+			name: "ordinary advertisement",
+			pp:   PeerPolicy{PeerID: testPeerID, Network: "mainnet", MiningFeeSatoshis: okSats, MiningFeeBytes: okBytes},
+		},
+		{
+			name: "zero fee is legitimate — a miner may accept free transactions",
+			pp:   PeerPolicy{PeerID: testPeerID, Network: "mainnet", MiningFeeSatoshis: 0, MiningFeeBytes: okBytes},
+		},
+		{
+			name:    "empty peer id",
+			pp:      PeerPolicy{Network: "mainnet", MiningFeeSatoshis: okSats, MiningFeeBytes: okBytes},
+			wantErr: true,
+			mustSay: "empty peer id",
+		},
+		{
+			name:    "zero byte basis would make the rate meaningless",
+			pp:      PeerPolicy{PeerID: testPeerID, MiningFeeSatoshis: okSats, MiningFeeBytes: 0},
+			wantErr: true,
+			mustSay: testPeerID,
+		},
+		{
+			name:    "satoshis above the signed-64-bit ceiling",
+			pp:      PeerPolicy{PeerID: testPeerID, MiningFeeSatoshis: math.MaxInt64 + 1, MiningFeeBytes: okBytes},
+			wantErr: true,
+			mustSay: testPeerID,
+		},
+		{
+			name:    "byte basis above the signed-64-bit ceiling",
+			pp:      PeerPolicy{PeerID: testPeerID, MiningFeeSatoshis: okSats, MiningFeeBytes: math.MaxInt64 + 1},
+			wantErr: true,
+			mustSay: testPeerID,
+		},
+		{
+			name: "exactly at the ceiling is storable",
+			pp:   PeerPolicy{PeerID: testPeerID, MiningFeeSatoshis: math.MaxInt64, MiningFeeBytes: math.MaxInt64},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.pp.Validate()
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if err == nil {
+				return
+			}
+			if !errors.Is(err, ErrInvalidPeerPolicy) {
+				t.Errorf("error %v does not wrap ErrInvalidPeerPolicy; callers branch on it to tell "+
+					"a bad advertisement from a store fault", err)
+			}
+			if tc.mustSay != "" && !strings.Contains(err.Error(), tc.mustSay) {
+				t.Errorf("error = %q, want it to mention %q", err, tc.mustSay)
+			}
+		})
+	}
+}
+
+// TestPeerPolicyValidate_CeilingCannotRejectAnHonestFee guards the choice of
+// bound. Rejecting a real advertisement would silently drop a peer from the
+// GET /policy calculation, so the ceiling has to sit far above anything the
+// chain can express: the entire 21-million-BSV supply is ~2.1e15 satoshis,
+// which must validate comfortably.
+func TestPeerPolicyValidate_CeilingCannotRejectAnHonestFee(t *testing.T) {
+	const wholeMoneySupplySatoshis = uint64(21_000_000) * uint64(100_000_000)
+
+	pp := PeerPolicy{PeerID: testPeerID, MiningFeeSatoshis: wholeMoneySupplySatoshis, MiningFeeBytes: 1000}
+	if err := pp.Validate(); err != nil {
+		t.Fatalf("a fee of the entire money supply must still be storable, got %v", err)
+	}
+	if wholeMoneySupplySatoshis >= maxStorableFee {
+		t.Fatalf("the storable ceiling (%d) is not above the money supply (%d); the bound would be "+
+			"rejecting values the chain can actually express", maxStorableFee, wholeMoneySupplySatoshis)
+	}
+}

--- a/store/postgres/peer_policies_test.go
+++ b/store/postgres/peer_policies_test.go
@@ -1,0 +1,97 @@
+//go:build postgres
+
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/arcade/store"
+)
+
+const ppNetMainnet = "mainnet"
+
+func TestPeerPolicies_UpsertAndList(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+
+	in := []store.PeerPolicy{
+		{PeerID: "peer-a", Network: ppNetMainnet, MiningFeeSatoshis: 100, MiningFeeBytes: 1000, LastSeen: now},
+		{PeerID: "peer-b", Network: ppNetMainnet, MiningFeeSatoshis: 50, MiningFeeBytes: 1000, LastSeen: now.Add(time.Minute)},
+	}
+	for _, pp := range in {
+		if err := s.UpsertPeerPolicy(ctx, pp); err != nil {
+			t.Fatalf("upsert %s: %v", pp.PeerID, err)
+		}
+	}
+
+	out, err := s.ListPeerPolicies(ctx, ppNetMainnet)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 policies, got %d: %+v", len(out), out)
+	}
+	got := map[string]store.PeerPolicy{}
+	for _, pp := range out {
+		got[pp.PeerID] = pp
+	}
+	for _, want := range in {
+		g, ok := got[want.PeerID]
+		if !ok {
+			t.Fatalf("missing peer %s", want.PeerID)
+		}
+		if g.MiningFeeSatoshis != want.MiningFeeSatoshis || g.MiningFeeBytes != want.MiningFeeBytes {
+			t.Errorf("%s fee: got {%d %d} want {%d %d}", want.PeerID,
+				g.MiningFeeSatoshis, g.MiningFeeBytes, want.MiningFeeSatoshis, want.MiningFeeBytes)
+		}
+		if !g.LastSeen.Equal(want.LastSeen) {
+			t.Errorf("%s last_seen: got %v want %v", want.PeerID, g.LastSeen, want.LastSeen)
+		}
+	}
+}
+
+func TestPeerPolicies_NetworkScopedAndOverwrite(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+
+	for _, pp := range []store.PeerPolicy{
+		{PeerID: "m1", Network: ppNetMainnet, MiningFeeSatoshis: 100, MiningFeeBytes: 1000, LastSeen: now},
+		{PeerID: "r1", Network: "regtest", MiningFeeSatoshis: 1, MiningFeeBytes: 1000, LastSeen: now},
+	} {
+		if err := s.UpsertPeerPolicy(ctx, pp); err != nil {
+			t.Fatalf("upsert %s: %v", pp.PeerID, err)
+		}
+	}
+
+	regtest, err := s.ListPeerPolicies(ctx, "regtest")
+	if err != nil {
+		t.Fatalf("list regtest: %v", err)
+	}
+	if len(regtest) != 1 || regtest[0].PeerID != "r1" {
+		t.Fatalf("regtest list: got %+v", regtest)
+	}
+
+	if upErr := s.UpsertPeerPolicy(ctx, store.PeerPolicy{
+		PeerID: "m1", Network: ppNetMainnet, MiningFeeSatoshis: 42, MiningFeeBytes: 1000, LastSeen: now.Add(time.Hour),
+	}); upErr != nil {
+		t.Fatalf("overwrite upsert: %v", upErr)
+	}
+	mainnet, err := s.ListPeerPolicies(ctx, ppNetMainnet)
+	if err != nil {
+		t.Fatalf("list mainnet: %v", err)
+	}
+	if len(mainnet) != 1 || mainnet[0].MiningFeeSatoshis != 42 {
+		t.Fatalf("mainnet list after overwrite: got %+v", mainnet)
+	}
+}
+
+func TestPeerPolicies_RejectsEmptyPeerID(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.UpsertPeerPolicy(context.Background(), store.PeerPolicy{Network: ppNetMainnet}); err == nil {
+		t.Fatal("expected error upserting peer policy with empty peer id")
+	}
+}

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -1687,6 +1687,51 @@ func (s *Store) ListDatahubEndpoints(ctx context.Context, network string) ([]sto
 	return out, nil
 }
 
+func (s *Store) UpsertPeerPolicy(ctx context.Context, pp store.PeerPolicy) error {
+	if pp.PeerID == "" {
+		return fmt.Errorf("upsert peer policy: empty peer id")
+	}
+	const q = `
+INSERT INTO peer_policies (peer_id, network, mining_fee_satoshis, mining_fee_bytes, last_seen)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (peer_id) DO UPDATE SET
+    network = EXCLUDED.network,
+    mining_fee_satoshis = EXCLUDED.mining_fee_satoshis,
+    mining_fee_bytes = EXCLUDED.mining_fee_bytes,
+    last_seen = EXCLUDED.last_seen`
+	if _, err := s.pool.Exec(ctx, q, pp.PeerID, pp.Network, int64(pp.MiningFeeSatoshis), int64(pp.MiningFeeBytes), pp.LastSeen); err != nil { //nolint:gosec // fees non-negative and bounded
+		return fmt.Errorf("upsert peer policy %s: %w", pp.PeerID, err)
+	}
+	return nil
+}
+
+func (s *Store) ListPeerPolicies(ctx context.Context, network string) ([]store.PeerPolicy, error) {
+	const q = `SELECT peer_id, network, mining_fee_satoshis, mining_fee_bytes, last_seen FROM peer_policies WHERE network = $1`
+	rows, err := s.pool.Query(ctx, q, network)
+	if err != nil {
+		return nil, fmt.Errorf("list peer policies: %w", err)
+	}
+	defer rows.Close()
+	var out []store.PeerPolicy
+	for rows.Next() {
+		var (
+			pp   store.PeerPolicy
+			sats int64
+			byts int64
+		)
+		if err := rows.Scan(&pp.PeerID, &pp.Network, &sats, &byts, &pp.LastSeen); err != nil {
+			return nil, fmt.Errorf("scan peer policy: %w", err)
+		}
+		pp.MiningFeeSatoshis = uint64(sats) //nolint:gosec // stored non-negative
+		pp.MiningFeeBytes = uint64(byts)    //nolint:gosec // stored non-negative
+		out = append(out, pp)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iter peer policies: %w", err)
+	}
+	return out, nil
+}
+
 // --- scan helpers ---
 
 type rowScanner interface {

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -1688,8 +1688,8 @@ func (s *Store) ListDatahubEndpoints(ctx context.Context, network string) ([]sto
 }
 
 func (s *Store) UpsertPeerPolicy(ctx context.Context, pp store.PeerPolicy) error {
-	if pp.PeerID == "" {
-		return fmt.Errorf("upsert peer policy: empty peer id")
+	if err := pp.Validate(); err != nil {
+		return err
 	}
 	const q = `
 INSERT INTO peer_policies (peer_id, network, mining_fee_satoshis, mining_fee_bytes, last_seen)
@@ -1699,7 +1699,8 @@ ON CONFLICT (peer_id) DO UPDATE SET
     mining_fee_satoshis = EXCLUDED.mining_fee_satoshis,
     mining_fee_bytes = EXCLUDED.mining_fee_bytes,
     last_seen = EXCLUDED.last_seen`
-	if _, err := s.pool.Exec(ctx, q, pp.PeerID, pp.Network, int64(pp.MiningFeeSatoshis), int64(pp.MiningFeeBytes), pp.LastSeen); err != nil { //nolint:gosec // fees non-negative and bounded
+	// The narrowing is safe: Validate rejected anything above MaxInt64 above.
+	if _, err := s.pool.Exec(ctx, q, pp.PeerID, pp.Network, int64(pp.MiningFeeSatoshis), int64(pp.MiningFeeBytes), pp.LastSeen); err != nil { //nolint:gosec // bounded by PeerPolicy.Validate
 		return fmt.Errorf("upsert peer policy %s: %w", pp.PeerID, err)
 	}
 	return nil

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -93,7 +93,7 @@ func runWithSharedStore(m *testing.M) (int, func()) {
 	return m.Run(), cleanup
 }
 
-const truncateSQL = `TRUNCATE transactions, bumps, stumps, submissions, leases, datahub_endpoints, block_processing`
+const truncateSQL = `TRUNCATE transactions, bumps, stumps, submissions, leases, datahub_endpoints, peer_policies, block_processing`
 
 func newTestStore(t *testing.T) *Store {
 	t.Helper()

--- a/store/postgres/schema.sql
+++ b/store/postgres/schema.sql
@@ -172,9 +172,11 @@ ALTER TABLE datahub_endpoints ADD COLUMN IF NOT EXISTS network TEXT NOT NULL DEF
 CREATE INDEX IF NOT EXISTS idx_dh_last_seen ON datahub_endpoints(last_seen);
 CREATE INDEX IF NOT EXISTS idx_dh_network   ON datahub_endpoints(network);
 
--- Peer mining fees observed from node_status announcements, keyed by peer id
--- and network-scoped. Read by the GET /policy endpoint to compute the
--- network-wide minimum fee (issue #212). last_seen drives TTL filtering.
+-- Peer mining fees observed from node_status announcements. Primary key is
+-- peer_id (a libp2p peer runs on a single network, so peer_id is unique);
+-- network is a filter column, not part of the key. Read by the fee refresher /
+-- GET /policy path to compute the network-wide minimum fee (issue #212).
+-- last_seen drives TTL filtering.
 CREATE TABLE IF NOT EXISTS peer_policies (
     peer_id              TEXT PRIMARY KEY,
     network              TEXT NOT NULL DEFAULT '',

--- a/store/postgres/schema.sql
+++ b/store/postgres/schema.sql
@@ -171,3 +171,16 @@ CREATE TABLE IF NOT EXISTS datahub_endpoints (
 ALTER TABLE datahub_endpoints ADD COLUMN IF NOT EXISTS network TEXT NOT NULL DEFAULT '';
 CREATE INDEX IF NOT EXISTS idx_dh_last_seen ON datahub_endpoints(last_seen);
 CREATE INDEX IF NOT EXISTS idx_dh_network   ON datahub_endpoints(network);
+
+-- Peer mining fees observed from node_status announcements, keyed by peer id
+-- and network-scoped. Read by the GET /policy endpoint to compute the
+-- network-wide minimum fee (issue #212). last_seen drives TTL filtering.
+CREATE TABLE IF NOT EXISTS peer_policies (
+    peer_id              TEXT PRIMARY KEY,
+    network              TEXT NOT NULL DEFAULT '',
+    mining_fee_satoshis  BIGINT NOT NULL,
+    mining_fee_bytes     BIGINT NOT NULL,
+    last_seen            TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_pp_network   ON peer_policies(network);
+CREATE INDEX IF NOT EXISTS idx_pp_last_seen ON peer_policies(last_seen);

--- a/store/store.go
+++ b/store/store.go
@@ -65,6 +65,25 @@ type StatusCensus struct {
 	Oldest time.Time
 }
 
+// PeerPolicy is a peer's mining fee observed from its node_status gossip
+// announcement, persisted to the shared store so the ARC-compatible
+// GET /policy endpoint (served by api-server pods) can compute the
+// network-wide minimum fee even though only the single p2p-client pod
+// observes node_status (issue #212).
+//
+// Keyed by PeerID and network-scoped for the same reasons as DatahubEndpoint.
+// LastSeen lets readers drop peers not re-heard within a TTL so a departed
+// cheap node cannot pin the advertised fee low forever. The mining fee is
+// stored as satoshis-per-Bytes (the node_status FeePolicy.MiningFee shape),
+// e.g. {Satoshis: 100, Bytes: 1000} == 100 sat/kB.
+type PeerPolicy struct {
+	PeerID            string
+	Network           string
+	MiningFeeSatoshis uint64
+	MiningFeeBytes    uint64
+	LastSeen          time.Time
+}
+
 // BatchInsertResult is one entry in the result slice returned by
 // BatchGetOrInsertStatus. Inserted is true when the row was newly written by
 // this call; false when an existing row was found and Existing carries it.
@@ -422,6 +441,15 @@ type Store interface {
 	// excluded — they will be re-registered with the correct network the next
 	// time their peer announces.
 	ListDatahubEndpoints(ctx context.Context, network string) ([]DatahubEndpoint, error)
+
+	// UpsertPeerPolicy records (or refreshes) a peer's observed mining fee.
+	// Called by p2p_client on each node_status announcement carrying a fee.
+	UpsertPeerPolicy(ctx context.Context, pp PeerPolicy) error
+
+	// ListPeerPolicies returns every recorded peer policy scoped to the given
+	// network. The GET /policy handler filters these by LastSeen and takes the
+	// minimum mining fee. Entries with an empty Network (legacy rows) are excluded.
+	ListPeerPolicies(ctx context.Context, network string) ([]PeerPolicy, error)
 
 	// Close closes the database connection
 	Close() error

--- a/store/store.go
+++ b/store/store.go
@@ -71,11 +71,12 @@ type StatusCensus struct {
 // network-wide minimum fee even though only the single p2p-client pod
 // observes node_status (issue #212).
 //
-// Keyed by PeerID and network-scoped for the same reasons as DatahubEndpoint.
-// LastSeen lets readers drop peers not re-heard within a TTL so a departed
-// cheap node cannot pin the advertised fee low forever. The mining fee is
-// stored as satoshis-per-Bytes (the node_status FeePolicy.MiningFee shape),
-// e.g. {Satoshis: 100, Bytes: 1000} == 100 sat/kB.
+// Keyed by PeerID (a libp2p peer runs on a single network, so PeerID is
+// unique); Network is a filter attribute, not part of the key — matching the
+// DatahubEndpoint pattern. LastSeen lets readers drop peers not re-heard within
+// a TTL so a departed cheap node cannot pin the advertised fee low forever. The
+// mining fee is stored as satoshis-per-Bytes (the node_status FeePolicy.MiningFee
+// shape), e.g. {Satoshis: 100, Bytes: 1000} == 100 sat/kB.
 type PeerPolicy struct {
 	PeerID            string
 	Network           string

--- a/store/store.go
+++ b/store/store.go
@@ -3,6 +3,8 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math"
 	"time"
 
 	"github.com/bsv-blockchain/arcade/models"
@@ -10,6 +12,11 @@ import (
 
 // ErrNotFound is returned when a requested record does not exist.
 var ErrNotFound = errors.New("not found")
+
+// ErrInvalidPeerPolicy is returned by PeerPolicy.Validate, and by every
+// backend's UpsertPeerPolicy, for a policy that cannot be stored faithfully.
+// Callers treat it as "drop this advertisement", never as a store fault.
+var ErrInvalidPeerPolicy = errors.New("invalid peer policy")
 
 // ErrReplayUnavailable is returned by IterateStatusesByToken when a backend
 // cannot serve the replay within its resource bounds — typically a token whose
@@ -83,6 +90,40 @@ type PeerPolicy struct {
 	MiningFeeSatoshis uint64
 	MiningFeeBytes    uint64
 	LastSeen          time.Time
+}
+
+// maxStorableFee bounds a peer policy's fee fields. The Postgres and Aerospike
+// backends store them in signed 64-bit columns, so a value above MaxInt64 wraps
+// negative on write and reads back as an astronomical uint64 — a silently
+// corrupted floor that GET /policy would then advertise as the network minimum.
+//
+// The bound can only ever reject garbage: the entire money supply, 21 million
+// BSV, is 2.1e15 satoshis — some four thousand times below MaxInt64 — so no
+// honest advertisement comes near it. It has to be checked rather than assumed
+// because node_status is unauthenticated gossip: the peer chooses the number.
+const maxStorableFee = uint64(math.MaxInt64)
+
+// Validate reports whether pp can be persisted without loss. Every backend
+// calls it before writing, so the uint64→int64 narrowing each one performs is
+// bounded by a check instead of by assumption.
+func (pp PeerPolicy) Validate() error {
+	switch {
+	case pp.PeerID == "":
+		return fmt.Errorf("%w: empty peer id", ErrInvalidPeerPolicy)
+	case pp.MiningFeeBytes == 0:
+		// A zero byte basis makes the fee meaningless: readers divide by it to
+		// normalize to sat/kB, and lowestObservedFeePerKB has to skip such rows.
+		// Refusing the write keeps them out of the store in the first place.
+		return fmt.Errorf("%w: peer %s has a zero mining fee byte basis", ErrInvalidPeerPolicy, pp.PeerID)
+	case pp.MiningFeeSatoshis > maxStorableFee:
+		return fmt.Errorf("%w: peer %s advertised %d satoshis, above the storable maximum %d",
+			ErrInvalidPeerPolicy, pp.PeerID, pp.MiningFeeSatoshis, maxStorableFee)
+	case pp.MiningFeeBytes > maxStorableFee:
+		return fmt.Errorf("%w: peer %s advertised a %d byte basis, above the storable maximum %d",
+			ErrInvalidPeerPolicy, pp.PeerID, pp.MiningFeeBytes, maxStorableFee)
+	default:
+		return nil
+	}
 }
 
 // BatchInsertResult is one entry in the result slice returned by

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -16,6 +16,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
+	"sync/atomic"
 
 	chaincfg "github.com/bsv-blockchain/go-chaincfg"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
@@ -67,6 +69,12 @@ const (
 	// max-tx-size setting; the engine rejects construction above it.
 	maxTxSizePolicyConsensusLimit = 1_000_000_000
 
+	// defaultMaxTxSizePolicy and defaultMaxScriptSizePolicy are teranode's
+	// canonical BSV policy defaults, applied when the operator leaves the
+	// corresponding config value unset. Kept in sync with defaultPolicySettings.
+	defaultMaxTxSizePolicy     = 10485760
+	defaultMaxScriptSizePolicy = 500000
+
 	// defaultNetwork is used by NewValidator, which retains the legacy
 	// network-less constructor for tests and callers that do not select one.
 	defaultNetwork = "mainnet"
@@ -80,6 +88,8 @@ var DefaultMinFeePerKB = uint64(100)
 type Policy struct {
 	// MaxTxSizePolicy caps transaction size in bytes (0 => defaultMaxTxSizePolicy).
 	MaxTxSizePolicy int
+	// MaxScriptSizePolicy caps script size in bytes (0 => defaultMaxScriptSizePolicy).
+	MaxScriptSizePolicy int
 	// MaxTxSigopsCountsPolicy caps sigops per transaction (0 => unlimited, the
 	// BSV post-Genesis default).
 	MaxTxSigopsCountsPolicy int64
@@ -93,10 +103,33 @@ type Policy struct {
 // floor and one that does not, so ValidateTransaction can honour skipFees
 // without disabling the script/standardness checks (which SkipPolicyChecks
 // would also turn off).
+//
+// The fee-enforcing validator (tv) is swappable at runtime via SetMinFeePerKB:
+// arcade dynamically tracks the lowest fee the network will accept (observed
+// from peer node_status announcements) and rebuilds tv to enforce it (issue
+// #212). tv is an atomic.Pointer so ValidateTransaction reads it lock-free
+// while the fee refresher swaps it. tvNoFee never enforces a fee, so it is
+// fixed.
 type Validator struct {
-	tv          *tnvalidator.TxValidator
+	tv          atomic.Pointer[tnvalidator.TxValidator]
 	tvNoFee     *tnvalidator.TxValidator
-	minFeePerKB uint64
+	minFeePerKB atomic.Uint64
+
+	// feeMu serializes SetMinFeePerKB so a concurrent burst rebuilds the BDK
+	// engine at most once per distinct value.
+	feeMu sync.Mutex
+
+	// Immutable inputs retained so SetMinFeePerKB can rebuild the fee-enforcing
+	// validator with a new fee floor but the same size/sigop policy.
+	logger ulogger.Logger
+	params *chaincfg.Params
+
+	// Resolved policy values (after applying defaults) surfaced by the
+	// accessors for the ARC-compatible GET /policy endpoint. These reflect
+	// exactly what the BDK validator was built to enforce.
+	maxTxSizePolicy         int
+	maxScriptSizePolicy     int
+	maxTxSigopsCountsPolicy int64
 }
 
 // NewValidator creates a validator for mainnet with the given policy. A nil
@@ -125,14 +158,19 @@ func NewValidatorForNetwork(network string, policy *Policy) (*Validator, error) 
 		minFee = *policy.MinFeePerKB
 	}
 
-	// 0 => keep the canonical default from defaultPolicySettings. An explicit
-	// override is capped at the BDK consensus limit so construction never panics.
-	maxTxSize := 0
+	// 0 => the canonical teranode default. An explicit override is capped at
+	// the BDK consensus limit so construction never panics.
+	maxTxSize := defaultMaxTxSizePolicy
 	if policy != nil && policy.MaxTxSizePolicy > 0 {
 		maxTxSize = policy.MaxTxSizePolicy
 		if maxTxSize > maxTxSizePolicyConsensusLimit {
 			maxTxSize = maxTxSizePolicyConsensusLimit
 		}
+	}
+
+	maxScriptSize := defaultMaxScriptSizePolicy
+	if policy != nil && policy.MaxScriptSizePolicy > 0 {
+		maxScriptSize = policy.MaxScriptSizePolicy
 	}
 
 	var maxSigops int64 // 0 => unlimited (BSV post-Genesis)
@@ -142,16 +180,58 @@ func NewValidatorForNetwork(network string, policy *Policy) (*Validator, error) 
 
 	logger := ulogger.New("arcade-validator")
 
-	return &Validator{
-		tv:          tnvalidator.NewTxValidator(logger, buildSettings(params, maxTxSize, maxSigops, minFee)),
-		tvNoFee:     tnvalidator.NewTxValidator(logger, buildSettings(params, maxTxSize, maxSigops, 0)),
-		minFeePerKB: minFee,
-	}, nil
+	v := &Validator{
+		tvNoFee:                 tnvalidator.NewTxValidator(logger, buildSettings(params, maxTxSize, maxScriptSize, maxSigops, 0)),
+		logger:                  logger,
+		params:                  params,
+		maxTxSizePolicy:         maxTxSize,
+		maxScriptSizePolicy:     maxScriptSize,
+		maxTxSigopsCountsPolicy: maxSigops,
+	}
+	v.tv.Store(tnvalidator.NewTxValidator(logger, buildSettings(params, maxTxSize, maxScriptSize, maxSigops, minFee)))
+	v.minFeePerKB.Store(minFee)
+	return v, nil
 }
 
-// MinFeePerKB returns the configured minimum fee per kB, in satoshis.
+// MinFeePerKB returns the current minimum fee floor per kB, in satoshis. It
+// reflects any runtime update applied via SetMinFeePerKB.
 func (v *Validator) MinFeePerKB() uint64 {
-	return v.minFeePerKB
+	return v.minFeePerKB.Load()
+}
+
+// SetMinFeePerKB updates the intake fee floor at runtime, rebuilding the
+// fee-enforcing BDK validator so subsequent ValidateTransaction calls enforce
+// the new floor. It is a no-op when minFee already equals the current floor, so
+// callers may invoke it on a ticker without churning the cgo engine. Safe for
+// concurrent use with ValidateTransaction. The superseded validator becomes
+// unreachable and the go-bdk finalizer frees its underlying C engine.
+func (v *Validator) SetMinFeePerKB(minFee uint64) {
+	v.feeMu.Lock()
+	defer v.feeMu.Unlock()
+	if v.minFeePerKB.Load() == minFee {
+		return
+	}
+	nv := tnvalidator.NewTxValidator(v.logger, buildSettings(v.params, v.maxTxSizePolicy, v.maxScriptSizePolicy, v.maxTxSigopsCountsPolicy, minFee))
+	v.tv.Store(nv)
+	v.minFeePerKB.Store(minFee)
+}
+
+// MaxTxSizePolicy returns the effective maximum accepted transaction size in
+// bytes, as reported by the ARC-compatible GET /policy endpoint.
+func (v *Validator) MaxTxSizePolicy() int {
+	return v.maxTxSizePolicy
+}
+
+// MaxScriptSizePolicy returns the effective maximum accepted script size in
+// bytes, as reported by GET /policy.
+func (v *Validator) MaxScriptSizePolicy() int {
+	return v.maxScriptSizePolicy
+}
+
+// MaxTxSigopsCountsPolicy returns the effective per-transaction sigop cap
+// (0 = unlimited, the BSV post-Genesis default), as reported by GET /policy.
+func (v *Validator) MaxTxSigopsCountsPolicy() int64 {
+	return v.maxTxSigopsCountsPolicy
 }
 
 // ValidateTransaction validates a transaction against current node consensus
@@ -173,7 +253,7 @@ func (v *Validator) ValidateTransaction(_ context.Context, tx *sdkTx.Transaction
 		utxoHeights[i] = unknownParentHeight
 	}
 
-	tv := v.tv
+	tv := v.tv.Load()
 	if skipFees {
 		tv = v.tvNoFee
 	}
@@ -191,14 +271,14 @@ func (v *Validator) ValidatePolicy(tx *sdkTx.Transaction) error {
 }
 
 // buildSettings assembles a teranode settings.Settings for the BDK validator:
-// canonical BSV policy defaults, with the operator-controlled tx-size, sigop
-// and fee values applied. minFeePerKB is in satoshis/kB and converted to the
-// BSV/kB units teranode's fee check expects (0 => no fee floor).
-func buildSettings(params *chaincfg.Params, maxTxSize int, maxSigops int64, minFeePerKB uint64) *settings.Settings {
+// canonical BSV policy defaults, with the operator-controlled tx-size,
+// script-size, sigop and fee values applied. The size values are already
+// resolved (never zero) by the caller. minFeePerKB is in satoshis/kB and
+// converted to the BSV/kB units teranode's fee check expects (0 => no fee floor).
+func buildSettings(params *chaincfg.Params, maxTxSize, maxScriptSize int, maxSigops int64, minFeePerKB uint64) *settings.Settings {
 	pol := defaultPolicySettings()
-	if maxTxSize > 0 {
-		pol.MaxTxSizePolicy = maxTxSize
-	}
+	pol.MaxTxSizePolicy = maxTxSize
+	pol.MaxScriptSizePolicy = maxScriptSize
 	pol.MaxTxSigopsCountsPolicy = maxSigops
 	pol.MinMiningTxFee = satPerKBToBSVPerKB(minFeePerKB)
 	return &settings.Settings{ChainCfgParams: params, Policy: pol}
@@ -213,10 +293,10 @@ func buildSettings(params *chaincfg.Params, maxTxSize int, maxSigops int64, minF
 func defaultPolicySettings() *settings.PolicySettings {
 	return &settings.PolicySettings{
 		ExcessiveBlockSize:              4294967296,
-		MaxTxSizePolicy:                 10485760,
+		MaxTxSizePolicy:                 defaultMaxTxSizePolicy,
 		MaxOrphanTxSize:                 1000000,
 		DataCarrierSize:                 1000000,
-		MaxScriptSizePolicy:             500000,
+		MaxScriptSizePolicy:             defaultMaxScriptSizePolicy,
 		MaxOpsPerScriptPolicy:           1000000,
 		MaxScriptNumLengthPolicy:        10000,
 		MaxPubKeysPerMultisigPolicy:     0,

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -43,6 +43,63 @@ func TestNewValidator_PreservesExplicitZeroFee(t *testing.T) {
 	}
 }
 
+// TestEffectivePolicy_Defaults verifies the size/sigop accessors report the
+// canonical teranode defaults when the policy leaves them unset — these are
+// the values GET /policy advertises.
+func TestEffectivePolicy_Defaults(t *testing.T) {
+	v := NewValidator(nil)
+	if got := v.MaxTxSizePolicy(); got != defaultMaxTxSizePolicy {
+		t.Errorf("MaxTxSizePolicy() = %d, want %d", got, defaultMaxTxSizePolicy)
+	}
+	if got := v.MaxScriptSizePolicy(); got != defaultMaxScriptSizePolicy {
+		t.Errorf("MaxScriptSizePolicy() = %d, want %d", got, defaultMaxScriptSizePolicy)
+	}
+	if got := v.MaxTxSigopsCountsPolicy(); got != 0 {
+		t.Errorf("MaxTxSigopsCountsPolicy() = %d, want 0 (unlimited)", got)
+	}
+}
+
+// TestSetMinFeePerKB_UpdatesFloor verifies the runtime fee-floor swap used by
+// the api-server's fee refresher to track the network minimum (issue #212).
+func TestSetMinFeePerKB_UpdatesFloor(t *testing.T) {
+	v := NewValidator(nil)
+	if v.MinFeePerKB() != DefaultMinFeePerKB {
+		t.Fatalf("initial floor = %d, want %d", v.MinFeePerKB(), DefaultMinFeePerKB)
+	}
+	v.SetMinFeePerKB(37)
+	if v.MinFeePerKB() != 37 {
+		t.Errorf("after SetMinFeePerKB(37), floor = %d, want 37", v.MinFeePerKB())
+	}
+	// Size/sigop policy is preserved across a fee-only rebuild.
+	if v.MaxTxSizePolicy() != defaultMaxTxSizePolicy || v.MaxScriptSizePolicy() != defaultMaxScriptSizePolicy {
+		t.Errorf("size policy changed after fee update: {%d %d}", v.MaxTxSizePolicy(), v.MaxScriptSizePolicy())
+	}
+	// A tx can still be validated after the swap (exercises the swapped tv).
+	v.SetMinFeePerKB(0)
+	if v.MinFeePerKB() != 0 {
+		t.Errorf("after SetMinFeePerKB(0), floor = %d, want 0", v.MinFeePerKB())
+	}
+}
+
+// TestEffectivePolicy_Overrides verifies operator overrides thread through to
+// the accessors.
+func TestEffectivePolicy_Overrides(t *testing.T) {
+	v := NewValidator(&Policy{
+		MaxTxSizePolicy:         2_000_000,
+		MaxScriptSizePolicy:     123_456,
+		MaxTxSigopsCountsPolicy: 42,
+	})
+	if got := v.MaxTxSizePolicy(); got != 2_000_000 {
+		t.Errorf("MaxTxSizePolicy() = %d, want 2000000", got)
+	}
+	if got := v.MaxScriptSizePolicy(); got != 123_456 {
+		t.Errorf("MaxScriptSizePolicy() = %d, want 123456", got)
+	}
+	if got := v.MaxTxSigopsCountsPolicy(); got != 42 {
+		t.Errorf("MaxTxSigopsCountsPolicy() = %d, want 42", got)
+	}
+}
+
 func TestNewValidatorForNetwork_KnownNetworks(t *testing.T) {
 	for _, n := range []string{"mainnet", "testnet", "teratestnet", "regtest"} {
 		if _, err := NewValidatorForNetwork(n, nil); err != nil {


### PR DESCRIPTION
## Summary

Implements the ARC-compatible `GET /policy` (and `/v1/policy`) endpoint (closes #212). Clients that call it to discover the fee rate and size limits before building transactions previously got a 404 with no alternative.

Beyond the base endpoint, the reported policy is **operator-configurable** (falling back to teranode's canonical defaults), and the **mining fee is discovered dynamically from the `node_status` gossip** arcade already receives: when the operator hasn't pinned a fee, arcade tracks the lowest fee the network will accept and **both enforces it at intake and advertises it via `/policy`**, so what it advertises always matches what it enforces.

### Response shape
```json
{
  "policy": {
    "miningFee": { "satoshis": 100, "bytes": 1000 },
    "maxtxsizepolicy": 10485760,
    "maxscriptsizepolicy": 500000,
    "maxtxsigopscountspolicy": 0,
    "standardFormatSupported": true
  },
  "timestamp": "2026-08-07T12:00:00Z"
}
```

## How the dynamic fee works

Only the single `p2p-client` pod observes `node_status`, but `/policy` and intake validation run in the api-server pods — so the observation crosses pods via the shared store (the same mechanism datahub URLs already use):

`p2p_client.handleNodeStatus` → records each peer's fee to a new `store.PeerPolicy` row → api-server **fee refresher** recomputes the network minimum over recently-seen peers → pushes it into the validator via `SetMinFeePerKB` → intake enforces it and `/policy` reports `validator.MinFeePerKB()`.

Precedence for the effective fee floor: **operator-configured** (`min_fee_per_kb` / `accept_zero_fee`) → **lowest observed on the network** (within TTL) → **built-in default (100 sat/kB)**.

## Changes

- **`validator`**: fee-enforcing BDK validator is now runtime-mutable (`atomic.Pointer` + `SetMinFeePerKB`, rebuild-on-change; the superseded cgo engine is reclaimed by go-bdk's `runtime.SetFinalizer`). New size/sigop accessors.
- **`services/api_server`**: `GET /policy` handler; `fee_refresher.go` goroutine (started in `Server.Start` only when the operator hasn't pinned a fee).
- **`services/p2p_client`**: `recordPeerFee` in `handleNodeStatus` (prefers `FeePolicy.MiningFee`, falls back to legacy `MinMiningTxFee`; URL-less peers still count); new `P2PPeerMinMiningFee` gauge.
- **`store`**: `PeerPolicy` + `UpsertPeerPolicy`/`ListPeerPolicies` across Postgres (new `peer_policies` table), Pebble, Aerospike.
- **`config`**: `min_fee_per_kb` default flipped `100 → 0` as the "unset" sentinel (intake still enforces 100 by default via the validator's built-in floor); new `max_tx_size_policy`, `max_script_size_policy`, `max_tx_sigops_counts_policy`, `standard_format_supported`, `observed_fee_ttl_ms`, `observed_fee_refresh_ms`.
- **docs**: OpenAPI path + `Policy`/`FeeAmount`/`PolicyResponse` schemas, in-app route docs, `config.example.yaml`.

## Testing

- Unit tests: `SetMinFeePerKB` swap; refresher min/stale/default/store-error/non-1000-basis; `/policy` reports the live validator floor + config fallbacks + `/v1` alias; config defaults & env overrides.
- Store round-trip tests for `PeerPolicy` (Pebble + embedded-Postgres).
- Lint (`golangci-lint`, incl. `-tags=postgres`), `gofmt`, `go build ./...` all clean.
- **End-to-end**: seeded a peer advertising 5 sat/kB, booted arcade unpinned → logs show `intake fee floor updated ... prev:100 new:5` and `/policy` returned `miningFee {5, 1000}` — the enforcing validator picked up the network minimum.

## Notes / decisions for review

- **Defaults source**: uses arcade's embedded teranode canonical values (prod-safe), not a runtime read of a `settings.conf` file. Every field is operator-overridable via config. (Loading a real `settings.conf` could be added later if wanted.)
- `maxtxsigopscountspolicy: 0` means unlimited (BSV post-Genesis default) and is reported verbatim.
- The `peer_policies` table is additive; the Postgres schema migration is idempotent (`CREATE TABLE IF NOT EXISTS`).
