### PR TITLE
fix(store): stop TxTracker hydration from loading terminal txs (api-server OOM)

### DIFF
--- a/store/tracker.go
+++ b/store/tracker.go
@@ -88,6 +88,17 @@ func (t *TxTracker) loadFromStore(ctx context.Context, store statusIterator, cur
 	}
 
 	err := store.IterateStatusesSince(ctx, time.Time{}, func(status *models.TransactionStatus) error {
+		// Skip terminal outcomes that never need tracking. The tracker exists to
+		// recognize in-flight txids that might still land in a mined subtree; a
+		// REJECTED / DOUBLE_SPEND_ATTEMPTED / IMMUTABLE tx never will. Without
+		// this, hydration loaded the entire terminal history into the map —
+		// REJECTED alone was ~44% of a 5M-row store — and OOM-killed the
+		// api-server at startup. MINED is terminal too but is handled below: it
+		// is retained until deeply confirmed so PruneConfirmed can promote it.
+		if status.Status.IsTerminal() && status.Status != models.StatusMined {
+			return nil
+		}
+
 		// Skip transactions that are deeply confirmed — these would only be
 		// pruned moments later, so never let them touch the tracker map.
 		if status.Status == models.StatusMined && status.BlockHeight > 0 {

--- a/store/tracker_test.go
+++ b/store/tracker_test.go
@@ -140,6 +140,47 @@ func TestTxTracker_LoadFromStore_DropsDeeplyConfirmed(t *testing.T) {
 	}
 }
 
+func TestTxTracker_LoadFromStore_DropsTerminalStatuses(t *testing.T) {
+	// Regression for the arcade-v2 OOM: hydration loaded terminal rows
+	// (REJECTED was ~44% of a 5M-row store) into the tracker map even though a
+	// terminal tx can never appear in a mined subtree. Only in-flight statuses
+	// and recently-mined rows (needed for PruneConfirmed) belong in the tracker.
+	const currentHeight = uint64(1_000_000)
+	rows := []*models.TransactionStatus{
+		// Terminal, never mined: must be dropped.
+		{TxID: txidHex(0), Status: models.StatusRejected},
+		{TxID: txidHex(1), Status: models.StatusDoubleSpendAttempted},
+		{TxID: txidHex(2), Status: models.StatusImmutable, BlockHeight: currentHeight - 10},
+		// Deeply confirmed mined: dropped (existing behavior).
+		{TxID: txidHex(3), Status: models.StatusMined, BlockHeight: currentHeight - ConfirmationsRequired - 1},
+		// Keep: in-flight + recently mined (still needs pruning tracking).
+		{TxID: txidHex(4), Status: models.StatusSeenOnNetwork},
+		{TxID: txidHex(5), Status: models.StatusReceived},
+		{TxID: txidHex(6), Status: models.StatusMined, BlockHeight: currentHeight - 10},
+	}
+
+	tracker := NewTxTracker()
+	store := &fakeIterStore{rows: rows, tr: tracker}
+
+	got, err := tracker.loadFromStore(context.Background(), store, currentHeight, 100)
+	if err != nil {
+		t.Fatalf("loadFromStore: %v", err)
+	}
+	if got != 3 {
+		t.Fatalf("expected 3 kept rows, got %d", got)
+	}
+	for _, drop := range []int{0, 1, 2, 3} {
+		if tracker.Contains(txidHex(drop)) {
+			t.Errorf("txid %d (%s) should NOT be tracked", drop, rows[drop].Status)
+		}
+	}
+	for _, keep := range []int{4, 5, 6} {
+		if !tracker.Contains(txidHex(keep)) {
+			t.Errorf("txid %d (%s) should be tracked", keep, rows[keep].Status)
+		}
+	}
+}
+
 func TestTxTracker_LoadFromStore_BoundedPeakMemory(t *testing.T) {
 	// Many old rows that will be pruned + a small tail of recent rows. If
 	// LoadFromStore materialized the full history before pruning, the


### PR DESCRIPTION
## Summary

Fixes an OOM crash-loop in the `api-server` at startup, found on the scale (`arcade-v2`) cluster: all 3 replicas were `OOMKilled` (exit 137 against a 1Gi limit, ~120 restarts each over 12 days), never reaching the `tx tracker hydrated` log line.

## Root cause

`TxTracker.LoadFromStore` hydrates the in-memory tracker at startup by iterating **every** row in the `transactions` table. The filter only skipped deeply-confirmed `MINED` rows — so every terminal `REJECTED` / `DOUBLE_SPEND_ATTEMPTED` / `IMMUTABLE` row was loaded into the tracker map as well. A terminal transaction can never appear in a mined subtree, which is the only thing the tracker is used for (`FilterTrackedHashes`), so these are pure dead weight.

On a long-lived, high-volume deployment this loads essentially the entire terminal history. Actual data in `arcade-v2`'s Postgres:

| status | rows | loaded before fix? |
|---|--:|---|
| **REJECTED** | **2,164,707** | ❌ yes (terminal — should be skipped) |
| MINED | 1,752,991 | mostly skipped (deeply-confirmed) |
| SEEN_MULTIPLE_NODES | 680,652 | ✅ in-flight |
| RECEIVED | 346,618 | ✅ in-flight |
| others | ~1,700 | ✅ |
| **total** | **4,946,666** (4.2 GB) | |

So hydration built a ~3.2M-entry map (2.16M of it REJECTED), and the GC target (≈2× the live set) plus the transient per-row allocations from the full-table scan pushed peak memory past 1Gi. The footprint grows unbounded with history, so bumping the memory limit only delays the crash.

## Fix

Skip terminal statuses during hydration, reusing `models.Status.IsTerminal()`. `MINED` is terminal too but is deliberately retained until deeply confirmed so `PruneConfirmed` can still promote it to `IMMUTABLE`; everything else terminal is dropped. This bounds the tracker to the real in-flight working set plus recently-mined rows — on `arcade-v2` that cuts the loaded set from ~3.2M to ~1M entries.

```go
if status.Status.IsTerminal() && status.Status != models.StatusMined {
    return nil
}
```

## Testing

- New `TestTxTracker_LoadFromStore_DropsTerminalStatuses` (fails before, passes after): asserts REJECTED / DOUBLE_SPEND_ATTEMPTED / IMMUTABLE / deeply-confirmed MINED are excluded while in-flight and recently-mined rows are kept.
- Existing tracker tests (`DropsDeeplyConfirmed`, `BoundedPeakMemory`, `FlushesOnBatchBoundary`, `PropagatesIterError`) still pass; `go build ./...`, `gofmt`, `golangci-lint ./store/` all clean.

## Follow-up (out of scope here)

Hydration still SELECTs the full row (incl. `raw_tx`, `merkle_path`) for every row via the shared `IterateStatusesSince`, generating transient allocation while scanning the whole table (and a pointless `ORDER BY`). A dedicated lightweight, status-filtered query (only `txid,status,block_height`, filtered in SQL) would further cut DB scan cost and client allocation — but it needs a new store method (that iterator is shared with the propagation replay/reaper, which need the full row), so it's left as a separate change. Not required to resolve this OOM.
