### PR TITLE
fix(reorg): re-anchor MINED txs after same-height block competition

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -29,7 +29,7 @@ jobs:
   smoke:
     name: smoke
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 40
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -57,4 +57,4 @@ jobs:
           # ubuntu runner the docker socket lives at the default path so we
           # leave it unset.
           TESTCONTAINERS_RYUK_DISABLED: "true"
-        run: go test -tags=e2e -timeout=20m -v ./tests/e2e/...
+        run: go test -tags=e2e -timeout=30m -v ./tests/e2e/...

--- a/app/app.go
+++ b/app/app.go
@@ -494,12 +494,20 @@ func BuildServices(d *Deps) []services.Service {
 	}
 	if shouldRun("bump-builder") {
 		// chainHeader is nil when chaintracks is disabled — bump-builder
-		// nil-guards and falls back to subtree-count-only validation.
+		// nil-guards and falls back to subtree-count-only validation, the
+		// anchor guard fails open, and the reconciler below is skipped.
 		var chainHeader bump_builder.ChainHeaderReader
 		if d.Chaintracks != nil {
 			chainHeader = chaintracksHeaderReader{ct: d.Chaintracks}
 		}
 		svcs = append(svcs, bump_builder.New(cfg, d.Logger, d.Producer, d.Publisher, d.Store, d.TeranodeClient, chainHeader))
+		// The anchor reconciler heals txs anchored to orphaned blocks
+		// (issue #279). Hosted in the bump-builder mode because it shares
+		// the MINED-publish machinery, the store, and the chaintracks
+		// header source; lease-gated for multi-replica deployments.
+		if rec := bump_builder.NewReconciler(cfg, d.Logger, d.Store, d.Publisher, chainHeader, d.MerkleClient, d.Leaser); rec != nil {
+			svcs = append(svcs, rec)
+		}
 	}
 	if shouldRun("watchdog") && cfg.Watchdog.Enabled {
 		if wd := watchdog.NewService(cfg, d.Logger, d.Store, d.Leaser, d.MerkleClient); wd != nil {
@@ -554,6 +562,10 @@ type chaintracksHeaderReader struct {
 
 func (a chaintracksHeaderReader) GetHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*chaintrackslib.BlockHeader, error) {
 	return a.ct.GetHeaderByHash(ctx, hash)
+}
+
+func (a chaintracksHeaderReader) GetHeaderByHeight(ctx context.Context, height uint32) (*chaintrackslib.BlockHeader, error) {
+	return a.ct.GetHeaderByHeight(ctx, height)
 }
 
 // endpointSourceValidationTTL is how long a discovered URL that passed

--- a/bump/bump.go
+++ b/bump/bump.go
@@ -451,6 +451,23 @@ func IndexCompound(bumpData []byte) (*CompoundIndex, error) {
 // proxy cache implementations use to budget resident memory.
 func (ci *CompoundIndex) Leaves() int { return ci.leaves }
 
+// BlockHeight reports the block height the compound BUMP anchors to.
+func (ci *CompoundIndex) BlockHeight() uint64 { return uint64(ci.blockHeight) }
+
+// Contains reports whether txid is a level-0 leaf of the compound — i.e.
+// whether this block provably includes the transaction. Used by the reorg
+// reconciler to decide re-anchor (tx present in the canonical block's
+// BUMP) vs revert. O(1) via the txOffsets map; false for unparseable
+// txids and duplicate-flag leaves (which carry no hash).
+func (ci *CompoundIndex) Contains(txid string) bool {
+	txHash, err := chainhash.NewHashFromHex(txid)
+	if err != nil {
+		return false
+	}
+	_, ok := ci.txOffsets[*txHash]
+	return ok
+}
+
 // leafAt returns the element at (level, offset), or nil when absent.
 func (ci *CompoundIndex) leafAt(level int, offset uint64) *transaction.PathElement {
 	if level >= len(ci.levels) {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -223,6 +223,26 @@ bump_builder:
   # malfunctioning endpoint. Set <= 0 to use the built-in default.
   # Mitigates F-007.
   # datahub_max_block_bytes: 1073741824
+  #
+  # Write-time anchor guard (issue #279): refuse to mark a block's txs MINED
+  # when chaintracks' active chain provably has a DIFFERENT block at its
+  # height (same-height competition loser). Fails open on any uncertainty.
+  # false restores legacy last-writer-wins behavior as a rollback lever.
+  # anchor_guard_enabled: true
+  #
+  # Anchor reconciler (issue #279): heals transactions anchored to orphaned
+  # blocks — re-anchors them to the active-chain block containing them (via
+  # the canonical block's stored compound BUMP) or reverts them to
+  # SEEN_ON_NETWORK, publishing corrected status events. Runs in the
+  # bump-builder mode, lease-gated across replicas.
+  # reconciler:
+  #   enabled: true
+  #   interval_ms: 30000       # orphan-queue tick cadence
+  #   batch_size: 5000         # txids per store write / bulk event
+  #   blocks_per_tick: 4       # orphaned blocks reconciled per tick
+  #   neighborhood_depth: 6    # heights above an orphan searched for re-binned txs
+  #   max_defer_attempts: 10   # ticks to wait for a missing canonical BUMP
+  #   startup_full_scan: true  # one-off whole-table sweep for stale anchors
 
 # Shared on-disk root for arcade state. Chaintracks headers default to
 # <storage_path>/chaintracks/.
@@ -234,6 +254,13 @@ bump_builder:
 # Set enabled: false in environments without outbound P2P.
 chaintracks_server:
   enabled: true
+  # Tie-scan (issue #279): on each tip update, re-verify the 'active'
+  # block_processing rows within tie_scan_depth of the tip against the
+  # active chain and mark same-height losers orphaned — the case where
+  # chaintracks emits NO ReorgEvent (an equal-chainwork alternate never
+  # becomes tip). 0 disables. Debounced by tie_scan_min_interval_ms.
+  # tie_scan_depth: 20
+  # tie_scan_min_interval_ms: 5000
 
 # go-chaintracks library config. See that library's docs for the full set.
 # Defaults are inherited from the library's SetDefaults — uncomment to override.

--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,17 @@ type ChaintracksServerConfig struct {
 	// differ from api.port and sse.port when the standalone service
 	// runs in the same process (mode=all).
 	Port int `mapstructure:"port"`
+	// TieScanDepth is how many heights below the tip the block-status
+	// tracker re-verifies on each tip update: any 'active' block_processing
+	// row in the window whose hash is not the active-chain block at its
+	// height is marked orphaned. This is the detection edge for same-height
+	// competition losers, which never produce a chaintracks ReorgEvent —
+	// an equal-chainwork alternate never becomes tip (issue #279). Default
+	// 20; 0 disables the scan.
+	TieScanDepth int `mapstructure:"tie_scan_depth"`
+	// TieScanMinIntervalMs debounces the scan across tip bursts (regtest
+	// mining, catch-up sync). Default 5000.
+	TieScanMinIntervalMs int `mapstructure:"tie_scan_min_interval_ms"`
 }
 
 type API struct {
@@ -481,6 +492,52 @@ type BumpBuilderConfig struct {
 	// Mitigates F-007 (DataHub block fetch reads unbounded response bodies
 	// into memory).
 	DataHubMaxBlockBytes int64 `mapstructure:"datahub_max_block_bytes"`
+	// AnchorGuardEnabled gates the write-time anchor guard (issue #279):
+	// before marking a block's txs MINED, bump-builder checks that the
+	// block is chaintracks' active-chain block at its height and refuses
+	// when the height is provably held by a same-height competitor. Fail-
+	// open on any uncertainty. Default true (viper); false restores the
+	// legacy last-writer-wins behavior as an instant rollback lever.
+	AnchorGuardEnabled bool `mapstructure:"anchor_guard_enabled"`
+	// Reconciler tunes the anchor reconciler that heals txs anchored to
+	// orphaned blocks (issue #279).
+	Reconciler ReconcilerConfig `mapstructure:"reconciler"`
+}
+
+// ReconcilerConfig tunes the anchor reconciler — the bump-builder-hosted
+// loop that consumes orphaned block_processing rows and re-anchors (or
+// reverts) the transactions still pointing at them. See
+// services/bump_builder/reconciler.go for the algorithm.
+type ReconcilerConfig struct {
+	// Enabled gates the whole loop. Default true (viper); false is the
+	// rollback lever — orphaned rows then queue up (reconciled_at stays
+	// NULL) and are healed when re-enabled.
+	Enabled bool `mapstructure:"enabled"`
+	// IntervalMs is the tick cadence for consuming the orphaned-block
+	// queue. Default 30000.
+	IntervalMs int `mapstructure:"interval_ms"`
+	// BatchSize caps txids per SetMinedByTxIDs call / bulk status event
+	// during re-anchor. Default 5000 (matches maxTxIDsPerBulkEvent).
+	BatchSize int `mapstructure:"batch_size"`
+	// BlocksPerTick bounds how many orphaned blocks one tick reconciles.
+	// Default 4.
+	BlocksPerTick int `mapstructure:"blocks_per_tick"`
+	// NeighborhoodDepth is how many heights ABOVE an orphan's height are
+	// searched for the canonical block containing its txs (a deeper reorg
+	// re-bins txs into later blocks). Default 6.
+	NeighborhoodDepth int `mapstructure:"neighborhood_depth"`
+	// MaxDeferAttempts bounds how many ticks an orphan waits for the
+	// canonical block's BUMP (each defer fires a merkle-service /reprocess
+	// when wired) before falling back to revert-all — safe, because
+	// SEEN_ON_NETWORK → MINED is lattice-legal and a late canonical
+	// redelivery re-mines via the short-circuit path. Default 10.
+	MaxDeferAttempts int `mapstructure:"max_defer_attempts"`
+	// StartupFullScan runs one pass over the whole block_processing table
+	// after startup, orphan-marking any 'active' row whose height's
+	// canonical header differs — the deep backstop that also heals
+	// incidents that predate this code (like the height-764 block on the
+	// scaling cluster). Default true.
+	StartupFullScan bool `mapstructure:"startup_full_scan"`
 }
 
 // WatchdogConfig tunes the stale-block recovery watchdog. Defaults are
@@ -900,6 +957,14 @@ func setDefaults() {
 	// two-plus orders of magnitude of headroom over a realistic payload
 	// while still bounding memory against a hostile DataHub. See F-007.
 	viper.SetDefault("bump_builder.datahub_max_block_bytes", int64(1*1024*1024*1024))
+	viper.SetDefault("bump_builder.anchor_guard_enabled", true)
+	viper.SetDefault("bump_builder.reconciler.enabled", true)
+	viper.SetDefault("bump_builder.reconciler.interval_ms", 30000)
+	viper.SetDefault("bump_builder.reconciler.batch_size", 5000)
+	viper.SetDefault("bump_builder.reconciler.blocks_per_tick", 4)
+	viper.SetDefault("bump_builder.reconciler.neighborhood_depth", 6)
+	viper.SetDefault("bump_builder.reconciler.max_defer_attempts", 10)
+	viper.SetDefault("bump_builder.reconciler.startup_full_scan", true)
 	// Block-processing watchdog (standalone arcade service — mode=watchdog
 	// in production, in-process under mode=all): on by default. The runtime
 	// nil-guards the merkle-service client; an unconfigured deployment
@@ -931,6 +996,8 @@ func setDefaults() {
 	// (mode=all).
 	viper.SetDefault("chaintracks_server.host", "0.0.0.0")
 	viper.SetDefault("chaintracks_server.port", 8083)
+	viper.SetDefault("chaintracks_server.tie_scan_depth", 20)
+	viper.SetDefault("chaintracks_server.tie_scan_min_interval_ms", 5000)
 
 	// Intake validator fee floor in satoshis per KB. Matches the
 	// current BSV miner policy minimum.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -391,6 +391,51 @@ var BumpBuilderShortCircuitTotal = promauto.NewCounter(prometheus.CounterOpts{
 	Help: "BLOCK_PROCESSED messages skipped because a compound BUMP already exists for the block.",
 })
 
+// BumpBuilderAnchorGuardDeniedTotal counts blocks the anchor guard refused
+// to mark MINED because chaintracks' active chain has a DIFFERENT block at
+// their height (issue #279 — same-height competition loser). path
+// distinguishes the fresh-build path from the short-circuit redelivery
+// path. Each denial routes the block into the anchor reconciler's queue.
+var BumpBuilderAnchorGuardDeniedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_bump_builder_anchor_guard_denied_total",
+	Help: "Blocks refused MINED anchoring because the active chain has a different block at their height.",
+}, []string{"path"})
+
+// ---------------------------------------------------------------------------
+// anchor reconciler (bump-builder-hosted — reorg tx re-anchoring, issue #279)
+
+// ReconcilerBlocksTotal counts orphaned blocks processed by the anchor
+// reconciler, by terminal outcome: reanchored (all affected txs moved to a
+// canonical block), reverted (all reverted to SEEN_ON_NETWORK), mixed,
+// empty (nothing anchored to the orphan anymore), resurrected (the block is
+// active again — stale orphan mark), deferred (waiting on the canonical
+// block's BUMP), error.
+var ReconcilerBlocksTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_reconciler_blocks_total",
+	Help: "Orphaned blocks processed by the anchor reconciler, by outcome.",
+}, []string{"outcome"})
+
+// ReconcilerTxsReanchoredTotal counts transactions the reconciler moved from
+// an orphaned block to the active-chain block containing them.
+var ReconcilerTxsReanchoredTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "arcade_reconciler_txs_reanchored_total",
+	Help: "Transactions re-anchored from an orphaned block to a canonical block.",
+})
+
+// ReconcilerTxsRevertedTotal counts transactions the reconciler reverted to
+// SEEN_ON_NETWORK because no canonical block contains them.
+var ReconcilerTxsRevertedTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "arcade_reconciler_txs_reverted_total",
+	Help: "Transactions reverted to SEEN_ON_NETWORK because their only block was orphaned.",
+})
+
+// ReconcilerBlockDuration observes wall time per reconciled block.
+var ReconcilerBlockDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+	Name:    "arcade_reconciler_block_duration_seconds",
+	Help:    "Wall time spent reconciling one orphaned block's transactions.",
+	Buckets: prometheus.ExponentialBuckets(0.01, 4, 8), // 10ms .. ~11m
+})
+
 // ---------------------------------------------------------------------------
 // watchdog (standalone service — block-processing recovery)
 // ---------------------------------------------------------------------------

--- a/metrics/preregister.go
+++ b/metrics/preregister.go
@@ -49,6 +49,9 @@ var bumpBuildOutcomes = []string{
 	// window was skipped, grace_waited otherwise) plus the non-build ones
 	"finalized_complete_no_grace", "grace_waited",
 	"short_circuited", "no_stumps", "context_canceled",
+	// the anchor guard refused to mark the block's txs MINED because the
+	// active chain has a different block at its height (issue #279)
+	"skipped_inactive_chain",
 	// failures
 	"parse_failed", "deferred_incomplete", "fetch_failed",
 	"no_subtrees", "build_failed", "validation_failed", "store_failed",

--- a/models/block.go
+++ b/models/block.go
@@ -55,4 +55,13 @@ type BlockProcessingStatus struct {
 	BUMPBuiltAt  *time.Time                 `json:"bumpBuiltAt,omitempty"`
 	Status       BlockProcessingStatusValue `json:"status"`
 	OrphanedAt   *time.Time                 `json:"orphanedAt,omitempty"`
+	// ReconciledAt is stamped by the anchor reconciler once every
+	// transaction anchored to this orphaned block has been re-anchored to
+	// the canonical block or reverted (issue #279). NULL on active/parked
+	// rows and on orphaned rows still awaiting reconciliation — the
+	// (status='orphaned' AND reconciled_at IS NULL) pair is the
+	// reconciler's durable work queue. Reset to NULL when the block is
+	// resurrected by a later reorg (UpsertBlockHeaderSeen conflict path)
+	// so a re-orphaning reconciles again.
+	ReconciledAt *time.Time `json:"reconciledAt,omitempty"`
 }

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -62,6 +62,15 @@ type TransactionStatus struct {
 	RetryCount   int       `json:"retryCount,omitempty"`
 	NextRetryAt  time.Time `json:"nextRetryAt,omitempty"`
 	CreatedAt    time.Time `json:"-"`
+	// OrphanedProofs preserves every block this tx was once MINED against
+	// before a reorg superseded the anchor (issue #279). Stores append an
+	// entry whenever an existing MINED anchor is overwritten with a
+	// different block (re-anchor) or cleared by a reorg revert, capped at
+	// MaxOrphanedAnchors. Each entry's MerklePath is enriched at read time
+	// from the orphaned block's retained compound BUMP — never persisted —
+	// so clients can still verify the historical proof against the
+	// orphaned header.
+	OrphanedProofs []OrphanedAnchor `json:"orphanedProofs,omitempty"`
 	// MerkleRegisteredAt is the wall-clock time of the most recent
 	// successful merkle-service /watch registration for this txid. Zero
 	// value means "never registered" (or registered before this field was
@@ -272,6 +281,57 @@ type Submission struct {
 	LastAttemptAt *time.Time
 	LastResult    string
 	CreatedAt     time.Time
+}
+
+// OrphanedAnchor is one historical MINED anchor a reorg superseded: the
+// block the tx was anchored to, and when the anchor was replaced. Kept on
+// the transaction row (capped at MaxOrphanedAnchors) so the orphaned
+// block's proof remains auditable after re-anchoring — see issue #279.
+type OrphanedAnchor struct {
+	BlockHash   string    `json:"blockHash"`
+	BlockHeight uint64    `json:"blockHeight"`
+	OrphanedAt  time.Time `json:"orphanedAt"`
+	// MerklePath is the tx's proof against the orphaned block, resolved at
+	// read time from that block's retained compound BUMP. Empty when the
+	// BUMP is no longer available. Never persisted.
+	MerklePath HexBytes `json:"merklePath,omitempty"`
+}
+
+// MaxOrphanedAnchors caps the orphaned-anchor history kept per transaction.
+// A flip-flopping competition rewrites the same two anchors, so a small cap
+// bounds row growth without losing real history.
+const MaxOrphanedAnchors = 5
+
+// ExtraInfo markers carried on reorg-correction status events (issue #279).
+// They ride the bulk event templates on arcade.tx_status so downstream
+// consumers (webhook, SSE) can distinguish a reorg correction from a plain
+// transition — in particular, the webhook's same-status dedup makes an
+// exception for a MINED event flagged as a re-anchor, since it carries a
+// new block hash + merkle path.
+const (
+	// ExtraInfoReorgReanchor marks a MINED event whose txs were re-anchored
+	// from an orphaned block to the active-chain block at its height.
+	ExtraInfoReorgReanchor = "reorg_reanchor"
+	// ExtraInfoReorgUnmined marks a SEEN_ON_NETWORK event whose txs were
+	// reverted out of an orphaned block they do not exist outside of.
+	ExtraInfoReorgUnmined = "reorg_unmined"
+)
+
+// AppendOrphanedAnchor appends anchor to history, dropping the oldest
+// entries beyond MaxOrphanedAnchors. Duplicate consecutive anchors for the
+// same block hash are collapsed (idempotent replays must not grow history).
+func AppendOrphanedAnchor(history []OrphanedAnchor, anchor OrphanedAnchor) []OrphanedAnchor {
+	if anchor.BlockHash == "" {
+		return history
+	}
+	if n := len(history); n > 0 && history[n-1].BlockHash == anchor.BlockHash {
+		return history
+	}
+	history = append(history, anchor)
+	if len(history) > MaxOrphanedAnchors {
+		history = history[len(history)-MaxOrphanedAnchors:]
+	}
+	return history
 }
 
 // BlockReorg represents a notification that a block was orphaned due to a chain reorganization

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -1,6 +1,10 @@
 package models
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+	"time"
+)
 
 // TestStatus_IsTerminal pins the set of statuses that the system treats as
 // terminal — i.e. statuses that callers must not silently overwrite with a
@@ -165,4 +169,63 @@ func TestStatus_CanTransitionFrom_Regressions(t *testing.T) {
 			t.Errorf("%s: %s → %s should be rejected", c.reason, c.prev, c.next)
 		}
 	}
+}
+
+// TestAppendOrphanedAnchor pins the orphaned-anchor history helper (issue
+// #279): empty block hashes are no-ops, consecutive duplicates collapse so
+// idempotent replays cannot grow history, and the history caps at
+// MaxOrphanedAnchors keeping the newest entries.
+func TestAppendOrphanedAnchor(t *testing.T) {
+	now := time.Now()
+
+	t.Run("EmptyHashNoOp", func(t *testing.T) {
+		history := []OrphanedAnchor{{BlockHash: "blk-A", BlockHeight: 1, OrphanedAt: now}}
+		got := AppendOrphanedAnchor(history, OrphanedAnchor{BlockHash: "", BlockHeight: 2, OrphanedAt: now})
+		if len(got) != 1 || got[0].BlockHash != "blk-A" {
+			t.Fatalf("empty hash must be a no-op, got %+v", got)
+		}
+		// Also from a nil history.
+		if got := AppendOrphanedAnchor(nil, OrphanedAnchor{}); got != nil {
+			t.Fatalf("empty hash on nil history must stay nil, got %+v", got)
+		}
+	})
+
+	t.Run("ConsecutiveDupCollapses", func(t *testing.T) {
+		var history []OrphanedAnchor
+		history = AppendOrphanedAnchor(history, OrphanedAnchor{BlockHash: "blk-A", BlockHeight: 1, OrphanedAt: now})
+		history = AppendOrphanedAnchor(history, OrphanedAnchor{BlockHash: "blk-A", BlockHeight: 1, OrphanedAt: now.Add(time.Minute)})
+		if len(history) != 1 {
+			t.Fatalf("consecutive duplicate must collapse, got %+v", history)
+		}
+		// A different hash appends; the SAME hash non-consecutively appends
+		// too (only the tail entry is compared).
+		history = AppendOrphanedAnchor(history, OrphanedAnchor{BlockHash: "blk-B", BlockHeight: 1, OrphanedAt: now})
+		history = AppendOrphanedAnchor(history, OrphanedAnchor{BlockHash: "blk-A", BlockHeight: 1, OrphanedAt: now})
+		if len(history) != 3 ||
+			history[0].BlockHash != "blk-A" || history[1].BlockHash != "blk-B" || history[2].BlockHash != "blk-A" {
+			t.Fatalf("non-consecutive re-append broken: %+v", history)
+		}
+	})
+
+	t.Run("CapKeepsNewest", func(t *testing.T) {
+		var history []OrphanedAnchor
+		for i := 0; i < MaxOrphanedAnchors+2; i++ {
+			history = AppendOrphanedAnchor(history, OrphanedAnchor{
+				BlockHash:   fmt.Sprintf("blk-%d", i),
+				BlockHeight: uint64(i),
+				OrphanedAt:  now.Add(time.Duration(i) * time.Minute),
+			})
+		}
+		if len(history) != MaxOrphanedAnchors {
+			t.Fatalf("history len = %d, want cap %d", len(history), MaxOrphanedAnchors)
+		}
+		// The two oldest entries (blk-0, blk-1) were dropped; the newest
+		// (blk-6) is the tail.
+		if history[0].BlockHash != "blk-2" {
+			t.Errorf("oldest surviving entry = %q, want blk-2", history[0].BlockHash)
+		}
+		if history[len(history)-1].BlockHash != fmt.Sprintf("blk-%d", MaxOrphanedAnchors+1) {
+			t.Errorf("newest entry = %q, want blk-%d", history[len(history)-1].BlockHash, MaxOrphanedAnchors+1)
+		}
+	})
 }

--- a/openapi/arcade.openapi.yaml
+++ b/openapi/arcade.openapi.yaml
@@ -1196,10 +1196,50 @@ components:
         merkleRegisteredAt:
           type: string
           format: date-time
+        orphanedProofs:
+          type: array
+          description: >-
+            Historical MINED anchors a chain reorganization superseded, newest
+            last (capped at 5). Present only on transactions that were once
+            anchored to a block that later lost its height to a competitor —
+            e.g. after a same-height reorg the tx re-anchors to the winning
+            block (blockHash/merklePath above) while the losing block's anchor
+            is preserved here, with its proof still resolvable against the
+            orphaned header.
+          items:
+            $ref: "#/components/schemas/OrphanedProof"
       required:
         - txid
         - txStatus
         - timestamp
+
+    OrphanedProof:
+      type: object
+      description: >-
+        One historical anchor a reorg superseded: the orphaned block the
+        transaction was MINED against, when the anchor was replaced, and the
+        transaction's BUMP against that block (best-effort — absent if the
+        orphaned block's compound BUMP is no longer retained).
+      properties:
+        blockHash:
+          type: string
+          description: Hash of the orphaned block.
+        blockHeight:
+          type: integer
+          format: int64
+        orphanedAt:
+          type: string
+          format: date-time
+          description: When the anchor was superseded (re-anchor or revert).
+        merklePath:
+          type: string
+          description: >-
+            BUMP merkle path against the ORPHANED block, hex-encoded. Computes
+            to the orphaned header's merkle root, not the active chain's.
+      required:
+        - blockHash
+        - blockHeight
+        - orphanedAt
 
     SubmitTxJSON:
       type: object

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -169,6 +169,14 @@ func (m *mockStore) SetMinedByTxIDs(context.Context, string, uint64, []string) (
 func (m *mockStore) MarkMerkleRegisteredByTxIDs(context.Context, []string, time.Time) error {
 	return nil
 }
+func (m *mockStore) GetTxIDsByBlockHash(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+func (m *mockStore) DeleteBUMPByBlockHash(context.Context, string) error          { return nil }
+func (m *mockStore) MarkBlockReconciled(context.Context, string, time.Time) error { return nil }
+func (m *mockStore) ListOrphanedBlocksToReconcile(context.Context, int) ([]*models.BlockProcessingStatus, error) {
+	return nil, nil
+}
 
 func (m *mockStore) InsertSubmission(_ context.Context, sub *models.Submission) error {
 	m.mu.Lock()

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -169,6 +169,7 @@ func (m *mockStore) SetMinedByTxIDs(context.Context, string, uint64, []string) (
 func (m *mockStore) MarkMerkleRegisteredByTxIDs(context.Context, []string, time.Time) error {
 	return nil
 }
+
 func (m *mockStore) GetTxIDsByBlockHash(context.Context, string) ([]string, error) {
 	return nil, nil
 }

--- a/services/bump_builder/builder.go
+++ b/services/bump_builder/builder.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -35,6 +36,14 @@ import (
 // failing the build outright on a transient chaintracks race.
 type ChainHeaderReader interface {
 	GetHeaderByHash(ctx context.Context, hash *chainhash.Hash) (*chaintrackslib.BlockHeader, error)
+	// GetHeaderByHeight returns the ACTIVE-chain header at height. A
+	// (nil, nil) or error return means "chaintracks cannot judge this
+	// height yet" — callers must fail open, never treat it as evidence.
+	// Unlike GetHeaderByHash, which also resolves same-height alternates
+	// from the header index, this is a main-chain-membership source: the
+	// anchor guard and the reorg reconciler both compare a block hash
+	// against it to decide canonicality (issue #279).
+	GetHeaderByHeight(ctx context.Context, height uint32) (*chaintrackslib.BlockHeader, error)
 }
 
 type Builder struct {
@@ -210,6 +219,75 @@ func (b *Builder) lookupHeaderWithWait(ctx context.Context, hashObj *chainhash.H
 	return header, lookupErr
 }
 
+// anchorVerdict is anchorDecision's outcome.
+type anchorVerdict int
+
+const (
+	// anchorAllow: the block is the active-chain block at its height, or
+	// chaintracks cannot judge (unknown height, lag, guard disabled, no
+	// chainHeader wired). Fail-open by design — a wrong optimistic anchor
+	// is healed by the anchor reconciler, whereas a false denial would
+	// strand the block's txs with no recovery trigger.
+	anchorAllow anchorVerdict = iota
+	// anchorDeny: positive evidence that the active chain has a DIFFERENT
+	// block at this height — anchoring txs to this block would repeat
+	// issue #279's orphan-anchored MINED rows.
+	anchorDeny
+)
+
+// anchorDecision is the write-time anchor guard (issue #279): before txs
+// are marked MINED against blockHash, check that the block is the
+// active-chain block at its height per chaintracks. Denial requires
+// positive evidence — GetHeaderByHeight knows the height AND the hash
+// differs. Everything else (nil reader, guard disabled, height unknown,
+// lookup error) allows: chaintracks' P2P ingestion legitimately races the
+// Kafka path that drives bump-builder, and the tie-scan + reconciler net
+// catches any optimistic anchor the race lets through.
+func (b *Builder) anchorDecision(ctx context.Context, logger *zap.Logger, blockHash string, blockHeight uint64) anchorVerdict {
+	if b.chainHeader == nil || !b.cfg.BumpBuilder.AnchorGuardEnabled {
+		return anchorAllow
+	}
+	if blockHeight == 0 || blockHeight > math.MaxUint32 {
+		return anchorAllow
+	}
+	active, err := b.chainHeader.GetHeaderByHeight(ctx, uint32(blockHeight))
+	if err != nil || active == nil {
+		logger.Debug("anchor guard could not verify canonicality; anchoring optimistically",
+			logfields.BlockHeight(blockHeight),
+			zap.Error(err))
+		return anchorAllow
+	}
+	if active.Hash.String() == blockHash {
+		return anchorAllow
+	}
+	logger.Error("anchor guard: active chain has a different block at this height — refusing to mark MINED",
+		logfields.BlockHash(blockHash),
+		logfields.BlockHeight(blockHeight),
+		zap.String("active_block_hash", active.Hash.String()))
+	return anchorDeny
+}
+
+// handleAnchorDenied finalizes a block the guard refused to anchor: the
+// processing row is stamped (so the watchdog never re-drives it) and marked
+// orphaned — routing it into the anchor reconciler's queue, which heals any
+// txs an EARLIER build anchored to it — and its STUMPs are pruned. The
+// stored compound BUMP is deliberately retained: it is the store-local
+// re-anchor fuel if this block later wins a flip-flop, and the source for
+// historical orphaned-anchor proofs.
+func (b *Builder) handleAnchorDenied(ctx context.Context, logger *zap.Logger, blockHash string, blockHeight uint64, path string) {
+	metrics.BumpBuilderAnchorGuardDeniedTotal.WithLabelValues(path).Inc()
+	// Stamp first: markBlockProcessed upserts the row when missing (a
+	// never-tip block has no chaintracks header-seen row), so the orphan
+	// mark below always has a row to land on.
+	b.markBlockProcessed(ctx, logger, blockHash, blockHeight)
+	if err := b.store.MarkBlocksOrphaned(ctx, []string{blockHash}, time.Now()); err != nil {
+		logger.Warn("anchor guard: failed to mark block orphaned; reconciler full-scan will catch it", zap.Error(err))
+	}
+	if err := b.store.DeleteStumpsByBlockHash(ctx, blockHash); err != nil {
+		logger.Warn("anchor guard: failed to clean up STUMPs", zap.Error(err))
+	}
+}
+
 // markMinedAndPublish moves the txids to MINED and fans the resulting status
 // updates out to the events Publisher. blockHeight is required so each
 // published status carries the block-height anchor that downstream SSE /
@@ -218,15 +296,60 @@ func (b *Builder) lookupHeaderWithWait(ctx context.Context, hashObj *chainhash.H
 // repairs it from the compound BUMP's height before fanning out so a
 // half-applied revert can never reintroduce the original bug.
 func (b *Builder) markMinedAndPublish(ctx context.Context, logger *zap.Logger, blockHash string, blockHeight uint64, txids []string) {
-	prevs, mined, err := b.store.SetMinedByTxIDs(ctx, blockHash, blockHeight, txids)
+	setMinedAndPublish(ctx, logger, b.store, b.publisher, blockHash, blockHeight, txids, "", false)
+}
+
+// setMinedAndPublish is the shared "mark MINED + fan out" core behind the
+// builder's build path and the anchor reconciler's re-anchor path (issue
+// #279). extraInfo, when non-empty, is stamped on the published bulk event
+// templates (e.g. models.ExtraInfoReorgReanchor) so consumers can tell a
+// reorg correction from a plain MINED. onlyChanged filters the fan-out to
+// rows whose anchor actually changed (previous status not MINED, or MINED
+// against a different block) — the reconciler re-mines a canonical block's
+// FULL BUMP set for idempotency, and rows already correctly anchored must
+// not spam duplicate events.
+func setMinedAndPublish(
+	ctx context.Context,
+	logger *zap.Logger,
+	st store.Store,
+	publisher events.Publisher,
+	blockHash string,
+	blockHeight uint64,
+	txids []string,
+	extraInfo string,
+	onlyChanged bool,
+) (changed int) {
+	prevs, mined, err := st.SetMinedByTxIDs(ctx, blockHash, blockHeight, txids)
 	if err != nil {
 		logger.Error("failed to set mined status", zap.Error(err))
-		return
+		return 0
 	}
+	// onlyChanged: keep only actual anchor transitions. prevs and mined are
+	// parallel slices per the SetMinedByTxIDs contract.
+	if onlyChanged {
+		filteredPrevs := prevs[:0]
+		filteredMined := mined[:0]
+		for i, prev := range prevs {
+			if i >= len(mined) {
+				break
+			}
+			if prev != nil && prev.Status == models.StatusMined && prev.BlockHash == blockHash {
+				continue
+			}
+			filteredPrevs = append(filteredPrevs, prev)
+			filteredMined = append(filteredMined, mined[i])
+		}
+		prevs, mined = filteredPrevs, filteredMined
+		if len(mined) == 0 {
+			return 0
+		}
+	}
+
 	logger.Info(
 		"set transactions to MINED",
 		zap.Int("count", len(mined)),
 		logfields.BlockHeight(blockHeight),
+		zap.String("extra_info", extraInfo),
 	)
 	metrics.BumpBuilderTxidsMinedTotal.Add(float64(len(mined)))
 	// Observe the per-tx age of the previous status row so an operator can see
@@ -264,8 +387,8 @@ func (b *Builder) markMinedAndPublish(ctx context.Context, logger *zap.Logger, b
 		)
 	})
 
-	if len(mined) == 0 || b.publisher == nil {
-		return
+	if len(mined) == 0 || publisher == nil {
+		return len(mined)
 	}
 	// Coalesce the N-per-block MINED fan-out into bulk events. Without this, a
 	// single BUMP build for a 14k-tx block produced 14k individual publish
@@ -291,8 +414,9 @@ func (b *Builder) markMinedAndPublish(ctx context.Context, logger *zap.Logger, b
 			BlockHeight: blockHeight,
 			Timestamp:   time.Now(),
 			TxIDs:       publishTxIDs[start:end],
+			ExtraInfo:   extraInfo,
 		}
-		if pubErr := b.publisher.PublishBulk(ctx, template); pubErr != nil {
+		if pubErr := publisher.PublishBulk(ctx, template); pubErr != nil {
 			logger.Warn(
 				"failed to publish bulk MINED",
 				logfields.BlockHash(blockHash),
@@ -303,6 +427,7 @@ func (b *Builder) markMinedAndPublish(ctx context.Context, logger *zap.Logger, b
 			)
 		}
 	}
+	return len(mined)
 }
 
 // maxTxIDsPerBulkEvent caps how many txids ride in a single bulk MINED event.
@@ -584,7 +709,12 @@ func (b *Builder) handleMessage(ctx context.Context, msg *kafka.Message) error {
 	// and tryShortCircuit re-stamps it on the redelivered BLOCK_PROCESSED.
 	b.markBlockProcessed(ctx, logger, blockHash, blockHeight)
 
-	// 6. Set tracked transactions to MINED.
+	// 6. Set tracked transactions to MINED — unless the anchor guard has
+	// positive evidence the block lost its height to a same-height
+	// competitor (issue #279). The BUMP built above stays stored either
+	// way: it is the store-local re-anchor fuel if the block later wins a
+	// flip-flop, and the source for historical orphaned-anchor proofs.
+	//
 	// blockHeight is threaded through here (and asserted on the returned
 	// statuses below) because downstream SSE/webhook consumers and the
 	// dedup path in BUMP-build rely on the height to anchor each MINED
@@ -597,6 +727,11 @@ func (b *Builder) handleMessage(ctx context.Context, msg *kafka.Message) error {
 	// previous in-memory pre-filter against TxTracker silently dropped txs
 	// submitted to api-server after bump-builder's per-pod tracker hydration
 	// in microservice mode.
+	if b.anchorDecision(ctx, logger, blockHash, blockHeight) == anchorDeny {
+		outcome = "skipped_inactive_chain"
+		b.handleAnchorDenied(ctx, logger, blockHash, blockHeight, "build")
+		return nil
+	}
 	if len(txids) > 0 {
 		b.markMinedAndPublish(ctx, logger, blockHash, blockHeight, txids)
 	}
@@ -895,6 +1030,14 @@ func (b *Builder) tryShortCircuit(ctx context.Context, logger *zap.Logger, block
 		zap.Int("level0_count", len(txids)),
 		logfields.BlockHeight(existingHeight),
 	)
+	// The guard runs on the redelivery path too: a replayed BLOCK_PROCESSED
+	// (DLQ redrive, watchdog /reprocess) for a block that lost its height
+	// must not re-anchor txs from its stored BUMP (issue #279). The denied
+	// block is finalized + orphan-marked exactly like the fresh-build path.
+	if b.anchorDecision(ctx, logger, blockHash, existingHeight) == anchorDeny {
+		b.handleAnchorDenied(ctx, logger, blockHash, existingHeight, "short_circuit")
+		return true
+	}
 	if len(txids) > 0 {
 		b.markMinedAndPublish(ctx, logger, blockHash, existingHeight, txids)
 	}

--- a/services/bump_builder/builder_test.go
+++ b/services/bump_builder/builder_test.go
@@ -1606,10 +1606,11 @@ func (h *heightDroppingMockStore) SetMinedByTxIDs(ctx context.Context, blockHash
 // inject a header mid-run (the ingestion race lookupHeaderWithWait rides
 // out), so reads and writes are mutex-guarded.
 type stubChaintracks struct {
-	mu      sync.Mutex
-	headers map[string]*chaintrackslib.BlockHeader
-	err     error
-	lookups int
+	mu       sync.Mutex
+	headers  map[string]*chaintrackslib.BlockHeader
+	byHeight map[uint32]*chaintrackslib.BlockHeader
+	err      error
+	lookups  int
 }
 
 func (s *stubChaintracks) GetHeaderByHash(_ context.Context, h *chainhash.Hash) (*chaintrackslib.BlockHeader, error) {
@@ -1620,6 +1621,26 @@ func (s *stubChaintracks) GetHeaderByHash(_ context.Context, h *chainhash.Hash) 
 		return nil, s.err
 	}
 	return s.headers[h.String()], nil
+}
+
+// byHeight backs GetHeaderByHeight for anchor-guard tests. Unset heights
+// return (nil, nil) — "cannot judge", which the guard treats as allow.
+func (s *stubChaintracks) GetHeaderByHeight(_ context.Context, height uint32) (*chaintrackslib.BlockHeader, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.byHeight[height], nil
+}
+
+func (s *stubChaintracks) setHeightHeader(height uint32, header *chaintrackslib.BlockHeader) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.byHeight == nil {
+		s.byHeight = make(map[uint32]*chaintrackslib.BlockHeader)
+	}
+	s.byHeight[height] = header
 }
 
 func (s *stubChaintracks) setHeader(hash string, header *chaintrackslib.BlockHeader) {

--- a/services/bump_builder/reconciler.go
+++ b/services/bump_builder/reconciler.go
@@ -299,21 +299,7 @@ func (r *Reconciler) reconcileBlock(ctx context.Context, row *models.BlockProces
 		}
 	}
 	if !canonicalReady && canonicalHash != "" {
-		maxDefer := r.cfg.BumpBuilder.Reconciler.MaxDeferAttempts
-		if maxDefer <= 0 {
-			maxDefer = 10
-		}
-		if r.defers[orphan] < maxDefer {
-			r.defers[orphan]++
-			logger.Info("canonical block's BUMP not stored yet — deferring",
-				zap.String("canonical_block_hash", canonicalHash),
-				zap.Int("defer_attempt", r.defers[orphan]),
-			)
-			if r.merkle != nil && r.cfg.CallbackURL != "" {
-				if err := r.merkle.Reprocess(ctx, canonicalHash, r.cfg.CallbackURL, r.cfg.CallbackToken); err != nil {
-					logger.Warn("merkle-service /reprocess for canonical block failed", zap.Error(err))
-				}
-			}
+		if r.deferForCanonicalBUMP(ctx, logger, orphan, canonicalHash) {
 			return "deferred"
 		}
 		logger.Warn("defer cap reached without a canonical BUMP — falling back to revert-all "+
@@ -329,47 +315,7 @@ func (r *Reconciler) reconcileBlock(ctx context.Context, row *models.BlockProces
 		logger.Warn("failed to read affected txids", zap.Error(err))
 		return "error"
 	}
-	if len(affected) > 0 {
-		depth := r.cfg.BumpBuilder.Reconciler.NeighborhoodDepth
-		if depth < 0 {
-			depth = 0
-		}
-		for h := height + 1; h <= height+uint64(depth) && len(affected) > 0; h++ {
-			if h > math.MaxUint32 {
-				break
-			}
-			active, err := r.chainHeader.GetHeaderByHeight(ctx, uint32(h))
-			if err != nil || active == nil {
-				break // above the tip — nothing further to check
-			}
-			neighbor := active.Hash.String()
-			_, bumpBytes, err := r.store.GetBUMP(ctx, neighbor)
-			if err != nil || len(bumpBytes) == 0 {
-				continue
-			}
-			idx, err := bump.IndexCompound(bumpBytes)
-			if err != nil {
-				continue
-			}
-			var contained []string
-			var rest []string
-			for _, txid := range affected {
-				if idx.Contains(txid) {
-					contained = append(contained, txid)
-				} else {
-					rest = append(rest, txid)
-				}
-			}
-			if len(contained) > 0 {
-				for start := 0; start < len(contained); start += batchSize {
-					end := min(start+batchSize, len(contained))
-					reanchored += setMinedAndPublish(ctx, logger, r.store, r.publisher,
-						neighbor, h, contained[start:end], models.ExtraInfoReorgReanchor, true)
-				}
-			}
-			affected = rest
-		}
-	}
+	reanchored += r.reanchorNeighborhood(ctx, logger, affected, height, batchSize)
 
 	// Revert the remainder: everything still anchored to O exists in no
 	// canonical block we can prove — SEEN_ON_NETWORK puts them back in
@@ -397,7 +343,8 @@ func (r *Reconciler) reconcileBlock(ctx context.Context, row *models.BlockProces
 
 	metrics.ReconcilerTxsReanchoredTotal.Add(float64(reanchored))
 	metrics.ReconcilerTxsRevertedTotal.Add(float64(len(reverted)))
-	logger.Info("orphaned block reconciled",
+	logger.Info(
+		"orphaned block reconciled",
 		logfields.BlockHeight(height),
 		zap.String("canonical_block_hash", canonicalHash),
 		zap.Int("txs_reanchored", reanchored),
@@ -413,6 +360,83 @@ func (r *Reconciler) reconcileBlock(ctx context.Context, row *models.BlockProces
 	default:
 		return "empty"
 	}
+}
+
+// deferForCanonicalBUMP handles the canonical-BUMP-missing branch: while
+// under the defer cap it bumps the orphan's counter, optionally pokes
+// merkle-service /reprocess for the canonical block, and reports true
+// (caller returns "deferred" without stamping reconciled_at). At the cap it
+// reports false so the caller falls back to revert-all.
+func (r *Reconciler) deferForCanonicalBUMP(ctx context.Context, logger *zap.Logger, orphan, canonicalHash string) bool {
+	maxDefer := r.cfg.BumpBuilder.Reconciler.MaxDeferAttempts
+	if maxDefer <= 0 {
+		maxDefer = 10
+	}
+	if r.defers[orphan] >= maxDefer {
+		return false
+	}
+	r.defers[orphan]++
+	logger.Info(
+		"canonical block's BUMP not stored yet — deferring",
+		zap.String("canonical_block_hash", canonicalHash),
+		zap.Int("defer_attempt", r.defers[orphan]),
+	)
+	if r.merkle != nil && r.cfg.CallbackURL != "" {
+		if err := r.merkle.Reprocess(ctx, canonicalHash, r.cfg.CallbackURL, r.cfg.CallbackToken); err != nil {
+			logger.Warn("merkle-service /reprocess for canonical block failed", zap.Error(err))
+		}
+	}
+	return true
+}
+
+// reanchorNeighborhood walks the heights above the orphan looking for
+// canonical blocks whose stored BUMPs contain the still-affected txs (a
+// deep reorg re-bins txs into later blocks) and re-anchors what it finds.
+// Returns the number of rows moved. The affected slice shrinks as txs are
+// claimed; whatever remains falls to the caller's revert.
+func (r *Reconciler) reanchorNeighborhood(ctx context.Context, logger *zap.Logger, affected []string, height uint64, batchSize int) int {
+	if len(affected) == 0 {
+		return 0
+	}
+	depth := r.cfg.BumpBuilder.Reconciler.NeighborhoodDepth
+	if depth < 0 {
+		depth = 0
+	}
+	reanchored := 0
+	for h := height + 1; h <= height+uint64(depth) && len(affected) > 0; h++ {
+		if h > math.MaxUint32 {
+			break
+		}
+		active, hdrErr := r.chainHeader.GetHeaderByHeight(ctx, uint32(h))
+		if hdrErr != nil || active == nil {
+			break // above the tip — nothing further to check
+		}
+		neighbor := active.Hash.String()
+		_, bumpBytes, bumpErr := r.store.GetBUMP(ctx, neighbor)
+		if bumpErr != nil || len(bumpBytes) == 0 {
+			continue
+		}
+		idx, idxErr := bump.IndexCompound(bumpBytes)
+		if idxErr != nil {
+			continue
+		}
+		contained := make([]string, 0, len(affected))
+		rest := make([]string, 0, len(affected))
+		for _, txid := range affected {
+			if idx.Contains(txid) {
+				contained = append(contained, txid)
+			} else {
+				rest = append(rest, txid)
+			}
+		}
+		for start := 0; start < len(contained); start += batchSize {
+			end := min(start+batchSize, len(contained))
+			reanchored += setMinedAndPublish(ctx, logger, r.store, r.publisher,
+				neighbor, h, contained[start:end], models.ExtraInfoReorgReanchor, true)
+		}
+		affected = rest
+	}
+	return reanchored
 }
 
 // remineFromStoredBUMP re-mines every level-0 txid of blockHash's stored

--- a/services/bump_builder/reconciler.go
+++ b/services/bump_builder/reconciler.go
@@ -394,6 +394,12 @@ func (r *Reconciler) reanchorNeighborhood(ctx context.Context, logger *zap.Logge
 	if len(affected) == 0 {
 		return 0
 	}
+	// A placeholder orphan row with no resolvable height (height==0) has no
+	// meaningful neighborhood above it — walking heights 1..depth is
+	// nonsensical. Skip straight to the caller's revert.
+	if height == 0 {
+		return 0
+	}
 	depth := r.cfg.BumpBuilder.Reconciler.NeighborhoodDepth
 	if depth < 0 {
 		depth = 0

--- a/services/bump_builder/reconciler.go
+++ b/services/bump_builder/reconciler.go
@@ -1,0 +1,460 @@
+package bump_builder
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/bump"
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/events"
+	"github.com/bsv-blockchain/arcade/logfields"
+	"github.com/bsv-blockchain/arcade/merkleservice"
+	"github.com/bsv-blockchain/arcade/metrics"
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
+)
+
+// ReconcilerLeaseName coordinates a single reconciler across bump-builder
+// replicas via the standard store.Leaser primitive. The work is idempotent
+// (re-anchor and revert both converge), so brief dual-holding during a
+// failover window is redundant work, not corruption.
+const ReconcilerLeaseName = "anchor-reconciler"
+
+// Reconciler heals the transactions of orphaned blocks (issue #279): for
+// every block_processing row with status='orphaned' and no reconciled_at,
+// it re-anchors the txs still MINED against the orphan to the active-chain
+// block that contains them (using the canonical block's already-stored
+// compound BUMP — no external calls in the common case), reverts the rest
+// to SEEN_ON_NETWORK, publishes corrected bulk status events, and stamps
+// reconciled_at.
+//
+// Detection is elsewhere: the chaintracks_server tracker marks blocks
+// orphaned from ReorgEvents and its tie-scan, and bump-builder's anchor
+// guard marks the blocks it refuses. The reconciler is remediation only —
+// plus its startup full-scan, the deep backstop that also detects orphans
+// predating this code (the height-764 incident block on the scaling
+// cluster heals through exactly that path).
+type Reconciler struct {
+	cfg         *config.Config
+	logger      *zap.Logger
+	store       store.Store
+	publisher   events.Publisher
+	chainHeader ChainHeaderReader
+	merkle      *merkleservice.Client // nil ⇒ the /reprocess defer path is disabled
+	leaser      store.Leaser          // nil ⇒ single-replica mode, no lease gating
+	holderID    string
+
+	// defers counts how many ticks each orphan has waited for its height's
+	// canonical BUMP. In-memory by design: a restart resets the counts and
+	// the worst case is a bounded number of duplicate /reprocess calls —
+	// the same trade-off the watchdog makes with its attempt state.
+	defers map[string]int
+
+	now    func() time.Time
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// NewReconciler wires the anchor reconciler. Returns nil (service skipped)
+// when disabled by config or when no chain-header source exists — without
+// chaintracks there is no canonicality oracle, which is the same condition
+// under which the anchor guard and tie-scan are inert, so the process
+// degrades to legacy behavior as one coherent unit.
+func NewReconciler(
+	cfg *config.Config,
+	logger *zap.Logger,
+	st store.Store,
+	publisher events.Publisher,
+	chainHeader ChainHeaderReader,
+	merkle *merkleservice.Client,
+	leaser store.Leaser,
+) *Reconciler {
+	if !cfg.BumpBuilder.Reconciler.Enabled {
+		logger.Info("anchor reconciler disabled by config")
+		return nil
+	}
+	if chainHeader == nil {
+		logger.Info("anchor reconciler skipped: no chaintracks header source (enable chaintracks_server)")
+		return nil
+	}
+	host, _ := os.Hostname()
+	return &Reconciler{
+		cfg:         cfg,
+		logger:      logger.Named("anchor-reconciler"),
+		store:       st,
+		publisher:   publisher,
+		chainHeader: chainHeader,
+		merkle:      merkle,
+		leaser:      leaser,
+		holderID:    fmt.Sprintf("%s-%d", host, os.Getpid()),
+		defers:      make(map[string]int),
+		now:         time.Now,
+		done:        make(chan struct{}),
+	}
+}
+
+// Name implements services.Service.
+func (r *Reconciler) Name() string { return "anchor-reconciler" }
+
+// Start runs the reconcile loop until ctx is canceled. The optional startup
+// full-scan runs once (lease-gated) before the first tick.
+func (r *Reconciler) Start(ctx context.Context) error {
+	ctx, r.cancel = context.WithCancel(ctx)
+	defer close(r.done)
+
+	interval := time.Duration(r.cfg.BumpBuilder.Reconciler.IntervalMs) * time.Millisecond
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+
+	if r.cfg.BumpBuilder.Reconciler.StartupFullScan && r.acquireLease(ctx) {
+		r.fullScan(ctx)
+	}
+	r.tick(ctx)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			if r.leaser != nil {
+				releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+				_ = r.leaser.Release(releaseCtx, ReconcilerLeaseName, r.holderID)
+				cancel()
+			}
+			return nil
+		case <-ticker.C:
+			r.tick(ctx)
+		}
+	}
+}
+
+// Stop implements services.Service.
+func (r *Reconciler) Stop() error {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	<-r.done
+	return nil
+}
+
+// acquireLease reports whether this replica currently leads. A nil leaser
+// means single-replica mode (always lead); lease errors skip the tick.
+func (r *Reconciler) acquireLease(ctx context.Context) bool {
+	if r.leaser == nil {
+		return true
+	}
+	interval := time.Duration(r.cfg.BumpBuilder.Reconciler.IntervalMs) * time.Millisecond
+	ttl := 3 * interval
+	if ttl < time.Minute {
+		ttl = time.Minute
+	}
+	heldUntil, err := r.leaser.TryAcquireOrRenew(ctx, ReconcilerLeaseName, r.holderID, ttl)
+	if err != nil {
+		r.logger.Warn("lease check failed, skipping tick", zap.Error(err))
+		return false
+	}
+	return !heldUntil.IsZero()
+}
+
+// tick consumes one batch of the orphaned-block queue.
+func (r *Reconciler) tick(ctx context.Context) {
+	if ctx.Err() != nil || !r.acquireLease(ctx) {
+		return
+	}
+	blocksPerTick := r.cfg.BumpBuilder.Reconciler.BlocksPerTick
+	if blocksPerTick <= 0 {
+		blocksPerTick = 4
+	}
+	rows, err := r.store.ListOrphanedBlocksToReconcile(ctx, blocksPerTick)
+	if err != nil {
+		r.logger.Warn("failed to list orphaned blocks", zap.Error(err))
+		return
+	}
+	for _, row := range rows {
+		if ctx.Err() != nil {
+			return
+		}
+		start := r.now()
+		outcome := r.reconcileBlock(ctx, row)
+		metrics.ReconcilerBlocksTotal.WithLabelValues(outcome).Inc()
+		metrics.ReconcilerBlockDuration.Observe(time.Since(start).Seconds())
+	}
+}
+
+// fullScan pages the entire block_processing table and orphan-marks every
+// 'active' row whose height is provably held by a different block on the
+// active chain. Unbounded horizon by design: this is what picks up orphans
+// that predate the detection edges (guard, tie-scan, ReorgEvents) — e.g. an
+// incident block far below the current tip. Marked rows are then consumed
+// by the normal tick.
+func (r *Reconciler) fullScan(ctx context.Context) {
+	const page = 1000
+	var before uint64
+	var marked []string
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		rows, err := r.store.ListBlockProcessingStatus(ctx, before, page)
+		if err != nil {
+			r.logger.Warn("startup full-scan: list failed", zap.Error(err))
+			return
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, row := range rows {
+			if row.Status != models.BlockStatusActive || row.BlockHeight == 0 || row.BlockHeight > math.MaxUint32 {
+				continue
+			}
+			active, err := r.chainHeader.GetHeaderByHeight(ctx, uint32(row.BlockHeight))
+			if err != nil || active == nil {
+				continue
+			}
+			if active.Hash.String() != row.BlockHash {
+				marked = append(marked, row.BlockHash)
+			}
+		}
+		before = rows[len(rows)-1].BlockHeight
+		if len(rows) < page || before == 0 {
+			break
+		}
+	}
+	if len(marked) == 0 {
+		r.logger.Info("startup full-scan: no stale anchors found")
+		return
+	}
+	if err := r.store.MarkBlocksOrphaned(ctx, marked, r.now()); err != nil {
+		r.logger.Warn("startup full-scan: failed to mark orphaned", zap.Error(err))
+		return
+	}
+	r.logger.Info("startup full-scan: marked off-chain blocks orphaned",
+		zap.Strings("block_hashes", marked))
+}
+
+// reconcileBlock heals one orphaned block O and returns the metric outcome.
+//
+// Ordering matters: re-anchor runs BEFORE revert, so txs moved to a
+// canonical block have left O's index by the time SetStatusByBlockHash
+// computes the remainder. Crash-resume is idempotent for the same reason —
+// reconciled_at is stamped last, and a re-run finds only whatever the crash
+// left anchored to O.
+func (r *Reconciler) reconcileBlock(ctx context.Context, row *models.BlockProcessingStatus) string {
+	orphan := row.BlockHash
+	logger := r.logger.With(logfields.BlockHash(orphan))
+
+	// Resolve the orphan's height — the row may be a height-0 placeholder
+	// created by MarkBlockProcessed before any header arrived; the stored
+	// BUMP knows the height.
+	height := row.BlockHeight
+	if height == 0 {
+		if h, _, err := r.store.GetBUMP(ctx, orphan); err == nil {
+			height = h
+		}
+	}
+
+	// Resurrection short-circuit: the block is the active-chain block at
+	// its height again (flip-flop). Reset the row to active — the upsert
+	// also clears orphaned_at/reconciled_at — and leave its txs alone; the
+	// COMPETITOR is now the orphan and heals through its own row.
+	if height > 0 && height <= math.MaxUint32 {
+		if active, err := r.chainHeader.GetHeaderByHeight(ctx, uint32(height)); err == nil && active != nil &&
+			active.Hash.String() == orphan {
+			logger.Warn("orphan mark is stale — block is on the active chain; resetting to active")
+			if err := r.store.UpsertBlockHeaderSeen(ctx, orphan, height, r.now()); err != nil {
+				logger.Warn("failed to reset resurrected block", zap.Error(err))
+				return "error"
+			}
+			delete(r.defers, orphan)
+			return "resurrected"
+		}
+	}
+
+	// The canonical block at O's height: re-mine its FULL BUMP set first.
+	// This simultaneously (a) re-anchors O's txs that are in it, (b) mines
+	// txs the anchor guard correctly refused while the canonical block was
+	// still an alternate, and (c) is a no-op for rows already anchored
+	// right (onlyChanged filters their events). Missing canonical BUMP ⇒
+	// defer (optionally poking merkle-service /reprocess) up to the cap.
+	batchSize := r.cfg.BumpBuilder.Reconciler.BatchSize
+	if batchSize <= 0 {
+		batchSize = maxTxIDsPerBulkEvent
+	}
+	reanchored := 0
+	canonicalReady := false
+	var canonicalHash string
+	if height > 0 && height <= math.MaxUint32 {
+		if active, err := r.chainHeader.GetHeaderByHeight(ctx, uint32(height)); err == nil && active != nil {
+			canonicalHash = active.Hash.String()
+			if n, ok := r.remineFromStoredBUMP(ctx, logger, canonicalHash, batchSize); ok {
+				canonicalReady = true
+				reanchored += n
+			}
+		}
+	}
+	if !canonicalReady && canonicalHash != "" {
+		maxDefer := r.cfg.BumpBuilder.Reconciler.MaxDeferAttempts
+		if maxDefer <= 0 {
+			maxDefer = 10
+		}
+		if r.defers[orphan] < maxDefer {
+			r.defers[orphan]++
+			logger.Info("canonical block's BUMP not stored yet — deferring",
+				zap.String("canonical_block_hash", canonicalHash),
+				zap.Int("defer_attempt", r.defers[orphan]),
+			)
+			if r.merkle != nil && r.cfg.CallbackURL != "" {
+				if err := r.merkle.Reprocess(ctx, canonicalHash, r.cfg.CallbackURL, r.cfg.CallbackToken); err != nil {
+					logger.Warn("merkle-service /reprocess for canonical block failed", zap.Error(err))
+				}
+			}
+			return "deferred"
+		}
+		logger.Warn("defer cap reached without a canonical BUMP — falling back to revert-all "+
+			"(SEEN_ON_NETWORK → MINED is lattice-legal; a late canonical redelivery re-mines them)",
+			zap.String("canonical_block_hash", canonicalHash))
+	}
+
+	// Deep-reorg neighborhood: txs re-binned into LATER canonical blocks.
+	// Only the txs still anchored to O are candidates; membership is an
+	// O(1) lookup against each neighbor's stored compound BUMP.
+	affected, err := r.store.GetTxIDsByBlockHash(ctx, orphan)
+	if err != nil {
+		logger.Warn("failed to read affected txids", zap.Error(err))
+		return "error"
+	}
+	if len(affected) > 0 {
+		depth := r.cfg.BumpBuilder.Reconciler.NeighborhoodDepth
+		if depth < 0 {
+			depth = 0
+		}
+		for h := height + 1; h <= height+uint64(depth) && len(affected) > 0; h++ {
+			if h > math.MaxUint32 {
+				break
+			}
+			active, err := r.chainHeader.GetHeaderByHeight(ctx, uint32(h))
+			if err != nil || active == nil {
+				break // above the tip — nothing further to check
+			}
+			neighbor := active.Hash.String()
+			_, bumpBytes, err := r.store.GetBUMP(ctx, neighbor)
+			if err != nil || len(bumpBytes) == 0 {
+				continue
+			}
+			idx, err := bump.IndexCompound(bumpBytes)
+			if err != nil {
+				continue
+			}
+			var contained []string
+			var rest []string
+			for _, txid := range affected {
+				if idx.Contains(txid) {
+					contained = append(contained, txid)
+				} else {
+					rest = append(rest, txid)
+				}
+			}
+			if len(contained) > 0 {
+				for start := 0; start < len(contained); start += batchSize {
+					end := min(start+batchSize, len(contained))
+					reanchored += setMinedAndPublish(ctx, logger, r.store, r.publisher,
+						neighbor, h, contained[start:end], models.ExtraInfoReorgReanchor, true)
+				}
+			}
+			affected = rest
+		}
+	}
+
+	// Revert the remainder: everything still anchored to O exists in no
+	// canonical block we can prove — SEEN_ON_NETWORK puts them back in
+	// flight (rebroadcast/propagation owns them from here), and the store
+	// appends O to their orphaned-anchor history.
+	reverted, err := r.store.SetStatusByBlockHash(ctx, orphan, models.StatusSeenOnNetwork)
+	if err != nil {
+		logger.Warn("failed to revert remaining txs", zap.Error(err))
+		return "error"
+	}
+	r.publishReverted(ctx, logger, reverted)
+
+	// Cleanup: STUMPs are per-subtree intermediates, safe to drop. The
+	// compound BUMP is deliberately RETAINED — it serves the historical
+	// orphanedProofs on GET /tx and is the store-local re-anchor fuel if
+	// this block wins a later flip-flop.
+	if err := r.store.DeleteStumpsByBlockHash(ctx, orphan); err != nil {
+		logger.Warn("failed to clean up orphan STUMPs", zap.Error(err))
+	}
+	if err := r.store.MarkBlockReconciled(ctx, orphan, r.now()); err != nil {
+		logger.Warn("failed to stamp reconciled_at", zap.Error(err))
+		return "error"
+	}
+	delete(r.defers, orphan)
+
+	metrics.ReconcilerTxsReanchoredTotal.Add(float64(reanchored))
+	metrics.ReconcilerTxsRevertedTotal.Add(float64(len(reverted)))
+	logger.Info("orphaned block reconciled",
+		logfields.BlockHeight(height),
+		zap.String("canonical_block_hash", canonicalHash),
+		zap.Int("txs_reanchored", reanchored),
+		zap.Int("txs_reverted", len(reverted)),
+	)
+	switch {
+	case reanchored > 0 && len(reverted) > 0:
+		return "mixed"
+	case reanchored > 0:
+		return "reanchored"
+	case len(reverted) > 0:
+		return "reverted"
+	default:
+		return "empty"
+	}
+}
+
+// remineFromStoredBUMP re-mines every level-0 txid of blockHash's stored
+// compound BUMP against it (onlyChanged — no duplicate events for rows
+// already anchored right). ok=false when no usable BUMP is stored.
+func (r *Reconciler) remineFromStoredBUMP(ctx context.Context, logger *zap.Logger, blockHash string, batchSize int) (changed int, ok bool) {
+	bumpHeight, bumpBytes, err := r.store.GetBUMP(ctx, blockHash)
+	if err != nil || len(bumpBytes) == 0 {
+		return 0, false
+	}
+	txids, err := levelZeroTxidsFromBUMP(bumpBytes)
+	if err != nil {
+		logger.Warn("stored canonical BUMP failed to parse",
+			zap.String("canonical_block_hash", blockHash), zap.Error(err))
+		return 0, false
+	}
+	for start := 0; start < len(txids); start += batchSize {
+		end := min(start+batchSize, len(txids))
+		changed += setMinedAndPublish(ctx, logger, r.store, r.publisher,
+			blockHash, bumpHeight, txids[start:end], models.ExtraInfoReorgReanchor, true)
+	}
+	return changed, true
+}
+
+// publishReverted fans out the bulk SEEN_ON_NETWORK correction events for a
+// reorg revert, chunked like the MINED fan-out.
+func (r *Reconciler) publishReverted(ctx context.Context, logger *zap.Logger, txids []string) {
+	if len(txids) == 0 || r.publisher == nil {
+		return
+	}
+	for start := 0; start < len(txids); start += maxTxIDsPerBulkEvent {
+		end := min(start+maxTxIDsPerBulkEvent, len(txids))
+		template := &models.TransactionStatus{
+			Status:    models.StatusSeenOnNetwork,
+			Timestamp: r.now(),
+			TxIDs:     txids[start:end],
+			ExtraInfo: models.ExtraInfoReorgUnmined,
+		}
+		if err := r.publisher.PublishBulk(ctx, template); err != nil {
+			logger.Warn("failed to publish bulk reorg revert",
+				zap.Int("chunk_start", start),
+				zap.Error(err))
+		}
+	}
+}

--- a/services/bump_builder/reconciler.go
+++ b/services/bump_builder/reconciler.go
@@ -195,40 +195,36 @@ func (r *Reconciler) tick(ctx context.Context) {
 // by the normal tick.
 func (r *Reconciler) fullScan(ctx context.Context) {
 	const page = 1000
-	var before uint64
-	var marked []string
-	for {
-		if ctx.Err() != nil {
+	// A set, not a slice: the boundary-safe pager may visit a row more than
+	// once at page boundaries (see store.ForEachBlockProcessing).
+	markedSet := make(map[string]struct{})
+	err := store.ForEachBlockProcessing(ctx, r.store, 0, page, func(row *models.BlockProcessingStatus) error {
+		if row.Status != models.BlockStatusActive || row.BlockHeight == 0 || row.BlockHeight > math.MaxUint32 {
+			return nil
+		}
+		active, hdrErr := r.chainHeader.GetHeaderByHeight(ctx, uint32(row.BlockHeight))
+		if hdrErr != nil || active == nil {
+			return nil //nolint:nilerr // fail-open by contract: never orphan on absence of evidence
+		}
+		if active.Hash.String() != row.BlockHash {
+			markedSet[row.BlockHash] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		r.logger.Warn("startup full-scan: incomplete", zap.Error(err))
+		if len(markedSet) == 0 {
 			return
 		}
-		rows, err := r.store.ListBlockProcessingStatus(ctx, before, page)
-		if err != nil {
-			r.logger.Warn("startup full-scan: list failed", zap.Error(err))
-			return
-		}
-		if len(rows) == 0 {
-			break
-		}
-		for _, row := range rows {
-			if row.Status != models.BlockStatusActive || row.BlockHeight == 0 || row.BlockHeight > math.MaxUint32 {
-				continue
-			}
-			active, err := r.chainHeader.GetHeaderByHeight(ctx, uint32(row.BlockHeight))
-			if err != nil || active == nil {
-				continue
-			}
-			if active.Hash.String() != row.BlockHash {
-				marked = append(marked, row.BlockHash)
-			}
-		}
-		before = rows[len(rows)-1].BlockHeight
-		if len(rows) < page || before == 0 {
-			break
-		}
+		// Whatever was found before the failure still routes into healing.
 	}
-	if len(marked) == 0 {
+	if len(markedSet) == 0 {
 		r.logger.Info("startup full-scan: no stale anchors found")
 		return
+	}
+	marked := make([]string, 0, len(markedSet))
+	for hash := range markedSet {
+		marked = append(marked, hash)
 	}
 	if err := r.store.MarkBlocksOrphaned(ctx, marked, r.now()); err != nil {
 		r.logger.Warn("startup full-scan: failed to mark orphaned", zap.Error(err))

--- a/services/bump_builder/reconciler_test.go
+++ b/services/bump_builder/reconciler_test.go
@@ -1,0 +1,358 @@
+package bump_builder
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sdkchainhash "github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
+	"github.com/bsv-blockchain/arcade/store/pebble"
+)
+
+// Anchor-reconciler tests (issue #279) run against a REAL pebble store so
+// the whole re-anchor/revert path — block-hash index maintenance, orphaned-
+// anchor history, reconciled_at bookkeeping, crash-resume idempotency — is
+// exercised end to end, not mocked.
+
+const (
+	recOrphan    = "0d6be57a5be1776686ee44a4c93623940463ec598104734a723d66c43efc5100"
+	recCanonical = "7abcd229ab91a477e553deb8534d64a756410b6210af438b5b8c86eb4b5d6200"
+	recNeighbor  = "13cd9751d86c0831b029719d681c17683960a5a54de4c931a943695e86f1e200"
+
+	recShared1 = "624b7c58572e84d651f778a6142adb359e74786f12540c52cf39ff1ebc2dd700"
+	recShared2 = "40626a72baa61c5e9cad3a3b15e9e32f29ebb8760001cfe7707afa798d9dc900"
+	recAOnly   = "adba6f6c1840ccf5c17afdaec99c7467a525a951505bbcd34ad198a3fcfd8d00"
+	recBOnly   = "65bbf60c689560769e4cbc7fcb65a2a2c2a67c789c6fee4502ce70ad11427400"
+	recRebin   = "07722a1642bf1d059dfebb0b3a0200c4c600acdbc6c622b008e11a2f40fd7100"
+)
+
+func newPebbleForTest(t *testing.T) store.Store {
+	t.Helper()
+	st, err := pebble.New(config.Pebble{Path: t.TempDir()})
+	if err != nil {
+		t.Fatalf("pebble.New: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+// makeCompoundForTest builds a parseable BRC-74 compound with every txid as
+// a flagged level-0 leaf. Root validity doesn't matter here — the
+// reconciler only parses leaves and tests membership.
+func makeCompoundForTest(t *testing.T, blockHeight uint32, txids ...string) []byte {
+	t.Helper()
+	leaves := make([]*transaction.PathElement, 0, len(txids))
+	isTxid := true
+	for i, id := range txids {
+		h, err := sdkchainhash.NewHashFromHex(id)
+		if err != nil {
+			t.Fatalf("parse txid %s: %v", id, err)
+		}
+		leaves = append(leaves, &transaction.PathElement{
+			Offset: uint64(i), //nolint:gosec // tiny test values
+			Hash:   h,
+			Txid:   &isTxid,
+		})
+	}
+	return transaction.NewMerklePath(blockHeight, [][]*transaction.PathElement{leaves}).Bytes()
+}
+
+// seedMined registers rows and anchors them to blockHash at height.
+func seedMined(t *testing.T, st store.Store, blockHash string, height uint64, txids ...string) {
+	t.Helper()
+	ctx := context.Background()
+	for _, id := range txids {
+		if _, _, err := st.GetOrInsertStatus(ctx, &models.TransactionStatus{
+			TxID: id, Status: models.StatusSeenOnNetwork, Timestamp: time.Now(),
+		}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+	if _, _, err := st.SetMinedByTxIDs(ctx, blockHash, height, txids); err != nil {
+		t.Fatalf("seed mined: %v", err)
+	}
+}
+
+func seedSeen(t *testing.T, st store.Store, txids ...string) {
+	t.Helper()
+	ctx := context.Background()
+	for _, id := range txids {
+		if _, _, err := st.GetOrInsertStatus(ctx, &models.TransactionStatus{
+			TxID: id, Status: models.StatusSeenOnNetwork, Timestamp: time.Now(),
+		}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+}
+
+func newTestReconciler(st store.Store, pub *capturePublisher, stub *stubChaintracks, tweak func(*config.ReconcilerConfig)) *Reconciler {
+	cfg := &config.Config{BumpBuilder: config.BumpBuilderConfig{
+		AnchorGuardEnabled: true,
+		Reconciler: config.ReconcilerConfig{
+			Enabled:           true,
+			IntervalMs:        50,
+			BatchSize:         100,
+			BlocksPerTick:     10,
+			NeighborhoodDepth: 6,
+			MaxDeferAttempts:  3,
+		},
+	}}
+	if tweak != nil {
+		tweak(&cfg.BumpBuilder.Reconciler)
+	}
+	return &Reconciler{
+		cfg:         cfg,
+		logger:      zap.NewNop(),
+		store:       st,
+		publisher:   pub,
+		chainHeader: stub,
+		defers:      make(map[string]int),
+		now:         time.Now,
+		done:        make(chan struct{}),
+	}
+}
+
+func statusOf(t *testing.T, st store.Store, txid string) *models.TransactionStatus {
+	t.Helper()
+	got, err := st.GetStatus(context.Background(), txid)
+	if err != nil || got == nil {
+		t.Fatalf("GetStatus %s: %v (nil=%v)", txid, err, got == nil)
+	}
+	return got
+}
+
+// TestReconciler_MixedReanchorAndRevert is the incident in miniature: the
+// orphan's shared txs re-anchor to the canonical block (whose stored BUMP
+// is the fuel), the guard-denied canonical-only tx finally mines, and the
+// orphan-only tx reverts to SEEN_ON_NETWORK — with corrected events,
+// orphaned-anchor history, STUMP cleanup, and a reconciled_at stamp. A
+// second pass proves idempotency (crash-resume contract).
+func TestReconciler_MixedReanchorAndRevert(t *testing.T) {
+	ctx := context.Background()
+	st := newPebbleForTest(t)
+	pub := &capturePublisher{}
+	stub := &stubChaintracks{}
+	stub.setHeightHeader(10, headerWithHash(t, recCanonical, 10))
+
+	// State as the reorg left it: shared+bOnly MINED@orphan, aOnly SEEN
+	// (the write guard refused it while the canonical block was an
+	// alternate), canonical BUMP stored, orphan row queued.
+	seedMined(t, st, recOrphan, 10, recShared1, recShared2, recBOnly)
+	seedSeen(t, st, recAOnly)
+	if err := st.InsertBUMP(ctx, recCanonical, 10, makeCompoundForTest(t, 10, recShared1, recShared2, recAOnly)); err != nil {
+		t.Fatalf("insert canonical BUMP: %v", err)
+	}
+	if err := st.InsertStump(ctx, &models.Stump{BlockHash: recOrphan, SubtreeIndex: 0, StumpData: []byte{0x01}}); err != nil {
+		t.Fatalf("insert stump: %v", err)
+	}
+	if err := st.UpsertBlockHeaderSeen(ctx, recOrphan, 10, time.Now()); err != nil {
+		t.Fatalf("upsert orphan row: %v", err)
+	}
+	if err := st.MarkBlocksOrphaned(ctx, []string{recOrphan}, time.Now()); err != nil {
+		t.Fatalf("mark orphaned: %v", err)
+	}
+
+	r := newTestReconciler(st, pub, stub, nil)
+	r.tick(ctx)
+
+	// Shared txs re-anchored with the orphan preserved as history.
+	for _, id := range []string{recShared1, recShared2} {
+		got := statusOf(t, st, id)
+		if got.Status != models.StatusMined || got.BlockHash != recCanonical {
+			t.Fatalf("%s: want MINED@%s, got %s@%s", id, recCanonical, got.Status, got.BlockHash)
+		}
+		if len(got.OrphanedProofs) != 1 || got.OrphanedProofs[0].BlockHash != recOrphan {
+			t.Fatalf("%s: want orphaned-anchor history [%s], got %+v", id, recOrphan, got.OrphanedProofs)
+		}
+	}
+	// The guard-denied canonical-only tx finally mined.
+	if got := statusOf(t, st, recAOnly); got.Status != models.StatusMined || got.BlockHash != recCanonical {
+		t.Fatalf("aOnly: want MINED@%s, got %s@%s", recCanonical, got.Status, got.BlockHash)
+	}
+	// The orphan-only tx reverted, history preserved, block fields cleared.
+	if got := statusOf(t, st, recBOnly); got.Status != models.StatusSeenOnNetwork || got.BlockHash != "" ||
+		len(got.OrphanedProofs) != 1 || got.OrphanedProofs[0].BlockHash != recOrphan {
+		t.Fatalf("bOnly: want reverted SEEN with history, got %+v", got)
+	}
+	// STUMPs pruned; the orphan's BUMP retained (historical proofs).
+	if stumps, _ := st.GetStumpsByBlockHash(ctx, recOrphan); len(stumps) != 0 {
+		t.Fatalf("orphan STUMPs must be pruned, got %d", len(stumps))
+	}
+	// Row stamped reconciled and off the queue.
+	if rows, err := st.ListOrphanedBlocksToReconcile(ctx, 10); err != nil || len(rows) != 0 {
+		t.Fatalf("queue must be empty after reconcile: rows=%v err=%v", rows, err)
+	}
+	bp, err := st.GetBlockProcessingStatus(ctx, recOrphan)
+	if err != nil || bp.ReconciledAt == nil {
+		t.Fatalf("reconciled_at must be stamped, got %+v err=%v", bp, err)
+	}
+
+	// Corrected events: one MINED bulk (re-anchor marker, canonical block,
+	// covering shared+aOnly) and one SEEN bulk (revert marker, bOnly).
+	var minedEv, seenEv *models.TransactionStatus
+	for _, ev := range pub.bulkEvents() {
+		switch ev.ExtraInfo {
+		case models.ExtraInfoReorgReanchor:
+			minedEv = ev
+		case models.ExtraInfoReorgUnmined:
+			seenEv = ev
+		}
+	}
+	if minedEv == nil || minedEv.BlockHash != recCanonical || len(minedEv.TxIDs) != 3 {
+		t.Fatalf("re-anchor event wrong: %+v", minedEv)
+	}
+	if seenEv == nil || len(seenEv.TxIDs) != 1 || seenEv.TxIDs[0] != recBOnly {
+		t.Fatalf("revert event wrong: %+v", seenEv)
+	}
+
+	// Idempotency: a second tick finds an empty queue and publishes nothing.
+	before := len(pub.bulkEvents())
+	r.tick(ctx)
+	if after := len(pub.bulkEvents()); after != before {
+		t.Fatalf("second tick must be a no-op, events %d → %d", before, after)
+	}
+}
+
+// TestReconciler_ResurrectedBlockResetsRow: a stale orphan mark on a block
+// that IS the active-chain block at its height resets the row to active
+// without touching transactions.
+func TestReconciler_ResurrectedBlockResetsRow(t *testing.T) {
+	ctx := context.Background()
+	st := newPebbleForTest(t)
+	pub := &capturePublisher{}
+	stub := &stubChaintracks{}
+	stub.setHeightHeader(10, headerWithHash(t, recOrphan, 10)) // the "orphan" is actually active
+
+	seedMined(t, st, recOrphan, 10, recShared1)
+	_ = st.UpsertBlockHeaderSeen(ctx, recOrphan, 10, time.Now())
+	_ = st.MarkBlocksOrphaned(ctx, []string{recOrphan}, time.Now())
+
+	r := newTestReconciler(st, pub, stub, nil)
+	r.tick(ctx)
+
+	if got := statusOf(t, st, recShared1); got.Status != models.StatusMined || got.BlockHash != recOrphan {
+		t.Fatalf("resurrected block's txs must be untouched, got %s@%s", got.Status, got.BlockHash)
+	}
+	bp, err := st.GetBlockProcessingStatus(ctx, recOrphan)
+	if err != nil || bp.Status != models.BlockStatusActive || bp.OrphanedAt != nil || bp.ReconciledAt != nil {
+		t.Fatalf("row must be reset to active with orphan/reconcile marks cleared, got %+v err=%v", bp, err)
+	}
+}
+
+// TestReconciler_DefersUntilCanonicalBUMPArrives: no canonical BUMP yet →
+// the orphan stays queued and its txs untouched; once the BUMP lands the
+// next tick heals.
+func TestReconciler_DefersUntilCanonicalBUMPArrives(t *testing.T) {
+	ctx := context.Background()
+	st := newPebbleForTest(t)
+	pub := &capturePublisher{}
+	stub := &stubChaintracks{}
+	stub.setHeightHeader(10, headerWithHash(t, recCanonical, 10))
+
+	seedMined(t, st, recOrphan, 10, recShared1)
+	_ = st.UpsertBlockHeaderSeen(ctx, recOrphan, 10, time.Now())
+	_ = st.MarkBlocksOrphaned(ctx, []string{recOrphan}, time.Now())
+
+	r := newTestReconciler(st, pub, stub, nil)
+	r.tick(ctx)
+
+	if got := statusOf(t, st, recShared1); got.BlockHash != recOrphan {
+		t.Fatalf("deferred orphan's txs must be untouched, got anchored to %s", got.BlockHash)
+	}
+	if rows, _ := st.ListOrphanedBlocksToReconcile(ctx, 10); len(rows) != 1 {
+		t.Fatalf("deferred orphan must stay queued, got %d rows", len(rows))
+	}
+
+	if err := st.InsertBUMP(ctx, recCanonical, 10, makeCompoundForTest(t, 10, recShared1)); err != nil {
+		t.Fatalf("insert canonical BUMP: %v", err)
+	}
+	r.tick(ctx)
+	if got := statusOf(t, st, recShared1); got.BlockHash != recCanonical {
+		t.Fatalf("post-BUMP tick must re-anchor, got %s", got.BlockHash)
+	}
+}
+
+// TestReconciler_DeferCapFallsBackToRevert: when the canonical BUMP never
+// arrives, the defer cap converts the orphan to revert-all — safe because
+// SEEN_ON_NETWORK → MINED is lattice-legal on a later redelivery.
+func TestReconciler_DeferCapFallsBackToRevert(t *testing.T) {
+	ctx := context.Background()
+	st := newPebbleForTest(t)
+	pub := &capturePublisher{}
+	stub := &stubChaintracks{}
+	stub.setHeightHeader(10, headerWithHash(t, recCanonical, 10))
+
+	seedMined(t, st, recOrphan, 10, recShared1)
+	_ = st.UpsertBlockHeaderSeen(ctx, recOrphan, 10, time.Now())
+	_ = st.MarkBlocksOrphaned(ctx, []string{recOrphan}, time.Now())
+
+	r := newTestReconciler(st, pub, stub, func(c *config.ReconcilerConfig) { c.MaxDeferAttempts = 1 })
+	r.tick(ctx) // defer 1/1
+	r.tick(ctx) // cap reached → revert-all
+
+	if got := statusOf(t, st, recShared1); got.Status != models.StatusSeenOnNetwork || got.BlockHash != "" {
+		t.Fatalf("defer-cap fallback must revert, got %s@%s", got.Status, got.BlockHash)
+	}
+	if rows, _ := st.ListOrphanedBlocksToReconcile(ctx, 10); len(rows) != 0 {
+		t.Fatalf("orphan must be reconciled after the fallback, got %d rows", len(rows))
+	}
+}
+
+// TestReconciler_NeighborhoodReanchor: a deep-reorg tx re-binned into a
+// LATER canonical block re-anchors there via the membership check.
+func TestReconciler_NeighborhoodReanchor(t *testing.T) {
+	ctx := context.Background()
+	st := newPebbleForTest(t)
+	pub := &capturePublisher{}
+	stub := &stubChaintracks{}
+	stub.setHeightHeader(10, headerWithHash(t, recCanonical, 10))
+	stub.setHeightHeader(11, headerWithHash(t, recNeighbor, 11))
+
+	seedMined(t, st, recOrphan, 10, recRebin)
+	// Canonical block at 10 does NOT contain the tx; the block at 11 does.
+	_ = st.InsertBUMP(ctx, recCanonical, 10, makeCompoundForTest(t, 10, recShared1))
+	_ = st.InsertBUMP(ctx, recNeighbor, 11, makeCompoundForTest(t, 11, recRebin))
+	_ = st.UpsertBlockHeaderSeen(ctx, recOrphan, 10, time.Now())
+	_ = st.MarkBlocksOrphaned(ctx, []string{recOrphan}, time.Now())
+
+	r := newTestReconciler(st, pub, stub, nil)
+	r.tick(ctx)
+
+	if got := statusOf(t, st, recRebin); got.Status != models.StatusMined || got.BlockHash != recNeighbor || got.BlockHeight != 11 {
+		t.Fatalf("re-binned tx must anchor to the neighbor block, got %s@%s h%d", got.Status, got.BlockHash, got.BlockHeight)
+	}
+}
+
+// TestReconciler_FullScanDetectsStaleAnchors: the startup sweep finds an
+// 'active' row whose height is held by a different block — the recovery
+// path for incidents that predate the detection edges (the height-764
+// scale-cluster block).
+func TestReconciler_FullScanDetectsStaleAnchors(t *testing.T) {
+	ctx := context.Background()
+	st := newPebbleForTest(t)
+	pub := &capturePublisher{}
+	stub := &stubChaintracks{}
+	stub.setHeightHeader(10, headerWithHash(t, recCanonical, 10))
+
+	seedMined(t, st, recOrphan, 10, recShared1)
+	_ = st.InsertBUMP(ctx, recCanonical, 10, makeCompoundForTest(t, 10, recShared1))
+	_ = st.UpsertBlockHeaderSeen(ctx, recOrphan, 10, time.Now()) // still 'active' — nothing ever detected it
+	_ = st.UpsertBlockHeaderSeen(ctx, recCanonical, 10, time.Now())
+
+	r := newTestReconciler(st, pub, stub, nil)
+	r.fullScan(ctx)
+	r.tick(ctx)
+
+	if got := statusOf(t, st, recShared1); got.Status != models.StatusMined || got.BlockHash != recCanonical {
+		t.Fatalf("full-scan must route the stale anchor into healing, got %s@%s", got.Status, got.BlockHash)
+	}
+	if len(pub.bulkEvents()) == 0 {
+		t.Fatal("expected corrected events from the full-scan heal")
+	}
+}

--- a/services/bump_builder/reconciler_test.go
+++ b/services/bump_builder/reconciler_test.go
@@ -55,7 +55,7 @@ func makeCompoundForTest(t *testing.T, blockHeight uint32, txids ...string) []by
 			t.Fatalf("parse txid %s: %v", id, err)
 		}
 		leaves = append(leaves, &transaction.PathElement{
-			Offset: uint64(i), //nolint:gosec // tiny test values
+			Offset: uint64(i),
 			Hash:   h,
 			Txid:   &isTxid,
 		})

--- a/services/bump_builder/reorg_guard_test.go
+++ b/services/bump_builder/reorg_guard_test.go
@@ -24,6 +24,7 @@ import (
 // MarkBlocksOrphaned (the embedded interface would panic).
 type orphanRecordingStore struct {
 	*mockStore
+
 	orphanMu      sync.Mutex
 	orphanedCalls [][]string
 }
@@ -229,12 +230,14 @@ func TestTryShortCircuit_GuardAllowsActiveBlock(t *testing.T) {
 // exercise setMinedAndPublish's onlyChanged filtering.
 type prevSeedingStore struct {
 	*mockStore
+
 	prevByTxid map[string]*models.TransactionStatus
 }
 
 func (s *prevSeedingStore) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, []*models.TransactionStatus, error) {
 	_, _, _ = s.mockStore.SetMinedByTxIDs(ctx, blockHash, blockHeight, txids) // record the call
-	var prevs, mined []*models.TransactionStatus
+	prevs := make([]*models.TransactionStatus, 0, len(txids))
+	mined := make([]*models.TransactionStatus, 0, len(txids))
 	for _, txid := range txids {
 		prev := s.prevByTxid[txid]
 		if prev == nil {

--- a/services/bump_builder/reorg_guard_test.go
+++ b/services/bump_builder/reorg_guard_test.go
@@ -1,0 +1,295 @@
+package bump_builder
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	chaintrackslib "github.com/bsv-blockchain/go-chaintracks/chaintracks"
+	sdkchainhash "github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// Anchor-guard unit tests (issue #279): bump-builder must refuse to mark a
+// block's txs MINED when chaintracks' active chain provably holds a
+// different block at its height, on both the fresh-build and the
+// short-circuit redelivery paths — and must fail open on any uncertainty.
+
+// orphanRecordingStore extends mockStore with a recording
+// MarkBlocksOrphaned (the embedded interface would panic).
+type orphanRecordingStore struct {
+	*mockStore
+	orphanMu      sync.Mutex
+	orphanedCalls [][]string
+}
+
+func (s *orphanRecordingStore) MarkBlocksOrphaned(_ context.Context, hashes []string, _ time.Time) error {
+	s.orphanMu.Lock()
+	defer s.orphanMu.Unlock()
+	s.orphanedCalls = append(s.orphanedCalls, append([]string(nil), hashes...))
+	return nil
+}
+
+// capturePublisher records PublishBulk templates.
+type capturePublisher struct {
+	mu        sync.Mutex
+	bulks     []*models.TransactionStatus
+	singles   []*models.TransactionStatus
+	subscribe chan *models.TransactionStatus
+}
+
+func (p *capturePublisher) Publish(_ context.Context, st *models.TransactionStatus) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.singles = append(p.singles, st)
+	return nil
+}
+
+func (p *capturePublisher) PublishBulk(_ context.Context, template *models.TransactionStatus) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	cp := *template
+	cp.TxIDs = append([]string(nil), template.TxIDs...)
+	p.bulks = append(p.bulks, &cp)
+	return nil
+}
+
+func (p *capturePublisher) Subscribe(context.Context, string) (<-chan *models.TransactionStatus, error) {
+	if p.subscribe == nil {
+		p.subscribe = make(chan *models.TransactionStatus, 16)
+	}
+	return p.subscribe, nil
+}
+
+func (p *capturePublisher) Close() error { return nil }
+
+func (p *capturePublisher) bulkEvents() []*models.TransactionStatus {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]*models.TransactionStatus(nil), p.bulks...)
+}
+
+func headerWithHash(t *testing.T, hashHex string, height uint32) *chaintrackslib.BlockHeader {
+	t.Helper()
+	h, err := sdkchainhash.NewHashFromHex(hashHex)
+	if err != nil {
+		t.Fatalf("parse hash %s: %v", hashHex, err)
+	}
+	return &chaintrackslib.BlockHeader{Height: height, Hash: *h}
+}
+
+const (
+	guardBlockA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	guardBlockB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	guardTxid   = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+)
+
+func guardBuilder(st *orphanRecordingStore, stub *stubChaintracks, enabled bool) *Builder {
+	return &Builder{
+		cfg: &config.Config{
+			BumpBuilder: config.BumpBuilderConfig{AnchorGuardEnabled: enabled},
+		},
+		logger:      zap.NewNop(),
+		store:       st,
+		chainHeader: stub,
+	}
+}
+
+func TestAnchorDecision_AllowsActiveBlock(t *testing.T) {
+	stub := &stubChaintracks{}
+	stub.setHeightHeader(10, headerWithHash(t, guardBlockA, 10))
+	b := guardBuilder(&orphanRecordingStore{mockStore: newMockStore()}, stub, true)
+
+	if got := b.anchorDecision(context.Background(), zap.NewNop(), guardBlockA, 10); got != anchorAllow {
+		t.Fatalf("active-chain block must be allowed, got %v", got)
+	}
+}
+
+func TestAnchorDecision_DeniesSameHeightLoser(t *testing.T) {
+	stub := &stubChaintracks{}
+	stub.setHeightHeader(10, headerWithHash(t, guardBlockA, 10))
+	b := guardBuilder(&orphanRecordingStore{mockStore: newMockStore()}, stub, true)
+
+	if got := b.anchorDecision(context.Background(), zap.NewNop(), guardBlockB, 10); got != anchorDeny {
+		t.Fatalf("competitor of the active block must be denied, got %v", got)
+	}
+}
+
+// TestAnchorDecision_FailsOpen pins the fail-open posture: denial requires
+// positive evidence, everything else allows.
+func TestAnchorDecision_FailsOpen(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	// Unknown height: chaintracks lags the Kafka path.
+	stub := &stubChaintracks{}
+	b := guardBuilder(&orphanRecordingStore{mockStore: newMockStore()}, stub, true)
+	if got := b.anchorDecision(ctx, logger, guardBlockB, 10); got != anchorAllow {
+		t.Fatalf("unknown height must fail open, got %v", got)
+	}
+
+	// Lookup error.
+	stubErr := &stubChaintracks{err: context.DeadlineExceeded}
+	b = guardBuilder(&orphanRecordingStore{mockStore: newMockStore()}, stubErr, true)
+	if got := b.anchorDecision(ctx, logger, guardBlockB, 10); got != anchorAllow {
+		t.Fatalf("lookup error must fail open, got %v", got)
+	}
+
+	// Height 0 (placeholder rows / unknown height).
+	if got := b.anchorDecision(ctx, logger, guardBlockB, 0); got != anchorAllow {
+		t.Fatalf("height 0 must fail open, got %v", got)
+	}
+
+	// Guard disabled by config.
+	stub2 := &stubChaintracks{}
+	stub2.setHeightHeader(10, headerWithHash(t, guardBlockA, 10))
+	b = guardBuilder(&orphanRecordingStore{mockStore: newMockStore()}, stub2, false)
+	if got := b.anchorDecision(ctx, logger, guardBlockB, 10); got != anchorAllow {
+		t.Fatalf("disabled guard must allow, got %v", got)
+	}
+
+	// No chainHeader wired at all.
+	b = &Builder{cfg: &config.Config{BumpBuilder: config.BumpBuilderConfig{AnchorGuardEnabled: true}}, logger: logger, store: newMockStore()}
+	if got := b.anchorDecision(ctx, logger, guardBlockB, 10); got != anchorAllow {
+		t.Fatalf("nil chainHeader must allow, got %v", got)
+	}
+}
+
+// TestTryShortCircuit_GuardDeniesRedelivery: a replayed BLOCK_PROCESSED for
+// a block that lost its height must not re-anchor txs from its stored BUMP.
+// The block is finalized (processed stamp), orphan-marked into the
+// reconciler queue, and its STUMPs pruned — with ZERO MINED writes.
+func TestTryShortCircuit_GuardDeniesRedelivery(t *testing.T) {
+	ms := &orphanRecordingStore{mockStore: newMockStore()}
+	ms.mu.Lock()
+	ms.bumps[guardBlockB] = makeMinimalSTUMPAtHeight(t, guardTxid, 10)
+	ms.bumpHeights[guardBlockB] = 10
+	ms.mu.Unlock()
+
+	stub := &stubChaintracks{}
+	stub.setHeightHeader(10, headerWithHash(t, guardBlockA, 10)) // A holds height 10
+
+	b := guardBuilder(ms, stub, true)
+	if !b.tryShortCircuit(context.Background(), zap.NewNop(), guardBlockB) {
+		t.Fatal("short-circuit should have handled the redelivery")
+	}
+
+	ms.mu.Lock()
+	mined := len(ms.minedCalls)
+	processed := len(ms.processedCalls)
+	deleted := append([]string(nil), ms.deletedBlocks...)
+	ms.mu.Unlock()
+	if mined != 0 {
+		t.Fatalf("guard-denied redelivery must not mark MINED, got %d calls", mined)
+	}
+	if processed != 1 {
+		t.Fatalf("denied block must still be stamped processed, got %d", processed)
+	}
+	if len(deleted) != 1 || deleted[0] != guardBlockB {
+		t.Fatalf("denied block's STUMPs must be pruned, got %v", deleted)
+	}
+	ms.orphanMu.Lock()
+	orphaned := append([][]string(nil), ms.orphanedCalls...)
+	ms.orphanMu.Unlock()
+	if len(orphaned) != 1 || len(orphaned[0]) != 1 || orphaned[0][0] != guardBlockB {
+		t.Fatalf("denied block must be orphan-marked for the reconciler, got %v", orphaned)
+	}
+}
+
+// TestTryShortCircuit_GuardAllowsActiveBlock: the same redelivery marks
+// MINED when the block IS the active-chain block at its height.
+func TestTryShortCircuit_GuardAllowsActiveBlock(t *testing.T) {
+	ms := &orphanRecordingStore{mockStore: newMockStore()}
+	ms.mu.Lock()
+	ms.bumps[guardBlockB] = makeMinimalSTUMPAtHeight(t, guardTxid, 10)
+	ms.bumpHeights[guardBlockB] = 10
+	ms.mu.Unlock()
+
+	stub := &stubChaintracks{}
+	stub.setHeightHeader(10, headerWithHash(t, guardBlockB, 10))
+
+	b := guardBuilder(ms, stub, true)
+	if !b.tryShortCircuit(context.Background(), zap.NewNop(), guardBlockB) {
+		t.Fatal("short-circuit should have handled the redelivery")
+	}
+
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if len(ms.minedCalls) != 1 || ms.minedCalls[0].blockHash != guardBlockB {
+		t.Fatalf("active block's redelivery must mark MINED, got %v", ms.minedCalls)
+	}
+}
+
+// prevSeedingStore lets a test script the prevs SetMinedByTxIDs returns, to
+// exercise setMinedAndPublish's onlyChanged filtering.
+type prevSeedingStore struct {
+	*mockStore
+	prevByTxid map[string]*models.TransactionStatus
+}
+
+func (s *prevSeedingStore) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, []*models.TransactionStatus, error) {
+	_, _, _ = s.mockStore.SetMinedByTxIDs(ctx, blockHash, blockHeight, txids) // record the call
+	var prevs, mined []*models.TransactionStatus
+	for _, txid := range txids {
+		prev := s.prevByTxid[txid]
+		if prev == nil {
+			prev = &models.TransactionStatus{TxID: txid, Status: models.StatusSeenOnNetwork, Timestamp: time.Now()}
+		}
+		prevs = append(prevs, prev)
+		mined = append(mined, &models.TransactionStatus{
+			TxID: txid, Status: models.StatusMined,
+			BlockHash: blockHash, BlockHeight: blockHeight, Timestamp: time.Now(),
+		})
+	}
+	return prevs, mined, nil
+}
+
+// TestSetMinedAndPublish_OnlyChangedFiltersEvents: rows already anchored to
+// the target block must not produce duplicate events on a reconciler
+// re-mine; rows re-anchored from another block and fresh mines must.
+func TestSetMinedAndPublish_OnlyChangedFiltersEvents(t *testing.T) {
+	txAlready, txReanchor, txFresh := "1111", "2222", "3333"
+	st := &prevSeedingStore{
+		mockStore: newMockStore(),
+		prevByTxid: map[string]*models.TransactionStatus{
+			txAlready:  {TxID: txAlready, Status: models.StatusMined, BlockHash: guardBlockA, Timestamp: time.Now()},
+			txReanchor: {TxID: txReanchor, Status: models.StatusMined, BlockHash: guardBlockB, Timestamp: time.Now()},
+			txFresh:    {TxID: txFresh, Status: models.StatusSeenOnNetwork, Timestamp: time.Now()},
+		},
+	}
+	pub := &capturePublisher{}
+
+	changed := setMinedAndPublish(context.Background(), zap.NewNop(), st, pub,
+		guardBlockA, 10, []string{txAlready, txReanchor, txFresh},
+		models.ExtraInfoReorgReanchor, true)
+	if changed != 2 {
+		t.Fatalf("expected 2 changed rows (re-anchor + fresh), got %d", changed)
+	}
+
+	bulks := pub.bulkEvents()
+	if len(bulks) != 1 {
+		t.Fatalf("expected 1 bulk event, got %d", len(bulks))
+	}
+	ev := bulks[0]
+	if ev.ExtraInfo != models.ExtraInfoReorgReanchor {
+		t.Fatalf("bulk event must carry the re-anchor marker, got %q", ev.ExtraInfo)
+	}
+	if ev.BlockHash != guardBlockA || len(ev.TxIDs) != 2 {
+		t.Fatalf("unexpected bulk event: block=%s txids=%v", ev.BlockHash, ev.TxIDs)
+	}
+	for _, id := range ev.TxIDs {
+		if id == txAlready {
+			t.Fatalf("already-anchored tx must be filtered from the fan-out, got %v", ev.TxIDs)
+		}
+	}
+}
+
+// mustHashGuard keeps the transaction import used (NewMerklePath helpers
+// live in builder_test.go); referenced here to avoid an unused-import churn
+// if helpers move.
+var _ = transaction.NewMerklePath

--- a/services/chaintracks_server/block_status_tracker.go
+++ b/services/chaintracks_server/block_status_tracker.go
@@ -2,38 +2,62 @@ package chaintracks_server
 
 import (
 	"context"
+	"math"
+	"sync"
 	"time"
 
 	"github.com/bsv-blockchain/go-chaintracks/chaintracks"
 	"go.uber.org/zap"
 
+	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/logfields"
+	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/store"
 )
 
 // blockStatusTracker subscribes to chaintracks tip + reorg channels and
-// translates each event into a write against the block-processing table:
+// translates each event into writes against the block-processing table:
 //
-//   - Tip headers       → UpsertBlockHeaderSeen
+//   - Tip headers       → UpsertBlockHeaderSeen, then a tie-scan
 //   - ReorgEvent.Orphans → MarkBlocksOrphaned (then upsert the new tip)
+//
+// The tie-scan (issue #279) is the detection edge chaintracks itself cannot
+// provide: a same-height competition loser has EQUAL chainwork, never
+// becomes tip, and therefore never appears in a ReorgEvent — yet
+// bump-builder may have anchored transactions to it. On each tip update the
+// scan re-verifies every 'active' block_processing row within
+// chaintracks_server.tie_scan_depth of the tip against the active chain and
+// marks mismatches orphaned, feeding the anchor reconciler's queue.
 //
 // chaintracks.Subscribe is a fan-out broadcaster, so this subscription does
 // not contend with the existing SSE one in chaintracksRoutes.
 //
 // Drop-on-overflow: chaintracks's broadcast does a non-blocking send onto a
 // buffer-1 channel. If a store write stalls long enough, a tip can be
-// silently dropped. The tracker is not load-bearing for correctness — the
-// table is observability-first, and the next header arrival overwrites
-// block_height — so we accept that risk in v1 and keep the loops simple.
+// silently dropped. That is acceptable for the orphan detection too: the
+// NEXT tip re-runs the scan over the whole window, and the anchor
+// reconciler's startup full-scan is the deep backstop.
 type blockStatusTracker struct {
 	store  store.Store
+	ct     chaintracks.Chaintracks
 	logger *zap.Logger
+
+	scanDepth       int
+	scanMinInterval time.Duration
+
+	// scanMu serializes tie-scans across the header and reorg loops and
+	// guards lastScan for the debounce.
+	scanMu   sync.Mutex
+	lastScan time.Time
 }
 
-func newBlockStatusTracker(ctx context.Context, cm chaintracks.Chaintracks, st store.Store, logger *zap.Logger) *blockStatusTracker {
+func newBlockStatusTracker(ctx context.Context, cfg *config.Config, cm chaintracks.Chaintracks, st store.Store, logger *zap.Logger) *blockStatusTracker {
 	t := &blockStatusTracker{
-		store:  st,
-		logger: logger.Named("block-status"),
+		store:           st,
+		ct:              cm,
+		logger:          logger.Named("block-status"),
+		scanDepth:       cfg.ChaintracksServer.TieScanDepth,
+		scanMinInterval: time.Duration(cfg.ChaintracksServer.TieScanMinIntervalMs) * time.Millisecond,
 	}
 	go t.runHeaderLoop(ctx, cm.Subscribe(ctx))
 	go t.runReorgLoop(ctx, cm.SubscribeReorg(ctx))
@@ -53,6 +77,7 @@ func (t *blockStatusTracker) runHeaderLoop(ctx context.Context, ch <-chan *chain
 				continue
 			}
 			t.recordHeader(ctx, h)
+			t.scanRecentActive(ctx, h.Height)
 		}
 	}
 }
@@ -70,6 +95,9 @@ func (t *blockStatusTracker) runReorgLoop(ctx context.Context, ch <-chan *chaint
 				continue
 			}
 			t.recordReorg(ctx, ev)
+			if ev.NewTip != nil {
+				t.scanRecentActive(ctx, ev.NewTip.Height)
+			}
 		}
 	}
 }
@@ -103,4 +131,71 @@ func (t *blockStatusTracker) recordReorg(ctx context.Context, ev *chaintracks.Re
 	if ev.NewTip != nil {
 		t.recordHeader(ctx, ev.NewTip)
 	}
+}
+
+// scanRecentActive verifies that every 'active' block_processing row within
+// scanDepth of the tip is still the active-chain block at its height, and
+// marks mismatches orphaned exactly as if a ReorgEvent had named them. This
+// catches the no-event case: a same-height loser filed by chaintracks as an
+// equal-work alternate (issue #279). Debounced to one scan per
+// scanMinInterval so regtest tip bursts and catch-up syncs don't hammer the
+// table; cost is otherwise ≤ a few header lookups against the in-memory
+// chain index plus one small table page.
+func (t *blockStatusTracker) scanRecentActive(ctx context.Context, tipHeight uint32) {
+	if t.scanDepth <= 0 || t.ct == nil {
+		return
+	}
+	t.scanMu.Lock()
+	defer t.scanMu.Unlock()
+	if !t.lastScan.IsZero() && time.Since(t.lastScan) < t.scanMinInterval {
+		return
+	}
+	t.lastScan = time.Now()
+
+	minHeight := uint64(1)
+	if uint64(tipHeight) > uint64(t.scanDepth) {
+		minHeight = uint64(tipHeight) - uint64(t.scanDepth)
+	}
+	// The list is height-DESC; a window of depth heights can hold a few
+	// competitors per height, so over-fetch generously and filter. The
+	// height-0 placeholder rows MarkBlockProcessed creates before any
+	// header arrives are excluded by the height filter.
+	rows, err := t.store.ListBlockProcessingStatus(ctx, 0, t.scanDepth*4)
+	if err != nil {
+		t.logger.Warn("tie-scan: failed to list block_processing rows", zap.Error(err))
+		return
+	}
+
+	var orphaned []string
+	for _, row := range rows {
+		if row.Status != models.BlockStatusActive ||
+			row.BlockHeight < minHeight ||
+			row.BlockHeight > uint64(tipHeight) ||
+			row.BlockHeight > math.MaxUint32 {
+			continue
+		}
+		active, err := t.ct.GetHeaderByHeight(ctx, uint32(row.BlockHeight))
+		if err != nil || active == nil {
+			continue // cannot judge: never orphan on absence of evidence
+		}
+		if active.Hash.String() != row.BlockHash {
+			orphaned = append(orphaned, row.BlockHash)
+			t.logger.Warn("tie-scan: active row lost its height to a competitor",
+				logfields.BlockHash(row.BlockHash),
+				logfields.BlockHeight(row.BlockHeight),
+				zap.String("active_block_hash", active.Hash.String()))
+		}
+	}
+	if len(orphaned) == 0 {
+		return
+	}
+	if err := t.store.MarkBlocksOrphaned(ctx, orphaned, time.Now()); err != nil {
+		t.logger.Warn("tie-scan: failed to mark blocks orphaned",
+			zap.Int("count", len(orphaned)),
+			zap.Error(err))
+		return
+	}
+	t.logger.Info("tie-scan: marked same-height losers orphaned",
+		zap.Strings("block_hashes", orphaned),
+		zap.Uint32("tip_height", tipHeight))
 }

--- a/services/chaintracks_server/block_status_tracker.go
+++ b/services/chaintracks_server/block_status_tracker.go
@@ -156,38 +156,49 @@ func (t *blockStatusTracker) scanRecentActive(ctx context.Context, tipHeight uin
 	if uint64(tipHeight) > uint64(t.scanDepth) {
 		minHeight = uint64(tipHeight) - uint64(t.scanDepth)
 	}
-	// The list is height-DESC; a window of depth heights can hold a few
-	// competitors per height, so over-fetch generously and filter. The
-	// height-0 placeholder rows MarkBlockProcessed creates before any
-	// header arrives are excluded by the height filter.
-	rows, err := t.store.ListBlockProcessingStatus(ctx, 0, t.scanDepth*4)
-	if err != nil {
-		t.logger.Warn("tie-scan: failed to list block_processing rows", zap.Error(err))
-		return
-	}
-
-	var orphaned []string
-	for _, row := range rows {
+	// Walk EVERY row down to minHeight via the boundary-safe pager — a
+	// fixed-size sample could miss active rows when competitors or churn
+	// crowd the top of the height-DESC listing, and a naive height cursor
+	// would skip same-height rows straddling a page boundary (the exact
+	// rows this scan exists to find). The pager may visit a boundary row
+	// twice, so mismatches collect into a set. The height-0 placeholder
+	// rows MarkBlockProcessed creates before any header arrives are
+	// excluded by the height filter.
+	orphanedSet := make(map[string]struct{})
+	err := store.ForEachBlockProcessing(ctx, t.store, minHeight, t.scanDepth*4, func(row *models.BlockProcessingStatus) error {
 		if row.Status != models.BlockStatusActive ||
 			row.BlockHeight < minHeight ||
 			row.BlockHeight > uint64(tipHeight) ||
 			row.BlockHeight > math.MaxUint32 {
-			continue
+			return nil
 		}
-		active, err := t.ct.GetHeaderByHeight(ctx, uint32(row.BlockHeight))
-		if err != nil || active == nil {
-			continue // cannot judge: never orphan on absence of evidence
+		if _, seen := orphanedSet[row.BlockHash]; seen {
+			return nil
+		}
+		active, hdrErr := t.ct.GetHeaderByHeight(ctx, uint32(row.BlockHeight))
+		if hdrErr != nil || active == nil {
+			return nil //nolint:nilerr // fail-open by contract: never orphan on absence of evidence
 		}
 		if active.Hash.String() != row.BlockHash {
-			orphaned = append(orphaned, row.BlockHash)
+			orphanedSet[row.BlockHash] = struct{}{}
 			t.logger.Warn("tie-scan: active row lost its height to a competitor",
 				logfields.BlockHash(row.BlockHash),
 				logfields.BlockHeight(row.BlockHeight),
 				zap.String("active_block_hash", active.Hash.String()))
 		}
+		return nil
+	})
+	if err != nil {
+		t.logger.Warn("tie-scan: incomplete", zap.Error(err))
+		// Fall through: whatever was found still gets marked; the next tip
+		// re-runs the scan and the reconciler full-scan is the backstop.
 	}
-	if len(orphaned) == 0 {
+	if len(orphanedSet) == 0 {
 		return
+	}
+	orphaned := make([]string, 0, len(orphanedSet))
+	for hash := range orphanedSet {
+		orphaned = append(orphaned, hash)
 	}
 	if err := t.store.MarkBlocksOrphaned(ctx, orphaned, time.Now()); err != nil {
 		t.logger.Warn("tie-scan: failed to mark blocks orphaned",

--- a/services/chaintracks_server/block_status_tracker_test.go
+++ b/services/chaintracks_server/block_status_tracker_test.go
@@ -2,6 +2,7 @@ package chaintracks_server
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -26,10 +27,25 @@ type trackerStore struct {
 	orphaned [][]string
 }
 
-func (s *trackerStore) ListBlockProcessingStatus(_ context.Context, _ uint64, _ int) ([]*models.BlockProcessingStatus, error) {
+func (s *trackerStore) ListBlockProcessingStatus(_ context.Context, beforeHeight uint64, limit int) ([]*models.BlockProcessingStatus, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return append([]*models.BlockProcessingStatus(nil), s.rows...), nil
+	// Honor the real keyset contract (height DESC, block_height < before,
+	// limit) — the tie-scan pages via store.ForEachBlockProcessing, which
+	// depends on it for termination.
+	sorted := append([]*models.BlockProcessingStatus(nil), s.rows...)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].BlockHeight > sorted[j].BlockHeight })
+	var out []*models.BlockProcessingStatus
+	for _, row := range sorted {
+		if beforeHeight > 0 && row.BlockHeight >= beforeHeight {
+			continue
+		}
+		out = append(out, row)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out, nil
 }
 
 func (s *trackerStore) MarkBlocksOrphaned(_ context.Context, hashes []string, _ time.Time) error {

--- a/services/chaintracks_server/block_status_tracker_test.go
+++ b/services/chaintracks_server/block_status_tracker_test.go
@@ -47,8 +47,7 @@ func (s *trackerStore) orphanCalls() [][]string {
 
 func headerAt(height uint32, seed byte) *chaintracks.BlockHeader {
 	var h chainhash.Hash
-	h[0] = seed
-	h[1] = byte(height)
+	h[0] = seed // seeds are unique per test row; height needn't feed the hash
 	return &chaintracks.BlockHeader{Height: height, Hash: h}
 }
 

--- a/services/chaintracks_server/block_status_tracker_test.go
+++ b/services/chaintracks_server/block_status_tracker_test.go
@@ -1,0 +1,158 @@
+package chaintracks_server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-chaintracks/chaintracks"
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
+)
+
+// trackerStore is the minimal store.Store fake the tie-scan touches:
+// canned ListBlockProcessingStatus rows + a recording MarkBlocksOrphaned.
+// The embedded nil interface panics on anything else, pinning the scan's
+// store surface.
+type trackerStore struct {
+	store.Store
+
+	mu       sync.Mutex
+	rows     []*models.BlockProcessingStatus
+	orphaned [][]string
+}
+
+func (s *trackerStore) ListBlockProcessingStatus(_ context.Context, _ uint64, _ int) ([]*models.BlockProcessingStatus, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*models.BlockProcessingStatus(nil), s.rows...), nil
+}
+
+func (s *trackerStore) MarkBlocksOrphaned(_ context.Context, hashes []string, _ time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.orphaned = append(s.orphaned, append([]string(nil), hashes...))
+	return nil
+}
+
+func (s *trackerStore) orphanCalls() [][]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([][]string(nil), s.orphaned...)
+}
+
+func headerAt(height uint32, seed byte) *chaintracks.BlockHeader {
+	var h chainhash.Hash
+	h[0] = seed
+	h[1] = byte(height)
+	return &chaintracks.BlockHeader{Height: height, Hash: h}
+}
+
+func activeRow(hash string, height uint64) *models.BlockProcessingStatus {
+	return &models.BlockProcessingStatus{
+		BlockHash:   hash,
+		BlockHeight: height,
+		Status:      models.BlockStatusActive,
+	}
+}
+
+func newTestTracker(ct chaintracks.Chaintracks, st store.Store, depth int, minInterval time.Duration) *blockStatusTracker {
+	return &blockStatusTracker{
+		store:           st,
+		ct:              ct,
+		logger:          zap.NewNop(),
+		scanDepth:       depth,
+		scanMinInterval: minInterval,
+	}
+}
+
+// TestTieScan_MarksSameHeightLoserOrphaned is the no-ReorgEvent detection
+// path of issue #279: an 'active' row whose height is held by a different
+// block on the active chain must be marked orphaned by the tip-update scan.
+func TestTieScan_MarksSameHeightLoserOrphaned(t *testing.T) {
+	ct := newFakeChaintracks()
+	winner := headerAt(10, 0xAA)
+	ct.headers[10] = winner
+
+	loserHash := headerAt(10, 0xBB).Hash.String()
+	st := &trackerStore{rows: []*models.BlockProcessingStatus{
+		activeRow(winner.Hash.String(), 10), // matches the active chain — untouched
+		activeRow(loserHash, 10),            // same height, different hash — orphan
+	}}
+
+	tr := newTestTracker(ct, st, 20, 0)
+	tr.scanRecentActive(context.Background(), 12)
+
+	calls := st.orphanCalls()
+	if len(calls) != 1 || len(calls[0]) != 1 || calls[0][0] != loserHash {
+		t.Fatalf("expected exactly the loser %s orphaned, got %v", loserHash, calls)
+	}
+}
+
+// TestTieScan_SkipsUnjudgeableRows: rows the scan cannot positively judge —
+// height 0 placeholders, heights above the tip, heights chaintracks doesn't
+// know, non-active rows — must never be orphaned.
+func TestTieScan_SkipsUnjudgeableRows(t *testing.T) {
+	ct := newFakeChaintracks()
+	ct.headers[10] = headerAt(10, 0xAA)
+
+	orphanRow := activeRow(headerAt(9, 0xEE).Hash.String(), 9)
+	orphanRow.Status = models.BlockStatusOrphaned
+
+	st := &trackerStore{rows: []*models.BlockProcessingStatus{
+		activeRow(headerAt(0, 0x01).Hash.String(), 0),   // placeholder: height filter
+		activeRow(headerAt(50, 0x02).Hash.String(), 50), // above tip
+		activeRow(headerAt(11, 0x03).Hash.String(), 11), // tip-window but chaintracks has no header at 11
+		orphanRow, // already orphaned — only 'active' rows are scanned
+	}}
+
+	tr := newTestTracker(ct, st, 20, 0)
+	tr.scanRecentActive(context.Background(), 12)
+
+	if calls := st.orphanCalls(); len(calls) != 0 {
+		t.Fatalf("expected no orphan marks, got %v", calls)
+	}
+}
+
+// TestTieScan_Debounce: scans inside the min interval are dropped; the next
+// one after it runs.
+func TestTieScan_Debounce(t *testing.T) {
+	ct := newFakeChaintracks()
+	ct.headers[10] = headerAt(10, 0xAA)
+	loser := activeRow(headerAt(10, 0xBB).Hash.String(), 10)
+	st := &trackerStore{rows: []*models.BlockProcessingStatus{loser}}
+
+	tr := newTestTracker(ct, st, 20, time.Hour)
+	tr.scanRecentActive(context.Background(), 12)
+	tr.scanRecentActive(context.Background(), 12) // debounced
+
+	if calls := st.orphanCalls(); len(calls) != 1 {
+		t.Fatalf("expected 1 scan to run (second debounced), got %d orphan calls", len(calls))
+	}
+
+	tr.lastScan = time.Now().Add(-2 * time.Hour)
+	tr.scanRecentActive(context.Background(), 12)
+	if calls := st.orphanCalls(); len(calls) != 2 {
+		t.Fatalf("expected the post-interval scan to run, got %d orphan calls", len(calls))
+	}
+}
+
+// TestTieScan_DisabledByZeroDepth: tie_scan_depth=0 turns the scan off.
+func TestTieScan_DisabledByZeroDepth(t *testing.T) {
+	ct := newFakeChaintracks()
+	ct.headers[10] = headerAt(10, 0xAA)
+	st := &trackerStore{rows: []*models.BlockProcessingStatus{
+		activeRow(headerAt(10, 0xBB).Hash.String(), 10),
+	}}
+
+	tr := newTestTracker(ct, st, 0, 0)
+	tr.scanRecentActive(context.Background(), 12)
+
+	if calls := st.orphanCalls(); len(calls) != 0 {
+		t.Fatalf("expected disabled scan to do nothing, got %v", calls)
+	}
+}

--- a/services/chaintracks_server/service.go
+++ b/services/chaintracks_server/service.go
@@ -83,9 +83,11 @@ func (s *Service) Start(ctx context.Context) error {
 	)
 
 	// Bridge chaintracks tip + reorg → block_processing store. Downstream
-	// services (watchdog, api-server) read from the shared table, so this
-	// service is responsible for keeping it fresh.
-	s.tracker = newBlockStatusTracker(ctx, s.ct, s.store, s.logger)
+	// services (watchdog, api-server, the anchor reconciler) read from the
+	// shared table, so this service is responsible for keeping it fresh —
+	// including the tie-scan that detects same-height competition losers
+	// chaintracks never emits a ReorgEvent for (issue #279).
+	s.tracker = newBlockStatusTracker(ctx, s.cfg, s.ct, s.store, s.logger)
 
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()

--- a/services/webhook/reorg_delivery_test.go
+++ b/services/webhook/reorg_delivery_test.go
@@ -1,0 +1,76 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// TestShouldDeliver_ReorgReanchorBypassesSameStatusDedup pins the issue
+// #279 exception: a MINED event flagged as a reorg re-anchor is the one
+// same-status transition that must be redelivered — the block hash and
+// merkle path changed, and suppressing it would leave the receiver holding
+// a proof anchored to an orphaned block. Every other same-status replay
+// stays deduped.
+func TestShouldDeliver_ReorgReanchorBypassesSameStatusDedup(t *testing.T) {
+	minedSub := &models.Submission{LastDeliveredStatus: models.StatusMined}
+	seenSub := &models.Submission{LastDeliveredStatus: models.StatusSeenOnNetwork, FullStatusUpdates: true}
+
+	cases := []struct {
+		name   string
+		sub    *models.Submission
+		status *models.TransactionStatus
+		want   bool
+	}{
+		{
+			name:   "reorg re-anchor bypasses MINED dedup",
+			sub:    minedSub,
+			status: &models.TransactionStatus{Status: models.StatusMined, ExtraInfo: models.ExtraInfoReorgReanchor},
+			want:   true,
+		},
+		{
+			name:   "plain MINED replay stays deduped",
+			sub:    minedSub,
+			status: &models.TransactionStatus{Status: models.StatusMined},
+			want:   false,
+		},
+		{
+			name:   "MINED with unrelated extraInfo stays deduped",
+			sub:    minedSub,
+			status: &models.TransactionStatus{Status: models.StatusMined, ExtraInfo: "something else"},
+			want:   false,
+		},
+		{
+			name:   "same-status SEEN revert replay stays deduped",
+			sub:    seenSub,
+			status: &models.TransactionStatus{Status: models.StatusSeenOnNetwork, ExtraInfo: models.ExtraInfoReorgUnmined},
+			want:   false,
+		},
+		{
+			name: "reorg revert delivers as a normal transition",
+			sub:  minedSub,
+			status: &models.TransactionStatus{
+				Status: models.StatusSeenOnNetwork, ExtraInfo: models.ExtraInfoReorgUnmined,
+			},
+			// FullStatusUpdates=false and SEEN is not terminal — the revert
+			// rides the store/API state, not a webhook push, unless the
+			// subscriber asked for full updates.
+			want: false,
+		},
+		{
+			name: "reorg revert delivers with FullStatusUpdates",
+			sub:  &models.Submission{LastDeliveredStatus: models.StatusMined, FullStatusUpdates: true},
+			status: &models.TransactionStatus{
+				Status: models.StatusSeenOnNetwork, ExtraInfo: models.ExtraInfoReorgUnmined,
+			},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldDeliver(tc.sub, tc.status); got != tc.want {
+				t.Fatalf("shouldDeliver = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/services/webhook/service.go
+++ b/services/webhook/service.go
@@ -328,10 +328,14 @@ func (s *Service) dispatchOne(ctx context.Context, status *models.TransactionSta
 //     delivered.
 //   - When FullStatusUpdates is false (the default), only terminal statuses
 //     (MINED, REJECTED, MINED_IN_STALE_BLOCK / IMMUTABLE) are delivered.
-//   - Same status as LastDeliveredStatus is suppressed (idempotent dedup).
+//   - Same status as LastDeliveredStatus is suppressed (idempotent dedup) —
+//     EXCEPT a MINED event flagged as a reorg re-anchor (issue #279): it is
+//     the one same-status transition that carries new information (the
+//     block hash + merkle path changed), and suppressing it would leave the
+//     receiver holding a proof anchored to an orphaned block.
 func shouldDeliver(sub *models.Submission, status *models.TransactionStatus) bool {
 	if sub.LastDeliveredStatus == status.Status {
-		return false
+		return status.Status == models.StatusMined && status.ExtraInfo == models.ExtraInfoReorgReanchor
 	}
 	if sub.FullStatusUpdates {
 		return true

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -137,6 +137,15 @@ func (s *fakeStore) GetOrInsertStatus(context.Context, *models.TransactionStatus
 func (s *fakeStore) BatchGetOrInsertStatus(context.Context, []*models.TransactionStatus) ([]store.BatchInsertResult, error) {
 	return nil, nil
 }
+
+func (s *fakeStore) GetTxIDsByBlockHash(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+func (s *fakeStore) DeleteBUMPByBlockHash(context.Context, string) error          { return nil }
+func (s *fakeStore) MarkBlockReconciled(context.Context, string, time.Time) error { return nil }
+func (s *fakeStore) ListOrphanedBlocksToReconcile(context.Context, int) ([]*models.BlockProcessingStatus, error) {
+	return nil, nil
+}
 func (s *fakeStore) UpdateStatus(context.Context, *models.TransactionStatus) error { return nil }
 func (s *fakeStore) BatchUpdateStatus(context.Context, []*models.TransactionStatus) error {
 	return nil

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -471,6 +471,7 @@ func (s *Store) GetStatus(ctx context.Context, txid string) (*models.Transaction
 
 	status := recordToStatus(rec, txid)
 	s.enrichMerklePath(ctx, status)
+	s.enrichOrphanedProofs(ctx, status)
 	return status, nil
 }
 
@@ -551,11 +552,73 @@ func (s *Store) IterateStatusesSince(ctx context.Context, _ time.Time, fn func(*
 	}
 }
 
+// binOrphAnchors is the transactions-set bin holding the row's orphaned-anchor
+// history as JSON-encoded []orphanedAnchorRecord (Aerospike bin names are
+// capped at 15 chars, hence the abbreviation). Written by SetMinedByTxIDs
+// (re-anchor to a different block) and SetStatusByBlockHash (reorg revert),
+// decoded back into models.TransactionStatus.OrphanedProofs by recordToStatus.
+const binOrphAnchors = "orph_anchors"
+
+// orphanedAnchorRecord is the persisted form of models.OrphanedAnchor — block
+// identity plus when the anchor was superseded, in unix milliseconds like the
+// other transactions-set timestamps. The proof itself is never persisted; it
+// is re-derived from the orphaned block's retained compound BUMP at read time.
+type orphanedAnchorRecord struct {
+	BlockHash    string `json:"block_hash"`
+	BlockHeight  uint64 `json:"block_height,omitempty"`
+	OrphanedAtMs int64  `json:"orphaned_at"`
+}
+
+// orphanedAnchorsFromRecord decodes the orph_anchors bin. A missing or
+// unparseable history reads as empty — the bin is best-effort bookkeeping,
+// never a gate.
+func orphanedAnchorsFromRecord(rec *aero.Record) []orphanedAnchorRecord {
+	var out []orphanedAnchorRecord
+	switch v := rec.Bins[binOrphAnchors].(type) {
+	case []byte:
+		_ = json.Unmarshal(v, &out)
+	case string:
+		_ = json.Unmarshal([]byte(v), &out)
+	}
+	return out
+}
+
+// appendOrphanedAnchor records that the blockHash/blockHeight anchor is being
+// superseded (re-anchor to a different block, or reorg revert). Collapses
+// consecutive duplicates and caps at models.MaxOrphanedAnchors, mirroring
+// models.AppendOrphanedAnchor.
+func appendOrphanedAnchor(history []orphanedAnchorRecord, blockHash string, blockHeight uint64, now time.Time) []orphanedAnchorRecord {
+	if blockHash == "" {
+		return history
+	}
+	if n := len(history); n > 0 && history[n-1].BlockHash == blockHash {
+		return history
+	}
+	history = append(history, orphanedAnchorRecord{
+		BlockHash:    blockHash,
+		BlockHeight:  blockHeight,
+		OrphanedAtMs: now.UnixMilli(),
+	})
+	if len(history) > models.MaxOrphanedAnchors {
+		history = history[len(history)-models.MaxOrphanedAnchors:]
+	}
+	return history
+}
+
+// SetStatusByBlockHash rewrites every transaction currently anchored to
+// blockHash. For SEEN_ON_NETWORK transitions block fields are cleared and the
+// cleared anchor is appended to the row's orph_anchors history (reorg revert,
+// issue #279); for IMMUTABLE they are kept. The secondary-index query is a
+// snapshot: each row is then re-read and CAS-written under a generation match
+// (the same read-check-write UpdateStatus uses for the lattice), so IMMUTABLE
+// rows are never touched and rows whose block_hash no longer matches at write
+// time — concurrently re-anchored to the canonical block — are skipped.
+// Returns only the txids actually rewritten.
 func (s *Store) SetStatusByBlockHash(ctx context.Context, blockHash string, newStatus models.Status) ([]string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	stmt := aero.NewStatement(s.namespace, setTransactions)
+	stmt := aero.NewStatement(s.namespace, setTransactions, "txid")
 	_ = stmt.SetFilter(aero.NewEqualFilter("block_hash", blockHash))
 
 	rs, err := s.client.Query(s.queryPolicy(ctx), stmt)
@@ -564,6 +627,112 @@ func (s *Store) SetStatusByBlockHash(ctx context.Context, blockHash string, newS
 	}
 	if err != nil {
 		return nil, fmt.Errorf("query by block hash: %w", err)
+	}
+
+	var candidates []string
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case rec, ok := <-rs.Results():
+			if !ok {
+				break loop
+			}
+			if rec.Err != nil {
+				continue
+			}
+			if txid := getString(rec.Record, "txid"); txid != "" {
+				candidates = append(candidates, txid)
+			}
+		}
+	}
+
+	clearBlock := newStatus == models.StatusSeenOnNetwork
+	now := time.Now()
+	var txids []string
+	for _, txid := range candidates {
+		if err := ctx.Err(); err != nil {
+			return txids, err
+		}
+		key, err := s.key(setTransactions, txid)
+		if err != nil {
+			continue
+		}
+		for {
+			rec, gerr := s.client.Get(s.readPolicy(ctx), key, "status", "block_hash", "block_height", binOrphAnchors)
+			if gerr != nil || rec == nil {
+				break
+			}
+			// Stale-index guard: the row moved to a different anchor between
+			// the index snapshot and this write — reverting it now would undo
+			// a concurrent re-anchor to the canonical block (issue #279).
+			if getString(rec, "block_hash") != blockHash {
+				break
+			}
+			// IMMUTABLE rows are never touched by block-scoped rewrites.
+			if getString(rec, "status") == string(models.StatusImmutable) {
+				break
+			}
+
+			ops := []*aero.Operation{
+				aero.PutOp(aero.NewBin("status", string(newStatus))),
+				aero.PutOp(aero.NewBin("timestamp", now.UnixMilli())),
+			}
+			if clearBlock {
+				// Preserve the anchor being cleared so the orphaned block's
+				// proof stays auditable (issue #279), then drop the block bins
+				// (Aerospike: writing a nil bin value deletes the bin).
+				height := uint64(getInt(rec, "block_height")) //nolint:gosec // height non-negative
+				history := appendOrphanedAnchor(orphanedAnchorsFromRecord(rec), blockHash, height, now)
+				if payload, mErr := json.Marshal(history); mErr == nil {
+					ops = append(ops, aero.PutOp(aero.NewBin(binOrphAnchors, payload)))
+				}
+				ops = append(ops,
+					aero.PutOp(aero.NewBin("block_hash", nil)),
+					aero.PutOp(aero.NewBin("block_height", nil)),
+				)
+			}
+
+			wp := s.writePolicy(ctx)
+			wp.GenerationPolicy = aero.EXPECT_GEN_EQUAL
+			wp.Generation = rec.Generation
+			wp.RecordExistsAction = aero.UPDATE_ONLY
+			if _, werr := s.client.Operate(wp, key, ops...); werr != nil {
+				// Generation mismatch means another writer landed between our
+				// read and our put — re-read and re-evaluate the guards rather
+				// than clobbering their write. Any other error skips the row,
+				// matching the per-record error tolerance of the old scan loop.
+				if isGenerationErr(werr) {
+					continue
+				}
+				break
+			}
+			txids = append(txids, txid)
+			break
+		}
+	}
+	return txids, nil
+}
+
+// GetTxIDsByBlockHash returns every txid currently anchored to blockHash via
+// the arcade_idx_tx_block_hash secondary index — the reorg reconciler's
+// affected set for an orphaned block. Rows already re-anchored or reverted no
+// longer match the index and don't appear. Only the txid bin is projected;
+// the reconciler wants identities, not rows.
+func (s *Store) GetTxIDsByBlockHash(ctx context.Context, blockHash string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	stmt := aero.NewStatement(s.namespace, setTransactions, "txid")
+	_ = stmt.SetFilter(aero.NewEqualFilter("block_hash", blockHash))
+
+	rs, err := s.client.Query(s.queryPolicy(ctx), stmt)
+	if rs != nil {
+		defer func() { _ = rs.Close() }()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query txids by block hash: %w", err)
 	}
 
 	var (
@@ -581,21 +750,14 @@ loop:
 				break loop
 			}
 			if rec.Err != nil {
-				continue
+				// A partial affected set would silently under-reconcile —
+				// surface the error instead of skipping the record.
+				loopErr = rec.Err
+				break loop
 			}
-			txid := getString(rec.Record, "txid")
-			if txid == "" {
-				continue
+			if txid := getString(rec.Record, "txid"); txid != "" {
+				txids = append(txids, txid)
 			}
-			key, err := s.key(setTransactions, txid)
-			if err != nil {
-				continue
-			}
-			bins := aero.BinMap{"status": string(newStatus), "timestamp": time.Now().UnixMilli()}
-			if err := s.client.Put(s.writePolicy(ctx), key, bins); err != nil {
-				continue
-			}
-			txids = append(txids, txid)
 		}
 	}
 	if loopErr != nil {
@@ -737,16 +899,92 @@ func (s *Store) ClearRetryState(ctx context.Context, txid string, finalStatus mo
 	return nil
 }
 
+// minedWrite computes the per-record MINED write from a snapshot of an
+// existing row: the ops to apply, the pre-write model for the prevs slice,
+// and whether the row is eligible. IMMUTABLE rows are ineligible — a replayed
+// BLOCK_PROCESSED must never demote a confirmation-depth promotion (issue
+// #279 hardening). A MINED row re-anchored to a DIFFERENT block appends the
+// anchor being superseded to its orph_anchors history first, so the orphaned
+// block's proof stays auditable; first-time MINED and idempotent same-block
+// replays leave history untouched.
+func minedWrite(rec *aero.Record, txid, blockHash string, blockHeight uint64, now time.Time) (ops []*aero.Operation, prev *models.TransactionStatus, ok bool) {
+	prevStatus := models.Status(getString(rec, "status"))
+	// Respect the status lattice: of all statuses only IMMUTABLE may not
+	// regress to MINED. See models.Status.CanTransitionFrom.
+	if !models.StatusMined.CanTransitionFrom(prevStatus) {
+		return nil, nil, false
+	}
+	prev = recordToStatus(rec, txid)
+	ops = []*aero.Operation{
+		aero.PutOp(aero.NewBin("status", string(models.StatusMined))),
+		aero.PutOp(aero.NewBin("block_hash", blockHash)),
+		aero.PutOp(aero.NewBin("block_height", int(blockHeight))), //nolint:gosec // block height fits in int on 64-bit platforms
+		aero.PutOp(aero.NewBin("timestamp", now.UnixMilli())),
+	}
+	if prevStatus == models.StatusMined && prev.BlockHash != "" && prev.BlockHash != blockHash {
+		history := appendOrphanedAnchor(orphanedAnchorsFromRecord(rec), prev.BlockHash, prev.BlockHeight, now)
+		if payload, err := json.Marshal(history); err == nil {
+			ops = append(ops, aero.PutOp(aero.NewBin(binOrphAnchors, payload)))
+		}
+	}
+	return ops, prev, true
+}
+
+// setMinedCAS is the per-record fallback for a batch MINED write that lost a
+// generation race: re-read, re-run the IMMUTABLE guard and anchor bookkeeping
+// against the fresh snapshot, and CAS-write — the same read-check-write loop
+// UpdateStatus uses for the lattice. Returns the pre-write row and whether
+// the write was applied (false = row missing or ineligible).
+func (s *Store) setMinedCAS(ctx context.Context, txid, blockHash string, blockHeight uint64, now time.Time) (*models.TransactionStatus, bool, error) {
+	key, err := s.key(setTransactions, txid)
+	if err != nil {
+		return nil, false, err
+	}
+	for {
+		rec, gerr := s.client.Get(s.readPolicy(ctx), key)
+		if gerr != nil && !isKeyNotFound(gerr) {
+			return nil, false, fmt.Errorf("read status for set mined %s: %w", txid, gerr)
+		}
+		if rec == nil {
+			return nil, false, nil
+		}
+		ops, prev, ok := minedWrite(rec, txid, blockHash, blockHeight, now)
+		if !ok {
+			return nil, false, nil
+		}
+		wp := s.writePolicy(ctx)
+		wp.GenerationPolicy = aero.EXPECT_GEN_EQUAL
+		wp.Generation = rec.Generation
+		wp.RecordExistsAction = aero.UPDATE_ONLY
+		if _, werr := s.client.Operate(wp, key, ops...); werr != nil {
+			if isGenerationErr(werr) {
+				continue
+			}
+			if isKeyNotFound(werr) {
+				return nil, false, nil
+			}
+			return nil, false, fmt.Errorf("set mined %s: %w", txid, werr)
+		}
+		return prev, true, nil
+	}
+}
+
 // SetMinedByTxIDs writes a MINED status batch keyed by blockHash + blockHeight.
 // blockHeight is persisted as the block_height bin and echoed back on each
 // returned TransactionStatus so SSE/webhook consumers always see the height
 // alongside the hash (issue #87 / F-029).
+//
+// Hardening (issue #279): rows are snapshot via BatchGet first. The snapshot
+// feeds the returned prevs, skips IMMUTABLE rows (never demote a
+// confirmation-depth promotion), and appends the previous anchor to
+// orph_anchors when a MINED row is re-anchored to a DIFFERENT block. Each
+// batch write carries a generation CAS pinned to its snapshot, so a record
+// that moved in between falls back to the per-record read-check-write
+// (setMinedCAS) instead of clobbering the concurrent write with stale
+// bookkeeping.
 func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeight uint64, txids []string) ([]*models.TransactionStatus, []*models.TransactionStatus, error) {
 	now := time.Now()
 	var prevs, statuses []*models.TransactionStatus
-
-	bwp := aero.NewBatchWritePolicy()
-	bwp.RecordExistsAction = aero.UPDATE_ONLY
 
 	for i := 0; i < len(txids); i += s.batchSize {
 		if err := ctx.Err(); err != nil {
@@ -758,11 +996,9 @@ func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeig
 		}
 		batch := txids[i:end]
 
-		// Snapshot pre-update rows so callers can observe the MINED
-		// transition age. BatchGet is a second round-trip but matches the
-		// access pattern Pebble does atomically via per-shard locks; for
-		// the current production deployment (Pebble) this code path is
-		// unused, so the extra latency is acceptable here.
+		// Snapshot pre-update rows. BatchGet is a second round-trip but
+		// matches the access pattern Pebble does atomically via per-shard
+		// locks; the generation CAS on each write closes the gap in between.
 		keys := make([]*aero.Key, 0, len(batch))
 		keyByTxID := make(map[string]int, len(batch))
 		for _, txid := range batch {
@@ -773,7 +1009,7 @@ func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeig
 			keyByTxID[txid] = len(keys)
 			keys = append(keys, key)
 		}
-		prevByTxID := make(map[string]*models.TransactionStatus, len(batch))
+		recByTxID := make(map[string]*aero.Record, len(batch))
 		if len(keys) > 0 {
 			recs, err := s.client.BatchGet(s.batchPolicy(ctx), keys)
 			if err != nil {
@@ -783,44 +1019,69 @@ func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeig
 				if idx >= len(recs) || recs[idx] == nil {
 					continue
 				}
-				prevByTxID[txid] = recordToStatus(recs[idx], txid)
+				recByTxID[txid] = recs[idx]
 			}
 		}
 
-		records := make([]aero.BatchRecordIfc, len(batch))
-		for j, txid := range batch {
-			key, err := s.key(setTransactions, txid)
-			if err != nil {
+		records := make([]aero.BatchRecordIfc, 0, len(batch))
+		written := make([]string, 0, len(batch))
+		prevForSlot := make([]*models.TransactionStatus, 0, len(batch))
+		for _, txid := range batch {
+			rec := recByTxID[txid]
+			if rec == nil {
+				// Unknown txid — silently skipped, never created.
 				continue
 			}
-			ops := []*aero.Operation{
-				aero.PutOp(aero.NewBin("status", string(models.StatusMined))),
-				aero.PutOp(aero.NewBin("block_hash", blockHash)),
-				aero.PutOp(aero.NewBin("block_height", int(blockHeight))), //nolint:gosec // block height fits in int on 64-bit platforms
-				aero.PutOp(aero.NewBin("timestamp", now.UnixMilli())),
+			ops, prev, ok := minedWrite(rec, txid, blockHash, blockHeight, now)
+			if !ok {
+				// IMMUTABLE — never demoted; no entry in either slice.
+				continue
 			}
-			records[j] = aero.NewBatchWrite(bwp, key, ops...)
+			bwp := aero.NewBatchWritePolicy()
+			bwp.RecordExistsAction = aero.UPDATE_ONLY
+			bwp.GenerationPolicy = aero.EXPECT_GEN_EQUAL
+			bwp.Generation = rec.Generation
+			records = append(records, aero.NewBatchWrite(bwp, keys[keyByTxID[txid]], ops...))
+			written = append(written, txid)
+			prevForSlot = append(prevForSlot, prev)
+		}
+		if len(records) == 0 {
+			continue
 		}
 
 		if err := s.client.BatchOperate(s.batchPolicy(ctx), records); err != nil {
 			return prevs, statuses, fmt.Errorf("batch set mined: %w", err)
 		}
 
-		for j, txid := range batch {
-			if records[j] != nil && records[j].BatchRec().Err == nil {
-				if prev, ok := prevByTxID[txid]; ok {
-					prevs = append(prevs, prev)
-				} else {
-					prevs = append(prevs, nil)
+		for j, txid := range written {
+			switch br := records[j].BatchRec(); {
+			case br.Err == nil:
+				prevs = append(prevs, prevForSlot[j])
+			case isGenerationErr(br.Err):
+				// Another writer landed between snapshot and CAS write —
+				// redo this record alone against a fresh read rather than
+				// silently dropping the MINED transition.
+				prev, applied, err := s.setMinedCAS(ctx, txid, blockHash, blockHeight, now)
+				if err != nil {
+					return prevs, statuses, err
 				}
-				statuses = append(statuses, &models.TransactionStatus{
-					TxID:        txid,
-					Status:      models.StatusMined,
-					BlockHash:   blockHash,
-					BlockHeight: blockHeight,
-					Timestamp:   now,
-				})
+				if !applied {
+					continue
+				}
+				prevs = append(prevs, prev)
+			default:
+				// UPDATE_ONLY on a row deleted since the snapshot, or another
+				// per-record error — skipped, matching the unknown-txid
+				// contract.
+				continue
 			}
+			statuses = append(statuses, &models.TransactionStatus{
+				TxID:        txid,
+				Status:      models.StatusMined,
+				BlockHash:   blockHash,
+				BlockHeight: blockHeight,
+				Timestamp:   now,
+			})
 		}
 	}
 
@@ -1133,6 +1394,39 @@ func (s *Store) deleteBumpChunkRange(ctx context.Context, blockHash string, from
 			return fmt.Errorf("batch delete bump chunks: %w", err)
 		}
 	}
+	return nil
+}
+
+// DeleteBUMPByBlockHash removes the stored compound BUMP — the manifest plus
+// every chunk record it references — and drops any cached parse. Idempotent:
+// a missing manifest is a no-op. The manifest is deleted before its chunks
+// (mirroring DeleteStumpsByBlockHash): a crash mid-delete then leaves only
+// unreferenced orphan chunks (harmless disk waste) rather than a manifest
+// pointing at missing chunks (a hard read error).
+func (s *Store) DeleteBUMPByBlockHash(ctx context.Context, blockHash string) error {
+	manifestKey, err := s.key(setBumps, blockHash)
+	if err != nil {
+		return err
+	}
+	rec, err := s.client.Get(s.readPolicy(ctx), manifestKey, "chunk_count")
+	if err != nil && !isKeyNotFound(err) {
+		return fmt.Errorf("read bump manifest %s: %w", blockHash, err)
+	}
+	if rec == nil {
+		// Nothing stored — still drop any cached parse so a stale in-memory
+		// compound can't outlive the delete.
+		s.bumpCache.Remove(blockHash)
+		return nil
+	}
+	chunkCount, _ := rec.Bins["chunk_count"].(int)
+
+	if _, err := s.client.Delete(s.writePolicy(ctx), manifestKey); err != nil {
+		return fmt.Errorf("delete bump manifest %s: %w", blockHash, err)
+	}
+	if err := s.deleteBumpChunkRange(ctx, blockHash, 0, chunkCount); err != nil {
+		return fmt.Errorf("delete bump chunks %s: %w", blockHash, err)
+	}
+	s.bumpCache.Remove(blockHash)
 	return nil
 }
 
@@ -1831,8 +2125,9 @@ loop:
 //   header_seen_at  int64 (unix nanos; 0 = unset)
 //   processed_at    int64 (unix nanos; 0 = unset)
 //   bump_built_at   int64 (unix nanos; 0 = unset)
-//   status          string ("active" | "orphaned")
+//   status          string ("active" | "orphaned" | "parked")
 //   orphaned_at     int64 (unix nanos; 0 = unset)
+//   reconciled_at   int64 (unix nanos; 0 = unset)
 //
 // Writers must use Operate with per-bin PutOps so concurrent header /
 // processed / bump-built paths only touch their own bins. A full-record
@@ -1846,6 +2141,7 @@ const (
 	binBUMPBuiltAt  = "bump_built_at"
 	binStatus       = "status"
 	binOrphanedAt   = "orphaned_at"
+	binReconciledAt = "reconciled_at"
 )
 
 func (s *Store) UpsertBlockHeaderSeen(ctx context.Context, blockHash string, blockHeight uint64, seenAt time.Time) error {
@@ -1857,12 +2153,14 @@ func (s *Store) UpsertBlockHeaderSeen(ctx context.Context, blockHash string, blo
 	// update we must NOT clobber processed_at or bump_built_at, which is
 	// what per-bin Operate gives us — bins not named here are left alone.
 	// We do overwrite block_height (chaintracks is authoritative) and reset
-	// status/orphaned_at so a returning orphan re-joins active.
+	// status/orphaned_at/reconciled_at so a returning orphan re-joins active
+	// and a later re-orphaning reconciles again (issue #279).
 	ops := []*aero.Operation{
 		aero.PutOp(aero.NewBin(binBlockHash, blockHash)),
 		aero.PutOp(aero.NewBin(binBlockHeight, int(blockHeight))), //nolint:gosec // block height fits in int on 64-bit platforms
 		aero.PutOp(aero.NewBin(binStatus, string(models.BlockStatusActive))),
 		aero.PutOp(aero.NewBin(binOrphanedAt, nil)),
+		aero.PutOp(aero.NewBin(binReconciledAt, nil)),
 		// header_seen_at: only set when the bin is currently absent. Aerospike
 		// has no client-side conditional bin write that's race-free, so we do
 		// a generation-CAS read+write loop to set it on first observation
@@ -1962,6 +2260,83 @@ func (s *Store) MarkBlocksOrphaned(ctx context.Context, blockHashes []string, or
 		}
 	}
 	return nil
+}
+
+// MarkBlockReconciled stamps reconciled_at on an orphaned block's row — the
+// anchor reconciler finished re-anchoring/reverting its transactions. A
+// missing row is a silent no-op (UPDATE_ONLY, the RecordDeliveryAttempt
+// pattern).
+func (s *Store) MarkBlockReconciled(ctx context.Context, blockHash string, at time.Time) error {
+	key, err := s.key(setBlockProcessing, blockHash)
+	if err != nil {
+		return err
+	}
+	policy := s.writePolicy(ctx)
+	policy.RecordExistsAction = aero.UPDATE_ONLY // never create a phantom block row
+	_, err = s.client.Operate(policy, key,
+		aero.PutOp(aero.NewBin(binReconciledAt, at.UnixNano())))
+	if isKeyNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("mark block reconciled %s: %w", blockHash, err)
+	}
+	return nil
+}
+
+// ListOrphanedBlocksToReconcile narrows by status='orphaned' via the secondary
+// index, then in-memory filters to rows with no reconciled_at, sorts by
+// orphaned_at ascending, and truncates to limit — the anchor reconciler's
+// durable work queue. Cardinality is bounded by unreconciled orphans, which
+// is near-zero in steady state.
+func (s *Store) ListOrphanedBlocksToReconcile(ctx context.Context, limit int) ([]*models.BlockProcessingStatus, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		return nil, fmt.Errorf("limit must be > 0")
+	}
+	stmt := aero.NewStatement(s.namespace, setBlockProcessing)
+	_ = stmt.SetFilter(aero.NewEqualFilter(binStatus, string(models.BlockStatusOrphaned)))
+	rs, err := s.client.Query(s.queryPolicy(ctx), stmt)
+	if rs != nil {
+		defer func() { _ = rs.Close() }()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query orphaned block_processing: %w", err)
+	}
+	var (
+		all     []*models.BlockProcessingStatus
+		loopErr error
+	)
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			loopErr = ctx.Err()
+			break loop
+		case rec, ok := <-rs.Results():
+			if !ok {
+				break loop
+			}
+			if rec.Err != nil {
+				continue
+			}
+			// Already reconciled rows are done — not work-queue members.
+			if getInt64(rec.Record, binReconciledAt) != 0 {
+				continue
+			}
+			all = append(all, blockProcessingFromRecord(rec.Record))
+		}
+	}
+	if loopErr != nil {
+		return all, loopErr
+	}
+	sortByOrphanedAtAsc(all)
+	if len(all) > limit {
+		all = all[:limit]
+	}
+	return all, nil
 }
 
 func (s *Store) MarkBlocksParked(ctx context.Context, blockHashes []string) error {
@@ -2089,6 +2464,10 @@ func blockProcessingFromRecord(rec *aero.Record) *models.BlockProcessingStatus {
 		t := time.Unix(0, v).UTC()
 		bp.OrphanedAt = &t
 	}
+	if v := getInt64(rec, binReconciledAt); v != 0 {
+		t := time.Unix(0, v).UTC()
+		bp.ReconciledAt = &t
+	}
 	return bp
 }
 
@@ -2199,6 +2578,29 @@ func sortByHeaderSeenAsc(rows []*models.BlockProcessingStatus) {
 	for i := 1; i < len(rows); i++ {
 		j := i
 		for j > 0 && rows[j-1].HeaderSeenAt.After(rows[j].HeaderSeenAt) {
+			rows[j-1], rows[j] = rows[j], rows[j-1]
+			j--
+		}
+	}
+}
+
+func sortByOrphanedAtAsc(rows []*models.BlockProcessingStatus) {
+	// Insertion sort matches the other block_processing sorts — the orphan
+	// backlog is at most a handful of rows. A nil orphaned_at sorts last,
+	// matching Postgres's ORDER BY orphaned_at ASC NULLS LAST.
+	before := func(a, b *models.BlockProcessingStatus) bool {
+		switch {
+		case a.OrphanedAt == nil:
+			return false
+		case b.OrphanedAt == nil:
+			return true
+		default:
+			return a.OrphanedAt.Before(*b.OrphanedAt)
+		}
+	}
+	for i := 1; i < len(rows); i++ {
+		j := i
+		for j > 0 && before(rows[j], rows[j-1]) {
 			rows[j-1], rows[j] = rows[j], rows[j-1]
 			j--
 		}
@@ -2349,6 +2751,13 @@ func recordToStatus(rec *aero.Record, txid string) *models.TransactionStatus {
 			status.MerkleRegisteredAt = time.UnixMilli(int64(ms))
 		}
 	}
+	for _, a := range orphanedAnchorsFromRecord(rec) {
+		status.OrphanedProofs = append(status.OrphanedProofs, models.OrphanedAnchor{
+			BlockHash:   a.BlockHash,
+			BlockHeight: a.BlockHeight,
+			OrphanedAt:  time.UnixMilli(a.OrphanedAtMs).UTC(),
+		})
+	}
 	return status
 }
 
@@ -2368,6 +2777,26 @@ func (s *Store) enrichMerklePath(ctx context.Context, status *models.Transaction
 		_, bumpData, err := s.GetBUMP(ctx, status.BlockHash)
 		return bumpData, err
 	})
+}
+
+// enrichOrphanedProofs resolves each historical anchor's merkle path from
+// the orphaned block's retained compound BUMP (issue #279). Best-effort:
+// an entry whose BUMP is gone or unparseable is served without a path.
+func (s *Store) enrichOrphanedProofs(ctx context.Context, status *models.TransactionStatus) {
+	if status == nil {
+		return
+	}
+	for i := range status.OrphanedProofs {
+		entry := &status.OrphanedProofs[i]
+		if len(entry.MerklePath) > 0 || entry.BlockHash == "" {
+			continue
+		}
+		hash := entry.BlockHash
+		entry.MerklePath = s.bumpCache.MinimalPath(hash, status.TxID, func() ([]byte, error) {
+			_, bumpData, err := s.GetBUMP(ctx, hash)
+			return bumpData, err
+		})
+	}
 }
 
 func recordToSubmission(rec *aero.Record) *models.Submission {

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -629,7 +629,10 @@ func (s *Store) SetStatusByBlockHash(ctx context.Context, blockHash string, newS
 		return nil, fmt.Errorf("query by block hash: %w", err)
 	}
 
-	var candidates []string
+	var (
+		candidates []string
+		loopErr    error
+	)
 loop:
 	for {
 		select {
@@ -640,12 +643,18 @@ loop:
 				break loop
 			}
 			if rec.Err != nil {
-				continue
+				// A partial affected set would silently under-reconcile —
+				// surface the error instead of skipping the record.
+				loopErr = rec.Err
+				break loop
 			}
 			if txid := getString(rec.Record, "txid"); txid != "" {
 				candidates = append(candidates, txid)
 			}
 		}
+	}
+	if loopErr != nil {
+		return nil, loopErr
 	}
 
 	clearBlock := newStatus == models.StatusSeenOnNetwork

--- a/store/bumpcache/bumpcache.go
+++ b/store/bumpcache/bumpcache.go
@@ -89,6 +89,23 @@ func (c *Cache) Enrich(status *models.TransactionStatus, fetch func() ([]byte, e
 	status.MerklePath = idx.MinimalPathBytes(status.TxID)
 }
 
+// MinimalPath returns txid's BRC-74 minimal path from blockHash's compound
+// BUMP, or nil when the BUMP cannot be fetched/parsed or the txid is not a
+// level-0 leaf. Unlike Enrich this is not tied to a status row's CURRENT
+// anchor — it resolves a proof against any retained block, which is how
+// orphaned-anchor proofs are served after a reorg re-anchor (issue #279).
+// fetch is only invoked on a cache miss.
+func (c *Cache) MinimalPath(blockHash, txid string, fetch func() ([]byte, error)) []byte {
+	if blockHash == "" || txid == "" {
+		return nil
+	}
+	idx := c.index(blockHash, fetch)
+	if idx == nil {
+		return nil
+	}
+	return idx.MinimalPathBytes(txid)
+}
+
 // Remove invalidates a block's cached index. Called by InsertBUMP: a rebuild
 // can overwrite the stored compound for an existing block (e.g. late STUMP
 // callbacks), so the next enrichment must re-fetch and re-parse.

--- a/store/paging.go
+++ b/store/paging.go
@@ -1,0 +1,79 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// forEachBlockProcessingMaxPage bounds the adaptive page growth in
+// ForEachBlockProcessing. 64k rows at one height is far beyond any real
+// competition; hitting the cap returns an error instead of silently
+// skipping rows.
+const forEachBlockProcessingMaxPage = 1 << 16
+
+// ForEachBlockProcessing streams every block_processing row with
+// block_height >= minHeight through fn, newest first, using
+// ListBlockProcessingStatus pages.
+//
+// ListBlockProcessingStatus paginates with a `block_height < before` keyset
+// cursor over a NON-unique key: naively advancing the cursor to the last
+// row's height skips any rows at that same height beyond the page boundary
+// — precisely the same-height competitors a reorg scan exists to find
+// (issue #279). This helper is boundary-safe: it re-includes the boundary
+// height on the next page (`before = last+1`) and, when an entire full page
+// sits at one height, grows the page until the height fits. The trade-off
+// is that fn can see a boundary row MORE THAN ONCE — callers must be
+// idempotent per row (both reorg scans are: they compare against the active
+// chain and collect into sets).
+//
+// fn returning a non-nil error stops the iteration and surfaces the error.
+func ForEachBlockProcessing(ctx context.Context, s Store, minHeight uint64, pageSize int, fn func(*models.BlockProcessingStatus) error) error {
+	if pageSize <= 0 {
+		return fmt.Errorf("pageSize must be > 0")
+	}
+	before := uint64(0) // 0 = unbounded (newest first)
+	limit := pageSize
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		rows, err := s.ListBlockProcessingStatus(ctx, before, limit)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			return nil
+		}
+		for _, row := range rows {
+			// Heights are descending: everything after the first row below
+			// minHeight is below it too.
+			if row.BlockHeight < minHeight {
+				return nil
+			}
+			if err := fn(row); err != nil {
+				return err
+			}
+		}
+		if len(rows) < limit {
+			return nil // final page
+		}
+		last := rows[len(rows)-1].BlockHeight
+		if rows[0].BlockHeight == last {
+			// The whole page sits at one height; the cursor cannot advance
+			// without skipping unseen same-height rows. Grow the page.
+			if limit >= forEachBlockProcessingMaxPage {
+				return fmt.Errorf("block_processing height %d has more than %d rows; scan incomplete", last, limit)
+			}
+			limit *= 2
+			continue
+		}
+		if last == 0 {
+			return nil
+		}
+		// Re-include the boundary height: rows above it are fully covered
+		// (descending order), rows AT it may extend past the page end.
+		before = last + 1
+	}
+}

--- a/store/paging_test.go
+++ b/store/paging_test.go
@@ -1,0 +1,136 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
+)
+
+// pagingStore implements just ListBlockProcessingStatus over a canned row
+// set, honoring the real keyset contract (height DESC, block_height <
+// beforeHeight, limit) so page boundaries land exactly where a test puts
+// them. The embedded nil interface panics on anything else.
+type pagingStore struct {
+	store.Store
+
+	rows []*models.BlockProcessingStatus
+}
+
+func (s *pagingStore) ListBlockProcessingStatus(_ context.Context, beforeHeight uint64, limit int) ([]*models.BlockProcessingStatus, error) {
+	sorted := append([]*models.BlockProcessingStatus(nil), s.rows...)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].BlockHeight > sorted[j].BlockHeight })
+	var out []*models.BlockProcessingStatus
+	for _, row := range sorted {
+		if beforeHeight > 0 && row.BlockHeight >= beforeHeight {
+			continue
+		}
+		out = append(out, row)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func pagingRows(heights ...uint64) []*models.BlockProcessingStatus {
+	out := make([]*models.BlockProcessingStatus, len(heights))
+	for i, h := range heights {
+		out[i] = &models.BlockProcessingStatus{
+			BlockHash:   fmt.Sprintf("blk-%d-%d", h, i),
+			BlockHeight: h,
+			Status:      models.BlockStatusActive,
+		}
+	}
+	return out
+}
+
+func collectDistinct(t *testing.T, s store.Store, minHeight uint64, pageSize int) map[string]int {
+	t.Helper()
+	visits := make(map[string]int)
+	err := store.ForEachBlockProcessing(context.Background(), s, minHeight, pageSize, func(row *models.BlockProcessingStatus) error {
+		visits[row.BlockHash]++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachBlockProcessing: %v", err)
+	}
+	return visits
+}
+
+// TestForEachBlockProcessing_SameHeightRunStraddlesPageBoundary is the
+// review finding on the reorg scans: with a `block_height < before` cursor
+// over a non-unique key, rows at the boundary height beyond the page end
+// were silently skipped. Every row must be visited at least once.
+func TestForEachBlockProcessing_SameHeightRunStraddlesPageBoundary(t *testing.T) {
+	// Page size 4: page 1 = [50, 49, 49, 49], leaving two more 49s and the
+	// tail behind the boundary.
+	s := &pagingStore{rows: pagingRows(50, 49, 49, 49, 49, 49, 48, 47)}
+	visits := collectDistinct(t, s, 0, 4)
+	if len(visits) != len(s.rows) {
+		t.Fatalf("visited %d distinct rows, want %d (boundary rows skipped)", len(visits), len(s.rows))
+	}
+}
+
+// TestForEachBlockProcessing_WholePageSingleHeight: when one height has
+// more rows than the page, the pager grows the page instead of skipping.
+func TestForEachBlockProcessing_WholePageSingleHeight(t *testing.T) {
+	s := &pagingStore{rows: pagingRows(20, 10, 10, 10, 10, 10, 10, 10, 10, 10, 5)}
+	visits := collectDistinct(t, s, 0, 2)
+	if len(visits) != len(s.rows) {
+		t.Fatalf("visited %d distinct rows, want %d", len(visits), len(s.rows))
+	}
+}
+
+// TestForEachBlockProcessing_MinHeightStops: rows below minHeight are never
+// delivered, rows at or above it always are.
+func TestForEachBlockProcessing_MinHeightStops(t *testing.T) {
+	s := &pagingStore{rows: pagingRows(12, 11, 10, 9, 8)}
+	visits := collectDistinct(t, s, 10, 2)
+	if len(visits) != 3 {
+		t.Fatalf("visited %d distinct rows, want 3 (>= minHeight)", len(visits))
+	}
+	for hash := range visits {
+		if hash == "blk-9-3" || hash == "blk-8-4" {
+			t.Fatalf("row below minHeight visited: %s", hash)
+		}
+	}
+}
+
+// TestForEachBlockProcessing_FnErrorStops: fn's error surfaces immediately.
+func TestForEachBlockProcessing_FnErrorStops(t *testing.T) {
+	s := &pagingStore{rows: pagingRows(3, 2, 1)}
+	sentinel := errors.New("stop here")
+	calls := 0
+	err := store.ForEachBlockProcessing(context.Background(), s, 0, 10, func(*models.BlockProcessingStatus) error {
+		calls++
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want sentinel", err)
+	}
+	if calls != 1 {
+		t.Fatalf("fn called %d times after error, want 1", calls)
+	}
+}
+
+// TestForEachBlockProcessing_OverflowingHeightErrors: a single height with
+// more rows than the growth cap must error loudly, never truncate silently.
+func TestForEachBlockProcessing_OverflowingHeightErrors(t *testing.T) {
+	heights := make([]uint64, 70000)
+	for i := range heights {
+		heights[i] = 42
+	}
+	heights = append([]uint64{100}, heights...)
+	s := &pagingStore{rows: pagingRows(heights...)}
+	err := store.ForEachBlockProcessing(context.Background(), s, 0, 1024, func(*models.BlockProcessingStatus) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected an overflow error for a height exceeding the page cap")
+	}
+}

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -1334,6 +1334,7 @@ func (s *Store) MarkBlockProcessed(ctx context.Context, blockHash string, blockH
 		cur.BUMPBuiltUnixNs = prev.BUMPBuiltUnixNs
 		cur.Status = prev.Status
 		cur.OrphanedAtUnixNs = prev.OrphanedAtUnixNs
+		cur.ReconciledAtUnixNs = prev.ReconciledAtUnixNs
 	} else {
 		// Row didn't exist — synthesize header_seen_at = processedAt for
 		// observability. The next UpsertBlockHeaderSeen will preserve it.
@@ -1366,6 +1367,7 @@ func (s *Store) MarkBlockBUMPBuilt(ctx context.Context, blockHash string, blockH
 		cur.ProcessedUnixNs = prev.ProcessedUnixNs
 		cur.Status = prev.Status
 		cur.OrphanedAtUnixNs = prev.OrphanedAtUnixNs
+		cur.ReconciledAtUnixNs = prev.ReconciledAtUnixNs
 	} else {
 		cur.HeaderSeenUnixNs = builtAt.UnixNano()
 	}

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -65,20 +65,52 @@ type Store struct {
 // unix-nanoseconds to dodge JSON time-zone drift and to keep retry index
 // keys byte-for-byte consistent.
 type storedStatus struct {
-	TxID                   string   `json:"txid"`
-	Status                 string   `json:"status"`
-	StatusCode             int      `json:"status_code,omitempty"`
-	BlockHash              string   `json:"block_hash,omitempty"`
-	BlockHeight            uint64   `json:"block_height,omitempty"`
-	MerklePath             []byte   `json:"merkle_path,omitempty"`
-	ExtraInfo              string   `json:"extra_info,omitempty"`
-	CompetingTxs           []string `json:"competing_txs,omitempty"`
-	RawTx                  []byte   `json:"raw_tx,omitempty"`
-	RetryCount             int      `json:"retry_count,omitempty"`
-	TimestampUnixNs        int64    `json:"ts"`
-	CreatedUnixNs          int64    `json:"created_at,omitempty"`
-	NextRetryUnixNs        int64    `json:"next_retry_at,omitempty"`
-	MerkleRegisteredUnixNs int64    `json:"merkle_registered_at,omitempty"`
+	TxID                   string                 `json:"txid"`
+	Status                 string                 `json:"status"`
+	StatusCode             int                    `json:"status_code,omitempty"`
+	BlockHash              string                 `json:"block_hash,omitempty"`
+	BlockHeight            uint64                 `json:"block_height,omitempty"`
+	MerklePath             []byte                 `json:"merkle_path,omitempty"`
+	ExtraInfo              string                 `json:"extra_info,omitempty"`
+	CompetingTxs           []string               `json:"competing_txs,omitempty"`
+	RawTx                  []byte                 `json:"raw_tx,omitempty"`
+	RetryCount             int                    `json:"retry_count,omitempty"`
+	TimestampUnixNs        int64                  `json:"ts"`
+	CreatedUnixNs          int64                  `json:"created_at,omitempty"`
+	NextRetryUnixNs        int64                  `json:"next_retry_at,omitempty"`
+	MerkleRegisteredUnixNs int64                  `json:"merkle_registered_at,omitempty"`
+	OrphanedAnchors        []storedOrphanedAnchor `json:"orphaned_anchors,omitempty"`
+}
+
+// storedOrphanedAnchor is the persisted form of models.OrphanedAnchor —
+// block identity + when the anchor was superseded. The proof itself is
+// never persisted; it is re-derived from the orphaned block's retained
+// compound BUMP at read time.
+type storedOrphanedAnchor struct {
+	BlockHash      string `json:"block_hash"`
+	BlockHeight    uint64 `json:"block_height,omitempty"`
+	OrphanedUnixNs int64  `json:"orphaned_at"`
+}
+
+// appendOrphanedAnchor records that the row's current anchor is being
+// superseded (re-anchor to a different block, or reorg revert). Collapses
+// consecutive duplicates and caps at models.MaxOrphanedAnchors, mirroring
+// models.AppendOrphanedAnchor.
+func appendOrphanedAnchor(row *storedStatus, now time.Time) {
+	if row.BlockHash == "" {
+		return
+	}
+	if n := len(row.OrphanedAnchors); n > 0 && row.OrphanedAnchors[n-1].BlockHash == row.BlockHash {
+		return
+	}
+	row.OrphanedAnchors = append(row.OrphanedAnchors, storedOrphanedAnchor{
+		BlockHash:      row.BlockHash,
+		BlockHeight:    row.BlockHeight,
+		OrphanedUnixNs: now.UnixNano(),
+	})
+	if len(row.OrphanedAnchors) > models.MaxOrphanedAnchors {
+		row.OrphanedAnchors = row.OrphanedAnchors[len(row.OrphanedAnchors)-models.MaxOrphanedAnchors:]
+	}
 }
 
 func (s storedStatus) toModel() *models.TransactionStatus {
@@ -105,6 +137,13 @@ func (s storedStatus) toModel() *models.TransactionStatus {
 	}
 	if s.MerkleRegisteredUnixNs != 0 {
 		out.MerkleRegisteredAt = time.Unix(0, s.MerkleRegisteredUnixNs)
+	}
+	for _, a := range s.OrphanedAnchors {
+		out.OrphanedProofs = append(out.OrphanedProofs, models.OrphanedAnchor{
+			BlockHash:   a.BlockHash,
+			BlockHeight: a.BlockHeight,
+			OrphanedAt:  time.Unix(0, a.OrphanedUnixNs).UTC(),
+		})
 	}
 	return out
 }
@@ -133,6 +172,13 @@ func fromModel(m *models.TransactionStatus) storedStatus {
 	}
 	if !m.MerkleRegisteredAt.IsZero() {
 		out.MerkleRegisteredUnixNs = m.MerkleRegisteredAt.UnixNano()
+	}
+	for _, a := range m.OrphanedProofs {
+		out.OrphanedAnchors = append(out.OrphanedAnchors, storedOrphanedAnchor{
+			BlockHash:      a.BlockHash,
+			BlockHeight:    a.BlockHeight,
+			OrphanedUnixNs: a.OrphanedAt.UnixNano(),
+		})
 	}
 	return out
 }
@@ -540,6 +586,7 @@ func (s *Store) GetStatus(ctx context.Context, txid string) (*models.Transaction
 		return nil, nil
 	}
 	s.enrichMerklePath(ctx, st)
+	s.enrichOrphanedProofs(ctx, st)
 	return st, nil
 }
 
@@ -620,7 +667,12 @@ func (s *Store) IterateStatusesSince(ctx context.Context, since time.Time, fn fu
 
 // SetStatusByBlockHash walks idx:tx:block:<blockHash>:* and rewrites each
 // referenced row with the new status. For SEEN_ON_NETWORK transitions block
-// fields are cleared (matches Aerospike contract); for IMMUTABLE they're kept.
+// fields are cleared and the cleared anchor is appended to the row's
+// orphaned-anchor history (reorg revert, issue #279); for IMMUTABLE they're
+// kept. The index walk is a snapshot: each row is re-checked under its shard
+// lock and skipped when its block_hash no longer matches (concurrently
+// re-anchored to the canonical block) or it is already IMMUTABLE. Returns
+// only the txids actually rewritten.
 func (s *Store) SetStatusByBlockHash(ctx context.Context, blockHash string, newStatus models.Status) ([]string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -634,20 +686,22 @@ func (s *Store) SetStatusByBlockHash(ctx context.Context, blockHash string, newS
 		return nil, err
 	}
 
-	var txids []string
+	var candidates []string
 	for iter.First(); iter.Valid(); iter.Next() {
 		if err := ctx.Err(); err != nil {
 			_ = iter.Close()
-			return txids, err
+			return nil, err
 		}
-		txids = append(txids, lastSegment(iter.Key()))
+		candidates = append(candidates, lastSegment(iter.Key()))
 	}
 	if err := iter.Close(); err != nil {
-		return txids, err
+		return nil, err
 	}
 
 	clearBlock := newStatus == models.StatusSeenOnNetwork
-	for _, txid := range txids {
+	var txids []string
+	now := time.Now()
+	for _, txid := range candidates {
 		mu := s.shardFor(txid)
 		mu.Lock()
 
@@ -656,11 +710,24 @@ func (s *Store) SetStatusByBlockHash(ctx context.Context, blockHash string, newS
 			mu.Unlock()
 			continue
 		}
+		// Stale-index guard: the row moved to a different anchor between the
+		// index snapshot and this write — reverting it now would undo a
+		// concurrent re-anchor to the canonical block.
+		if existing.BlockHash != blockHash {
+			mu.Unlock()
+			continue
+		}
+		// IMMUTABLE rows are never touched by block-scoped rewrites.
+		if existing.Status == string(models.StatusImmutable) {
+			mu.Unlock()
+			continue
+		}
 
 		updated := *existing
 		updated.Status = string(newStatus)
-		updated.TimestampUnixNs = time.Now().UnixNano()
+		updated.TimestampUnixNs = now.UnixNano()
 		if clearBlock {
+			appendOrphanedAnchor(&updated, now)
 			updated.BlockHash = ""
 			updated.BlockHeight = 0
 		}
@@ -685,6 +752,35 @@ func (s *Store) SetStatusByBlockHash(ctx context.Context, blockHash string, newS
 		if err != nil {
 			return txids, err
 		}
+		txids = append(txids, txid)
+	}
+	return txids, nil
+}
+
+// GetTxIDsByBlockHash walks idx:tx:block:<blockHash>:* and returns every
+// txid currently anchored to the block. The reorg reconciler reads this as
+// an orphaned block's affected set; rows already re-anchored or reverted
+// have left the index and no longer appear.
+func (s *Store) GetTxIDsByBlockHash(ctx context.Context, blockHash string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	prefix := idxTxBlockPrefix(blockHash)
+	iter, err := s.db.NewIter(&pebbledb.IterOptions{
+		LowerBound: prefix,
+		UpperBound: endOfPrefix(prefix),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = iter.Close() }()
+
+	var txids []string
+	for iter.First(); iter.Valid(); iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return txids, err
+		}
+		txids = append(txids, lastSegment(iter.Key()))
 	}
 	return txids, nil
 }
@@ -894,9 +990,23 @@ func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeig
 			mu.Unlock()
 			continue
 		}
+		// Respect the status lattice: of all statuses only IMMUTABLE may not
+		// regress to MINED — a future confirmation-depth promotion must never
+		// be pulled back by a replayed BLOCK_PROCESSED (issue #279 hardening).
+		if !models.StatusMined.CanTransitionFrom(models.Status(existing.Status)) {
+			mu.Unlock()
+			continue
+		}
 		prev := existing.toModel()
 
 		updated := *existing
+		// Re-anchor (MINED against a DIFFERENT block): preserve the anchor
+		// being superseded so the orphaned block's proof stays auditable
+		// (issue #279). First-time MINED and idempotent same-block replays
+		// leave history untouched.
+		if existing.Status == string(models.StatusMined) && existing.BlockHash != blockHash {
+			appendOrphanedAnchor(&updated, now)
+		}
 		updated.Status = string(models.StatusMined)
 		updated.BlockHash = blockHash
 		updated.BlockHeight = blockHeight
@@ -1019,6 +1129,19 @@ func (s *Store) GetBUMP(ctx context.Context, blockHash string) (uint64, []byte, 
 	return b.BlockHeight, b.BumpData, nil
 }
 
+// DeleteBUMPByBlockHash removes the stored compound BUMP for a block and
+// drops any cached parse. Idempotent.
+func (s *Store) DeleteBUMPByBlockHash(ctx context.Context, blockHash string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := s.db.Delete(bumpKey(blockHash), s.writeOpts); err != nil {
+		return fmt.Errorf("delete bump %s: %w", blockHash, err)
+	}
+	s.bumpCache.Remove(blockHash)
+	return nil
+}
+
 func (s *Store) InsertStump(ctx context.Context, stump *models.Stump) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -1072,13 +1195,14 @@ func (s *Store) GetStumpsByBlockHash(ctx context.Context, blockHash string) ([]*
 // nanoseconds (0 == "not yet") to match the conventions used by storedStatus
 // and to avoid JSON timezone drift.
 type storedBlockProcessing struct {
-	BlockHash        string `json:"block_hash"`
-	BlockHeight      uint64 `json:"block_height"`
-	HeaderSeenUnixNs int64  `json:"header_seen_at,omitempty"`
-	ProcessedUnixNs  int64  `json:"processed_at,omitempty"`
-	BUMPBuiltUnixNs  int64  `json:"bump_built_at,omitempty"`
-	Status           string `json:"status"`
-	OrphanedAtUnixNs int64  `json:"orphaned_at,omitempty"`
+	BlockHash          string `json:"block_hash"`
+	BlockHeight        uint64 `json:"block_height"`
+	HeaderSeenUnixNs   int64  `json:"header_seen_at,omitempty"`
+	ProcessedUnixNs    int64  `json:"processed_at,omitempty"`
+	BUMPBuiltUnixNs    int64  `json:"bump_built_at,omitempty"`
+	Status             string `json:"status"`
+	OrphanedAtUnixNs   int64  `json:"orphaned_at,omitempty"`
+	ReconciledAtUnixNs int64  `json:"reconciled_at,omitempty"`
 }
 
 func (b storedBlockProcessing) toModel() *models.BlockProcessingStatus {
@@ -1101,6 +1225,10 @@ func (b storedBlockProcessing) toModel() *models.BlockProcessingStatus {
 	if b.OrphanedAtUnixNs != 0 {
 		t := time.Unix(0, b.OrphanedAtUnixNs).UTC()
 		out.OrphanedAt = &t
+	}
+	if b.ReconciledAtUnixNs != 0 {
+		t := time.Unix(0, b.ReconciledAtUnixNs).UTC()
+		out.ReconciledAt = &t
 	}
 	return out
 }
@@ -1270,6 +1398,76 @@ func (s *Store) MarkBlocksOrphaned(ctx context.Context, blockHashes []string, or
 		mu.Unlock()
 	}
 	return nil
+}
+
+// MarkBlockReconciled stamps reconciled_at on an orphaned block's row —
+// the anchor reconciler finished re-anchoring/reverting its transactions.
+// Missing rows are silently skipped.
+func (s *Store) MarkBlockReconciled(ctx context.Context, blockHash string, at time.Time) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	mu := s.shardFor(blockHash)
+	mu.Lock()
+	defer mu.Unlock()
+	prev, err := s.readBlockProc(blockHash)
+	if err != nil {
+		return err
+	}
+	if prev == nil {
+		return nil
+	}
+	cur := *prev
+	cur.ReconciledAtUnixNs = at.UnixNano()
+	return s.writeBlockProc(prev, &cur)
+}
+
+// ListOrphanedBlocksToReconcile scans the block_processing rows for
+// status='orphaned' AND reconciled_at unset, oldest orphaned_at first.
+// The table holds one row per block, so a prefix scan is cheap.
+func (s *Store) ListOrphanedBlocksToReconcile(ctx context.Context, limit int) ([]*models.BlockProcessingStatus, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		return nil, fmt.Errorf("limit must be > 0")
+	}
+	prefix := []byte(prefixBlockProc)
+	iter, err := s.db.NewIter(&pebbledb.IterOptions{
+		LowerBound: prefix,
+		UpperBound: endOfPrefix(prefix),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = iter.Close() }()
+
+	var rows []*storedBlockProcessing
+	for iter.First(); iter.Valid(); iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		var b storedBlockProcessing
+		if err := json.Unmarshal(iter.Value(), &b); err != nil {
+			continue
+		}
+		if b.Status != string(models.BlockStatusOrphaned) || b.ReconciledAtUnixNs != 0 {
+			continue
+		}
+		row := b
+		rows = append(rows, &row)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].OrphanedAtUnixNs < rows[j].OrphanedAtUnixNs
+	})
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	out := make([]*models.BlockProcessingStatus, len(rows))
+	for i, r := range rows {
+		out[i] = r.toModel()
+	}
+	return out, nil
 }
 
 func (s *Store) MarkBlocksParked(ctx context.Context, blockHashes []string) error {
@@ -1951,4 +2149,24 @@ func (s *Store) enrichMerklePath(ctx context.Context, status *models.Transaction
 		_, bumpData, err := s.GetBUMP(ctx, status.BlockHash)
 		return bumpData, err
 	})
+}
+
+// enrichOrphanedProofs resolves each historical anchor's merkle path from
+// the orphaned block's retained compound BUMP (issue #279). Best-effort:
+// an entry whose BUMP is gone or unparseable is served without a path.
+func (s *Store) enrichOrphanedProofs(ctx context.Context, status *models.TransactionStatus) {
+	if status == nil {
+		return
+	}
+	for i := range status.OrphanedProofs {
+		entry := &status.OrphanedProofs[i]
+		if len(entry.MerklePath) > 0 || entry.BlockHash == "" {
+			continue
+		}
+		hash := entry.BlockHash
+		entry.MerklePath = s.bumpCache.MinimalPath(hash, status.TxID, func() ([]byte, error) {
+			_, bumpData, err := s.GetBUMP(ctx, hash)
+			return bumpData, err
+		})
+	}
 }

--- a/store/pebble/reorg_test.go
+++ b/store/pebble/reorg_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/bsv-blockchain/arcade/store"
 )
 
+// testBlockA is the primary anchor block used across these tests.
+const testBlockA = "blk-A"
+
 // Store-layer reorg semantics for issue #279: IMMUTABLE rows are never
 // touched by block-scoped rewrites, superseded MINED anchors are preserved
 // in the row's orphaned-anchor history (capped, dup-collapsed), and the
@@ -29,7 +32,7 @@ func TestSetMinedByTxIDs_SkipsImmutable(t *testing.T) {
 
 	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
 		TxID: txid, Status: models.StatusImmutable,
-		BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+		BlockHash: testBlockA, BlockHeight: 10, Timestamp: time.Now(),
 	}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -49,7 +52,7 @@ func TestSetMinedByTxIDs_SkipsImmutable(t *testing.T) {
 	if got.Status != models.StatusImmutable {
 		t.Errorf("status = %s, want IMMUTABLE", got.Status)
 	}
-	if got.BlockHash != "blk-A" || got.BlockHeight != 10 {
+	if got.BlockHash != testBlockA || got.BlockHeight != 10 {
 		t.Errorf("anchor moved: hash=%q height=%d, want blk-A/10", got.BlockHash, got.BlockHeight)
 	}
 	if len(got.OrphanedProofs) != 0 {
@@ -68,7 +71,7 @@ func TestSetMinedByTxIDs_ReanchorAppendsOrphanedAnchor(t *testing.T) {
 
 	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
 		TxID: txid, Status: models.StatusMined,
-		BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+		BlockHash: testBlockA, BlockHeight: 10, Timestamp: time.Now(),
 	}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -93,7 +96,7 @@ func TestSetMinedByTxIDs_ReanchorAppendsOrphanedAnchor(t *testing.T) {
 		t.Fatalf("OrphanedProofs = %+v, want exactly 1 entry", got.OrphanedProofs)
 	}
 	entry := got.OrphanedProofs[0]
-	if entry.BlockHash != "blk-A" || entry.BlockHeight != 10 {
+	if entry.BlockHash != testBlockA || entry.BlockHeight != 10 {
 		t.Errorf("orphaned anchor = {%s %d}, want {blk-A 10}", entry.BlockHash, entry.BlockHeight)
 	}
 	if entry.OrphanedAt.Before(before.Add(-time.Minute)) || entry.OrphanedAt.After(time.Now().Add(time.Minute)) {
@@ -110,15 +113,15 @@ func TestSetMinedByTxIDs_ReanchorAppendsOrphanedAnchor(t *testing.T) {
 	}
 
 	// Re-anchor back to A: the current anchor (B) joins the history.
-	if _, _, err := s.SetMinedByTxIDs(ctx, "blk-A", 10, []string{txid}); err != nil {
+	if _, _, err := s.SetMinedByTxIDs(ctx, testBlockA, 10, []string{txid}); err != nil {
 		t.Fatalf("re-anchor back: %v", err)
 	}
 	got, _ = s.GetStatus(ctx, txid)
-	if got.BlockHash != "blk-A" {
+	if got.BlockHash != testBlockA {
 		t.Errorf("hash after re-anchor back = %q, want blk-A", got.BlockHash)
 	}
 	if len(got.OrphanedProofs) != 2 ||
-		got.OrphanedProofs[0].BlockHash != "blk-A" || got.OrphanedProofs[1].BlockHash != "blk-B" {
+		got.OrphanedProofs[0].BlockHash != testBlockA || got.OrphanedProofs[1].BlockHash != "blk-B" {
 		t.Fatalf("history after flip back = %+v, want [blk-A blk-B]", got.OrphanedProofs)
 	}
 
@@ -205,19 +208,19 @@ func TestSetStatusByBlockHash_RevertAppendsHistoryAndSkipsImmutable(t *testing.T
 	for _, txid := range []string{"rv-1", "rv-2"} {
 		if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
 			TxID: txid, Status: models.StatusMined,
-			BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+			BlockHash: testBlockA, BlockHeight: 10, Timestamp: time.Now(),
 		}); err != nil {
 			t.Fatalf("seed %s: %v", txid, err)
 		}
 	}
 	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
 		TxID: "rv-imm", Status: models.StatusImmutable,
-		BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+		BlockHash: testBlockA, BlockHeight: 10, Timestamp: time.Now(),
 	}); err != nil {
 		t.Fatalf("seed rv-imm: %v", err)
 	}
 
-	updated, err := s.SetStatusByBlockHash(ctx, "blk-A", models.StatusSeenOnNetwork)
+	updated, err := s.SetStatusByBlockHash(ctx, testBlockA, models.StatusSeenOnNetwork)
 	if err != nil {
 		t.Fatalf("SetStatusByBlockHash: %v", err)
 	}
@@ -227,9 +230,9 @@ func TestSetStatusByBlockHash_RevertAppendsHistoryAndSkipsImmutable(t *testing.T
 	}
 
 	for _, txid := range []string{"rv-1", "rv-2"} {
-		got, err := s.GetStatus(ctx, txid)
-		if err != nil {
-			t.Fatal(err)
+		got, getErr := s.GetStatus(ctx, txid)
+		if getErr != nil {
+			t.Fatal(getErr)
 		}
 		if got.Status != models.StatusSeenOnNetwork {
 			t.Errorf("%s: status = %s, want SEEN_ON_NETWORK", txid, got.Status)
@@ -238,7 +241,7 @@ func TestSetStatusByBlockHash_RevertAppendsHistoryAndSkipsImmutable(t *testing.T
 			t.Errorf("%s: block fields not cleared: hash=%q height=%d", txid, got.BlockHash, got.BlockHeight)
 		}
 		if len(got.OrphanedProofs) != 1 ||
-			got.OrphanedProofs[0].BlockHash != "blk-A" || got.OrphanedProofs[0].BlockHeight != 10 {
+			got.OrphanedProofs[0].BlockHash != testBlockA || got.OrphanedProofs[0].BlockHeight != 10 {
 			t.Errorf("%s: OrphanedProofs = %+v, want [{blk-A 10}]", txid, got.OrphanedProofs)
 		}
 	}
@@ -247,7 +250,7 @@ func TestSetStatusByBlockHash_RevertAppendsHistoryAndSkipsImmutable(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if imm.Status != models.StatusImmutable || imm.BlockHash != "blk-A" || imm.BlockHeight != 10 {
+	if imm.Status != models.StatusImmutable || imm.BlockHash != testBlockA || imm.BlockHeight != 10 {
 		t.Errorf("IMMUTABLE row touched: status=%s hash=%q height=%d", imm.Status, imm.BlockHash, imm.BlockHeight)
 	}
 	if len(imm.OrphanedProofs) != 0 {
@@ -266,7 +269,7 @@ func TestSetStatusByBlockHash_SkipsConcurrentlyReanchoredRow(t *testing.T) {
 
 	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
 		TxID: txid, Status: models.StatusMined,
-		BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+		BlockHash: testBlockA, BlockHeight: 10, Timestamp: time.Now(),
 	}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -276,11 +279,11 @@ func TestSetStatusByBlockHash_SkipsConcurrentlyReanchoredRow(t *testing.T) {
 	}
 	// Re-inject the now-stale blk-A index entry, as if the revert's index
 	// snapshot had been taken before the re-anchor removed it.
-	if err := s.db.Set(idxTxBlockKey("blk-A", txid), nil, s.writeOpts); err != nil {
+	if err := s.db.Set(idxTxBlockKey(testBlockA, txid), nil, s.writeOpts); err != nil {
 		t.Fatalf("inject stale index: %v", err)
 	}
 
-	updated, err := s.SetStatusByBlockHash(ctx, "blk-A", models.StatusSeenOnNetwork)
+	updated, err := s.SetStatusByBlockHash(ctx, testBlockA, models.StatusSeenOnNetwork)
 	if err != nil {
 		t.Fatalf("SetStatusByBlockHash: %v", err)
 	}
@@ -307,7 +310,7 @@ func TestGetTxIDsByBlockHash(t *testing.T) {
 	for _, txid := range []string{"ba-1", "ba-2", "ba-3"} {
 		if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
 			TxID: txid, Status: models.StatusMined,
-			BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+			BlockHash: testBlockA, BlockHeight: 10, Timestamp: time.Now(),
 		}); err != nil {
 			t.Fatalf("seed %s: %v", txid, err)
 		}
@@ -319,7 +322,7 @@ func TestGetTxIDsByBlockHash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := s.GetTxIDsByBlockHash(ctx, "blk-A")
+	got, err := s.GetTxIDsByBlockHash(ctx, testBlockA)
 	if err != nil {
 		t.Fatalf("GetTxIDsByBlockHash: %v", err)
 	}
@@ -329,10 +332,10 @@ func TestGetTxIDsByBlockHash(t *testing.T) {
 	}
 
 	// Re-anchor one row to blk-B — it must leave blk-A's set.
-	if _, _, err := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{"ba-2"}); err != nil {
-		t.Fatalf("re-anchor: %v", err)
+	if _, _, mineErr := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{"ba-2"}); mineErr != nil {
+		t.Fatalf("re-anchor: %v", mineErr)
 	}
-	got, err = s.GetTxIDsByBlockHash(ctx, "blk-A")
+	got, err = s.GetTxIDsByBlockHash(ctx, testBlockA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -403,8 +406,8 @@ func TestMarkBlockReconciled_And_ListOrphanedBlocksToReconcile(t *testing.T) {
 	}
 
 	// Reconcile rb-2 — only rb-1 remains queued.
-	if err := s.MarkBlockReconciled(ctx, "rb-2", t0.Add(3*time.Minute)); err != nil {
-		t.Fatalf("MarkBlockReconciled: %v", err)
+	if mrErr := s.MarkBlockReconciled(ctx, "rb-2", t0.Add(3*time.Minute)); mrErr != nil {
+		t.Fatalf("MarkBlockReconciled: %v", mrErr)
 	}
 	rows, err = s.ListOrphanedBlocksToReconcile(ctx, 10)
 	if err != nil {
@@ -422,14 +425,14 @@ func TestMarkBlockReconciled_And_ListOrphanedBlocksToReconcile(t *testing.T) {
 	}
 
 	// Missing rows are silently skipped.
-	if err := s.MarkBlockReconciled(ctx, "never-seen", t0); err != nil {
-		t.Fatalf("MarkBlockReconciled on missing row: %v", err)
+	if missErr := s.MarkBlockReconciled(ctx, "never-seen", t0); missErr != nil {
+		t.Fatalf("MarkBlockReconciled on missing row: %v", missErr)
 	}
 
 	// Resurrection: the reconciled block re-joins the main chain with both
 	// reorg markers cleared, so a future re-orphaning reconciles again.
-	if err := s.UpsertBlockHeaderSeen(ctx, "rb-2", 601, t0.Add(time.Hour)); err != nil {
-		t.Fatalf("resurrect: %v", err)
+	if upErr := s.UpsertBlockHeaderSeen(ctx, "rb-2", 601, t0.Add(time.Hour)); upErr != nil {
+		t.Fatalf("resurrect: %v", upErr)
 	}
 	got, err = s.GetBlockProcessingStatus(ctx, "rb-2")
 	if err != nil {
@@ -463,21 +466,21 @@ func TestGetStatus_EnrichesOrphanedProofPaths(t *testing.T) {
 	}
 	txid := blk.Txids[0]
 
-	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+	if _, _, seedErr := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
 		TxID: txid, Status: models.StatusSeenOnNetwork, Timestamp: time.Now(),
-	}); err != nil {
-		t.Fatalf("seed: %v", err)
+	}); seedErr != nil {
+		t.Fatalf("seed: %v", seedErr)
 	}
 	// Mine into blockA (whose compound BUMP is retained), then re-anchor to
 	// blockB so blockA lands in the orphaned-anchor history.
-	if _, _, err := s.SetMinedByTxIDs(ctx, blockA, 900010, []string{txid}); err != nil {
-		t.Fatalf("mine @A: %v", err)
+	if _, _, mineErr := s.SetMinedByTxIDs(ctx, blockA, 900010, []string{txid}); mineErr != nil {
+		t.Fatalf("mine @A: %v", mineErr)
 	}
-	if err := s.InsertBUMP(ctx, blockA, 900010, blk.BumpBytes); err != nil {
-		t.Fatalf("InsertBUMP: %v", err)
+	if insErr := s.InsertBUMP(ctx, blockA, 900010, blk.BumpBytes); insErr != nil {
+		t.Fatalf("InsertBUMP: %v", insErr)
 	}
-	if _, _, err := s.SetMinedByTxIDs(ctx, blockB, 900010, []string{txid}); err != nil {
-		t.Fatalf("re-anchor @B: %v", err)
+	if _, _, mineBErr := s.SetMinedByTxIDs(ctx, blockB, 900010, []string{txid}); mineBErr != nil {
+		t.Fatalf("re-anchor @B: %v", mineBErr)
 	}
 
 	got, err := s.GetStatus(ctx, txid)
@@ -493,14 +496,14 @@ func TestGetStatus_EnrichesOrphanedProofPaths(t *testing.T) {
 	}
 	// The path must parse (NewMerklePathFromBinary) and compute the orphaned
 	// block's merkle root for this txid.
-	if err := synthblock.VerifyMerklePath(path, txid, blk.Root); err != nil {
-		t.Fatalf("orphaned proof does not verify: %v", err)
+	if verErr := synthblock.VerifyMerklePath(path, txid, blk.Root); verErr != nil {
+		t.Fatalf("orphaned proof does not verify: %v", verErr)
 	}
 
 	// Best-effort: once blockA's BUMP is gone the entry is served without a
 	// path rather than failing the read.
-	if err := s.DeleteBUMPByBlockHash(ctx, blockA); err != nil {
-		t.Fatalf("DeleteBUMPByBlockHash: %v", err)
+	if delErr := s.DeleteBUMPByBlockHash(ctx, blockA); delErr != nil {
+		t.Fatalf("DeleteBUMPByBlockHash: %v", delErr)
 	}
 	got, err = s.GetStatus(ctx, txid)
 	if err != nil {

--- a/store/pebble/reorg_test.go
+++ b/store/pebble/reorg_test.go
@@ -1,0 +1,516 @@
+package pebble
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/arcade/internal/synthblock"
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
+)
+
+// Store-layer reorg semantics for issue #279: IMMUTABLE rows are never
+// touched by block-scoped rewrites, superseded MINED anchors are preserved
+// in the row's orphaned-anchor history (capped, dup-collapsed), and the
+// history's proofs are re-derived at read time from each orphaned block's
+// retained compound BUMP.
+
+// TestSetMinedByTxIDs_SkipsImmutable pins the lattice hardening: a replayed
+// BLOCK_PROCESSED must never demote a confirmation-depth promotion, so an
+// IMMUTABLE row keeps its status AND its original anchor, and does not
+// appear in the returned slices.
+func TestSetMinedByTxIDs_SkipsImmutable(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	txid := "imm-tx"
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusImmutable,
+		BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	prevs, mined, err := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{txid})
+	if err != nil {
+		t.Fatalf("SetMinedByTxIDs: %v", err)
+	}
+	if len(prevs) != 0 || len(mined) != 0 {
+		t.Fatalf("IMMUTABLE row must not be returned: prevs=%d mined=%d", len(prevs), len(mined))
+	}
+
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StatusImmutable {
+		t.Errorf("status = %s, want IMMUTABLE", got.Status)
+	}
+	if got.BlockHash != "blk-A" || got.BlockHeight != 10 {
+		t.Errorf("anchor moved: hash=%q height=%d, want blk-A/10", got.BlockHash, got.BlockHeight)
+	}
+	if len(got.OrphanedProofs) != 0 {
+		t.Errorf("IMMUTABLE row must not gain history: %+v", got.OrphanedProofs)
+	}
+}
+
+// TestSetMinedByTxIDs_ReanchorAppendsOrphanedAnchor covers the same-height
+// re-anchor path: MINED against a DIFFERENT block preserves the superseded
+// anchor, idempotent same-block replays leave history untouched, and a
+// first-time MINED appends nothing.
+func TestSetMinedByTxIDs_ReanchorAppendsOrphanedAnchor(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	txid := "reanchor-tx"
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusMined,
+		BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Re-anchor A → B at the same height.
+	before := time.Now()
+	if _, mined, err := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{txid}); err != nil {
+		t.Fatalf("re-anchor: %v", err)
+	} else if len(mined) != 1 {
+		t.Fatalf("re-anchor returned %d rows, want 1", len(mined))
+	}
+
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StatusMined || got.BlockHash != "blk-B" || got.BlockHeight != 10 {
+		t.Fatalf("row after re-anchor: status=%s hash=%q height=%d, want MINED/blk-B/10",
+			got.Status, got.BlockHash, got.BlockHeight)
+	}
+	if len(got.OrphanedProofs) != 1 {
+		t.Fatalf("OrphanedProofs = %+v, want exactly 1 entry", got.OrphanedProofs)
+	}
+	entry := got.OrphanedProofs[0]
+	if entry.BlockHash != "blk-A" || entry.BlockHeight != 10 {
+		t.Errorf("orphaned anchor = {%s %d}, want {blk-A 10}", entry.BlockHash, entry.BlockHeight)
+	}
+	if entry.OrphanedAt.Before(before.Add(-time.Minute)) || entry.OrphanedAt.After(time.Now().Add(time.Minute)) {
+		t.Errorf("OrphanedAt = %v, want ~now", entry.OrphanedAt)
+	}
+
+	// Idempotent replay against the SAME block must not grow history.
+	if _, _, err := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{txid}); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	got, _ = s.GetStatus(ctx, txid)
+	if len(got.OrphanedProofs) != 1 {
+		t.Fatalf("history grew on idempotent replay: %+v", got.OrphanedProofs)
+	}
+
+	// Re-anchor back to A: the current anchor (B) joins the history.
+	if _, _, err := s.SetMinedByTxIDs(ctx, "blk-A", 10, []string{txid}); err != nil {
+		t.Fatalf("re-anchor back: %v", err)
+	}
+	got, _ = s.GetStatus(ctx, txid)
+	if got.BlockHash != "blk-A" {
+		t.Errorf("hash after re-anchor back = %q, want blk-A", got.BlockHash)
+	}
+	if len(got.OrphanedProofs) != 2 ||
+		got.OrphanedProofs[0].BlockHash != "blk-A" || got.OrphanedProofs[1].BlockHash != "blk-B" {
+		t.Fatalf("history after flip back = %+v, want [blk-A blk-B]", got.OrphanedProofs)
+	}
+
+	// First-time MINED (from SEEN_ON_NETWORK) appends nothing.
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: "fresh-tx", Status: models.StatusSeenOnNetwork, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{"fresh-tx"}); err != nil {
+		t.Fatal(err)
+	}
+	fresh, _ := s.GetStatus(ctx, "fresh-tx")
+	if len(fresh.OrphanedProofs) != 0 {
+		t.Errorf("first-time MINED must not append history: %+v", fresh.OrphanedProofs)
+	}
+}
+
+// TestSetMinedByTxIDs_HistoryCap drives 7 alternating re-anchors and asserts
+// the history caps at models.MaxOrphanedAnchors, keeping the newest entries.
+func TestSetMinedByTxIDs_HistoryCap(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	txid := "cap-tx"
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusMined,
+		BlockHash: "cap-0", BlockHeight: 10, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Alternate cap-A / cap-B so every re-anchor supersedes a different
+	// block and no consecutive-dup collapse kicks in.
+	var last string
+	for i := 0; i < 7; i++ {
+		next := "cap-A"
+		if i%2 == 1 {
+			next = "cap-B"
+		}
+		if _, _, err := s.SetMinedByTxIDs(ctx, next, 10, []string{txid}); err != nil {
+			t.Fatalf("re-anchor %d → %s: %v", i, next, err)
+		}
+		last = next
+	}
+
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.BlockHash != last {
+		t.Errorf("current anchor = %q, want %q", got.BlockHash, last)
+	}
+	if len(got.OrphanedProofs) != models.MaxOrphanedAnchors {
+		t.Fatalf("history len = %d, want cap %d: %+v",
+			len(got.OrphanedProofs), models.MaxOrphanedAnchors, got.OrphanedProofs)
+	}
+	// The oldest entries (the original cap-0 anchor) were evicted.
+	for _, e := range got.OrphanedProofs {
+		if e.BlockHash == "cap-0" {
+			t.Errorf("oldest anchor cap-0 survived the cap: %+v", got.OrphanedProofs)
+		}
+	}
+	// Newest entry is the anchor superseded by the last re-anchor: with the
+	// A/B alternation that is the opposite block of the current anchor.
+	newest := got.OrphanedProofs[len(got.OrphanedProofs)-1].BlockHash
+	wantNewest := "cap-A"
+	if last == "cap-A" {
+		wantNewest = "cap-B"
+	}
+	if newest != wantNewest {
+		t.Errorf("newest history entry = %q, want %q", newest, wantNewest)
+	}
+}
+
+// TestSetStatusByBlockHash_RevertAppendsHistoryAndSkipsImmutable pins the
+// reorg-revert path: MINED rows in the orphaned block are returned and
+// reverted with block fields cleared plus the cleared anchor appended to
+// history; IMMUTABLE rows are untouched and NOT returned.
+func TestSetStatusByBlockHash_RevertAppendsHistoryAndSkipsImmutable(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, txid := range []string{"rv-1", "rv-2"} {
+		if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+			TxID: txid, Status: models.StatusMined,
+			BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+		}); err != nil {
+			t.Fatalf("seed %s: %v", txid, err)
+		}
+	}
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: "rv-imm", Status: models.StatusImmutable,
+		BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed rv-imm: %v", err)
+	}
+
+	updated, err := s.SetStatusByBlockHash(ctx, "blk-A", models.StatusSeenOnNetwork)
+	if err != nil {
+		t.Fatalf("SetStatusByBlockHash: %v", err)
+	}
+	sort.Strings(updated)
+	if len(updated) != 2 || updated[0] != "rv-1" || updated[1] != "rv-2" {
+		t.Fatalf("updated = %v, want [rv-1 rv-2]", updated)
+	}
+
+	for _, txid := range []string{"rv-1", "rv-2"} {
+		got, err := s.GetStatus(ctx, txid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != models.StatusSeenOnNetwork {
+			t.Errorf("%s: status = %s, want SEEN_ON_NETWORK", txid, got.Status)
+		}
+		if got.BlockHash != "" || got.BlockHeight != 0 {
+			t.Errorf("%s: block fields not cleared: hash=%q height=%d", txid, got.BlockHash, got.BlockHeight)
+		}
+		if len(got.OrphanedProofs) != 1 ||
+			got.OrphanedProofs[0].BlockHash != "blk-A" || got.OrphanedProofs[0].BlockHeight != 10 {
+			t.Errorf("%s: OrphanedProofs = %+v, want [{blk-A 10}]", txid, got.OrphanedProofs)
+		}
+	}
+
+	imm, err := s.GetStatus(ctx, "rv-imm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imm.Status != models.StatusImmutable || imm.BlockHash != "blk-A" || imm.BlockHeight != 10 {
+		t.Errorf("IMMUTABLE row touched: status=%s hash=%q height=%d", imm.Status, imm.BlockHash, imm.BlockHeight)
+	}
+	if len(imm.OrphanedProofs) != 0 {
+		t.Errorf("IMMUTABLE row gained history: %+v", imm.OrphanedProofs)
+	}
+}
+
+// TestSetStatusByBlockHash_SkipsConcurrentlyReanchoredRow exercises the
+// stale-index/hash-recheck guard: a row that moved to a different anchor
+// between the index snapshot and the write must not be reverted. The stale
+// index entry is injected by hand to simulate the race deterministically.
+func TestSetStatusByBlockHash_SkipsConcurrentlyReanchoredRow(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	txid := "cr-1"
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusMined,
+		BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Concurrent re-anchor to the canonical block.
+	if _, _, err := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{txid}); err != nil {
+		t.Fatalf("re-anchor: %v", err)
+	}
+	// Re-inject the now-stale blk-A index entry, as if the revert's index
+	// snapshot had been taken before the re-anchor removed it.
+	if err := s.db.Set(idxTxBlockKey("blk-A", txid), nil, s.writeOpts); err != nil {
+		t.Fatalf("inject stale index: %v", err)
+	}
+
+	updated, err := s.SetStatusByBlockHash(ctx, "blk-A", models.StatusSeenOnNetwork)
+	if err != nil {
+		t.Fatalf("SetStatusByBlockHash: %v", err)
+	}
+	if len(updated) != 0 {
+		t.Fatalf("re-anchored row must be skipped, got %v", updated)
+	}
+
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StatusMined || got.BlockHash != "blk-B" {
+		t.Errorf("row reverted despite re-anchor: status=%s hash=%q, want MINED/blk-B", got.Status, got.BlockHash)
+	}
+}
+
+// TestGetTxIDsByBlockHash covers the reorg reconciler's affected-set read:
+// only rows CURRENTLY anchored to the block are returned, so a re-anchored
+// row leaves the set.
+func TestGetTxIDsByBlockHash(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, txid := range []string{"ba-1", "ba-2", "ba-3"} {
+		if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+			TxID: txid, Status: models.StatusMined,
+			BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+		}); err != nil {
+			t.Fatalf("seed %s: %v", txid, err)
+		}
+	}
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: "bb-1", Status: models.StatusMined,
+		BlockHash: "blk-B", BlockHeight: 10, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetTxIDsByBlockHash(ctx, "blk-A")
+	if err != nil {
+		t.Fatalf("GetTxIDsByBlockHash: %v", err)
+	}
+	sort.Strings(got)
+	if len(got) != 3 || got[0] != "ba-1" || got[1] != "ba-2" || got[2] != "ba-3" {
+		t.Fatalf("blk-A txids = %v, want [ba-1 ba-2 ba-3]", got)
+	}
+
+	// Re-anchor one row to blk-B — it must leave blk-A's set.
+	if _, _, err := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{"ba-2"}); err != nil {
+		t.Fatalf("re-anchor: %v", err)
+	}
+	got, err = s.GetTxIDsByBlockHash(ctx, "blk-A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "ba-1" || got[1] != "ba-3" {
+		t.Fatalf("blk-A txids after re-anchor = %v, want [ba-1 ba-3]", got)
+	}
+}
+
+// TestDeleteBUMPByBlockHash: delete removes the stored compound and is
+// idempotent — a second delete of the same (now missing) block is a no-op.
+func TestDeleteBUMPByBlockHash(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	if err := s.InsertBUMP(ctx, "blk-del", 42, []byte{0xde, 0xad, 0xbe, 0xef}); err != nil {
+		t.Fatalf("InsertBUMP: %v", err)
+	}
+	if h, data, err := s.GetBUMP(ctx, "blk-del"); err != nil || h != 42 || len(data) != 4 {
+		t.Fatalf("GetBUMP before delete: h=%d data=%x err=%v", h, data, err)
+	}
+
+	if err := s.DeleteBUMPByBlockHash(ctx, "blk-del"); err != nil {
+		t.Fatalf("DeleteBUMPByBlockHash: %v", err)
+	}
+	if _, _, err := s.GetBUMP(ctx, "blk-del"); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("GetBUMP after delete: err=%v, want ErrNotFound", err)
+	}
+	if err := s.DeleteBUMPByBlockHash(ctx, "blk-del"); err != nil {
+		t.Fatalf("second delete must be a no-op, got %v", err)
+	}
+}
+
+// TestMarkBlockReconciled_And_ListOrphanedBlocksToReconcile covers the
+// reconciler's durable work queue: orphaned-and-unreconciled rows surface
+// oldest-first, MarkBlockReconciled removes a row from the queue, and a
+// resurrected block clears both orphaned_at and reconciled_at.
+func TestMarkBlockReconciled_And_ListOrphanedBlocksToReconcile(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	t0 := time.Unix(1700000500, 0).UTC()
+
+	for i, hash := range []string{"rb-1", "rb-2", "rb-3"} {
+		if err := s.UpsertBlockHeaderSeen(ctx, hash, uint64(600+i), t0); err != nil {
+			t.Fatalf("seed %s: %v", hash, err)
+		}
+	}
+	// Orphan rb-2 first in wall-clock terms so the list orders by
+	// orphaned_at, not by insertion or height.
+	if err := s.MarkBlocksOrphaned(ctx, []string{"rb-2"}, t0.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkBlocksOrphaned(ctx, []string{"rb-1"}, t0.Add(2*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := s.ListOrphanedBlocksToReconcile(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListOrphanedBlocksToReconcile: %v", err)
+	}
+	if len(rows) != 2 || rows[0].BlockHash != "rb-2" || rows[1].BlockHash != "rb-1" {
+		t.Fatalf("queue = %v, want [rb-2 rb-1] oldest-first", hashesOf(rows))
+	}
+	for _, r := range rows {
+		if r.ReconciledAt != nil {
+			t.Errorf("%s: ReconciledAt = %v, want nil while queued", r.BlockHash, r.ReconciledAt)
+		}
+	}
+
+	// Reconcile rb-2 — only rb-1 remains queued.
+	if err := s.MarkBlockReconciled(ctx, "rb-2", t0.Add(3*time.Minute)); err != nil {
+		t.Fatalf("MarkBlockReconciled: %v", err)
+	}
+	rows, err = s.ListOrphanedBlocksToReconcile(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].BlockHash != "rb-1" {
+		t.Fatalf("queue after reconcile = %v, want [rb-1]", hashesOf(rows))
+	}
+	got, err := s.GetBlockProcessingStatus(ctx, "rb-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ReconciledAt == nil {
+		t.Error("rb-2: ReconciledAt should be set after MarkBlockReconciled")
+	}
+
+	// Missing rows are silently skipped.
+	if err := s.MarkBlockReconciled(ctx, "never-seen", t0); err != nil {
+		t.Fatalf("MarkBlockReconciled on missing row: %v", err)
+	}
+
+	// Resurrection: the reconciled block re-joins the main chain with both
+	// reorg markers cleared, so a future re-orphaning reconciles again.
+	if err := s.UpsertBlockHeaderSeen(ctx, "rb-2", 601, t0.Add(time.Hour)); err != nil {
+		t.Fatalf("resurrect: %v", err)
+	}
+	got, err = s.GetBlockProcessingStatus(ctx, "rb-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.BlockStatusActive {
+		t.Errorf("resurrected status = %q, want active", got.Status)
+	}
+	if got.OrphanedAt != nil || got.ReconciledAt != nil {
+		t.Errorf("resurrection must clear reorg markers: orphanedAt=%v reconciledAt=%v",
+			got.OrphanedAt, got.ReconciledAt)
+	}
+}
+
+// TestGetStatus_EnrichesOrphanedProofPaths builds a real compound BUMP for
+// the orphaned block so GetStatus can re-derive the historical anchor's
+// minimal path at read time; the extracted path must parse and compute the
+// orphaned block's root. Once the BUMP is deleted the entry is served
+// without a path (best-effort contract).
+func TestGetStatus_EnrichesOrphanedProofPaths(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	const (
+		blockA = "000000000000000000000000000000000000000000000000000000000000aaaa"
+		blockB = "000000000000000000000000000000000000000000000000000000000000bbbb"
+	)
+	blk, err := synthblock.Build(4, 900010)
+	if err != nil {
+		t.Fatalf("synthblock.Build: %v", err)
+	}
+	txid := blk.Txids[0]
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusSeenOnNetwork, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Mine into blockA (whose compound BUMP is retained), then re-anchor to
+	// blockB so blockA lands in the orphaned-anchor history.
+	if _, _, err := s.SetMinedByTxIDs(ctx, blockA, 900010, []string{txid}); err != nil {
+		t.Fatalf("mine @A: %v", err)
+	}
+	if err := s.InsertBUMP(ctx, blockA, 900010, blk.BumpBytes); err != nil {
+		t.Fatalf("InsertBUMP: %v", err)
+	}
+	if _, _, err := s.SetMinedByTxIDs(ctx, blockB, 900010, []string{txid}); err != nil {
+		t.Fatalf("re-anchor @B: %v", err)
+	}
+
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.OrphanedProofs) != 1 || got.OrphanedProofs[0].BlockHash != blockA {
+		t.Fatalf("OrphanedProofs = %+v, want one entry for blockA", got.OrphanedProofs)
+	}
+	path := got.OrphanedProofs[0].MerklePath
+	if len(path) == 0 {
+		t.Fatal("historical anchor's MerklePath not enriched from retained BUMP")
+	}
+	// The path must parse (NewMerklePathFromBinary) and compute the orphaned
+	// block's merkle root for this txid.
+	if err := synthblock.VerifyMerklePath(path, txid, blk.Root); err != nil {
+		t.Fatalf("orphaned proof does not verify: %v", err)
+	}
+
+	// Best-effort: once blockA's BUMP is gone the entry is served without a
+	// path rather than failing the read.
+	if err := s.DeleteBUMPByBlockHash(ctx, blockA); err != nil {
+		t.Fatalf("DeleteBUMPByBlockHash: %v", err)
+	}
+	got, err = s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.OrphanedProofs) != 1 {
+		t.Fatalf("history lost after BUMP delete: %+v", got.OrphanedProofs)
+	}
+	if len(got.OrphanedProofs[0].MerklePath) != 0 {
+		t.Errorf("entry must be served without a path once the BUMP is deleted, got %x",
+			got.OrphanedProofs[0].MerklePath)
+	}
+}

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -557,21 +557,84 @@ func disallowedPrevAsStrings(s models.Status) []string {
 }
 
 func (s *Store) GetStatus(ctx context.Context, txid string) (*models.TransactionStatus, error) {
+	// orphaned_anchors rides only on this single-tx read (the GET /tx path
+	// where historical proofs matter) — the scanStatus-shared bulk queries
+	// deliberately skip it.
 	const q = `
 SELECT txid, status, status_code, block_hash, block_height, merkle_path,
        extra_info, competing_txs, raw_tx, retry_count, next_retry_at,
-       timestamp_at, created_at, merkle_registered_at
+       timestamp_at, created_at, merkle_registered_at,
+       COALESCE(orphaned_anchors, 'null'::jsonb)
 FROM transactions WHERE txid = $1`
 	row := s.pool.QueryRow(ctx, q, txid)
-	st, err := scanStatus(row)
+	st, anchorsJSON, err := scanStatusWithAnchors(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
+	if len(anchorsJSON) > 0 && string(anchorsJSON) != "null" {
+		_ = json.Unmarshal(anchorsJSON, &st.OrphanedProofs)
+	}
 	s.enrichMerklePath(ctx, st)
+	s.enrichOrphanedProofs(ctx, st)
 	return st, nil
+}
+
+// scanStatusWithAnchors is scanStatus + the trailing orphaned_anchors JSONB
+// column GetStatus selects.
+func scanStatusWithAnchors(row rowScanner) (*models.TransactionStatus, []byte, error) {
+	var (
+		st                 models.TransactionStatus
+		statusCode         *int
+		blockHash          *string
+		blockHeight        *int64
+		merklePath         []byte
+		extraInfo          *string
+		competingTxs       []byte
+		rawTx              []byte
+		nextRetry          *time.Time
+		merkleRegisteredAt *time.Time
+		anchors            []byte
+	)
+	if err := row.Scan(
+		&st.TxID, &st.Status, &statusCode,
+		&blockHash, &blockHeight, &merklePath,
+		&extraInfo, &competingTxs, &rawTx,
+		&st.RetryCount, &nextRetry,
+		&st.Timestamp, &st.CreatedAt, &merkleRegisteredAt, &anchors,
+	); err != nil {
+		return nil, nil, err
+	}
+	if statusCode != nil {
+		st.StatusCode = *statusCode
+	}
+	if blockHash != nil {
+		st.BlockHash = *blockHash
+	}
+	if blockHeight != nil {
+		st.BlockHeight = uint64(*blockHeight) //nolint:gosec // block height fits in either signed/unsigned 64-bit
+	}
+	if len(merklePath) > 0 {
+		st.MerklePath = merklePath
+	}
+	if extraInfo != nil {
+		st.ExtraInfo = *extraInfo
+	}
+	if len(competingTxs) > 0 {
+		_ = json.Unmarshal(competingTxs, &st.CompetingTxs)
+	}
+	if len(rawTx) > 0 {
+		st.RawTx = rawTx
+	}
+	if nextRetry != nil {
+		st.NextRetryAt = *nextRetry
+	}
+	if merkleRegisteredAt != nil {
+		st.MerkleRegisteredAt = *merkleRegisteredAt
+	}
+	return &st, anchors, nil
 }
 
 func (s *Store) GetStatusesSince(ctx context.Context, since time.Time) ([]*models.TransactionStatus, error) {
@@ -631,22 +694,69 @@ ORDER BY timestamp_at DESC`
 
 // SetStatusByBlockHash rewrites every row in the block. Block fields are
 // cleared on SEEN_ON_NETWORK transitions (reorg path) and kept otherwise —
-// matches the Aerospike / Pebble contract.
+// matches the Aerospike / Pebble contract. IMMUTABLE rows are never touched,
+// and the WHERE block_hash predicate is atomic per row, so a tx concurrently
+// re-anchored to a different block simply falls out of the match (issue
+// #279). Reverts append the cleared anchor to orphaned_anchors so the
+// orphaned block's proof stays auditable.
 func (s *Store) SetStatusByBlockHash(ctx context.Context, blockHash string, newStatus models.Status) ([]string, error) {
 	clearBlock := newStatus == models.StatusSeenOnNetwork
 
 	var q string
 	if clearBlock {
-		q = `UPDATE transactions SET status=$2, block_hash=NULL, block_height=NULL, timestamp_at=NOW()
-             WHERE block_hash=$1 RETURNING txid`
+		q = `UPDATE transactions SET status=$2,
+               orphaned_anchors = CASE
+                 WHEN COALESCE(orphaned_anchors -> -1 ->> 'blockHash', '') <> block_hash
+                 THEN (
+                   SELECT jsonb_agg(elem ORDER BY ord)
+                   FROM (
+                     SELECT elem, ord
+                     FROM jsonb_array_elements(
+                            COALESCE(orphaned_anchors, '[]'::jsonb) ||
+                            jsonb_build_array(jsonb_build_object(
+                              'blockHash',   block_hash,
+                              'blockHeight', COALESCE(block_height, 0),
+                              'orphanedAt',  NOW()
+                            ))
+                          ) WITH ORDINALITY AS x(elem, ord)
+                     ORDER BY ord DESC
+                     LIMIT 5
+                   ) tail
+                 )
+                 ELSE orphaned_anchors
+               END,
+               block_hash=NULL, block_height=NULL, timestamp_at=NOW()
+             WHERE block_hash=$1 AND status <> 'IMMUTABLE' RETURNING txid`
 	} else {
 		q = `UPDATE transactions SET status=$2, timestamp_at=NOW()
-             WHERE block_hash=$1 RETURNING txid`
+             WHERE block_hash=$1 AND status <> 'IMMUTABLE' RETURNING txid`
 	}
 
 	rows, err := s.pool.Query(ctx, q, blockHash, string(newStatus))
 	if err != nil {
 		return nil, fmt.Errorf("update by block hash: %w", err)
+	}
+	defer rows.Close()
+
+	var txids []string
+	for rows.Next() {
+		var txid string
+		if err := rows.Scan(&txid); err != nil {
+			return txids, err
+		}
+		txids = append(txids, txid)
+	}
+	return txids, rows.Err()
+}
+
+// GetTxIDsByBlockHash returns every txid currently anchored to blockHash —
+// the reorg reconciler's affected set for an orphaned block. Resolved via
+// idx_tx_block_hash.
+func (s *Store) GetTxIDsByBlockHash(ctx context.Context, blockHash string) ([]string, error) {
+	const q = `SELECT txid FROM transactions WHERE block_hash = $1`
+	rows, err := s.pool.Query(ctx, q, blockHash)
+	if err != nil {
+		return nil, fmt.Errorf("get txids by block hash: %w", err)
 	}
 	defer rows.Close()
 
@@ -757,16 +867,44 @@ func (s *Store) SetMinedByTxIDs(ctx context.Context, blockHash string, blockHeig
 		return nil, nil, nil
 	}
 	now := time.Now()
+	// Lattice hardening + orphaned-anchor history (issue #279):
+	//   - IMMUTABLE rows are excluded from the join — a replayed
+	//     BLOCK_PROCESSED must never demote a confirmation-depth promotion.
+	//   - A MINED row re-anchored to a DIFFERENT block appends its previous
+	//     anchor to orphaned_anchors (models.OrphanedAnchor JSON shape,
+	//     capped at 5 = models.MaxOrphanedAnchors, consecutive duplicates
+	//     collapsed) so the orphaned block's proof stays auditable.
 	const q = `
 WITH prev AS (
-  SELECT txid, status, timestamp_at, block_hash, block_height
+  SELECT txid, status, timestamp_at, block_hash, block_height, orphaned_anchors
   FROM transactions
   WHERE txid = ANY($5)
 )
 UPDATE transactions t
-SET status=$1, block_hash=$2, block_height=$3, timestamp_at=$4
+SET status=$1, block_hash=$2, block_height=$3, timestamp_at=$4,
+    orphaned_anchors = CASE
+      WHEN prev.status = 'MINED' AND prev.block_hash IS NOT NULL AND prev.block_hash <> $2
+           AND COALESCE(prev.orphaned_anchors -> -1 ->> 'blockHash', '') <> prev.block_hash
+      THEN (
+        SELECT jsonb_agg(elem ORDER BY ord)
+        FROM (
+          SELECT elem, ord
+          FROM jsonb_array_elements(
+                 COALESCE(prev.orphaned_anchors, '[]'::jsonb) ||
+                 jsonb_build_array(jsonb_build_object(
+                   'blockHash',   prev.block_hash,
+                   'blockHeight', COALESCE(prev.block_height, 0),
+                   'orphanedAt',  $4::timestamptz
+                 ))
+               ) WITH ORDINALITY AS x(elem, ord)
+          ORDER BY ord DESC
+          LIMIT 5
+        ) tail
+      )
+      ELSE prev.orphaned_anchors
+    END
 FROM prev
-WHERE t.txid = prev.txid
+WHERE t.txid = prev.txid AND t.status <> 'IMMUTABLE'
 RETURNING t.txid, prev.status, prev.timestamp_at, prev.block_hash, prev.block_height`
 	rows, err := s.pool.Query(ctx, q, string(models.StatusMined), blockHash, int64(blockHeight), now, txids) //nolint:gosec // block height fits in int64
 	if err != nil {
@@ -908,9 +1046,10 @@ func (s *Store) UpsertBlockHeaderSeen(ctx context.Context, blockHash string, blo
 INSERT INTO block_processing (block_hash, block_height, header_seen_at, status)
 VALUES ($1, $2, $3, 'active')
 ON CONFLICT (block_hash) DO UPDATE SET
-    block_height = EXCLUDED.block_height,
-    status       = 'active',
-    orphaned_at  = NULL`
+    block_height  = EXCLUDED.block_height,
+    status        = 'active',
+    orphaned_at   = NULL,
+    reconciled_at = NULL`
 	_, err := s.pool.Exec(ctx, q, blockHash, int64(blockHeight), seenAt) //nolint:gosec // block height fits in int64
 	if err != nil {
 		return fmt.Errorf("upsert block header seen %s: %w", blockHash, err)
@@ -959,6 +1098,46 @@ WHERE block_hash = ANY($1)`
 	return nil
 }
 
+// MarkBlockReconciled stamps reconciled_at on an orphaned block's row —
+// the anchor reconciler finished re-anchoring/reverting its transactions.
+// Missing rows are silently skipped.
+func (s *Store) MarkBlockReconciled(ctx context.Context, blockHash string, at time.Time) error {
+	const q = `UPDATE block_processing SET reconciled_at = $2 WHERE block_hash = $1`
+	if _, err := s.pool.Exec(ctx, q, blockHash, at); err != nil {
+		return fmt.Errorf("mark block reconciled %s: %w", blockHash, err)
+	}
+	return nil
+}
+
+// ListOrphanedBlocksToReconcile returns the reconciler's work queue:
+// orphaned rows not yet reconciled, oldest orphaned_at first. Served by
+// the idx_bp_orphaned_unreconciled partial index.
+func (s *Store) ListOrphanedBlocksToReconcile(ctx context.Context, limit int) ([]*models.BlockProcessingStatus, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("limit must be > 0")
+	}
+	const q = `
+SELECT block_hash, block_height, header_seen_at, processed_at, bump_built_at, status, orphaned_at, reconciled_at
+FROM block_processing
+WHERE status = 'orphaned' AND reconciled_at IS NULL
+ORDER BY orphaned_at ASC NULLS LAST
+LIMIT $1`
+	rows, err := s.pool.Query(ctx, q, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list orphaned blocks to reconcile: %w", err)
+	}
+	defer rows.Close()
+	var out []*models.BlockProcessingStatus
+	for rows.Next() {
+		bp, err := scanBlockProcessing(rows.Scan)
+		if err != nil {
+			return out, err
+		}
+		out = append(out, bp)
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) MarkBlocksParked(ctx context.Context, blockHashes []string) error {
 	if len(blockHashes) == 0 {
 		return nil
@@ -978,7 +1157,7 @@ WHERE block_hash = ANY($1) AND status = 'active'`
 
 func (s *Store) GetBlockProcessingStatus(ctx context.Context, blockHash string) (*models.BlockProcessingStatus, error) {
 	const q = `
-SELECT block_hash, block_height, header_seen_at, processed_at, bump_built_at, status, orphaned_at
+SELECT block_hash, block_height, header_seen_at, processed_at, bump_built_at, status, orphaned_at, reconciled_at
 FROM block_processing
 WHERE block_hash = $1`
 	row := s.pool.QueryRow(ctx, q, blockHash)
@@ -997,7 +1176,7 @@ func (s *Store) ListBlockProcessingStatus(ctx context.Context, beforeHeight uint
 		return nil, nil
 	}
 	const q = `
-SELECT block_hash, block_height, header_seen_at, processed_at, bump_built_at, status, orphaned_at
+SELECT block_hash, block_height, header_seen_at, processed_at, bump_built_at, status, orphaned_at, reconciled_at
 FROM block_processing
 WHERE ($1 = 0 OR block_height < $1)
 ORDER BY block_height DESC
@@ -1038,7 +1217,7 @@ func (s *Store) ListStaleBlockProcessingStatus(ctx context.Context, olderThan ti
 		return nil, nil
 	}
 	const q = `
-SELECT block_hash, block_height, header_seen_at, processed_at, bump_built_at, status, orphaned_at
+SELECT block_hash, block_height, header_seen_at, processed_at, bump_built_at, status, orphaned_at, reconciled_at
 FROM block_processing
 WHERE processed_at IS NULL
   AND status = 'active'
@@ -1066,15 +1245,16 @@ LIMIT $3`
 // shape lets us share this between QueryRow.Scan and Rows.Scan.
 func scanBlockProcessing(scan func(...any) error) (*models.BlockProcessingStatus, error) {
 	var (
-		bp         models.BlockProcessingStatus
-		height     int64
-		processed  *time.Time
-		bumpBuilt  *time.Time
-		statusVal  string
-		orphanedAt *time.Time
-		seenAt     time.Time
+		bp           models.BlockProcessingStatus
+		height       int64
+		processed    *time.Time
+		bumpBuilt    *time.Time
+		statusVal    string
+		orphanedAt   *time.Time
+		reconciledAt *time.Time
+		seenAt       time.Time
 	)
-	if err := scan(&bp.BlockHash, &height, &seenAt, &processed, &bumpBuilt, &statusVal, &orphanedAt); err != nil {
+	if err := scan(&bp.BlockHash, &height, &seenAt, &processed, &bumpBuilt, &statusVal, &orphanedAt, &reconciledAt); err != nil {
 		return nil, err
 	}
 	bp.BlockHeight = uint64(height) //nolint:gosec // height non-negative in storage
@@ -1083,6 +1263,7 @@ func scanBlockProcessing(scan func(...any) error) (*models.BlockProcessingStatus
 	bp.BUMPBuiltAt = bumpBuilt
 	bp.Status = models.BlockProcessingStatusValue(statusVal)
 	bp.OrphanedAt = orphanedAt
+	bp.ReconciledAt = reconciledAt
 	return &bp, nil
 }
 
@@ -1506,4 +1687,35 @@ func (s *Store) enrichMerklePath(ctx context.Context, status *models.Transaction
 		_, bumpData, err := s.GetBUMP(ctx, status.BlockHash)
 		return bumpData, err
 	})
+}
+
+// enrichOrphanedProofs resolves each historical anchor's merkle path from
+// the orphaned block's retained compound BUMP (issue #279). Best-effort:
+// an entry whose BUMP is gone or unparseable is served without a path.
+func (s *Store) enrichOrphanedProofs(ctx context.Context, status *models.TransactionStatus) {
+	if status == nil {
+		return
+	}
+	for i := range status.OrphanedProofs {
+		entry := &status.OrphanedProofs[i]
+		if len(entry.MerklePath) > 0 || entry.BlockHash == "" {
+			continue
+		}
+		hash := entry.BlockHash
+		entry.MerklePath = s.bumpCache.MinimalPath(hash, status.TxID, func() ([]byte, error) {
+			_, bumpData, err := s.GetBUMP(ctx, hash)
+			return bumpData, err
+		})
+	}
+}
+
+// DeleteBUMPByBlockHash removes the stored compound BUMP for a block and
+// drops any cached parse. Idempotent.
+func (s *Store) DeleteBUMPByBlockHash(ctx context.Context, blockHash string) error {
+	const q = `DELETE FROM bumps WHERE block_hash = $1`
+	if _, err := s.pool.Exec(ctx, q, blockHash); err != nil {
+		return fmt.Errorf("delete bump %s: %w", blockHash, err)
+	}
+	s.bumpCache.Remove(blockHash)
+	return nil
 }

--- a/store/postgres/reorg_test.go
+++ b/store/postgres/reorg_test.go
@@ -1,0 +1,516 @@
+//go:build postgres
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/arcade/internal/synthblock"
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
+)
+
+// Store-layer reorg semantics for issue #279: IMMUTABLE rows are never
+// touched by block-scoped rewrites, superseded MINED anchors are preserved
+// in the row's orphaned_anchors JSONB history (capped, dup-collapsed), and
+// the history's proofs are re-derived at read time from each orphaned
+// block's retained compound BUMP.
+
+// TestSetMinedByTxIDs_SkipsImmutable pins the lattice hardening: a replayed
+// BLOCK_PROCESSED must never demote a confirmation-depth promotion, so an
+// IMMUTABLE row keeps its status AND its original anchor, and does not
+// appear in the returned slices.
+func TestSetMinedByTxIDs_SkipsImmutable(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	txid := "imm-tx"
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusImmutable,
+		BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	prevs, mined, err := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{txid})
+	if err != nil {
+		t.Fatalf("SetMinedByTxIDs: %v", err)
+	}
+	if len(prevs) != 0 || len(mined) != 0 {
+		t.Fatalf("IMMUTABLE row must not be returned: prevs=%d mined=%d", len(prevs), len(mined))
+	}
+
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StatusImmutable {
+		t.Errorf("status = %s, want IMMUTABLE", got.Status)
+	}
+	if got.BlockHash != "blk-A" || got.BlockHeight != 10 {
+		t.Errorf("anchor moved: hash=%q height=%d, want blk-A/10", got.BlockHash, got.BlockHeight)
+	}
+	if len(got.OrphanedProofs) != 0 {
+		t.Errorf("IMMUTABLE row must not gain history: %+v", got.OrphanedProofs)
+	}
+}
+
+// TestSetMinedByTxIDs_ReanchorAppendsOrphanedAnchor covers the same-height
+// re-anchor path: MINED against a DIFFERENT block preserves the superseded
+// anchor, idempotent same-block replays leave history untouched, and a
+// first-time MINED appends nothing.
+func TestSetMinedByTxIDs_ReanchorAppendsOrphanedAnchor(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	txid := "reanchor-tx"
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusMined,
+		BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Re-anchor A → B at the same height.
+	before := time.Now()
+	if _, mined, err := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{txid}); err != nil {
+		t.Fatalf("re-anchor: %v", err)
+	} else if len(mined) != 1 {
+		t.Fatalf("re-anchor returned %d rows, want 1", len(mined))
+	}
+
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StatusMined || got.BlockHash != "blk-B" || got.BlockHeight != 10 {
+		t.Fatalf("row after re-anchor: status=%s hash=%q height=%d, want MINED/blk-B/10",
+			got.Status, got.BlockHash, got.BlockHeight)
+	}
+	if len(got.OrphanedProofs) != 1 {
+		t.Fatalf("OrphanedProofs = %+v, want exactly 1 entry", got.OrphanedProofs)
+	}
+	entry := got.OrphanedProofs[0]
+	if entry.BlockHash != "blk-A" || entry.BlockHeight != 10 {
+		t.Errorf("orphaned anchor = {%s %d}, want {blk-A 10}", entry.BlockHash, entry.BlockHeight)
+	}
+	if entry.OrphanedAt.Before(before.Add(-time.Minute)) || entry.OrphanedAt.After(time.Now().Add(time.Minute)) {
+		t.Errorf("OrphanedAt = %v, want ~now", entry.OrphanedAt)
+	}
+
+	// Idempotent replay against the SAME block must not grow history.
+	if _, _, err := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{txid}); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	got, _ = s.GetStatus(ctx, txid)
+	if len(got.OrphanedProofs) != 1 {
+		t.Fatalf("history grew on idempotent replay: %+v", got.OrphanedProofs)
+	}
+
+	// Re-anchor back to A: the current anchor (B) joins the history.
+	if _, _, err := s.SetMinedByTxIDs(ctx, "blk-A", 10, []string{txid}); err != nil {
+		t.Fatalf("re-anchor back: %v", err)
+	}
+	got, _ = s.GetStatus(ctx, txid)
+	if got.BlockHash != "blk-A" {
+		t.Errorf("hash after re-anchor back = %q, want blk-A", got.BlockHash)
+	}
+	if len(got.OrphanedProofs) != 2 ||
+		got.OrphanedProofs[0].BlockHash != "blk-A" || got.OrphanedProofs[1].BlockHash != "blk-B" {
+		t.Fatalf("history after flip back = %+v, want [blk-A blk-B]", got.OrphanedProofs)
+	}
+
+	// First-time MINED (from SEEN_ON_NETWORK) appends nothing.
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: "fresh-tx", Status: models.StatusSeenOnNetwork, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{"fresh-tx"}); err != nil {
+		t.Fatal(err)
+	}
+	fresh, _ := s.GetStatus(ctx, "fresh-tx")
+	if len(fresh.OrphanedProofs) != 0 {
+		t.Errorf("first-time MINED must not append history: %+v", fresh.OrphanedProofs)
+	}
+}
+
+// TestSetMinedByTxIDs_HistoryCap drives 7 alternating re-anchors and asserts
+// the JSONB history caps at models.MaxOrphanedAnchors, keeping the newest.
+func TestSetMinedByTxIDs_HistoryCap(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	txid := "cap-tx"
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusMined,
+		BlockHash: "cap-0", BlockHeight: 10, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Alternate cap-A / cap-B so every re-anchor supersedes a different
+	// block and no consecutive-dup collapse kicks in.
+	var last string
+	for i := 0; i < 7; i++ {
+		next := "cap-A"
+		if i%2 == 1 {
+			next = "cap-B"
+		}
+		if _, _, err := s.SetMinedByTxIDs(ctx, next, 10, []string{txid}); err != nil {
+			t.Fatalf("re-anchor %d → %s: %v", i, next, err)
+		}
+		last = next
+	}
+
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.BlockHash != last {
+		t.Errorf("current anchor = %q, want %q", got.BlockHash, last)
+	}
+	if len(got.OrphanedProofs) != models.MaxOrphanedAnchors {
+		t.Fatalf("history len = %d, want cap %d: %+v",
+			len(got.OrphanedProofs), models.MaxOrphanedAnchors, got.OrphanedProofs)
+	}
+	// The oldest entries (the original cap-0 anchor) were evicted.
+	for _, e := range got.OrphanedProofs {
+		if e.BlockHash == "cap-0" {
+			t.Errorf("oldest anchor cap-0 survived the cap: %+v", got.OrphanedProofs)
+		}
+	}
+	// Newest entry is the anchor superseded by the last re-anchor: with the
+	// A/B alternation that is the opposite block of the current anchor.
+	newest := got.OrphanedProofs[len(got.OrphanedProofs)-1].BlockHash
+	wantNewest := "cap-A"
+	if last == "cap-A" {
+		wantNewest = "cap-B"
+	}
+	if newest != wantNewest {
+		t.Errorf("newest history entry = %q, want %q", newest, wantNewest)
+	}
+}
+
+// TestSetStatusByBlockHash_RevertAppendsHistoryAndSkipsImmutable pins the
+// reorg-revert path: MINED rows in the orphaned block are returned and
+// reverted with block fields cleared plus the cleared anchor appended to
+// orphaned_anchors; IMMUTABLE rows are untouched and NOT returned.
+func TestSetStatusByBlockHash_RevertAppendsHistoryAndSkipsImmutable(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, txid := range []string{"rv-1", "rv-2"} {
+		if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+			TxID: txid, Status: models.StatusMined,
+			BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+		}); err != nil {
+			t.Fatalf("seed %s: %v", txid, err)
+		}
+	}
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: "rv-imm", Status: models.StatusImmutable,
+		BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed rv-imm: %v", err)
+	}
+
+	updated, err := s.SetStatusByBlockHash(ctx, "blk-A", models.StatusSeenOnNetwork)
+	if err != nil {
+		t.Fatalf("SetStatusByBlockHash: %v", err)
+	}
+	sort.Strings(updated)
+	if len(updated) != 2 || updated[0] != "rv-1" || updated[1] != "rv-2" {
+		t.Fatalf("updated = %v, want [rv-1 rv-2]", updated)
+	}
+
+	for _, txid := range []string{"rv-1", "rv-2"} {
+		got, err := s.GetStatus(ctx, txid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != models.StatusSeenOnNetwork {
+			t.Errorf("%s: status = %s, want SEEN_ON_NETWORK", txid, got.Status)
+		}
+		if got.BlockHash != "" || got.BlockHeight != 0 {
+			t.Errorf("%s: block fields not cleared: hash=%q height=%d", txid, got.BlockHash, got.BlockHeight)
+		}
+		if len(got.OrphanedProofs) != 1 ||
+			got.OrphanedProofs[0].BlockHash != "blk-A" || got.OrphanedProofs[0].BlockHeight != 10 {
+			t.Errorf("%s: OrphanedProofs = %+v, want [{blk-A 10}]", txid, got.OrphanedProofs)
+		}
+	}
+
+	imm, err := s.GetStatus(ctx, "rv-imm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imm.Status != models.StatusImmutable || imm.BlockHash != "blk-A" || imm.BlockHeight != 10 {
+		t.Errorf("IMMUTABLE row touched: status=%s hash=%q height=%d", imm.Status, imm.BlockHash, imm.BlockHeight)
+	}
+	if len(imm.OrphanedProofs) != 0 {
+		t.Errorf("IMMUTABLE row gained history: %+v", imm.OrphanedProofs)
+	}
+}
+
+// TestSetStatusByBlockHash_SkipsConcurrentlyReanchoredRow asserts the WHERE
+// block_hash predicate: a row already re-anchored to the canonical block no
+// longer matches the orphaned hash, so a revert of the old block returns
+// empty and leaves the re-anchored row untouched. (Postgres evaluates the
+// predicate atomically per row, so unlike Pebble there is no separate
+// stale-index recheck to simulate.)
+func TestSetStatusByBlockHash_SkipsConcurrentlyReanchoredRow(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	txid := "cr-1"
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusMined,
+		BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Concurrent re-anchor to the canonical block.
+	if _, _, err := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{txid}); err != nil {
+		t.Fatalf("re-anchor: %v", err)
+	}
+
+	updated, err := s.SetStatusByBlockHash(ctx, "blk-A", models.StatusSeenOnNetwork)
+	if err != nil {
+		t.Fatalf("SetStatusByBlockHash: %v", err)
+	}
+	if len(updated) != 0 {
+		t.Fatalf("re-anchored row must be skipped, got %v", updated)
+	}
+
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StatusMined || got.BlockHash != "blk-B" {
+		t.Errorf("row reverted despite re-anchor: status=%s hash=%q, want MINED/blk-B", got.Status, got.BlockHash)
+	}
+}
+
+// TestGetTxIDsByBlockHash covers the reorg reconciler's affected-set read:
+// only rows CURRENTLY anchored to the block are returned, so a re-anchored
+// row leaves the set.
+func TestGetTxIDsByBlockHash(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, txid := range []string{"ba-1", "ba-2", "ba-3"} {
+		if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+			TxID: txid, Status: models.StatusMined,
+			BlockHash: "blk-A", BlockHeight: 10, Timestamp: time.Now(),
+		}); err != nil {
+			t.Fatalf("seed %s: %v", txid, err)
+		}
+	}
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: "bb-1", Status: models.StatusMined,
+		BlockHash: "blk-B", BlockHeight: 10, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetTxIDsByBlockHash(ctx, "blk-A")
+	if err != nil {
+		t.Fatalf("GetTxIDsByBlockHash: %v", err)
+	}
+	sort.Strings(got)
+	if len(got) != 3 || got[0] != "ba-1" || got[1] != "ba-2" || got[2] != "ba-3" {
+		t.Fatalf("blk-A txids = %v, want [ba-1 ba-2 ba-3]", got)
+	}
+
+	// Re-anchor one row to blk-B — it must leave blk-A's set.
+	if _, _, err := s.SetMinedByTxIDs(ctx, "blk-B", 10, []string{"ba-2"}); err != nil {
+		t.Fatalf("re-anchor: %v", err)
+	}
+	got, err = s.GetTxIDsByBlockHash(ctx, "blk-A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "ba-1" || got[1] != "ba-3" {
+		t.Fatalf("blk-A txids after re-anchor = %v, want [ba-1 ba-3]", got)
+	}
+}
+
+// TestDeleteBUMPByBlockHash: delete removes the stored compound and is
+// idempotent — a second delete of the same (now missing) block is a no-op.
+func TestDeleteBUMPByBlockHash(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	if err := s.InsertBUMP(ctx, "blk-del", 42, []byte{0xde, 0xad, 0xbe, 0xef}); err != nil {
+		t.Fatalf("InsertBUMP: %v", err)
+	}
+	if h, data, err := s.GetBUMP(ctx, "blk-del"); err != nil || h != 42 || len(data) != 4 {
+		t.Fatalf("GetBUMP before delete: h=%d data=%x err=%v", h, data, err)
+	}
+
+	if err := s.DeleteBUMPByBlockHash(ctx, "blk-del"); err != nil {
+		t.Fatalf("DeleteBUMPByBlockHash: %v", err)
+	}
+	if _, _, err := s.GetBUMP(ctx, "blk-del"); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("GetBUMP after delete: err=%v, want ErrNotFound", err)
+	}
+	if err := s.DeleteBUMPByBlockHash(ctx, "blk-del"); err != nil {
+		t.Fatalf("second delete must be a no-op, got %v", err)
+	}
+}
+
+// TestMarkBlockReconciled_And_ListOrphanedBlocksToReconcile covers the
+// reconciler's durable work queue: orphaned-and-unreconciled rows surface
+// oldest-first, MarkBlockReconciled removes a row from the queue, and a
+// resurrected block clears both orphaned_at and reconciled_at
+// (UpsertBlockHeaderSeen conflict path).
+func TestMarkBlockReconciled_And_ListOrphanedBlocksToReconcile(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	t0 := time.Unix(1700000500, 0).UTC()
+
+	for i, hash := range []string{"rb-1", "rb-2", "rb-3"} {
+		if err := s.UpsertBlockHeaderSeen(ctx, hash, uint64(600+i), t0); err != nil {
+			t.Fatalf("seed %s: %v", hash, err)
+		}
+	}
+	// Orphan rb-2 first in wall-clock terms so the list orders by
+	// orphaned_at, not by insertion or height.
+	if err := s.MarkBlocksOrphaned(ctx, []string{"rb-2"}, t0.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkBlocksOrphaned(ctx, []string{"rb-1"}, t0.Add(2*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := s.ListOrphanedBlocksToReconcile(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListOrphanedBlocksToReconcile: %v", err)
+	}
+	if len(rows) != 2 || rows[0].BlockHash != "rb-2" || rows[1].BlockHash != "rb-1" {
+		t.Fatalf("queue = %v, want [rb-2 rb-1] oldest-first", hashesOf(rows))
+	}
+	for _, r := range rows {
+		if r.ReconciledAt != nil {
+			t.Errorf("%s: ReconciledAt = %v, want nil while queued", r.BlockHash, r.ReconciledAt)
+		}
+	}
+
+	// Reconcile rb-2 — only rb-1 remains queued.
+	if err := s.MarkBlockReconciled(ctx, "rb-2", t0.Add(3*time.Minute)); err != nil {
+		t.Fatalf("MarkBlockReconciled: %v", err)
+	}
+	rows, err = s.ListOrphanedBlocksToReconcile(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].BlockHash != "rb-1" {
+		t.Fatalf("queue after reconcile = %v, want [rb-1]", hashesOf(rows))
+	}
+	got, err := s.GetBlockProcessingStatus(ctx, "rb-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ReconciledAt == nil {
+		t.Error("rb-2: ReconciledAt should be set after MarkBlockReconciled")
+	}
+
+	// Missing rows are silently skipped.
+	if err := s.MarkBlockReconciled(ctx, "never-seen", t0); err != nil {
+		t.Fatalf("MarkBlockReconciled on missing row: %v", err)
+	}
+
+	// Resurrection: the reconciled block re-joins the main chain with both
+	// reorg markers cleared, so a future re-orphaning reconciles again.
+	if err := s.UpsertBlockHeaderSeen(ctx, "rb-2", 601, t0.Add(time.Hour)); err != nil {
+		t.Fatalf("resurrect: %v", err)
+	}
+	got, err = s.GetBlockProcessingStatus(ctx, "rb-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.BlockStatusActive {
+		t.Errorf("resurrected status = %q, want active", got.Status)
+	}
+	if got.OrphanedAt != nil || got.ReconciledAt != nil {
+		t.Errorf("resurrection must clear reorg markers: orphanedAt=%v reconciledAt=%v",
+			got.OrphanedAt, got.ReconciledAt)
+	}
+}
+
+// TestGetStatus_EnrichesOrphanedProofPaths builds a real compound BUMP for
+// the orphaned block so GetStatus can re-derive the historical anchor's
+// minimal path at read time; the extracted path must parse and compute the
+// orphaned block's root. Once the BUMP is deleted the entry is served
+// without a path (best-effort contract).
+func TestGetStatus_EnrichesOrphanedProofPaths(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	const (
+		blockA = "000000000000000000000000000000000000000000000000000000000000aaaa"
+		blockB = "000000000000000000000000000000000000000000000000000000000000bbbb"
+	)
+	blk, err := synthblock.Build(4, 900010)
+	if err != nil {
+		t.Fatalf("synthblock.Build: %v", err)
+	}
+	txid := blk.Txids[0]
+
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID: txid, Status: models.StatusSeenOnNetwork, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Mine into blockA (whose compound BUMP is retained), then re-anchor to
+	// blockB so blockA lands in the orphaned-anchor history.
+	if _, _, err := s.SetMinedByTxIDs(ctx, blockA, 900010, []string{txid}); err != nil {
+		t.Fatalf("mine @A: %v", err)
+	}
+	if err := s.InsertBUMP(ctx, blockA, 900010, blk.BumpBytes); err != nil {
+		t.Fatalf("InsertBUMP: %v", err)
+	}
+	if _, _, err := s.SetMinedByTxIDs(ctx, blockB, 900010, []string{txid}); err != nil {
+		t.Fatalf("re-anchor @B: %v", err)
+	}
+
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.OrphanedProofs) != 1 || got.OrphanedProofs[0].BlockHash != blockA {
+		t.Fatalf("OrphanedProofs = %+v, want one entry for blockA", got.OrphanedProofs)
+	}
+	path := got.OrphanedProofs[0].MerklePath
+	if len(path) == 0 {
+		t.Fatal("historical anchor's MerklePath not enriched from retained BUMP")
+	}
+	// The path must parse (NewMerklePathFromBinary) and compute the orphaned
+	// block's merkle root for this txid.
+	if err := synthblock.VerifyMerklePath(path, txid, blk.Root); err != nil {
+		t.Fatalf("orphaned proof does not verify: %v", err)
+	}
+
+	// Best-effort: once blockA's BUMP is gone the entry is served without a
+	// path rather than failing the read.
+	if err := s.DeleteBUMPByBlockHash(ctx, blockA); err != nil {
+		t.Fatalf("DeleteBUMPByBlockHash: %v", err)
+	}
+	got, err = s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.OrphanedProofs) != 1 {
+		t.Fatalf("history lost after BUMP delete: %+v", got.OrphanedProofs)
+	}
+	if len(got.OrphanedProofs[0].MerklePath) != 0 {
+		t.Errorf("entry must be served without a path once the BUMP is deleted, got %x",
+			got.OrphanedProofs[0].MerklePath)
+	}
+}

--- a/store/postgres/schema.sql
+++ b/store/postgres/schema.sql
@@ -22,6 +22,12 @@ CREATE TABLE IF NOT EXISTS transactions (
 -- introduced. Existing rows keep NULL until the next successful /watch call
 -- repopulates the marker — see issue #145.
 ALTER TABLE transactions ADD COLUMN IF NOT EXISTS merkle_registered_at TIMESTAMPTZ;
+-- Orphaned-anchor history (issue #279): every block this tx was once MINED
+-- against before a reorg superseded the anchor, as a JSONB array of
+-- {blockHash, blockHeight, orphanedAt} in models.OrphanedAnchor shape,
+-- capped at 5 entries by the writers. NULL for the overwhelming majority of
+-- rows that never lived through a reorg.
+ALTER TABLE transactions ADD COLUMN IF NOT EXISTS orphaned_anchors JSONB;
 
 CREATE INDEX IF NOT EXISTS idx_tx_status        ON transactions(status);
 CREATE INDEX IF NOT EXISTS idx_tx_block_hash    ON transactions(block_hash);
@@ -69,6 +75,15 @@ CREATE INDEX IF NOT EXISTS idx_bp_status_height ON block_processing(status, bloc
 CREATE INDEX IF NOT EXISTS idx_bp_stale_seen
     ON block_processing(header_seen_at)
     WHERE processed_at IS NULL AND status = 'active';
+-- Reorg reconciliation marker (issue #279): stamped by the anchor
+-- reconciler once every tx anchored to this orphaned block has been
+-- re-anchored or reverted; reset to NULL when the block is resurrected.
+ALTER TABLE block_processing ADD COLUMN IF NOT EXISTS reconciled_at TIMESTAMPTZ;
+-- Partial index over the reconciler's work queue — orphaned rows still
+-- awaiting tx reconciliation. Stays proportional to the (tiny) backlog.
+CREATE INDEX IF NOT EXISTS idx_bp_orphaned_unreconciled
+    ON block_processing(orphaned_at)
+    WHERE status = 'orphaned' AND reconciled_at IS NULL;
 
 CREATE TABLE IF NOT EXISTS submissions (
     submission_id         TEXT PRIMARY KEY,

--- a/store/store.go
+++ b/store/store.go
@@ -128,14 +128,31 @@ type Store interface {
 
 	// SetStatusByBlockHash updates all transactions with the given block hash to a new status.
 	// Returns the txids that were updated. For unmined statuses (SEEN_ON_NETWORK),
-	// block fields are cleared. For IMMUTABLE, block fields are preserved.
+	// block fields are cleared and the cleared anchor is appended to the row's
+	// orphaned-anchor history (reorg revert). For IMMUTABLE, block fields are
+	// preserved. IMMUTABLE rows are never touched, and rows whose block_hash no
+	// longer matches at write time are skipped — a tx concurrently re-anchored
+	// to the canonical block must not be reverted by a stale index read.
 	SetStatusByBlockHash(ctx context.Context, blockHash string, newStatus models.Status) ([]string, error)
+
+	// GetTxIDsByBlockHash returns the txids of every transaction row currently
+	// anchored to blockHash (MINED or IMMUTABLE). The reorg reconciler reads
+	// this as the affected set of an orphaned block; rows that have already
+	// been re-anchored or reverted no longer appear.
+	GetTxIDsByBlockHash(ctx context.Context, blockHash string) ([]string, error)
 
 	// InsertBUMP stores a compound BUMP for a block.
 	InsertBUMP(ctx context.Context, blockHash string, blockHeight uint64, bumpData []byte) error
 
 	// GetBUMP retrieves the compound BUMP for a block.
 	GetBUMP(ctx context.Context, blockHash string) (blockHeight uint64, bumpData []byte, err error)
+
+	// DeleteBUMPByBlockHash removes the stored compound BUMP for a block and
+	// invalidates any cached parse. Idempotent — deleting a missing BUMP is a
+	// no-op. Operator/cleanup lever; note the reorg reconciler deliberately
+	// RETAINS orphaned blocks' BUMPs so historical orphaned-anchor proofs
+	// stay resolvable (issue #279).
+	DeleteBUMPByBlockHash(ctx context.Context, blockHash string) error
 
 	// --- Block processing status ---
 	//
@@ -168,8 +185,19 @@ type Store interface {
 	// MarkBlocksOrphaned transitions every named block to status='orphaned'
 	// and stamps orphaned_at. Hashes that have no row are silently skipped
 	// (chaintracks may emit OrphanedHashes for blocks observed before the
-	// service started recording).
+	// service started recording). Orphaned rows with reconciled_at IS NULL
+	// form the anchor reconciler's work queue.
 	MarkBlocksOrphaned(ctx context.Context, blockHashes []string, orphanedAt time.Time) error
+
+	// MarkBlockReconciled stamps reconciled_at on an orphaned block's row,
+	// recording that tx re-anchor/revert for this orphan completed. A
+	// missing row is a silent no-op.
+	MarkBlockReconciled(ctx context.Context, blockHash string, at time.Time) error
+
+	// ListOrphanedBlocksToReconcile returns up to limit rows with
+	// status='orphaned' AND reconciled_at IS NULL, oldest orphaned_at
+	// first — the anchor reconciler's durable work queue. limit must be > 0.
+	ListOrphanedBlocksToReconcile(ctx context.Context, limit int) ([]*models.BlockProcessingStatus, error)
 
 	// MarkBlocksParked transitions every named block from status='active' to
 	// status='parked' — the watchdog's terminal state for blocks whose

--- a/tests/e2e/harness/arcade.go
+++ b/tests/e2e/harness/arcade.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 	"time"
 
+	chaintracksconfig "github.com/bsv-blockchain/go-chaintracks/config"
+	msgbus "github.com/bsv-blockchain/go-p2p-message-bus"
+	teranodep2p "github.com/bsv-blockchain/go-teranode-p2p-client"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
@@ -59,6 +62,22 @@ type ArcadeOptions struct {
 	// callback requests. Must match what merkle-service is configured
 	// to send.
 	CallbackToken string
+
+	// EnableChaintracks brings up the embedded go-chaintracks instance
+	// (and the chaintracks_server service with its blockStatusTracker).
+	// Chaintracks joins the same gossipsub mesh as merkle-service and
+	// tracks the headers of blocks the test publishes. Required for
+	// reorg scenarios; off by default because the extra libp2p host
+	// adds ~1s of mesh-formation latency the plain mined-path smoke
+	// tests don't need.
+	EnableChaintracks bool
+
+	// LibP2PLoopback is the harness host's loopback multiaddr
+	// (LibP2PHost.LoopbackMultiaddr()). Required when EnableChaintracks
+	// is set: chaintracks runs on the host, and the announce address in
+	// LibP2PBootstrap (gateway IP / host.docker.internal) is only
+	// dialable from inside containers.
+	LibP2PLoopback string
 }
 
 // StartArcade boots arcade in-process via the same code path the
@@ -90,7 +109,7 @@ func StartArcade(t *testing.T, opts ArcadeOptions) *ArcadeRuntime {
 		Logger:  logger,
 		Port:    port,
 		BaseURL: fmt.Sprintf("http://127.0.0.1:%d", port),
-		HostURL: fmt.Sprintf("http://host.docker.internal:%d", port),
+		HostURL: fmt.Sprintf("http://%s:%d", callbackHost(), port),
 		cancel:  cancel,
 		cleanup: cleanup,
 	}
@@ -139,7 +158,7 @@ func buildArcadeConfig(t *testing.T, port int, opts ArcadeOptions) *config.Confi
 		LogLevel:      "warn",
 		Network:       config.NetworkRegtest,
 		StoragePath:   t.TempDir(),
-		CallbackURL:   fmt.Sprintf("http://host.docker.internal:%d/api/v1/merkle-service/callback", port),
+		CallbackURL:   fmt.Sprintf("http://%s:%d/api/v1/merkle-service/callback", callbackHost(), port),
 		CallbackToken: opts.CallbackToken,
 		APIServer: config.API{
 			Host: "0.0.0.0",
@@ -188,9 +207,11 @@ func buildArcadeConfig(t *testing.T, port int, opts ArcadeOptions) *config.Confi
 		Validator: config.ValidatorConfig{
 			MinFeePerKB: 50,
 		},
-		// Disable chaintracks: regtest has no embedded genesis, and the
-		// smoke test doesn't need header tracking — block announcements
-		// flow direct from harness libp2p host to merkle-service.
+		// Chaintracks default-off: the plain mined-path smoke tests don't
+		// need header tracking — block announcements flow direct from the
+		// harness libp2p host to merkle-service. Reorg tests opt in via
+		// EnableChaintracks (go-chaintracks sources the regtest genesis
+		// from go-chaincfg, so embedded mode works fine on regtest).
 		ChaintracksServer: config.ChaintracksServerConfig{Enabled: false},
 		// Propagation defaults — endpoint health probes off the harness
 		// datahub. Tightened backoff so retries don't slow down tests.
@@ -225,7 +246,58 @@ func buildArcadeConfig(t *testing.T, port int, opts ArcadeOptions) *config.Confi
 			AllowPrivateURLs: true,
 		},
 	}
+	if opts.EnableChaintracks {
+		ctPort, err := pickFreeTCPPort()
+		if err != nil {
+			t.Fatalf("pick chaintracks port: %v", err)
+		}
+		if opts.LibP2PLoopback == "" {
+			t.Fatal("EnableChaintracks requires LibP2PLoopback (LibP2PHost.LoopbackMultiaddr()) — " +
+				"the bootstrap announce address is not dialable from the host process")
+		}
+		cfg.ChaintracksServer = config.ChaintracksServerConfig{
+			Enabled: true,
+			Host:    "127.0.0.1",
+			Port:    ctPort,
+		}
+		// app.initChaintracks threads cfg.Network → Chaintracks.P2P.Network
+		// and cfg.P2P.BootstrapPeers → Chaintracks.P2P.MsgBus.BootstrapPeers,
+		// BUT go-p2p-message-bus ignores BootstrapPeers entirely when
+		// testing.Testing() is true ("isolated mode") — and arcade runs
+		// in-process here, so its chaintracks p2p client is inside the test
+		// binary. StaticPeers bypass that test-mode gate: they are dialed
+		// unconditionally and kept alive by a maintenance loop, which is
+		// exactly what joins chaintracks to the harness's gossipsub mesh.
+		// The other msgbus fields are the ones p2p.Config.Initialize does
+		// NOT default for us: DHTMode "" is not "off" (it would try to
+		// reach the public DHT).
+		cfg.Chaintracks = chaintracksconfig.Config{
+			Mode:        chaintracksconfig.ModeEmbedded,
+			StoragePath: t.TempDir(),
+			P2P: teranodep2p.Config{
+				StoragePath: t.TempDir(),
+				MsgBus: msgbus.Config{
+					DHTMode:         "off",
+					AllowPrivateIPs: true,
+					StaticPeers:     []string{opts.LibP2PLoopback},
+					PeerCacheFile:   t.TempDir() + "/peer_cache.json",
+				},
+			},
+		}
+	}
 	return cfg
+}
+
+// callbackHost is the hostname the merkle-service container uses to
+// POST callbacks back to the in-process arcade: podman injects (and
+// correctly maps) host.containers.internal; Docker gets
+// host.docker.internal via the ExtraHosts host-gateway entry the
+// container start adds.
+func callbackHost() string {
+	if isPodmanRuntime() {
+		return "host.containers.internal"
+	}
+	return "host.docker.internal"
 }
 
 // waitReady polls /health until arcade's api-server starts answering

--- a/tests/e2e/harness/arcade.go
+++ b/tests/e2e/harness/arcade.go
@@ -233,6 +233,21 @@ func buildArcadeConfig(t *testing.T, port int, opts ArcadeOptions) *config.Confi
 		BumpBuilder: config.BumpBuilderConfig{
 			GraceWindowMs:        500,
 			DataHubMaxBlockBytes: 1024 * 1024 * 16,
+			// The harness builds this struct directly, so the viper
+			// defaults (both true) don't apply — mirror production
+			// behavior explicitly. Reorg tests depend on the guard +
+			// reconciler; the mined-path smoke tests are unaffected
+			// (guard fails open without chaintracks, reconciler skips).
+			AnchorGuardEnabled: true,
+			Reconciler: config.ReconcilerConfig{
+				Enabled:           true,
+				IntervalMs:        2000, // fast ticks: e2e waits on convergence
+				BatchSize:         5000,
+				BlocksPerTick:     8,
+				NeighborhoodDepth: 6,
+				MaxDeferAttempts:  10,
+				StartupFullScan:   true,
+			},
 		},
 		// Datahub discovery off: we seeded a static URL into DatahubURLs,
 		// so arcade's bump-builder + propagation see it without needing
@@ -259,6 +274,10 @@ func buildArcadeConfig(t *testing.T, port int, opts ArcadeOptions) *config.Confi
 			Enabled: true,
 			Host:    "127.0.0.1",
 			Port:    ctPort,
+			// Tight tie-scan cadence: the reorg e2e scenarios wait on the
+			// no-ReorgEvent detection path (issue #279).
+			TieScanDepth:         20,
+			TieScanMinIntervalMs: 500,
 		}
 		// app.initChaintracks threads cfg.Network → Chaintracks.P2P.Network
 		// and cfg.P2P.BootstrapPeers → Chaintracks.P2P.MsgBus.BootstrapPeers,

--- a/tests/e2e/harness/containers.go
+++ b/tests/e2e/harness/containers.go
@@ -5,6 +5,7 @@ package harness
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -92,6 +93,46 @@ type Containers struct {
 	// routable from the container, so we have to thread the real
 	// gateway through explicitly.
 	GatewayIP string
+
+	// HostFromContainer is the hostname/IP containers on this network
+	// should use to reach listeners bound on the TEST HOST (the harness
+	// datahub, the libp2p host, arcade's callback receiver). Prefer this
+	// over GatewayIP: on current rootless podman (pasta) the bridge
+	// gateway no longer maps to the host at all — connections are
+	// refused — while the podman-injected host.containers.internal alias
+	// maps correctly. On Docker this is the GatewayIP recipe as before.
+	HostFromContainer string
+}
+
+// hostFromContainerAddr resolves the address containers use to reach
+// host-bound listeners. Podman injects host.containers.internal into
+// every container's /etc/hosts and maps it through pasta to the host;
+// the bridge-network gateway IP stopped being host-mapped in podman ≥5.8
+// (dials are refused), so the alias is the only reliable route. Docker
+// keeps the gateway recipe (host.docker.internal:host-gateway resolves
+// to it and routes to the host).
+func hostFromContainerAddr(gatewayIP string) string {
+	if isPodmanRuntime() {
+		return "host.containers.internal"
+	}
+	if gatewayIP != "" {
+		return gatewayIP
+	}
+	return "host.docker.internal"
+}
+
+// isPodmanRuntime sniffs whether the container runtime testcontainers
+// resolves to is podman: an explicit podman DOCKER_HOST, or (when unset)
+// the presence of the rootless podman socket.
+func isPodmanRuntime() bool {
+	if host := os.Getenv("DOCKER_HOST"); host != "" {
+		return strings.Contains(host, "podman")
+	}
+	sock := fmt.Sprintf("/run/user/%d/podman/podman.sock", os.Getuid())
+	if _, err := os.Stat(sock); err == nil {
+		return true
+	}
+	return false
 }
 
 // MerkleStartOptions tells StartContainers how to wire merkle-service to
@@ -179,7 +220,7 @@ func startContainersOnNetwork(ctx context.Context, t *testing.T, opts MerkleStar
 		opts.P2PNetwork = "regtest"
 	}
 
-	out := &Containers{Network: nw, GatewayIP: gateway}
+	out := &Containers{Network: nw, GatewayIP: gateway, HostFromContainer: hostFromContainerAddr(gateway)}
 
 	// Postgres ----------------------------------------------------------
 	// BasicWaitStrategies() composes the log-and-port wait the postgres

--- a/tests/e2e/harness/datahub.go
+++ b/tests/e2e/harness/datahub.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -35,6 +36,7 @@ type Datahub struct {
 	mu       sync.RWMutex
 	blocks   map[string][]byte
 	subtrees map[string][]byte
+	headers  map[string][]byte
 
 	// Per-path fetch counters. blockFetches is load-bearing for the issue
 	// #195 datahub-independence assertion: when merkle-service enriches
@@ -90,6 +92,7 @@ func NewDatahubOnPort(t *testing.T, opts DatahubOptions, port int) (*Datahub, er
 	d := &Datahub{
 		blocks:   make(map[string][]byte),
 		subtrees: make(map[string][]byte),
+		headers:  make(map[string][]byte),
 	}
 
 	// Bind on 0.0.0.0 so the merkle-service container can reach us via
@@ -150,6 +153,22 @@ func (d *Datahub) StageSubtree(hash chainhash.Hash, payload []byte) {
 	d.subtrees[hash.String()] = append([]byte(nil), payload...)
 }
 
+// StageHeader registers an 80-byte block header keyed by its block hash.
+// Headers feed GET /headers/<hash>?n=N — go-chaintracks' backward crawl
+// (SyncFromRemoteTip) walks child→parent through these when it receives
+// a block whose parent is off its main chain (the reorg-trigger path).
+// Stage every header on the branch you want chaintracks able to crawl,
+// including the fork point's ancestors it already knows — the walk stops
+// at the first header chaintracks recognizes as main-chain.
+func (d *Datahub) StageHeader(hash chainhash.Hash, header []byte) {
+	if len(header) != 80 {
+		panic(fmt.Sprintf("StageHeader %s: header must be 80 bytes, got %d", hash, len(header)))
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.headers[hash.String()] = append([]byte(nil), header...)
+}
+
 // StageFixture stages every binary a RealBlockFixture carries: the
 // block.bin under /block/<hash> and each subtree under /subtree/<hash>.
 // One call per fixture is enough to make merkle-service's block-fetch
@@ -170,6 +189,31 @@ func (d *Datahub) Close() {
 	d.server.Close()
 }
 
+// headersBackward walks the staged headers child→parent starting at
+// startHash, concatenating up to n 80-byte headers (newest first) — the
+// wire format go-chaintracks' fetchHeadersBackward expects. The walk
+// stops when a parent isn't staged; ok is false when even startHash is
+// unknown (→ 404, matching a real datahub asked for a foreign hash).
+func (d *Datahub) headersBackward(startHash string, n int) ([]byte, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	var out []byte
+	cur := startHash
+	for i := 0; i < n; i++ {
+		h, ok := d.headers[cur]
+		if !ok {
+			break
+		}
+		out = append(out, h...)
+		// prevHash is bytes 4:36 of the serialized header.
+		var prev chainhash.Hash
+		copy(prev[:], h[4:36])
+		cur = prev.String()
+	}
+	return out, len(out) > 0
+}
+
 func (d *Datahub) handle(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/block/"):
@@ -180,6 +224,21 @@ func (d *Datahub) handle(w http.ResponseWriter, r *http.Request) {
 		d.mu.RUnlock()
 		if !ok {
 			http.Error(w, "block not staged", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(payload)
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/headers/"):
+		hash := strings.TrimPrefix(r.URL.Path, "/headers/")
+		n := 1000
+		if q := r.URL.Query().Get("n"); q != "" {
+			if parsed, err := strconv.Atoi(q); err == nil && parsed > 0 {
+				n = parsed
+			}
+		}
+		payload, ok := d.headersBackward(hash, n)
+		if !ok {
+			http.Error(w, "header not staged", http.StatusNotFound)
 			return
 		}
 		w.Header().Set("Content-Type", "application/octet-stream")

--- a/tests/e2e/harness/datahub_test.go
+++ b/tests/e2e/harness/datahub_test.go
@@ -4,6 +4,7 @@ package harness
 
 import (
 	"context"
+	"encoding/binary"
 	"io"
 	"net/http"
 	"testing"
@@ -75,6 +76,76 @@ func TestDatahub_StageAndServe(t *testing.T) {
 	}
 	if gotMerkle == nil || gotMerkle.String() != merkleRoot.String() {
 		t.Errorf("merkle root round-trip: got %v, want %s", gotMerkle, merkleRoot)
+	}
+}
+
+// fakeHeader builds a syntactically valid 80-byte header whose prevHash
+// points at parent, with nonce varying the hash. Returns bytes + hash.
+func fakeHeader(t *testing.T, parent chainhash.Hash, nonce uint32) ([]byte, chainhash.Hash) {
+	t.Helper()
+	h := make([]byte, 80)
+	binary.LittleEndian.PutUint32(h[0:4], 1) // version
+	copy(h[4:36], parent[:])                 // prevHash
+	// merkleRoot [36:68], time [68:72], bits [72:76] left zero.
+	binary.LittleEndian.PutUint32(h[76:80], nonce)
+	return h, chainhash.DoubleHashH(h)
+}
+
+// TestDatahub_HeadersBackwardWalk pins the /headers/<hash>?n=N contract
+// go-chaintracks' SyncFromRemoteTip depends on: concatenated 80-byte
+// headers, newest first, walking child→parent, stopping at the first
+// unstaged parent; 404 for an unknown start hash.
+func TestDatahub_HeadersBackwardWalk(t *testing.T) {
+	d, err := NewDatahub(t)
+	if err != nil {
+		t.Fatalf("new datahub: %v", err)
+	}
+
+	// Chain: g <- a <- b <- c, with g's parent NOT staged.
+	gBytes, gHash := fakeHeader(t, chainhash.Hash{}, 0)
+	aBytes, aHash := fakeHeader(t, gHash, 1)
+	bBytes, bHash := fakeHeader(t, aHash, 2)
+	cBytes, cHash := fakeHeader(t, bHash, 3)
+	for _, hdr := range []struct {
+		hash  chainhash.Hash
+		bytes []byte
+	}{{gHash, gBytes}, {aHash, aBytes}, {bHash, bBytes}, {cHash, cBytes}} {
+		d.StageHeader(hdr.hash, hdr.bytes)
+	}
+
+	// Full walk from c over HTTP: c, b, a, g (g's parent is unstaged → stop).
+	resp, err := http.Get(d.LocalURL() + "/headers/" + cHash.String() + "?n=1000")
+	if err != nil {
+		t.Fatalf("GET headers: %v", err)
+	}
+	payload, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d want 200", resp.StatusCode)
+	}
+	if len(payload) != 4*80 {
+		t.Fatalf("expected 4 headers (320 bytes), got %d bytes", len(payload))
+	}
+	for i, want := range [][]byte{cBytes, bBytes, aBytes, gBytes} {
+		got := payload[i*80 : (i+1)*80]
+		if string(got) != string(want) {
+			t.Fatalf("header %d mismatch (walk must be newest-first child→parent)", i)
+		}
+	}
+
+	// n caps the walk.
+	if payload, ok := d.headersBackward(cHash.String(), 2); !ok || len(payload) != 2*80 {
+		t.Fatalf("n=2 walk: ok=%v len=%d, want 160 bytes", ok, len(payload))
+	}
+
+	// Unknown start hash → 404.
+	resp, err = http.Get(d.LocalURL() + "/headers/" + chainhash.Hash{0xff}.String())
+	if err != nil {
+		t.Fatalf("GET unknown: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown hash: status=%d want 404", resp.StatusCode)
 	}
 }
 

--- a/tests/e2e/harness/harness.go
+++ b/tests/e2e/harness/harness.go
@@ -76,15 +76,17 @@ func New(t *testing.T, opts ...Option) *Harness {
 		_ = nw.Remove(closeCtx)
 	})
 
-	// Step 3: libp2p host with the gateway IP baked into its announce
-	// multiaddr. Skipped when the caller explicitly passed a bootstrap
-	// peer string — that mode is for tests that want to wire their own
-	// libp2p configuration.
+	// Step 3: libp2p host with the container-reachable host address baked
+	// into its announce multiaddr (host.containers.internal on podman,
+	// the gateway IP on Docker — see hostFromContainerAddr). Skipped when
+	// the caller explicitly passed a bootstrap peer string — that mode is
+	// for tests that want to wire their own libp2p configuration.
+	hostAddr := hostFromContainerAddr(gateway)
 	var libp2p *LibP2PHost
 	if cfg.merkleStart.BootstrapPeers == "" {
 		libp2p, err = NewLibP2PHostWith(t, LibP2PHostOptions{
 			Network:      cfg.merkleStart.P2PNetwork,
-			AnnounceHost: gateway,
+			AnnounceHost: hostAddr,
 		})
 		if err != nil {
 			t.Fatalf("build libp2p host: %v", err)
@@ -108,7 +110,7 @@ func New(t *testing.T, opts ...Option) *Harness {
 		if cfg.merkleStart.ExtraEnv == nil {
 			cfg.merkleStart.ExtraEnv = make(map[string]string)
 		}
-		cfg.merkleStart.ExtraEnv["DATAHUB_FALLBACK_URLS"] = fmt.Sprintf("http://%s:%d", gateway, datahubPort)
+		cfg.merkleStart.ExtraEnv["DATAHUB_FALLBACK_URLS"] = fmt.Sprintf("http://%s:%d", hostAddr, datahubPort)
 	}
 
 	// Step 4: Postgres + Redpanda + merkle-service on the prepared
@@ -125,7 +127,7 @@ func New(t *testing.T, opts ...Option) *Harness {
 	// dead listener).
 	var datahub *Datahub
 	if cfg.reprocessReady {
-		datahub, err = NewDatahubOnPort(t, DatahubOptions{AnnounceHost: gateway}, datahubPort)
+		datahub, err = NewDatahubOnPort(t, DatahubOptions{AnnounceHost: hostAddr}, datahubPort)
 		if err != nil {
 			t.Fatalf("bind pre-registered datahub: %v", err)
 		}
@@ -156,16 +158,17 @@ func New(t *testing.T, opts ...Option) *Harness {
 }
 
 // NewDatahub spins up an in-process datahub HTTP server announcing on
-// the docker-network gateway IP discovered when the harness's network
-// was created. The returned datahub is reachable from the merkle-service
-// container regardless of whether host.docker.internal is routable on
-// the runtime — same fix as the libp2p host.
+// the container-reachable host address resolved when the harness's
+// network was created (host.containers.internal on podman, the gateway
+// IP on Docker). The returned datahub is reachable from the
+// merkle-service container regardless of whether host.docker.internal
+// is routable on the runtime — same fix as the libp2p host.
 //
 // Lifetime is tied to t via t.Cleanup. Tests call this from within a
 // scenario after harness.New(t) has run.
 func (h *Harness) NewDatahub(t *testing.T) *Datahub {
 	t.Helper()
-	d, err := NewDatahubWith(t, DatahubOptions{AnnounceHost: h.Containers.GatewayIP})
+	d, err := NewDatahubWith(t, DatahubOptions{AnnounceHost: h.Containers.HostFromContainer})
 	if err != nil {
 		t.Fatalf("new datahub: %v", err)
 	}

--- a/tests/e2e/harness/libp2p_host.go
+++ b/tests/e2e/harness/libp2p_host.go
@@ -182,6 +182,18 @@ func announceMultiaddr(announceHost string, listenPort int) string {
 // P2P_BOOTSTRAP_PEERS env var.
 func (h *LibP2PHost) BootstrapMultiaddr() string { return h.bootstrapMA }
 
+// LoopbackMultiaddr is the /ip4/127.0.0.1/.../p2p/<id> form for peers
+// running ON THE HOST (arcade's embedded chaintracks in the e2e tests).
+// The announce address embedded in BootstrapMultiaddr points at the
+// container-side gateway (host.docker.internal / the podman bridge IP),
+// which is dialable from containers but NOT from the host itself on
+// rootless podman — the bridge lives inside the rootless network
+// namespace. The msgbus listener binds 0.0.0.0, so loopback always
+// reaches it from the host.
+func (h *LibP2PHost) LoopbackMultiaddr() string {
+	return fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/p2p/%s", h.listenPort, h.peerID)
+}
+
 // PeerID returns the libp2p peer ID this host advertises.
 func (h *LibP2PHost) PeerID() string { return h.peerID }
 

--- a/tests/e2e/harness/poll.go
+++ b/tests/e2e/harness/poll.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+	teranode "github.com/bsv-blockchain/teranode/services/p2p"
 )
 
 // BroadcastTx submits a single transaction to arcade via POST /tx in
@@ -64,6 +65,29 @@ type txStatusResponse struct {
 	BlockHeight uint64 `json:"blockHeight,omitempty"`
 	MerklePath  string `json:"merklePath,omitempty"`
 	ExtraInfo   string `json:"extraInfo,omitempty"`
+	// OrphanedProofs carries the historical anchors a reorg superseded
+	// (issue #279): every block this tx was once MINED against, with the
+	// proof still resolvable from the retained compound BUMP.
+	OrphanedProofs []OrphanedProof `json:"orphanedProofs,omitempty"`
+}
+
+// OrphanedProof is one historical (superseded) anchor on GET /tx.
+type OrphanedProof struct {
+	BlockHash   string `json:"blockHash"`
+	BlockHeight uint64 `json:"blockHeight"`
+	OrphanedAt  string `json:"orphanedAt"`
+	MerklePath  string `json:"merklePath,omitempty"`
+}
+
+// GetOrphanedProof returns the orphaned-proof entry for wantBlock, if
+// the tx's status carries one.
+func (r txStatusResponse) GetOrphanedProof(wantBlock string) (OrphanedProof, bool) {
+	for _, p := range r.OrphanedProofs {
+		if p.BlockHash == wantBlock {
+			return p, true
+		}
+	}
+	return OrphanedProof{}, false
 }
 
 // GetTxStatus fetches a single tx's status from arcade. Returns
@@ -269,6 +293,225 @@ func AssertMerklePathsMatchHeaderRoot(t *testing.T, rt *ArcadeRuntime, expectedH
 			t.Errorf("merkle root mismatch for %s: got %x want %x", id, root[:], wantInternal)
 		}
 	}
+}
+
+// WaitForMinedInBlock polls /tx/:txid for every txid until each reports
+// MINED (or IMMUTABLE) with a non-empty merklePath AND blockHash equal to
+// wantBlockHash. Use in reorg scenarios where plain WaitForMined would
+// accept an anchor to either competing block.
+func WaitForMinedInBlock(ctx context.Context, t *testing.T, rt *ArcadeRuntime, txids []string, wantBlockHash string, timeout time.Duration) error {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	pending := make(map[string]struct{}, len(txids))
+	for _, id := range txids {
+		pending[id] = struct{}{}
+	}
+	last := txStatusResponse{}
+	lastSeen := ""
+	for len(pending) > 0 {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for MINED@%s: %d/%d pending; last seen txid=%s status=%s block=%s",
+				wantBlockHash, len(pending), len(txids), lastSeen, last.TxStatus, last.BlockHash)
+		}
+		for id := range pending {
+			st, ok, err := GetTxStatus(ctx, rt, id)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				continue
+			}
+			last, lastSeen = st, id
+			if st.TxStatus == "REJECTED" || st.TxStatus == "DOUBLE_SPEND_ATTEMPTED" {
+				return fmt.Errorf("tx %s rejected with status %s extra=%s", id, st.TxStatus, st.ExtraInfo)
+			}
+			if (st.TxStatus == "MINED" || st.TxStatus == "IMMUTABLE") && st.MerklePath != "" && st.BlockHash == wantBlockHash {
+				delete(pending, id)
+			}
+		}
+		if len(pending) == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+	return nil
+}
+
+// WaitForStatus polls /tx/:txid until it reports wantStatus (e.g.
+// SEEN_ON_NETWORK after a reorg revert) or the timeout elapses.
+func WaitForStatus(ctx context.Context, rt *ArcadeRuntime, txid, wantStatus string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	last := ""
+	for {
+		st, ok, err := GetTxStatus(ctx, rt, txid)
+		if err != nil {
+			return err
+		}
+		if ok {
+			if st.TxStatus == wantStatus {
+				return nil
+			}
+			last = st.TxStatus
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for %s on %s (last %q)", wantStatus, txid, last)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}
+
+// WaitForBUMPStored polls arcade's store until the compound BUMP for
+// blockHash exists. In reorg scenarios this is the gate between
+// announcing competing blocks: the losing block's BUMP being persisted
+// proves bump-builder fully processed its BLOCK_PROCESSED before the
+// test moves on.
+func WaitForBUMPStored(ctx context.Context, rt *ArcadeRuntime, blockHash string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		_, data, err := rt.Deps.Store.GetBUMP(ctx, blockHash)
+		if err == nil && len(data) > 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for BUMP of %s (last err: %v)", blockHash, err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}
+
+// AssertAnchorsStable polls every txid for the given window and fails
+// the test the moment any reports blockHash == forbiddenBlock. Use after
+// announcing a same-height competitor: on buggy code the competitor's
+// STUMPs re-anchor already-MINED txs to it within a second or two, so a
+// short window catches the flip with a crisp message; on fixed code the
+// window passes quietly.
+func AssertAnchorsStable(ctx context.Context, t *testing.T, rt *ArcadeRuntime, txids []string, forbiddenBlock string, window time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(window)
+	for time.Now().Before(deadline) {
+		for _, id := range txids {
+			st, ok, err := GetTxStatus(ctx, rt, id)
+			if err != nil {
+				t.Fatalf("status %s: %v", id, err)
+			}
+			if ok && st.BlockHash == forbiddenBlock {
+				t.Fatalf("tx %s re-anchored to the losing same-height block %s (status=%s) — "+
+					"MINED anchors must never move to a block off the active chain (issue #279)",
+					id, forbiddenBlock, st.TxStatus)
+			}
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context done during stability window: %v", ctx.Err())
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}
+
+// publishBlockUntil republishes every msg variant on the block topic
+// every 2s until done() reports true. Gossipsub publishes into a mesh
+// that takes 1-3s to form, so a single early publish can be silently
+// lost; republishing until the observable effect lands is the
+// idempotent fix (chaintracks and merkle-service both dedup by block
+// hash). Multiple variants of the same block (differing DataHubURL) let
+// host-side chaintracks and the containerized merkle-service each find
+// a URL they can actually reach.
+func publishBlockUntil(ctx context.Context, lp *LibP2PHost, msgs []teranode.BlockMessage, timeout time.Duration, done func() bool) error {
+	if len(msgs) == 0 {
+		return fmt.Errorf("no block message variants to publish")
+	}
+	publishAll := func() error {
+		for _, msg := range msgs {
+			if err := lp.PublishBlock(ctx, msg); err != nil {
+				return fmt.Errorf("publish block %s: %w", msg.Hash, err)
+			}
+		}
+		return nil
+	}
+	deadline := time.Now().Add(timeout)
+	if err := publishAll(); err != nil {
+		return err
+	}
+	next := time.Now().Add(2 * time.Second)
+	for {
+		if done() {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out publishing block %s until condition", msgs[0].Hash)
+		}
+		if time.Now().After(next) {
+			if err := publishAll(); err != nil {
+				return err
+			}
+			next = time.Now().Add(2 * time.Second)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(150 * time.Millisecond):
+		}
+	}
+}
+
+// PublishBlockUntilTracked publishes msg until arcade's embedded
+// chaintracks knows the header (by hash) — regardless of whether it
+// became tip. Use for the same-height alternate in reorg scenarios.
+func PublishBlockUntilTracked(ctx context.Context, rt *ArcadeRuntime, lp *LibP2PHost, msg teranode.BlockMessage, timeout time.Duration) error {
+	if rt.Deps.Chaintracks == nil {
+		return fmt.Errorf("chaintracks not enabled on this arcade runtime (set ArcadeOptions.EnableChaintracks)")
+	}
+	want, err := chainhash.NewHashFromHex(msg.Hash)
+	if err != nil {
+		return fmt.Errorf("parse block hash %s: %w", msg.Hash, err)
+	}
+	return publishBlockUntil(ctx, lp, []teranode.BlockMessage{msg}, timeout, func() bool {
+		h, err := rt.Deps.Chaintracks.GetHeaderByHash(ctx, want)
+		return err == nil && h != nil
+	})
+}
+
+// PublishBlockUntilTip publishes msg until arcade's embedded chaintracks
+// reports it as the chain tip.
+func PublishBlockUntilTip(ctx context.Context, rt *ArcadeRuntime, lp *LibP2PHost, msg teranode.BlockMessage, timeout time.Duration) error {
+	return PublishBlockVariantsUntilTip(ctx, rt, lp, []teranode.BlockMessage{msg}, timeout)
+}
+
+// PublishBlockVariantsUntilTip publishes every variant of the same
+// block (identical hash, different DataHubURL) until chaintracks
+// reports it as tip. Use when the announcement must carry a
+// container-reachable URL for merkle-service AND a host-reachable URL
+// for chaintracks' backward header crawl (the reorg-trigger path
+// C-on-orphaned-parent, where chaintracks HTTP-GETs /headers/<hash>).
+func PublishBlockVariantsUntilTip(ctx context.Context, rt *ArcadeRuntime, lp *LibP2PHost, msgs []teranode.BlockMessage, timeout time.Duration) error {
+	if rt.Deps.Chaintracks == nil {
+		return fmt.Errorf("chaintracks not enabled on this arcade runtime (set ArcadeOptions.EnableChaintracks)")
+	}
+	if len(msgs) == 0 {
+		return fmt.Errorf("no block message variants")
+	}
+	wantHash := msgs[0].Hash
+	for _, m := range msgs {
+		if m.Hash != wantHash {
+			return fmt.Errorf("variants must announce the same block: %s vs %s", wantHash, m.Hash)
+		}
+	}
+	return publishBlockUntil(ctx, lp, msgs, timeout, func() bool {
+		tip := rt.Deps.Chaintracks.GetTip(ctx)
+		return tip != nil && tip.Hash.String() == wantHash
+	})
 }
 
 // WaitForMined polls /tx/:txid for every txid in the slice until each

--- a/tests/e2e/harness/txbuilder.go
+++ b/tests/e2e/harness/txbuilder.go
@@ -7,11 +7,14 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"math/big"
+	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/teranode/model"
+	teranode "github.com/bsv-blockchain/teranode/services/p2p"
 )
 
 // nonDataScript returns an OP_DROP OP_TRUE locking script. Paired with the
@@ -119,6 +122,21 @@ func TxIDs(txs []*bt.Tx) []chainhash.Hash {
 	for i, tx := range txs {
 		id := tx.TxIDChainHash()
 		out[i] = *id
+	}
+	return out
+}
+
+// TxIDsFromHex converts display-order txid hex strings (as returned by
+// BroadcastTx / GET /tx) into chainhash form for block fabrication.
+func TxIDsFromHex(t *testing.T, ids []string) []chainhash.Hash {
+	t.Helper()
+	out := make([]chainhash.Hash, len(ids))
+	for i, id := range ids {
+		h, err := chainhash.NewHashFromStr(id)
+		if err != nil {
+			t.Fatalf("parse txid %s: %v", id, err)
+		}
+		out[i] = *h
 	}
 	return out
 }
@@ -265,4 +283,235 @@ func EncodeUint32LE(v uint32) []byte {
 	out := make([]byte, 4)
 	binary.LittleEndian.PutUint32(out, v)
 	return out
+}
+
+// coinbasePlaceholder is teranode's subtree-0/leaf-0 coinbase stand-in:
+// 32 bytes of 0xFF (go-subtree's CoinbasePlaceholder). The subtree an
+// announcing node publishes carries this placeholder at leaf 0; the
+// block header's merkle root is computed with the placeholder replaced
+// by the real coinbase txid. merkle-service's coinbase-BUMP builder and
+// arcade's applyCoinbaseToSTUMP both rely on this convention.
+var coinbasePlaceholder = chainhash.Hash{
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+}
+
+// regtestBits is the standard regtest compact difficulty (0x207fffff),
+// little-endian as serialized in the header.
+var regtestBits = [4]byte{0xff, 0xff, 0x7f, 0x20}
+
+// RegtestGenesisHash returns the regtest genesis block hash — the
+// prevHash for a synthetic block at height 1. Matches go-chaincfg's
+// RegressionNetParams (what embedded go-chaintracks initializes from).
+func RegtestGenesisHash() chainhash.Hash {
+	// 0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
+	// (display order). chainhash bytes are the reverse.
+	h, _ := chainhash.NewHashFromStr("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206")
+	return *h
+}
+
+// SyntheticBlock is a fully fabricated single-subtree block: everything
+// a test needs to stage it on a Datahub and announce it over libp2p so
+// that merkle-service, arcade, and embedded chaintracks all accept it.
+//
+// Layout is teranode's: the announced subtree's leaf 0 is the coinbase
+// placeholder; the header merkle root is the same tree with leaf 0
+// replaced by the real coinbase txid (single-subtree block ⇒ the
+// corrected subtree root IS the block root).
+type SyntheticBlock struct {
+	Hash        chainhash.Hash   // block hash (header hash)
+	Height      uint32           //
+	HeaderBin   []byte           // 80-byte serialized header (StageHeader input)
+	HeaderHex   string           // hex(HeaderBin) — BlockMessage.Header
+	CoinbaseHex string           // hex(coinbase bytes) — BlockMessage.Coinbase
+	CoinbaseID  chainhash.Hash   // coinbase txid
+	MerkleRoot  chainhash.Hash   // header merkle root (coinbase-corrected)
+	SubtreeHash chainhash.Hash   // announced subtree id (placeholder-based root)
+	SubtreeBin  []byte           // bytes served at /subtree/<SubtreeHash>
+	BlockBin    []byte           // bytes served at /block/<Hash>
+	TxIDs       []chainhash.Hash // non-coinbase txids, in leaf order 1..n
+}
+
+// SyntheticBlockSpec parameterizes BuildSyntheticBlock. Two same-height
+// competitors are built by calling it twice with the same PrevHash and
+// Height but different TxIDs and/or CBExtra (which varies the coinbase
+// txid the way two different miners' coinbases differ).
+type SyntheticBlockSpec struct {
+	PrevHash  chainhash.Hash
+	Height    uint32
+	Timestamp uint32
+	CBExtra   uint32
+	// TxIDs are the non-coinbase txids in leaf order. len(TxIDs)+1
+	// should ideally be a power of two (e.g. 7 txids → 8 leaves) so no
+	// odd-level duplication rules come into play anywhere in the
+	// pipeline, though go-subtree and this builder share the standard
+	// duplicate-when-odd rule either way.
+	TxIDs []chainhash.Hash
+}
+
+// BuildSyntheticBlock fabricates a single-subtree block per spec. The
+// header nonce is ground so the block hash satisfies the regtest
+// difficulty target (cheap: ~2 attempts expected).
+func BuildSyntheticBlock(spec SyntheticBlockSpec) (*SyntheticBlock, error) {
+	if len(spec.TxIDs) == 0 {
+		return nil, fmt.Errorf("synthetic block needs at least one non-coinbase txid")
+	}
+
+	coinbase := BuildCoinbase(spec.Height)
+	// Vary the coinbase txid between same-height competitors the way two
+	// miners' coinbases naturally differ. Version is otherwise unused by
+	// every consumer in the pipeline (only the txid matters).
+	if spec.CBExtra != 0 {
+		coinbase.Version = spec.CBExtra
+	}
+	cbID := *coinbase.TxIDChainHash()
+
+	// Announced subtree: placeholder at leaf 0.
+	announcedLeaves := append([]chainhash.Hash{coinbasePlaceholder}, spec.TxIDs...)
+	subtreeHash := SubtreeRoot(announcedLeaves)
+	subtreeBin := SubtreeBinary(announcedLeaves)
+
+	// Header root: same tree with the real coinbase txid at leaf 0.
+	correctedLeaves := append([]chainhash.Hash{cbID}, spec.TxIDs...)
+	merkleRoot := SubtreeRoot(correctedLeaves)
+
+	// Grind the nonce against the regtest target so anything that
+	// validates PoW accepts the header.
+	nonce, headerBin, blockHash, err := grindHeaderNonce(spec.PrevHash, merkleRoot, spec.Timestamp)
+	if err != nil {
+		return nil, err
+	}
+
+	bits, err := model.NewNBitFromSlice(regtestBits[:])
+	if err != nil {
+		return nil, fmt.Errorf("regtest nbit: %w", err)
+	}
+	// sizeBytes is advisory — nothing in the pipeline validates it, but
+	// zero looks broken in logs; use a plausible per-tx estimate.
+	sizeBytes := uint64(80 + (len(spec.TxIDs)+1)*256)
+	blockBin, builtHash, err := BuildBlockBinary(
+		spec.PrevHash, merkleRoot, spec.Height, spec.Timestamp, bits, nonce,
+		[]chainhash.Hash{subtreeHash}, coinbase, nil,
+		uint64(len(spec.TxIDs)+1), sizeBytes,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build block binary: %w", err)
+	}
+	if !builtHash.IsEqual(&blockHash) {
+		return nil, fmt.Errorf("header serialization mismatch: ground %s, model built %s", blockHash, builtHash)
+	}
+
+	return &SyntheticBlock{
+		Hash:        blockHash,
+		Height:      spec.Height,
+		HeaderBin:   headerBin,
+		HeaderHex:   hex.EncodeToString(headerBin),
+		CoinbaseHex: hexEncodeTx(coinbase),
+		CoinbaseID:  cbID,
+		MerkleRoot:  merkleRoot,
+		SubtreeHash: subtreeHash,
+		SubtreeBin:  subtreeBin,
+		BlockBin:    blockBin,
+		TxIDs:       append([]chainhash.Hash(nil), spec.TxIDs...),
+	}, nil
+}
+
+// Stage registers the block, its subtree, and its header on the datahub.
+func (b *SyntheticBlock) Stage(d *Datahub) {
+	d.StageBlock(b.Hash, b.BlockBin)
+	if len(b.SubtreeBin) > 0 {
+		d.StageSubtree(b.SubtreeHash, b.SubtreeBin)
+	}
+	d.StageHeader(b.Hash, b.HeaderBin)
+}
+
+// BlockMessage renders the teranode gossip announcement for this block,
+// pointing consumers at dataHubURL for the block/subtree fetches.
+func (b *SyntheticBlock) BlockMessage(dataHubURL string) teranode.BlockMessage {
+	return teranode.BlockMessage{
+		Hash:       b.Hash.String(),
+		Height:     b.Height,
+		DataHubURL: dataHubURL,
+		Header:     b.HeaderHex,
+		Coinbase:   b.CoinbaseHex,
+	}
+}
+
+// BuildEmptySyntheticBlock fabricates a coinbase-only block (zero
+// subtrees) — the cheapest way to extend a chain by one height in a
+// reorg scenario. Its header merkle root is the coinbase txid, matching
+// Bitcoin's single-tx-block rule; merkle-service takes its coinbase-only
+// BLOCK_PROCESSED path and chaintracks gets a well-formed header.
+func BuildEmptySyntheticBlock(prevHash chainhash.Hash, height, timestamp, cbExtra uint32) (*SyntheticBlock, error) {
+	coinbase := BuildCoinbase(height)
+	if cbExtra != 0 {
+		coinbase.Version = cbExtra
+	}
+	cbID := *coinbase.TxIDChainHash()
+
+	nonce, headerBin, blockHash, err := grindHeaderNonce(prevHash, cbID, timestamp)
+	if err != nil {
+		return nil, err
+	}
+	bits, err := model.NewNBitFromSlice(regtestBits[:])
+	if err != nil {
+		return nil, fmt.Errorf("regtest nbit: %w", err)
+	}
+	blockBin, builtHash, err := BuildBlockBinary(
+		prevHash, cbID, height, timestamp, bits, nonce,
+		nil, coinbase, nil, 1, 320,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build block binary: %w", err)
+	}
+	if !builtHash.IsEqual(&blockHash) {
+		return nil, fmt.Errorf("header serialization mismatch: ground %s, model built %s", blockHash, builtHash)
+	}
+	return &SyntheticBlock{
+		Hash:        blockHash,
+		Height:      height,
+		HeaderBin:   headerBin,
+		HeaderHex:   hex.EncodeToString(headerBin),
+		CoinbaseHex: hexEncodeTx(coinbase),
+		CoinbaseID:  cbID,
+		MerkleRoot:  cbID,
+		BlockBin:    blockBin,
+	}, nil
+}
+
+func hexEncodeTx(tx *bt.Tx) string {
+	return hex.EncodeToString(tx.Bytes())
+}
+
+// grindHeaderNonce serializes the 80-byte header with increasing nonces
+// until the hash satisfies the regtest compact target 0x207fffff
+// (mantissa 0x7fffff at exponent 0x20 ⇒ target = 0x7fffff << 232; a
+// uniformly random hash passes with p≈1/2). Returns the winning nonce,
+// header bytes, and block hash.
+func grindHeaderNonce(prev, root chainhash.Hash, timestamp uint32) (uint32, []byte, chainhash.Hash, error) {
+	target := new(big.Int).Lsh(big.NewInt(0x7fffff), 232)
+	header := make([]byte, 80)
+	binary.LittleEndian.PutUint32(header[0:4], 1)
+	copy(header[4:36], prev[:])
+	copy(header[36:68], root[:])
+	binary.LittleEndian.PutUint32(header[68:72], timestamp)
+	copy(header[72:76], regtestBits[:])
+	for nonce := uint32(0); nonce < 1<<20; nonce++ {
+		binary.LittleEndian.PutUint32(header[76:80], nonce)
+		hash := chainhash.DoubleHashH(header)
+		// Numeric comparison uses display order (reversed bytes) as a
+		// big-endian integer.
+		rev := make([]byte, 32)
+		for i := range hash {
+			rev[i] = hash[31-i]
+		}
+		if new(big.Int).SetBytes(rev).Cmp(target) <= 0 {
+			out := make([]byte, 80)
+			copy(out, header)
+			return nonce, out, hash, nil
+		}
+	}
+	return 0, nil, chainhash.Hash{}, fmt.Errorf("no nonce satisfied the regtest target in 2^20 attempts")
 }

--- a/tests/e2e/harness/txbuilder_test.go
+++ b/tests/e2e/harness/txbuilder_test.go
@@ -3,8 +3,10 @@
 package harness
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
 
 	"github.com/bsv-blockchain/arcade/validator"
@@ -47,5 +49,94 @@ func TestBuildValidatableTxs_UniqueTxIDs(t *testing.T) {
 			t.Fatalf("tx %d: duplicate txid %s", i, id)
 		}
 		seen[id] = struct{}{}
+	}
+}
+
+// TestBuildSyntheticBlock_Composition pins the teranode composition
+// rules the reorg tests depend on: the announced subtree root is over
+// [placeholder, txids...], the header merkle root is the same tree with
+// the real coinbase txid at leaf 0, the ground nonce satisfies the
+// regtest target, and two same-height competitors get distinct hashes.
+func TestBuildSyntheticBlock_Composition(t *testing.T) {
+	txids := TxIDs(BuildTxs(7, 100))
+	spec := SyntheticBlockSpec{
+		PrevHash:  RegtestGenesisHash(),
+		Height:    1,
+		Timestamp: 1700000000,
+		TxIDs:     txids,
+	}
+	blk, err := BuildSyntheticBlock(spec)
+	if err != nil {
+		t.Fatalf("BuildSyntheticBlock: %v", err)
+	}
+
+	// Announced subtree: placeholder at leaf 0.
+	wantSubtree := SubtreeRoot(append([]chainhash.Hash{coinbasePlaceholder}, txids...))
+	if !blk.SubtreeHash.IsEqual(&wantSubtree) {
+		t.Errorf("subtree hash: got %s want %s", blk.SubtreeHash, wantSubtree)
+	}
+	if len(blk.SubtreeBin) != 8*32 {
+		t.Errorf("subtree binary: got %d bytes want %d", len(blk.SubtreeBin), 8*32)
+	}
+	if !bytes.Equal(blk.SubtreeBin[:32], coinbasePlaceholder[:]) {
+		t.Error("subtree binary leaf 0 must be the coinbase placeholder")
+	}
+
+	// Header root: coinbase-corrected tree.
+	wantRoot := SubtreeRoot(append([]chainhash.Hash{blk.CoinbaseID}, txids...))
+	if !blk.MerkleRoot.IsEqual(&wantRoot) {
+		t.Errorf("merkle root: got %s want %s", blk.MerkleRoot, wantRoot)
+	}
+
+	// Simulate merkle-service's coinbase-BUMP self-validation: fold the
+	// coinbase txid up the placeholder tree's proof-of-leaf-0 siblings;
+	// the result must equal the header merkle root.
+	folded := blk.CoinbaseID
+	level := append([]chainhash.Hash{coinbasePlaceholder}, txids...)
+	for len(level) > 1 {
+		sibling := level[1] // leaf 0 climbs the left spine
+		folded = sha256d(folded[:], sibling[:])
+		next := make([]chainhash.Hash, 0, (len(level)+1)/2)
+		for i := 0; i < len(level); i += 2 {
+			next = append(next, sha256d(level[i][:], level[i+1][:]))
+		}
+		level = next
+	}
+	if !folded.IsEqual(&blk.MerkleRoot) {
+		t.Errorf("coinbase fold: got %s want %s", folded, blk.MerkleRoot)
+	}
+
+	// Header parses back to the block hash and satisfies the regtest
+	// compact target (top byte of display-order hash <= 0x7f).
+	if got := chainhash.DoubleHashH(blk.HeaderBin); !got.IsEqual(&blk.Hash) {
+		t.Errorf("header hash: got %s want %s", got, blk.Hash)
+	}
+	if blk.Hash[31] > 0x7f {
+		t.Errorf("block hash %s does not satisfy the regtest target", blk.Hash)
+	}
+
+	// A same-height competitor with a different coinbase + overlapping
+	// txs must hash differently.
+	spec2 := spec
+	spec2.CBExtra = 7
+	spec2.TxIDs = append(append([]chainhash.Hash(nil), txids[:5]...), TxIDs(BuildTxs(2, 500))...)
+	blk2, err := BuildSyntheticBlock(spec2)
+	if err != nil {
+		t.Fatalf("BuildSyntheticBlock competitor: %v", err)
+	}
+	if blk2.Hash.IsEqual(&blk.Hash) {
+		t.Error("competitors must have distinct block hashes")
+	}
+	if blk2.CoinbaseID.IsEqual(&blk.CoinbaseID) {
+		t.Error("CBExtra must vary the coinbase txid")
+	}
+
+	// Determinism: same spec, same block.
+	blk3, err := BuildSyntheticBlock(spec)
+	if err != nil {
+		t.Fatalf("BuildSyntheticBlock repeat: %v", err)
+	}
+	if !blk3.Hash.IsEqual(&blk.Hash) {
+		t.Error("BuildSyntheticBlock must be deterministic for a fixed spec")
 	}
 }

--- a/tests/e2e/reorg_test.go
+++ b/tests/e2e/reorg_test.go
@@ -1,0 +1,372 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"encoding/hex"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	sdkchainhash "github.com/bsv-blockchain/go-sdk/chainhash"
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+	teranode "github.com/bsv-blockchain/teranode/services/p2p"
+
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/tests/e2e/harness"
+)
+
+// reorgStack is the shared scaffolding for the same-height reorg
+// scenarios (issue #279): containers + arcade with embedded chaintracks,
+// two datahubs, and three tx groups broadcast + registered:
+//
+//	shared — mined in BOTH competing blocks (must follow the winner)
+//	aOnly  — only in block A (the eventual canonical block)
+//	bOnly  — only in block B (the eventual orphan; must end unmined)
+//
+// Blocks: A and B compete at height 1 on the regtest genesis (7 txs +
+// coinbase placeholder = 8 subtree leaves each); C is a coinbase-only
+// block on top of A that resolves the competition in A's favor.
+type reorgStack struct {
+	h             *harness.Harness
+	rt            *harness.ArcadeRuntime
+	msDatahub     *harness.Datahub
+	arcadeDatahub *harness.Datahub
+
+	shared, aOnly, bOnly []string
+	blkA, blkB, blkC     *harness.SyntheticBlock
+}
+
+func newReorgStack(ctx context.Context, t *testing.T) *reorgStack {
+	t.Helper()
+
+	s := &reorgStack{h: harness.New(t)}
+	s.msDatahub = s.h.NewDatahub(t)
+	s.arcadeDatahub = s.h.NewDatahub(t)
+
+	s.rt = harness.StartArcade(t, harness.ArcadeOptions{
+		MerkleServiceURL:  s.h.Containers.MerkleHostURL,
+		DatahubURL:        s.arcadeDatahub.LocalURL(),
+		LibP2PBootstrap:   s.h.LibP2P.BootstrapMultiaddr(),
+		LibP2PLoopback:    s.h.LibP2P.LoopbackMultiaddr(),
+		MerkleAuthToken:   "e2e-watch-token",
+		CallbackToken:     "e2e-callback-token",
+		EnableChaintracks: true,
+	})
+
+	// 5 shared + 2 A-only + 2 B-only = 9 broadcasts.
+	txs := harness.BuildValidatableTxs(9, 2000)
+	ids := make([]string, 0, len(txs))
+	for _, tx := range txs {
+		id, err := harness.BroadcastTx(ctx, t, s.rt, tx)
+		if err != nil {
+			t.Fatalf("broadcast: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	for _, id := range ids {
+		if err := harness.WaitForMerkleRegistration(ctx, s.h.Containers.MerkleHostURL, id, 60*time.Second); err != nil {
+			t.Fatalf("watch %s: %v", id, err)
+		}
+	}
+	s.shared, s.aOnly, s.bOnly = ids[:5], ids[5:7], ids[7:9]
+
+	ts := uint32(time.Now().Unix()) //nolint:gosec // wall clock fits in uint32 until 2106
+	var err error
+	s.blkA, err = harness.BuildSyntheticBlock(harness.SyntheticBlockSpec{
+		PrevHash:  harness.RegtestGenesisHash(),
+		Height:    1,
+		Timestamp: ts,
+		CBExtra:   1,
+		TxIDs:     harness.TxIDsFromHex(t, append(append([]string{}, s.shared...), s.aOnly...)),
+	})
+	if err != nil {
+		t.Fatalf("build block A: %v", err)
+	}
+	s.blkB, err = harness.BuildSyntheticBlock(harness.SyntheticBlockSpec{
+		PrevHash:  harness.RegtestGenesisHash(),
+		Height:    1,
+		Timestamp: ts + 1,
+		CBExtra:   2,
+		TxIDs:     harness.TxIDsFromHex(t, append(append([]string{}, s.shared...), s.bOnly...)),
+	})
+	if err != nil {
+		t.Fatalf("build block B: %v", err)
+	}
+	s.blkC, err = harness.BuildEmptySyntheticBlock(s.blkA.Hash, 2, ts+2, 3)
+	if err != nil {
+		t.Fatalf("build block C: %v", err)
+	}
+	if s.blkA.Hash.IsEqual(&s.blkB.Hash) {
+		t.Fatal("competing blocks must differ")
+	}
+
+	for _, blk := range []*harness.SyntheticBlock{s.blkA, s.blkB, s.blkC} {
+		blk.Stage(s.msDatahub)
+		blk.Stage(s.arcadeDatahub)
+	}
+
+	for _, blk := range []*harness.SyntheticBlock{s.blkA, s.blkB} {
+		if err := s.h.LibP2P.PublishSubtree(ctx, teranode.SubtreeMessage{
+			Hash:       blk.SubtreeHash.String(),
+			DataHubURL: s.msDatahub.HostURL(),
+		}); err != nil {
+			t.Fatalf("publish subtree %s: %v", blk.SubtreeHash, err)
+		}
+	}
+
+	t.Logf("stack: A=%s B=%s C=%s shared=%v aOnly=%v bOnly=%v",
+		s.blkA.Hash, s.blkB.Hash, s.blkC.Hash, s.shared, s.aOnly, s.bOnly)
+	return s
+}
+
+// assertMinedPathsAgainst asserts each txid is MINED against blk with a
+// merklePath folding to blk's header root.
+func (s *reorgStack) assertMinedPathsAgainst(ctx context.Context, t *testing.T, blk *harness.SyntheticBlock, txids []string, timeout time.Duration) {
+	t.Helper()
+	if err := harness.WaitForMinedInBlock(ctx, t, s.rt, txids, blk.Hash.String(), timeout); err != nil {
+		t.Fatalf("MINED@%s: %v", blk.Hash, err)
+	}
+	harness.AssertMerklePathsMatchHeaderRoot(t, s.rt, blk.MerkleRoot.String(), txids)
+}
+
+// TestReorg_SameHeightTie_OrphanProcessedSecond replicates the
+// scale-cluster incident ordering with the roles reversed at the
+// chain-selection layer: the canonical block A is announced (and becomes
+// tip) FIRST, then the same-height competitor B arrives. go-chaintracks
+// files B as an alternate — equal chainwork, no tip change, and
+// crucially NO ReorgEvent. On unfixed arcade, B's STUMP/BLOCK_PROCESSED
+// pipeline still unconditionally re-anchors the shared txs to B
+// (SetMinedByTxIDs is last-writer-wins) and falsely mines the B-only
+// txs, with no recovery trigger ever firing — exactly the ~92,700
+// orphan-anchored MINED txs of issue #279.
+func TestReorg_SameHeightTie_OrphanProcessedSecond(t *testing.T) {
+	skipIfNoDocker(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer cancel()
+	s := newReorgStack(ctx, t)
+
+	// 1. A becomes tip and mines its txs.
+	if err := harness.PublishBlockUntilTip(ctx, s.rt, s.h.LibP2P, s.blkA.BlockMessage(s.msDatahub.HostURL()), 90*time.Second); err != nil {
+		t.Fatalf("A → tip: %v", err)
+	}
+	s.assertMinedPathsAgainst(ctx, t, s.blkA, append(append([]string{}, s.shared...), s.aOnly...), 90*time.Second)
+	t.Logf("phase 1: shared+aOnly MINED@A=%s", s.blkA.Hash)
+
+	// 2. B arrives second: same height, equal chainwork — an alternate
+	//    that never becomes tip and never triggers a ReorgEvent. Wait
+	//    until chaintracks has the header AND arcade fully processed B's
+	//    BLOCK_PROCESSED (its compound BUMP is persisted).
+	if err := harness.PublishBlockUntilTracked(ctx, s.rt, s.h.LibP2P, s.blkB.BlockMessage(s.msDatahub.HostURL()), 90*time.Second); err != nil {
+		t.Fatalf("B → tracked: %v", err)
+	}
+	if err := harness.WaitForBUMPStored(ctx, s.rt, s.blkB.Hash.String(), 90*time.Second); err != nil {
+		t.Fatalf("B BUMP: %v", err)
+	}
+	t.Logf("phase 2: B=%s processed by the full pipeline", s.blkB.Hash)
+
+	// 3. THE core regression assertion (fails on unfixed arcade): no tx
+	//    may be anchored to B — not the shared ones (they were MINED@A
+	//    and must stay), not the B-only ones (B is off the active chain;
+	//    mining them against it is a false MINED).
+	all := append(append(append([]string{}, s.shared...), s.aOnly...), s.bOnly...)
+	harness.AssertAnchorsStable(ctx, t, s.rt, all, s.blkB.Hash.String(), 15*time.Second)
+	t.Log("phase 3: no anchors moved to the same-height loser")
+
+	// 4. C extends A: competition resolved, tip advances along A's
+	//    branch. Anchors must remain stable.
+	if err := harness.PublishBlockUntilTip(ctx, s.rt, s.h.LibP2P, s.blkC.BlockMessage(s.msDatahub.HostURL()), 90*time.Second); err != nil {
+		t.Fatalf("C → tip: %v", err)
+	}
+	harness.AssertAnchorsStable(ctx, t, s.rt, all, s.blkB.Hash.String(), 10*time.Second)
+	s.assertMinedPathsAgainst(ctx, t, s.blkA, append(append([]string{}, s.shared...), s.aOnly...), 60*time.Second)
+
+	// 5. B-only txs must not be MINED at all (their only containing
+	//    block lost the height).
+	for _, id := range s.bOnly {
+		st, ok, err := harness.GetTxStatus(ctx, s.rt, id)
+		if err != nil || !ok {
+			t.Fatalf("status %s: ok=%v err=%v", id, ok, err)
+		}
+		if st.TxStatus == string(models.StatusMined) || st.TxStatus == string(models.StatusImmutable) {
+			t.Errorf("bOnly tx %s reports %s @ %s — its only block lost the same-height competition",
+				id, st.TxStatus, st.BlockHash)
+		}
+	}
+}
+
+// TestReorg_SameHeightTie_OrphanWasTip_ReanchorsOnReorgEvent drives the
+// other ordering: B is announced first and legitimately becomes tip
+// (its MINED anchors are correct at that moment), then A arrives as an
+// alternate, then C extends A — chaintracks emits a ReorgEvent orphaning
+// B. Fixed arcade must re-anchor the shared txs to A (using A's stored
+// compound BUMP), mine the A-only txs it previously (correctly) refused
+// to anchor, revert the B-only txs to SEEN_ON_NETWORK, publish corrected
+// events, and expose B as an orphaned proof on GET /tx. Unfixed arcade
+// leaves the B-only txs MINED@B forever (recordReorg only touches the
+// block_processing table).
+func TestReorg_SameHeightTie_OrphanWasTip_ReanchorsOnReorgEvent(t *testing.T) {
+	skipIfNoDocker(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 6*time.Minute)
+	defer cancel()
+	s := newReorgStack(ctx, t)
+
+	// Collect status events so the corrected-event contract is asserted
+	// too (webhook/SSE consumers must learn about re-anchors).
+	events := make([]*models.TransactionStatus, 0, 64)
+	var eventsMu sync.Mutex
+	evCh, err := s.rt.Deps.Publisher.Subscribe(ctx, "reorg-e2e")
+	if err != nil {
+		t.Fatalf("subscribe events: %v", err)
+	}
+	go func() {
+		for ev := range evCh {
+			eventsMu.Lock()
+			events = append(events, ev)
+			eventsMu.Unlock()
+		}
+	}()
+
+	// 1. B first: legitimately tip, its txs legitimately MINED@B.
+	if err := harness.PublishBlockUntilTip(ctx, s.rt, s.h.LibP2P, s.blkB.BlockMessage(s.msDatahub.HostURL()), 90*time.Second); err != nil {
+		t.Fatalf("B → tip: %v", err)
+	}
+	s.assertMinedPathsAgainst(ctx, t, s.blkB, append(append([]string{}, s.shared...), s.bOnly...), 90*time.Second)
+	t.Logf("phase 1: shared+bOnly legitimately MINED@B=%s", s.blkB.Hash)
+
+	// 2. A second: alternate, never tip. Arcade must still fully process
+	//    and persist A's compound BUMP — it is the re-anchor fuel.
+	if err := harness.PublishBlockUntilTracked(ctx, s.rt, s.h.LibP2P, s.blkA.BlockMessage(s.msDatahub.HostURL()), 90*time.Second); err != nil {
+		t.Fatalf("A → tracked: %v", err)
+	}
+	if err := harness.WaitForBUMPStored(ctx, s.rt, s.blkA.Hash.String(), 90*time.Second); err != nil {
+		t.Fatalf("A's compound BUMP must be persisted even while A is an alternate: %v", err)
+	}
+	t.Logf("phase 2: A=%s processed, BUMP persisted", s.blkA.Hash)
+
+	// 3. C extends A → A's branch is strictly heavier → chaintracks
+	//    reorganizes and emits ReorgEvent{orphaned: [B]}. The C
+	//    announcement carries two DataHubURL variants: the
+	//    container-reachable one for merkle-service and the host-local
+	//    one for chaintracks' backward /headers crawl (C's parent A is
+	//    off chaintracks' main chain at this moment, so it must crawl).
+	cVariants := []teranode.BlockMessage{
+		s.blkC.BlockMessage(s.msDatahub.HostURL()),
+		s.blkC.BlockMessage(s.msDatahub.LocalURL()),
+	}
+	if err := harness.PublishBlockVariantsUntilTip(ctx, s.rt, s.h.LibP2P, cVariants, 120*time.Second); err != nil {
+		t.Fatalf("C → tip (reorg): %v", err)
+	}
+	t.Logf("phase 3: tip=C=%s, B orphaned", s.blkC.Hash)
+
+	// 4. Post-reorg convergence (fails on unfixed arcade):
+	//    shared re-anchored to A with valid A-paths…
+	s.assertMinedPathsAgainst(ctx, t, s.blkA, s.shared, 120*time.Second)
+	//    …aOnly finally mined against A (the write guard correctly
+	//    refused them while B was tip)…
+	s.assertMinedPathsAgainst(ctx, t, s.blkA, s.aOnly, 120*time.Second)
+	//    …and bOnly reverted to SEEN_ON_NETWORK (not in the canonical
+	//    block; a MINED@B report would be a false MINED).
+	for _, id := range s.bOnly {
+		if err := harness.WaitForStatus(ctx, s.rt, id, string(models.StatusSeenOnNetwork), 120*time.Second); err != nil {
+			t.Fatalf("bOnly %s must revert to SEEN_ON_NETWORK after B is orphaned: %v", id, err)
+		}
+	}
+	t.Log("phase 4: re-anchor + revert converged")
+
+	// 5. Historical anchor preserved: every re-anchored tx exposes B as
+	//    an orphaned proof whose merklePath still folds to B's root.
+	for _, id := range s.shared {
+		st, ok, err := harness.GetTxStatus(ctx, s.rt, id)
+		if err != nil || !ok {
+			t.Fatalf("status %s: ok=%v err=%v", id, ok, err)
+		}
+		proof, found := st.GetOrphanedProof(s.blkB.Hash.String())
+		if !found {
+			t.Errorf("tx %s: missing orphanedProofs entry for superseded anchor %s", id, s.blkB.Hash)
+			continue
+		}
+		if proof.MerklePath == "" {
+			t.Errorf("tx %s: orphaned proof for %s has no merklePath", id, s.blkB.Hash)
+			continue
+		}
+		assertPathFoldsToRoot(t, id, proof.MerklePath, s.blkB.MerkleRoot.String())
+	}
+	t.Log("phase 5: orphaned proofs preserved and verifiable")
+
+	// 6. Corrected events reached the status stream: a MINED@A event
+	//    flagged as a reorg re-anchor covering the shared txs, and a
+	//    revert event for the bOnly txs.
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		eventsMu.Lock()
+		gotReanchor := eventCovers(events, s.shared, string(models.StatusMined), s.blkA.Hash.String(), "reorg_reanchor")
+		gotRevert := eventCovers(events, s.bOnly, string(models.StatusSeenOnNetwork), "", "reorg_unmined")
+		eventsMu.Unlock()
+		if gotReanchor && gotRevert {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("corrected status events missing: reanchor=%v revert=%v", gotReanchor, gotRevert)
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Log("phase 6: corrected events published")
+}
+
+// eventCovers reports whether the collected events include every txid in
+// want with the given status, blockHash (when non-empty), and extraInfo.
+func eventCovers(events []*models.TransactionStatus, want []string, status, blockHash, extraInfo string) bool {
+	covered := make(map[string]bool, len(want))
+	for _, ev := range events {
+		if string(ev.Status) != status || ev.ExtraInfo != extraInfo {
+			continue
+		}
+		if blockHash != "" && ev.BlockHash != blockHash {
+			continue
+		}
+		if ev.TxID != "" {
+			covered[ev.TxID] = true
+		}
+		for _, id := range ev.TxIDs {
+			covered[id] = true
+		}
+	}
+	for _, id := range want {
+		if !covered[id] {
+			return false
+		}
+	}
+	return true
+}
+
+// assertPathFoldsToRoot parses a BRC-74 merklePath and asserts
+// ComputeRoot for txid equals wantRoot (display-order hex).
+func assertPathFoldsToRoot(t *testing.T, txid, merklePathHex, wantRoot string) {
+	t.Helper()
+	raw, err := hex.DecodeString(merklePathHex)
+	if err != nil {
+		t.Errorf("tx %s: decode orphaned merklePath: %v", txid, err)
+		return
+	}
+	mp, err := sdkTx.NewMerklePathFromBinary(raw)
+	if err != nil {
+		t.Errorf("tx %s: parse orphaned merklePath: %v", txid, err)
+		return
+	}
+	th, err := sdkchainhash.NewHashFromHex(txid)
+	if err != nil {
+		t.Errorf("tx %s: parse txid: %v", txid, err)
+		return
+	}
+	root, err := mp.ComputeRoot(th)
+	if err != nil {
+		t.Errorf("tx %s: ComputeRoot: %v", txid, err)
+		return
+	}
+	if !strings.EqualFold(root.String(), wantRoot) {
+		t.Errorf("tx %s: orphaned proof folds to %s, want %s", txid, root, wantRoot)
+	}
+}

--- a/tests/e2e/synthetic_block_test.go
+++ b/tests/e2e/synthetic_block_test.go
@@ -1,0 +1,107 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	teranode "github.com/bsv-blockchain/teranode/services/p2p"
+
+	"github.com/bsv-blockchain/arcade/tests/e2e/harness"
+)
+
+// TestSmoke_SyntheticBlockMined proves the synthetic-block path end to
+// end: a fully fabricated single-subtree block (teranode composition
+// rules: coinbase placeholder at subtree leaf 0, coinbase-corrected
+// header root, regtest-target nonce) is accepted by merkle-service,
+// drives arcade's watched txs to MINED with verifiable merkle paths,
+// and is tracked as the tip by arcade's embedded chaintracks.
+//
+// This is the go/no-go gate for the reorg scenarios in reorg_test.go,
+// which fabricate two competing synthetic blocks at the same height.
+// If this test breaks, fix it before reading a reorg failure as real.
+func TestSmoke_SyntheticBlockMined(t *testing.T) {
+	skipIfNoDocker(t)
+
+	h := harness.New(t)
+
+	msDatahub := h.NewDatahub(t)
+	arcadeDatahub := h.NewDatahub(t)
+
+	rt := harness.StartArcade(t, harness.ArcadeOptions{
+		MerkleServiceURL:  h.Containers.MerkleHostURL,
+		DatahubURL:        arcadeDatahub.LocalURL(),
+		LibP2PBootstrap:   h.LibP2P.BootstrapMultiaddr(),
+		LibP2PLoopback:    h.LibP2P.LoopbackMultiaddr(),
+		MerkleAuthToken:   "e2e-watch-token",
+		CallbackToken:     "e2e-callback-token",
+		EnableChaintracks: true,
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 4*time.Minute)
+	defer cancel()
+
+	// 1. Broadcast 7 validatable txs through arcade → propagation
+	//    registers them with merkle-service via /watch.
+	txs := harness.BuildValidatableTxs(7, 1000)
+	txids := make([]string, 0, len(txs))
+	for _, tx := range txs {
+		id, err := harness.BroadcastTx(ctx, t, rt, tx)
+		if err != nil {
+			t.Fatalf("broadcast: %v", err)
+		}
+		txids = append(txids, id)
+	}
+	for _, id := range txids {
+		if err := harness.WaitForMerkleRegistration(ctx, h.Containers.MerkleHostURL, id, 60*time.Second); err != nil {
+			t.Fatalf("watch %s: %v", id, err)
+		}
+	}
+	t.Logf("broadcast + registered %d txs", len(txids))
+
+	// 2. Fabricate the block: 7 txs + coinbase = 8 leaves, height 1 on
+	//    the regtest genesis.
+	blk, err := harness.BuildSyntheticBlock(harness.SyntheticBlockSpec{
+		PrevHash:  harness.RegtestGenesisHash(),
+		Height:    1,
+		Timestamp: uint32(time.Now().Unix()), //nolint:gosec // wall clock fits in uint32 until 2106
+		TxIDs:     harness.TxIDsFromHex(t, txids),
+	})
+	if err != nil {
+		t.Fatalf("build synthetic block: %v", err)
+	}
+	blk.Stage(msDatahub)
+	blk.Stage(arcadeDatahub)
+	t.Logf("synthetic block %s (subtree %s, root %s)", blk.Hash, blk.SubtreeHash, blk.MerkleRoot)
+
+	// 3. Announce subtree then block; republish the block until arcade's
+	//    embedded chaintracks reports it as tip (gossipsub mesh formation
+	//    can swallow early publishes; all consumers dedup by hash).
+	if err := h.LibP2P.PublishSubtree(ctx, teranode.SubtreeMessage{
+		Hash:       blk.SubtreeHash.String(),
+		DataHubURL: msDatahub.HostURL(),
+	}); err != nil {
+		t.Fatalf("publish subtree: %v", err)
+	}
+	blockMsg := teranode.BlockMessage{
+		Hash:       blk.Hash.String(),
+		Height:     blk.Height,
+		DataHubURL: msDatahub.HostURL(),
+		Header:     blk.HeaderHex,
+		Coinbase:   blk.CoinbaseHex,
+	}
+	if err := harness.PublishBlockUntilTip(ctx, rt, h.LibP2P, blockMsg, 90*time.Second); err != nil {
+		t.Fatalf("chaintracks never adopted the synthetic block as tip: %v", err)
+	}
+	t.Logf("chaintracks tip = %s", blk.Hash)
+
+	// 4. All txs MINED against this block, with paths that fold to the
+	//    synthetic header's merkle root.
+	if err := harness.WaitForMinedInBlock(ctx, t, rt, txids, blk.Hash.String(), 90*time.Second); err != nil {
+		t.Fatalf("MINED@%s: %v", blk.Hash, err)
+	}
+	harness.AssertMerklePathsMatchHeaderRoot(t, rt, blk.MerkleRoot.String(), txids)
+	t.Logf("all %d txs MINED with paths matching the synthetic root", len(txids))
+}


### PR DESCRIPTION
Fixes #279.

## Problem

After a same-height block competition at height 764 on the scaling cluster, ~92,700 transactions stayed `MINED` against the **orphaned** block indefinitely, serving BUMPs that compute to the orphan's merkle root — SPV clients verifying against canonical headers correctly reject them. Root cause analysis in [#279 (comment)](https://github.com/bsv-blockchain/arcade/issues/279#issuecomment-5234258431); reproduced red in e2e in [#279 (comment)](https://github.com/bsv-blockchain/arcade/issues/279#issuecomment-5234437081):

1. `SetMinedByTxIDs` was an unconditional last-writer-wins overwrite → the two competing blocks' pipelines raced per-tx (the ~101k/​~92k split).
2. `recordReorg` only stamped `block_processing.status='orphaned'` — transactions were never re-anchored or reverted; the `SetStatusByBlockHash` revert lever had zero callers.
3. An equal-chainwork same-height alternate never becomes chaintracks' tip → **no ReorgEvent ever fires** for exactly this incident shape.

## Fix — three cooperating layers (arcade only; no merkle-service / go-chaintracks changes)

**1. Write-time anchor guard** (`bump_builder.anchor_guard_enabled`, default on)
Before marking a block's txs MINED — on the fresh-build *and* short-circuit redelivery paths — check that the block is chaintracks' active-chain block at its height. Denial requires positive evidence; everything uncertain fails open (the nets below catch optimistic anchors). Denied blocks are finalized, orphan-marked into the reconciler queue, and their compound BUMP retained.

**2. Tie-scan** (`chaintracks_server.tie_scan_depth`, default 20)
On each tip update, re-verify recent `active` block_processing rows against the active chain and mark same-height losers orphaned — the detection edge for the no-ReorgEvent case.

**3. Anchor reconciler** (`bump_builder.reconciler.*`, new lease-gated loop in the bump-builder mode)
Consumes `status='orphaned' AND reconciled_at IS NULL` rows:
- re-anchors affected txs to the canonical block using its **already-stored compound BUMP** (no external calls in the common case; merkle-service `/reprocess` defer as fallback),
- mines txs the guard correctly refused while the canonical block was still an alternate,
- reverts txs contained in no canonical block to `SEEN_ON_NETWORK`,
- publishes corrected bulk events (`reorg_reanchor` / `reorg_unmined`; webhooks redeliver the one same-status transition that carries new information),
- stamps `reconciled_at`.

Its **startup full-scan** sweeps the whole block_processing table for `active` rows whose height is held by a different block — the deep backstop that heals incidents predating this code. **The stuck height-764 txs on the scaling cluster heal through exactly this path on deploy, store-locally** (the canonical block's BUMP is already in arcade's bumps store).

## Orphaned-anchor history

Whenever a MINED anchor is superseded (re-anchor or revert), the store appends it to the row's history (capped at 5). `GET /tx` now returns `orphanedProofs`: each superseded block with the tx's merkle path still resolvable from that block's **retained** compound BUMP — the historical proof stays auditable against the orphaned header. OpenAPI updated.

## Store layer (pebble, postgres, aerospike)

`SetMinedByTxIDs` respects the IMMUTABLE lattice + records history; `SetStatusByBlockHash` skips IMMUTABLE, re-checks the anchor at write time (concurrent re-anchor guard), records history; new `GetTxIDsByBlockHash`, `DeleteBUMPByBlockHash`, `MarkBlockReconciled`, `ListOrphanedBlocksToReconcile`; `block_processing.reconciled_at` (idempotent schema migration; reset on resurrection).

## Tests — fails-before / passes-after

The e2e scenarios landed first and ran **red** against the pre-fix commit `e8c8005` (evidence on #279):

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| `TestSmoke_SyntheticBlockMined` (go/no-go gate for the synthetic-block machinery) | ✅ 18.6s | ✅ |
| `TestReorg_SameHeightTie_OrphanProcessedSecond` (no-ReorgEvent path) | ❌ *"tx … re-anchored to the losing same-height block"* in 18s | ✅ 47.6s |
| `TestReorg_SameHeightTie_OrphanWasTip_ReanchorsOnReorgEvent` (ReorgEvent path) | ❌ *"must revert to SEEN_ON_NETWORK … timed out (last MINED)"* | ✅ 24.7s (re-anchor, revert, verifiable orphanedProofs, corrected events) |

The harness now runs embedded chaintracks in the e2e arcade (msgbus `StaticPeers` bypasses the `testing.Testing()` isolated mode; loopback multiaddr because the container announce address isn't host-dialable), fabricates competing synthetic blocks under teranode composition rules (coinbase placeholder at subtree leaf 0, coinbase-corrected header root, regtest-target nonce), and serves go-chaintracks' `/headers` backward crawl. Container→host reachability on current rootless podman switched to `host.containers.internal` (the bridge gateway IP no longer maps to the host; Docker CI unchanged).

New unit coverage: anchor guard (allow/deny/fail-open/redelivery), reconciler (mixed re-anchor+revert, resurrection, defer→heal, defer-cap fallback, neighborhood re-bin, full-scan, crash-resume idempotency), tie-scan (detection/skips/debounce/disable), webhook redelivery exception, store reorg semantics in pebble + postgres (IMMUTABLE guards, history append/cap, stale-index skip, reconcile queue, proof enrichment round-trip), `models.AppendOrphanedAnchor`.

Full unit suite, `-tags=postgres` suite, and the complete `-tags=e2e` suite are green. `e2e-smoke.yml` timeout bumped 25→40 min for the two new container-stack scenarios.

## Rollout

Single release; schema migrates itself. Instant rollback levers without redeploy: `anchor_guard_enabled: false`, `reconciler.enabled: false`, `tie_scan_depth: 0`. On the scaling cluster, watch `arcade_reconciler_*` and `arcade_bump_builder_anchor_guard_denied_total` during the startup full-scan heal, then verify the #279 reference txids (`00f143aa…` → `blockHash 12114cd0…`, path folding to `04e3eb54…`, plus an `orphanedProofs` entry for `5a55997b…`).
