### PR TITLE
fix(sse): enlarge per-connection buffer and coalesce frame writes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -556,6 +556,14 @@ type SSEConfig struct {
 	// Port the SSE listener binds to. Default 8082. Must differ from
 	// api.port when SSE runs in the same process (mode=all).
 	Port int `mapstructure:"port"`
+	// ClientBufferSize is the per-connection SSE send-channel capacity.
+	// The manager unfans one Kafka message into a burst of per-tx events
+	// (bulk-unfan coalesces ~50 txids per message), so a single burst of
+	// ~50 must fit with headroom; sizing this too small silently drops
+	// events for slow or bursty consumers (the channel send is
+	// non-blocking, so overflow is lost, not backpressured). Default
+	// DefaultSSEClientBuffer. A value <= 0 selects the default.
+	ClientBufferSize int `mapstructure:"client_buffer_size"`
 }
 
 // WebhookConfig tunes the HTTP webhook delivery service. The service
@@ -652,6 +660,14 @@ type EventsConfig struct {
 // non-positive. 4096 is 16× the original 256 — enough headroom for typical
 // status-update bursts without committing significant memory upfront.
 const DefaultEventsSubscriberBuffer = 4096
+
+// DefaultSSEClientBuffer is the fallback per-connection SSE send-channel
+// capacity when SSEConfig.ClientBufferSize is unset or non-positive. The
+// manager unfans one Kafka message into a burst of per-tx events, so the
+// buffer must absorb many such bursts between writer drains; 8192 gives ample
+// headroom over a single ~50-event bulk-unfan while staying a modest
+// per-connection memory cost (channel of *TransactionStatus pointers).
+const DefaultSSEClientBuffer = 8192
 
 // ValidatorConfig controls intake-time transaction validation. It carries the
 // operator-facing fee floor enforced against EF/BEEF submissions; the consensus
@@ -908,6 +924,7 @@ func setDefaults() {
 	viper.SetDefault("sse.enabled", true)
 	viper.SetDefault("sse.host", "0.0.0.0")
 	viper.SetDefault("sse.port", 8082)
+	viper.SetDefault("sse.client_buffer_size", DefaultSSEClientBuffer)
 
 	// chaintracks standalone service: enabled by default. The bind port
 	// must differ from api.port and sse.port in single-binary deployments

--- a/services/sse/manager.go
+++ b/services/sse/manager.go
@@ -70,9 +70,23 @@ type Manager struct {
 
 	nextClientID atomic.Int64
 
+	// clientBufferSize is the capacity of each new client's send channel.
+	// Wired from config.SSEConfig.ClientBufferSize by the Service at
+	// startup; when unset (<= 0, e.g. tests that construct via newManager
+	// without threading config) NewClient falls back to
+	// defaultClientBuffer.
+	clientBufferSize int
+
 	mu      sync.RWMutex
 	clients map[int64]*Client
 }
+
+// defaultClientBuffer is the fallback capacity for a client's send channel
+// when Manager.clientBufferSize is unset (<= 0). Mirrors
+// config.DefaultSSEClientBuffer; kept local so newManager callers that don't
+// thread config (tests) still get a burst-tolerant buffer instead of the old
+// silently-dropping 64-slot channel.
+const defaultClientBuffer = 8192
 
 // newManager constructs the manager and starts a single subscriber
 // goroutine that runs for the lifetime of ctx. Returns (nil, nil) only
@@ -249,10 +263,14 @@ func (m *Manager) NewClient(token string) *Client {
 	// cancel is stored on Client and invoked by Manager.Unregister — its
 	// lifetime is the client connection, not this function.
 	ctx, cancel := context.WithCancel(parent)
+	size := m.clientBufferSize
+	if size <= 0 {
+		size = defaultClientBuffer
+	}
 	return &Client{
 		ID:     m.nextClientID.Add(1),
 		Token:  token,
-		Ch:     make(chan *models.TransactionStatus, 64),
+		Ch:     make(chan *models.TransactionStatus, size),
 		Ctx:    ctx,
 		Cancel: cancel,
 	}
@@ -306,10 +324,31 @@ func (s *Service) handleEvents(c *gin.Context) {
 		case <-ctx.Done():
 			return
 		case status := <-client.Ch:
-			if status == nil {
-				continue
+			if status != nil {
+				if err := writeStatusBuffered(writer, status); err != nil {
+					return
+				}
 			}
-			if err := writeStatus(writer, status); err != nil {
+			// Coalesce the rest of this burst: drain everything already
+			// buffered on the channel (the default arm breaks the loop once
+			// the channel is empty, so this only ever writes what's ready and
+			// can't spin) and flush once. A bulk-unfan of one Kafka message
+			// lands ~50 frames here; without coalescing we'd flush per frame.
+		drain:
+			for {
+				select {
+				case s := <-client.Ch:
+					if s == nil {
+						continue
+					}
+					if err := writeStatusBuffered(writer, s); err != nil {
+						return
+					}
+				default:
+					break drain
+				}
+			}
+			if err := writer.flush(); err != nil {
 				return
 			}
 		case <-keepalive.C:
@@ -405,9 +444,10 @@ func (m *Manager) enrichMerklePath(ctx context.Context, status *models.Transacti
 	}
 }
 
-// writeStatus emits one status frame. Event id is the timestamp in
-// nanoseconds so clients can use it as Last-Event-ID on reconnect.
-func writeStatus(w *sseWriter, status *models.TransactionStatus) error {
+// buildStatusFrame renders one status as an SSE frame. Event id is the
+// timestamp in nanoseconds so clients can use it as Last-Event-ID on
+// reconnect.
+func buildStatusFrame(status *models.TransactionStatus) (string, error) {
 	data, err := json.Marshal(statusPayload{
 		TxID:        status.TxID,
 		TxStatus:    string(status.Status),
@@ -417,10 +457,31 @@ func writeStatus(w *sseWriter, status *models.TransactionStatus) error {
 		MerklePath:  status.MerklePath,
 	})
 	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("id: %d\nevent: status\ndata: %s\n\n", status.Timestamp.UnixNano(), data), nil
+}
+
+// writeStatus emits one status frame and flushes it. Used for single frames
+// (keepalive/catchup) where there is no burst to coalesce.
+func writeStatus(w *sseWriter, status *models.TransactionStatus) error {
+	frame, err := buildStatusFrame(status)
+	if err != nil {
 		return err
 	}
-	frame := fmt.Sprintf("id: %d\nevent: status\ndata: %s\n\n", status.Timestamp.UnixNano(), data)
 	return w.write(frame)
+}
+
+// writeStatusBuffered emits one status frame WITHOUT flushing. The live
+// fan-out path writes a whole burst this way and then calls w.flush() once, so
+// a bulk-unfan (~50 frames from one Kafka message) drains with a single flush
+// instead of one flush per frame.
+func writeStatusBuffered(w *sseWriter, status *models.TransactionStatus) error {
+	frame, err := buildStatusFrame(status)
+	if err != nil {
+		return err
+	}
+	return w.writeNoFlush(frame)
 }
 
 // statusPayload is the JSON shape inside a `data:` field. txid/txStatus/timestamp

--- a/services/sse/service.go
+++ b/services/sse/service.go
@@ -66,6 +66,13 @@ func (s *Service) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("initializing SSE manager: %w", err)
 	}
+	// Thread the configured per-connection buffer capacity through to the
+	// manager so NewClient sizes each client's send channel accordingly.
+	// A non-positive value leaves clientBufferSize at 0, which NewClient
+	// treats as "use defaultClientBuffer".
+	if mgr != nil {
+		mgr.clientBufferSize = s.cfg.SSE.ClientBufferSize
+	}
 	s.manager = mgr
 
 	gin.SetMode(gin.ReleaseMode)

--- a/services/sse/writer.go
+++ b/services/sse/writer.go
@@ -28,3 +28,27 @@ func (s *sseWriter) write(payload string) error {
 	s.f.Flush()
 	return nil
 }
+
+// writeNoFlush writes a frame WITHOUT flushing. It exists so a burst of
+// per-tx status frames (the manager unfans one Kafka message into ~50 frames)
+// can be written back-to-back and drained with a single flush() rather than
+// one flush per frame. The caller MUST call flush() after the burst to push
+// the buffered frames onto the wire.
+func (s *sseWriter) writeNoFlush(payload string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, err := fmt.Fprint(s.w, payload); err != nil {
+		return err
+	}
+	return nil
+}
+
+// flush flushes any buffered frames to the wire. http.Flusher.Flush has no
+// error return, so this always returns nil; the signature carries an error to
+// stay symmetric with write/writeNoFlush at call sites.
+func (s *sseWriter) flush() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.f.Flush()
+	return nil
+}


### PR DESCRIPTION
## Problem

Under a sustained ~1500 TPS broadcast load, the SSE service delivers only ~48% of status events to a single subscriber — ~52% of transactions never receive a `SEEN_*`/status event over the stream, even though arcade has correctly advanced them (confirmed via `GET /tx/{txid}` returning `SEEN_MULTIPLE_NODES`). A wallet consuming the stream is left with a local ledger that diverges badly from arcade's truth, and the Last-Event-ID poll fallback is far too slow to reconcile the gap.

## Root cause (it is **not** a fan-out/replica problem)

The 3 `sse` replicas share a Kafka broadcast bus (unique consumer group per replica → every replica gets every event), and a subscriber pinned to one replica has 100% of events available. During the incident the `sse` pods sat **idle (23–61 millicores)** while `api-server` did ~1 core of work — the events were available, not delivered.

Two compounding causes in the per-connection path:

1. **Each SSE connection had a hardcoded 64-slot, non-blocking send channel** (`manager.go` `NewClient`). The manager unfans one Kafka message (~50 coalesced txids) into a ~50-event burst pushed onto that shallow buffer, so the tail of every burst overflowed and was **silently dropped** via the non-blocking `default` arm (`slow_client` metric). Dropped *live* events are never re-pushed — only recoverable via Last-Event-ID catchup on reconnect, which never happens on a sustained connection.
2. **The per-connection writer flushed once per frame**, so a burst drained slowly, keeping the channel full longer and widening the drop window.

## Fix

**A. Configurable, larger per-connection buffer.** Add `SSEConfig.ClientBufferSize` (default `DefaultSSEClientBuffer = 8192`, viper key `sse.client_buffer_size`), threaded through to `Manager.clientBufferSize`; `NewClient` sizes each client channel from it, falling back to a package-local `defaultClientBuffer` (8192) when unset (e.g. tests). A ~50-event bulk-unfan burst now fits with large headroom.

**B. Coalesce frame writes.** Add `sseWriter.writeNoFlush` + `sseWriter.flush`; `handleEvents` writes the first status plus every status already buffered on the channel (a bounded non-blocking drain that can't spin), then flushes **once per drained burst** instead of once per frame. Keepalive and catchup single frames keep using `write` (write+flush).

Together these let a subscriber drain bursts fast enough that the buffer stops overflowing, closing the delivery gap. (A slow downstream consumer can still backpressure; that side is being addressed independently in the toolbox's status-apply throughput.)

## Testing

- `go build ./...` — clean
- `go test ./services/sse/...` — pass
- `go vet ./services/sse/... ./config/...` — clean

https://claude.ai/code/session_01BvyMDBbGFAD2RDQAYhRdP3
