### PR TITLE
fix(postgres): skip boot-time schema apply when schema is already current

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -114,7 +114,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *zap.Logger) (*De
 		_ = producer.Close()
 		return nil, nil, fmt.Errorf("creating store: %w", err)
 	}
-	if idxErr := st.EnsureIndexes(); idxErr != nil {
+	if idxErr := st.EnsureIndexes(ctx); idxErr != nil {
 		_ = st.Close()
 		_ = producer.Close()
 		return nil, nil, fmt.Errorf("ensuring store indexes: %w", idxErr)

--- a/config.example.standalone.yaml
+++ b/config.example.standalone.yaml
@@ -82,6 +82,10 @@ store:
 #     embedded_port: 0       # 0 = auto-pick a free port
 #     embedded_data_dir: ""  # defaults to <storage_path>/postgres
 #     embedded_cache_dir: "" # defaults to <storage_path>/postgres-cache
+#     # Ceiling for the boot-time schema apply when it actually has to run
+#     # (fresh database or schema change); restarts with a current schema
+#     # verify a stored checksum and skip DDL entirely. See issue #278.
+#     schema_apply_timeout_ms: 300000
 
 # Statically configured datahub propagation targets. Leave empty to rely
 # entirely on p2p discovery below (requires datahub_discovery: true).

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -76,6 +76,15 @@ store:
     # Per-attempt socket timeout. Should be <= op_timeout_ms; the client
     # may retry on socket timeout up to the op deadline.
     socket_timeout_ms: 5000
+  # Alternative: external PostgreSQL. Only read when backend: postgres.
+  # postgres:
+  #   dsn: postgres://user:pass@host:5432/arcade
+  #   max_conns: 16
+  #   # Ceiling for the boot-time schema apply when it actually has to run
+  #   # (fresh database or schema change). Restarts with a current schema
+  #   # verify a stored checksum and skip DDL entirely, so they boot
+  #   # instantly even under heavy DB load. See issue #278.
+  #   schema_apply_timeout_ms: 300000
 
 # datahub_urls:
 #   - "https://datahub1.example.com"

--- a/config/config.go
+++ b/config/config.go
@@ -256,6 +256,11 @@ type Postgres struct {
 	EmbeddedDataDir  string `mapstructure:"embedded_data_dir"`
 	EmbeddedCacheDir string `mapstructure:"embedded_cache_dir"`
 	MaxConns         int32  `mapstructure:"max_conns"`
+	// SchemaApplyTimeoutMs bounds the slow path of EnsureIndexes (schema apply
+	// on a fresh DB or after a schema change). The checksum fast path makes
+	// normal restarts skip DDL entirely, so this can be generous. 0 = default
+	// (5 minutes). See issue #278.
+	SchemaApplyTimeoutMs int `mapstructure:"schema_apply_timeout_ms"`
 }
 
 // Pebble configures the embedded Pebble KV backend. Path is the data directory
@@ -859,6 +864,7 @@ func setDefaults() {
 	viper.SetDefault("store.postgres.embedded_data_dir", "~/.arcade/postgres")
 	viper.SetDefault("store.postgres.embedded_cache_dir", "~/.arcade/postgres-cache")
 	viper.SetDefault("store.postgres.max_conns", 16)
+	viper.SetDefault("store.postgres.schema_apply_timeout_ms", 300000)
 	viper.SetDefault("health.port", 8081)
 
 	// OTEL telemetry export: off by default. See TelemetryConfig doc comment
@@ -1027,6 +1033,9 @@ func validate(cfg *Config) error {
 	case "postgres":
 		if !cfg.Store.Postgres.Embedded && cfg.Store.Postgres.DSN == "" {
 			return fmt.Errorf("store.postgres.dsn is required when store.backend=postgres and postgres.embedded=false")
+		}
+		if cfg.Store.Postgres.SchemaApplyTimeoutMs < 0 {
+			return fmt.Errorf("store.postgres.schema_apply_timeout_ms must be >= 0 (0 = default)")
 		}
 	default:
 		return fmt.Errorf("unknown store.backend %q (expected aerospike, pebble, or postgres)", cfg.Store.Backend)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -322,3 +322,31 @@ func TestValidate_TelemetryRejectsSchemedEndpoint(t *testing.T) {
 		}
 	}
 }
+
+// Issue #278: the schema-apply slow path (fresh DB or schema change) runs
+// under store.postgres.schema_apply_timeout_ms. Zero means "use the built-in
+// default" so an unset YAML block can't foot-gun boot; only negatives are
+// config errors.
+func TestValidate_RejectsNegativeSchemaApplyTimeout(t *testing.T) {
+	cfg := baseValidConfig()
+	cfg.Store.Backend = "postgres"
+	cfg.Store.Postgres.Embedded = true
+	cfg.Store.Postgres.SchemaApplyTimeoutMs = -1
+	err := validate(cfg)
+	if err == nil {
+		t.Fatal("negative schema_apply_timeout_ms should be rejected")
+	}
+	if !strings.Contains(err.Error(), "schema_apply_timeout_ms") {
+		t.Errorf("error should mention schema_apply_timeout_ms, got: %v", err)
+	}
+}
+
+func TestValidate_AllowsZeroSchemaApplyTimeout(t *testing.T) {
+	cfg := baseValidConfig()
+	cfg.Store.Backend = "postgres"
+	cfg.Store.Postgres.Embedded = true
+	cfg.Store.Postgres.SchemaApplyTimeoutMs = 0
+	if err := validate(cfg); err != nil {
+		t.Fatalf("zero schema_apply_timeout_ms (= use default) should be accepted, got: %v", err)
+	}
+}

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -260,7 +260,7 @@ func (m *mockStore) GetReadyRetries(context.Context, time.Time, int) ([]*store.P
 func (m *mockStore) ClearRetryState(context.Context, string, models.Status, string) error {
 	return nil
 }
-func (m *mockStore) EnsureIndexes() error { return nil }
+func (m *mockStore) EnsureIndexes(context.Context) error { return nil }
 func (m *mockStore) UpsertDatahubEndpoint(context.Context, store.DatahubEndpoint) error {
 	return nil
 }

--- a/services/bump_builder/builder_test.go
+++ b/services/bump_builder/builder_test.go
@@ -140,7 +140,7 @@ func (m *mockStore) ListBlockProcessingStatus(_ context.Context, beforeHeight ui
 	return out, nil
 }
 
-func (m *mockStore) EnsureIndexes() error { return nil }
+func (m *mockStore) EnsureIndexes(context.Context) error { return nil }
 
 func (m *mockStore) InsertStump(_ context.Context, stump *models.Stump) error {
 	m.mu.Lock()

--- a/services/propagation/propagator_test.go
+++ b/services/propagation/propagator_test.go
@@ -157,7 +157,7 @@ func newMockStore() *mockStore {
 	}
 }
 
-func (m *mockStore) EnsureIndexes() error { return nil }
+func (m *mockStore) EnsureIndexes(context.Context) error { return nil }
 
 func (m *mockStore) UpdateStatus(_ context.Context, status *models.TransactionStatus) error {
 	m.mu.Lock()

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -237,7 +237,7 @@ func (s *fakeStore) ListSubmissionsReadyForRetry(_ context.Context, now time.Tim
 func (s *fakeStore) ClearRetryState(context.Context, string, models.Status, string) error {
 	return nil
 }
-func (s *fakeStore) EnsureIndexes() error { return nil }
+func (s *fakeStore) EnsureIndexes(context.Context) error { return nil }
 func (s *fakeStore) UpsertDatahubEndpoint(context.Context, store.DatahubEndpoint) error {
 	return nil
 }

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -91,7 +91,7 @@ type Store struct {
 }
 
 // New creates an Aerospike-backed Store connected to the configured cluster.
-func New(cfg config.Aero) (*Store, error) {
+func New(ctx context.Context, cfg config.Aero) (*Store, error) {
 	hosts := make([]*aero.Host, 0, len(cfg.Hosts))
 	for _, h := range cfg.Hosts {
 		hostname, portStr, err := net.SplitHostPort(h)
@@ -160,7 +160,7 @@ func New(cfg config.Aero) (*Store, error) {
 		bumpCache:     bumpcache.New(),
 	}
 
-	if err := s.EnsureIndexes(); err != nil {
+	if err := s.EnsureIndexes(ctx); err != nil {
 		client.Close()
 		return nil, fmt.Errorf("creating indexes: %w", err)
 	}
@@ -177,7 +177,7 @@ func (s *Store) Close() error {
 	return nil
 }
 
-func (s *Store) EnsureIndexes() error {
+func (s *Store) EnsureIndexes(ctx context.Context) error {
 	indexes := []struct {
 		set, bin, name string
 		indexType      aero.IndexType
@@ -213,6 +213,8 @@ func (s *Store) EnsureIndexes() error {
 			if taskErr != nil {
 				return fmt.Errorf("waiting for index %s: %w", idx.name, taskErr)
 			}
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for index %s: %w", idx.name, ctx.Err())
 		case <-time.After(30 * time.Second):
 			return fmt.Errorf("timed out waiting for index %s to build", idx.name)
 		}

--- a/store/aerospike/ctx_test.go
+++ b/store/aerospike/ctx_test.go
@@ -20,7 +20,7 @@ import (
 
 func integrationStore(t *testing.T) *Store {
 	t.Helper()
-	s, err := New(config.Aero{
+	s, err := New(context.Background(), config.Aero{
 		Hosts:           []string{"localhost:3200"},
 		Namespace:       "arcade",
 		BatchSize:       100,

--- a/store/factory/factory.go
+++ b/store/factory/factory.go
@@ -22,7 +22,7 @@ import (
 func New(ctx context.Context, cfg *config.Config) (store.Store, store.Leaser, error) {
 	switch cfg.Store.Backend {
 	case "", "aerospike":
-		s, err := aerospike.New(cfg.Store.Aerospike)
+		s, err := aerospike.New(ctx, cfg.Store.Aerospike)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -279,7 +279,7 @@ func (s *Store) Close() error {
 // EnsureIndexes is a no-op — Pebble's indexes are just prefix key ranges
 // that are written atomically with primary rows. There's nothing to
 // provision at startup.
-func (s *Store) EnsureIndexes() error { return nil }
+func (s *Store) EnsureIndexes(context.Context) error { return nil }
 
 func (s *Store) shardFor(txid string) *sync.Mutex {
 	h := fnv.New32a()

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -13,7 +13,6 @@ package postgres
 
 import (
 	"context"
-	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,9 +28,6 @@ import (
 	"github.com/bsv-blockchain/arcade/store/bumpcache"
 )
 
-//go:embed schema.sql
-var schemaSQL string
-
 var (
 	_ store.Store  = (*Store)(nil)
 	_ store.Leaser = (*Store)(nil)
@@ -44,6 +40,9 @@ type Store struct {
 	// bumpCache holds parsed+indexed compound BUMPs for merkle-path
 	// enrichment — sizing, budget, and singleflight live in bumpcache.
 	bumpCache *bumpcache.Cache
+	// schemaApplyTimeout bounds EnsureIndexes' slow path; <=0 means
+	// defaultSchemaApplyTimeout. See schema.go.
+	schemaApplyTimeout time.Duration
 }
 
 // New connects to Postgres (optionally starting the embedded-postgres process
@@ -80,19 +79,12 @@ func New(ctx context.Context, cfg config.Postgres) (*Store, error) {
 		return nil, fmt.Errorf("connect postgres: %w", err)
 	}
 
-	return &Store{pool: pool, stopEmb: stopEmbedded, bumpCache: bumpcache.New()}, nil
-}
-
-// EnsureIndexes applies the schema. Safe to call repeatedly — every CREATE
-// statement in schema.sql is IF NOT EXISTS.
-func (s *Store) EnsureIndexes() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	_, err := s.pool.Exec(ctx, schemaSQL)
-	if err != nil {
-		return fmt.Errorf("apply schema: %w", err)
-	}
-	return nil
+	return &Store{
+		pool:               pool,
+		stopEmb:            stopEmbedded,
+		bumpCache:          bumpcache.New(),
+		schemaApplyTimeout: time.Duration(cfg.SchemaApplyTimeoutMs) * time.Millisecond,
+	}, nil
 }
 
 // Close drains the pool and stops the embedded Postgres process (if any).

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -77,7 +77,7 @@ func runWithSharedStore(m *testing.M) (int, func()) {
 		sharedStoreErr = err
 		return m.Run(), func() { _ = os.RemoveAll(sharedDir) }
 	}
-	if err := s.EnsureIndexes(); err != nil {
+	if err := s.EnsureIndexes(ctx); err != nil {
 		_ = s.Close()
 		sharedStoreErr = err
 		return m.Run(), func() { _ = os.RemoveAll(sharedDir) }

--- a/store/postgres/schema.go
+++ b/store/postgres/schema.go
@@ -1,0 +1,203 @@
+package postgres
+
+import (
+	"context"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+//go:embed schema.sql
+var schemaSQL string
+
+// schemaChecksum is the compiled-in identity of schema.sql. It is stored in
+// schema_info after a successful apply; a match on startup means this exact
+// script has already run, so EnsureIndexes can skip every DDL statement —
+// and, with them, the ACCESS EXCLUSIVE lock requests that crash-looped boots
+// under load (issue #278).
+var schemaChecksum = func() string {
+	sum := sha256.Sum256([]byte(schemaSQL))
+	return hex.EncodeToString(sum[:])
+}()
+
+// schemaLockKey serializes schema application across replicas via
+// pg_advisory_lock. Advisory locks are per-database, so the constant only has
+// to be unique among arcade's own advisory locks. "arcade" in ASCII hex;
+// changing it would let two versions apply concurrently — never change it.
+const schemaLockKey = int64(0x617263616465)
+
+// defaultSchemaApplyTimeout bounds the slow path when
+// store.postgres.schema_apply_timeout_ms is unset. The apply is one-shot at
+// boot and idempotent, so generous beats fragile.
+const defaultSchemaApplyTimeout = 5 * time.Minute
+
+// Vars rather than consts only so schema_test.go can compress timings.
+var (
+	// schemaLockTimeout caps how long any single DDL statement may sit in a
+	// lock queue (SET LOCAL lock_timeout). While an ALTER TABLE waits for
+	// ACCESS EXCLUSIVE, every later query on that table queues behind it —
+	// a bounded wait plus retry keeps a busy database responsive while a
+	// schema change is pending.
+	schemaLockTimeout = 10 * time.Second
+	// schemaRetryBackoff is the delay before re-attempting after a lock
+	// timeout or deadlock; doubles per attempt up to schemaRetryBackoffMax.
+	schemaRetryBackoff    = time.Second
+	schemaRetryBackoffMax = 15 * time.Second
+	// schemaFastPathTimeout bounds the checksum probe so a hung read can't
+	// eat the whole apply budget.
+	schemaFastPathTimeout = 10 * time.Second
+)
+
+const (
+	sqlstateLockNotAvailable = "55P03"
+	sqlstateDeadlockDetected = "40P01"
+)
+
+func hasSQLState(err error, code string) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == code
+}
+
+const upsertSchemaInfoSQL = `
+INSERT INTO schema_info (id, checksum, applied_at) VALUES (TRUE, $1, now())
+ON CONFLICT (id) DO UPDATE SET checksum = EXCLUDED.checksum, applied_at = EXCLUDED.applied_at`
+
+// EnsureIndexes brings the database schema up to date. The common case —
+// schema already current — is a single-row checksum read that takes no DDL
+// locks, so restarts and rollouts boot instantly no matter how contended the
+// database is. When the schema does need applying (fresh database or version
+// change), replicas serialize on an advisory lock and each attempt bounds its
+// lock waits, retrying until the deadline (store.postgres.
+// schema_apply_timeout_ms, default 5m) expires. See issue #278.
+func (s *Store) EnsureIndexes(ctx context.Context) error {
+	timeout := s.schemaApplyTimeout
+	if timeout <= 0 {
+		timeout = defaultSchemaApplyTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if schemaCurrent(ctx, s.pool) {
+		return nil
+	}
+	if err := s.applySchemaSerialized(ctx); err != nil {
+		return fmt.Errorf("apply schema: %w", err)
+	}
+	return nil
+}
+
+// rowQuerier is satisfied by both *pgxpool.Pool and *pgxpool.Conn, letting
+// schemaCurrent serve the fast path (pool) and the post-lock re-check
+// (pinned conn) alike.
+type rowQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// schemaCurrent reports whether schema_info's stored checksum matches the
+// compiled-in one. Every failure mode — no row, table missing (42P01),
+// connectivity trouble — returns false: the slow path re-checks under the
+// advisory lock and surfaces real errors with proper context.
+func schemaCurrent(ctx context.Context, q rowQuerier) bool {
+	ctx, cancel := context.WithTimeout(ctx, schemaFastPathTimeout)
+	defer cancel()
+	var stored string
+	if err := q.QueryRow(ctx, `SELECT checksum FROM schema_info`).Scan(&stored); err != nil {
+		return false
+	}
+	return stored == schemaChecksum
+}
+
+// applySchemaSerialized pins one connection, serializes on the advisory lock
+// so only one replica runs DDL at a time, and retries bounded-lock-wait
+// apply attempts until ctx expires.
+func (s *Store) applySchemaSerialized(ctx context.Context) error {
+	conn, err := s.pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire connection: %w", err)
+	}
+	locked := false
+	defer func() { //nolint:contextcheck // cleanup must run even after ctx is cancelled — that's the point
+		// Advisory locks are session state, and pgxpool does NOT reset
+		// sessions on Release — a session still holding the lock must never
+		// go back into the pool. Unlock explicitly; destroy the session when
+		// that fails, or when we can't tell whether the lock was granted
+		// (a ctx cancel can race the grant).
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if locked {
+			if _, uerr := conn.Exec(cleanupCtx, `SELECT pg_advisory_unlock($1)`, schemaLockKey); uerr != nil {
+				_ = conn.Conn().Close(cleanupCtx)
+			}
+		} else {
+			_ = conn.Conn().Close(cleanupCtx)
+		}
+		conn.Release()
+	}()
+
+	if _, err := conn.Exec(ctx, `SELECT pg_advisory_lock($1)`, schemaLockKey); err != nil {
+		return fmt.Errorf("waiting for schema lock: %w", err)
+	}
+	locked = true
+
+	// Another replica may have applied while we queued on the lock.
+	if schemaCurrent(ctx, conn) {
+		return nil
+	}
+
+	backoff := schemaRetryBackoff
+	for attempt := 1; ; attempt++ {
+		err := applySchemaAttempt(ctx, conn)
+		if err == nil {
+			return nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("timed out after %d attempts waiting for table locks (another session holds a conflicting lock on an arcade table): %w", attempt, ctxErr)
+		}
+		if !hasSQLState(err, sqlstateLockNotAvailable) && !hasSQLState(err, sqlstateDeadlockDetected) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out after %d attempts waiting for table locks (another session holds a conflicting lock on an arcade table): %w", attempt, ctx.Err())
+		case <-time.After(backoff):
+		}
+		backoff = min(backoff*2, schemaRetryBackoffMax)
+	}
+}
+
+// applySchemaAttempt is one all-or-nothing transactional apply. SET LOCAL
+// scopes lock_timeout to this transaction, so an abort can't leak the
+// setting back into the pool, and a lock-timeout abort rolls the whole
+// script back cleanly — the retry re-runs it from scratch (every statement
+// is IF NOT EXISTS, so that's idempotent by construction).
+func applySchemaAttempt(ctx context.Context, conn *pgxpool.Conn) error {
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer func() { //nolint:contextcheck // rollback must run even after ctx is cancelled
+		// Rollback on a background ctx so a cancelled apply still leaves the
+		// session clean; no-op after a successful Commit.
+		rbCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = tx.Rollback(rbCtx)
+	}()
+
+	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL lock_timeout = '%dms'", schemaLockTimeout.Milliseconds())); err != nil {
+		return fmt.Errorf("set lock_timeout: %w", err)
+	}
+	if _, err := tx.Exec(ctx, schemaSQL); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, upsertSchemaInfoSQL, schemaChecksum); err != nil {
+		return fmt.Errorf("record schema checksum: %w", err)
+	}
+	return tx.Commit(ctx)
+}

--- a/store/postgres/schema.go
+++ b/store/postgres/schema.go
@@ -117,6 +117,12 @@ func schemaCurrent(ctx context.Context, q rowQuerier) bool {
 // applySchemaSerialized pins one connection, serializes on the advisory lock
 // so only one replica runs DDL at a time, and retries bounded-lock-wait
 // apply attempts until ctx expires.
+//
+// The advisory lock, the apply transaction, and the unlock must all observe
+// the same server session — a transaction-pooling proxy (e.g. pgbouncer in
+// transaction mode) between arcade and Postgres would scatter them across
+// sessions and leak the lock; point the DSN at Postgres (or a session-mode
+// pooler) instead.
 func (s *Store) applySchemaSerialized(ctx context.Context) error {
 	conn, err := s.pool.Acquire(ctx)
 	if err != nil {
@@ -157,10 +163,15 @@ func (s *Store) applySchemaSerialized(ctx context.Context) error {
 		if err == nil {
 			return nil
 		}
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return fmt.Errorf("timed out after %d attempts waiting for table locks (another session holds a conflicting lock on an arcade table): %w", attempt, ctxErr)
-		}
 		if !hasSQLState(err, sqlstateLockNotAvailable) && !hasSQLState(err, sqlstateDeadlockDetected) {
+			// Not lock contention. Keep the real error — when the deadline
+			// cancelled the attempt mid-statement it includes pgx's
+			// cancellation, and anything else (permissions, disk, bad DDL)
+			// must reach the operator verbatim, not a fabricated lock
+			// diagnosis.
+			if ctx.Err() != nil {
+				return fmt.Errorf("deadline expired on attempt %d (raise store.postgres.schema_apply_timeout_ms if the database is contended): %w", attempt, err)
+			}
 			return err
 		}
 		select {
@@ -190,7 +201,9 @@ func applySchemaAttempt(ctx context.Context, conn *pgxpool.Conn) error {
 		_ = tx.Rollback(rbCtx)
 	}()
 
-	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL lock_timeout = '%dms'", schemaLockTimeout.Milliseconds())); err != nil {
+	// Clamp to >=1ms: Postgres treats lock_timeout = 0 as "wait forever",
+	// the exact opposite of the bounded-wait intent.
+	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL lock_timeout = '%dms'", max(schemaLockTimeout.Milliseconds(), 1))); err != nil {
 		return fmt.Errorf("set lock_timeout: %w", err)
 	}
 	if _, err := tx.Exec(ctx, schemaSQL); err != nil {

--- a/store/postgres/schema.sql
+++ b/store/postgres/schema.sql
@@ -1,5 +1,11 @@
 -- Schema for the Postgres store backend. Applied idempotently by
 -- Store.EnsureIndexes() via pgx.Exec; safe to run repeatedly.
+--
+-- The whole file runs inside ONE transaction: statements that cannot run in
+-- a transaction block (CREATE INDEX CONCURRENTLY, ALTER TYPE ... ADD VALUE,
+-- VACUUM) must not be added here. Any byte change to this file — comments
+-- included — changes its checksum and triggers one serialized reapply on the
+-- next rollout.
 
 -- Schema-identity bookkeeping (issue #278). EnsureIndexes stores a SHA-256 of
 -- this entire file after a successful apply; when the stored checksum matches

--- a/store/postgres/schema.sql
+++ b/store/postgres/schema.sql
@@ -1,6 +1,18 @@
 -- Schema for the Postgres store backend. Applied idempotently by
 -- Store.EnsureIndexes() via pgx.Exec; safe to run repeatedly.
 
+-- Schema-identity bookkeeping (issue #278). EnsureIndexes stores a SHA-256 of
+-- this entire file after a successful apply; when the stored checksum matches
+-- the binary's, startup skips every statement below — no DDL, no ACCESS
+-- EXCLUSIVE lock requests queueing behind live traffic.
+-- Escape hatch after manual DDL drift (e.g. a hand-dropped index):
+--   DELETE FROM schema_info;  -- forces a full idempotent reapply on next start
+CREATE TABLE IF NOT EXISTS schema_info (
+    id         BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id),  -- single-row table
+    checksum   TEXT NOT NULL,
+    applied_at TIMESTAMPTZ NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS transactions (
     txid                 TEXT PRIMARY KEY,
     status               TEXT NOT NULL,

--- a/store/postgres/schema_test.go
+++ b/store/postgres/schema_test.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,9 +14,8 @@ import (
 	"github.com/bsv-blockchain/arcade/store/bumpcache"
 )
 
-// isolatedDBSeq numbers throwaway databases. Tests in this package run
-// sequentially (no t.Parallel), so a plain counter is race-free.
-var isolatedDBSeq int
+// isolatedDBSeq numbers throwaway databases.
+var isolatedDBSeq atomic.Int64
 
 // newIsolatedStore creates a throwaway database on the shared postgres
 // instance and returns a Store pointed at it. The schema tests hold table
@@ -29,8 +29,7 @@ func newIsolatedStore(t *testing.T) *Store {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	isolatedDBSeq++
-	name := fmt.Sprintf("arcade_schema_test_%d", isolatedDBSeq)
+	name := fmt.Sprintf("arcade_schema_test_%d", isolatedDBSeq.Add(1))
 	if _, err := sharedStore.pool.Exec(ctx, "CREATE DATABASE "+name); err != nil {
 		t.Skipf("cannot create isolated database (external DSN without CREATEDB?): %v", err)
 	}
@@ -49,6 +48,28 @@ func newIsolatedStore(t *testing.T) *Store {
 	st := &Store{pool: pool, bumpCache: bumpcache.New(), schemaApplyTimeout: 30 * time.Second}
 	t.Cleanup(func() { _ = st.Close() })
 	return st
+}
+
+// waitForLockQueue polls pg_locks until an ungranted lock request is present
+// (wantQueued=true) or absent (wantQueued=false).
+func waitForLockQueue(t *testing.T, st *Store, wantQueued bool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	for {
+		var waiting int
+		if err := st.pool.QueryRow(ctx, `SELECT COUNT(*) FROM pg_locks WHERE NOT granted`).Scan(&waiting); err != nil {
+			t.Fatalf("poll pg_locks: %v", err)
+		}
+		if (waiting > 0) == wantQueued {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("pg_locks never reached queued=%v", wantQueued)
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
 }
 
 func mustApplySchema(t *testing.T, st *Store) {
@@ -167,9 +188,13 @@ func TestEnsureIndexes_StaleChecksumRetriesUntilLockReleased(t *testing.T) {
 		done <- st.EnsureIndexes(callCtx)
 	}()
 
-	// Hold the lock long enough for at least one lock_timeout abort, then
-	// release and let the retry succeed.
-	time.Sleep(1 * time.Second)
+	// Deterministically guarantee at least one lock_timeout abort-and-retry
+	// cycle: wait until the apply attempt is queued behind the table lock
+	// (an ungranted request appears in pg_locks), then wait for that queue
+	// entry to vanish again — with the blocker still held, the only way out
+	// of the queue is the 55P03 rollback. Then release and let a retry win.
+	waitForLockQueue(t, st, true)
+	waitForLockQueue(t, st, false)
 	if err := blocker.Rollback(ctx); err != nil {
 		t.Fatalf("release blocking lock: %v", err)
 	}

--- a/store/postgres/schema_test.go
+++ b/store/postgres/schema_test.go
@@ -1,0 +1,274 @@
+//go:build postgres
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/bsv-blockchain/arcade/store/bumpcache"
+)
+
+// isolatedDBSeq numbers throwaway databases. Tests in this package run
+// sequentially (no t.Parallel), so a plain counter is race-free.
+var isolatedDBSeq int
+
+// newIsolatedStore creates a throwaway database on the shared postgres
+// instance and returns a Store pointed at it. The schema tests hold table
+// locks, drop indexes, and corrupt schema_info — none of which can share the
+// TRUNCATE-isolated store the rest of the package uses.
+func newIsolatedStore(t *testing.T) *Store {
+	t.Helper()
+	if sharedStore == nil {
+		t.Skipf("postgres unavailable, skipping: %v", sharedStoreErr)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	isolatedDBSeq++
+	name := fmt.Sprintf("arcade_schema_test_%d", isolatedDBSeq)
+	if _, err := sharedStore.pool.Exec(ctx, "CREATE DATABASE "+name); err != nil {
+		t.Skipf("cannot create isolated database (external DSN without CREATEDB?): %v", err)
+	}
+	t.Cleanup(func() {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer dropCancel()
+		_, _ = sharedStore.pool.Exec(dropCtx, "DROP DATABASE "+name+" WITH (FORCE)")
+	})
+
+	poolCfg := sharedStore.pool.Config().Copy()
+	poolCfg.ConnConfig.Database = name
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		t.Fatalf("connect isolated database: %v", err)
+	}
+	st := &Store{pool: pool, bumpCache: bumpcache.New(), schemaApplyTimeout: 30 * time.Second}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func mustApplySchema(t *testing.T, st *Store) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if err := st.EnsureIndexes(ctx); err != nil {
+		t.Fatalf("initial EnsureIndexes: %v", err)
+	}
+}
+
+func storedChecksum(t *testing.T, st *Store) (checksum string, appliedAt time.Time) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := st.pool.QueryRow(ctx, `SELECT checksum, applied_at FROM schema_info`).Scan(&checksum, &appliedAt); err != nil {
+		t.Fatalf("read schema_info: %v", err)
+	}
+	return checksum, appliedAt
+}
+
+func indexExists(t *testing.T, st *Store, name string) bool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var n int
+	if err := st.pool.QueryRow(ctx, `SELECT COUNT(*) FROM pg_indexes WHERE indexname = $1`, name).Scan(&n); err != nil {
+		t.Fatalf("query pg_indexes: %v", err)
+	}
+	return n == 1
+}
+
+func TestEnsureIndexes_FreshDatabaseAppliesSchemaAndChecksum(t *testing.T) {
+	st := newIsolatedStore(t)
+	mustApplySchema(t, st)
+
+	got, _ := storedChecksum(t, st)
+	if got != schemaChecksum {
+		t.Errorf("stored checksum = %q, want compiled-in %q", got, schemaChecksum)
+	}
+	if !indexExists(t, st, "idx_tx_status") {
+		t.Error("idx_tx_status missing after fresh apply")
+	}
+}
+
+func TestEnsureIndexes_SecondCallIsFastPathNoop(t *testing.T) {
+	st := newIsolatedStore(t)
+	mustApplySchema(t, st)
+	_, first := storedChecksum(t, st)
+
+	mustApplySchema(t, st)
+	_, second := storedChecksum(t, st)
+	if !second.Equal(first) {
+		t.Errorf("applied_at changed %v -> %v: second call re-applied the schema instead of fast-path skipping", first, second)
+	}
+}
+
+// The issue #278 regression test: with the schema already current, boot-time
+// EnsureIndexes must succeed quickly even while another session holds an
+// ACCESS EXCLUSIVE lock on an arcade table — the fast path takes no DDL
+// locks at all. Today's implementation queues on the lock and times out.
+func TestEnsureIndexes_FastPathSucceedsUnderAccessExclusiveLock(t *testing.T) {
+	st := newIsolatedStore(t)
+	mustApplySchema(t, st)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	blocker, err := st.pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin blocker tx: %v", err)
+	}
+	defer func() { _ = blocker.Rollback(ctx) }()
+	if _, err := blocker.Exec(ctx, `LOCK TABLE transactions IN ACCESS EXCLUSIVE MODE`); err != nil {
+		t.Fatalf("acquire blocking lock: %v", err)
+	}
+
+	callCtx, callCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer callCancel()
+	start := time.Now()
+	if err := st.EnsureIndexes(callCtx); err != nil {
+		t.Fatalf("EnsureIndexes under ACCESS EXCLUSIVE lock: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("fast path took %v; expected well under a second (did it issue DDL?)", elapsed)
+	}
+}
+
+func TestEnsureIndexes_StaleChecksumRetriesUntilLockReleased(t *testing.T) {
+	st := newIsolatedStore(t)
+	mustApplySchema(t, st)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if _, err := st.pool.Exec(ctx, `UPDATE schema_info SET checksum = 'stale'`); err != nil {
+		t.Fatalf("corrupt checksum: %v", err)
+	}
+
+	// Compress the retry timings so one held lock guarantees at least one
+	// 55P03 rollback-and-retry cycle inside a short test.
+	origLockTimeout, origBackoff := schemaLockTimeout, schemaRetryBackoff
+	schemaLockTimeout, schemaRetryBackoff = 250*time.Millisecond, 100*time.Millisecond
+	t.Cleanup(func() { schemaLockTimeout, schemaRetryBackoff = origLockTimeout, origBackoff })
+
+	blocker, err := st.pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin blocker tx: %v", err)
+	}
+	if _, err := blocker.Exec(ctx, `LOCK TABLE transactions IN ACCESS EXCLUSIVE MODE`); err != nil {
+		t.Fatalf("acquire blocking lock: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		callCtx, callCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer callCancel()
+		done <- st.EnsureIndexes(callCtx)
+	}()
+
+	// Hold the lock long enough for at least one lock_timeout abort, then
+	// release and let the retry succeed.
+	time.Sleep(1 * time.Second)
+	if err := blocker.Rollback(ctx); err != nil {
+		t.Fatalf("release blocking lock: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("EnsureIndexes should succeed once the lock is released: %v", err)
+	}
+	if got, _ := storedChecksum(t, st); got != schemaChecksum {
+		t.Errorf("checksum = %q after reapply, want %q", got, schemaChecksum)
+	}
+}
+
+func TestEnsureIndexes_ConcurrentFreshDatabase(t *testing.T) {
+	st := newIsolatedStore(t)
+
+	errs := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+			errs <- st.EnsureIndexes(ctx)
+		}()
+	}
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("concurrent EnsureIndexes: %v", err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var rows int
+	if err := st.pool.QueryRow(ctx, `SELECT COUNT(*) FROM schema_info`).Scan(&rows); err != nil {
+		t.Fatalf("count schema_info: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("schema_info has %d rows, want 1", rows)
+	}
+}
+
+// The documented escape hatch for manual DDL drift: deleting the schema_info
+// row forces a full idempotent reapply on the next start.
+func TestEnsureIndexes_DeleteChecksumRowForcesReapply(t *testing.T) {
+	st := newIsolatedStore(t)
+	mustApplySchema(t, st)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := st.pool.Exec(ctx, `DROP INDEX idx_tx_status`); err != nil {
+		t.Fatalf("drop index: %v", err)
+	}
+	if _, err := st.pool.Exec(ctx, `DELETE FROM schema_info`); err != nil {
+		t.Fatalf("delete checksum row: %v", err)
+	}
+
+	mustApplySchema(t, st)
+	if !indexExists(t, st, "idx_tx_status") {
+		t.Error("idx_tx_status not recreated after escape-hatch reapply")
+	}
+	if got, _ := storedChecksum(t, st); got != schemaChecksum {
+		t.Errorf("checksum = %q after reapply, want %q", got, schemaChecksum)
+	}
+}
+
+// A replica cancelled (or timed out) while queued on the advisory lock must
+// not poison the pool: pgxpool does not reset session state on Release, so
+// the implementation has to destroy the session instead of returning it.
+func TestEnsureIndexes_CancelledWhileWaitingForAdvisoryLock(t *testing.T) {
+	st := newIsolatedStore(t)
+	mustApplySchema(t, st)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if _, err := st.pool.Exec(ctx, `UPDATE schema_info SET checksum = 'stale'`); err != nil {
+		t.Fatalf("corrupt checksum: %v", err)
+	}
+
+	holder, err := st.pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire holder conn: %v", err)
+	}
+	if _, err := holder.Exec(ctx, `SELECT pg_advisory_lock($1)`, schemaLockKey); err != nil {
+		t.Fatalf("hold advisory lock: %v", err)
+	}
+	defer func() {
+		// Destroying the session releases its advisory lock.
+		_ = holder.Conn().Close(ctx)
+		holder.Release()
+	}()
+
+	callCtx, callCancel := context.WithTimeout(ctx, 1*time.Second)
+	defer callCancel()
+	if err := st.EnsureIndexes(callCtx); err == nil {
+		t.Fatal("EnsureIndexes should fail when the advisory lock never frees within its deadline")
+	}
+
+	// The pool must still be healthy afterwards — the waiter's session may
+	// not come back holding half-acquired state.
+	var one int
+	if err := st.pool.QueryRow(ctx, `SELECT 1`).Scan(&one); err != nil || one != 1 {
+		t.Fatalf("pool unhealthy after cancelled schema wait: %v", err)
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -354,8 +354,10 @@ type Store interface {
 	// issue #145.
 	MarkMerkleRegisteredByTxIDs(ctx context.Context, txids []string, ts time.Time) error
 
-	// EnsureIndexes creates any required secondary indexes for query operations.
-	EnsureIndexes() error
+	// EnsureIndexes provisions whatever the backend needs for query operations
+	// (schema, secondary indexes). ctx bounds the whole operation; backends may
+	// layer tighter internal deadlines on top.
+	EnsureIndexes(ctx context.Context) error
 
 	// UpsertDatahubEndpoint registers (or refreshes the LastSeen of) a datahub
 	// URL. Used by p2p_client to publish discovered URLs and by main to seed


### PR DESCRIPTION
## What Changed

- `store/postgres`: `EnsureIndexes` now stores a SHA-256 of `schema.sql` in a new single-row `schema_info` table. On boot, a single-row read (ACCESS SHARE only — cannot queue behind DDL) skips the apply entirely when the checksum matches the binary's, which is every normal restart/rollout.
- When the schema **does** need applying (fresh database or version change): replicas serialize on a `pg_advisory_lock`, each attempt runs in an explicit transaction with `SET LOCAL lock_timeout = '10s'`, and lock-timeout (55P03) / deadlock (40P01) aborts retry with backoff under a configurable deadline. A session that fails to unlock is destroyed rather than returned to the pool (pgxpool does not reset session state on Release).
- New config knob `store.postgres.schema_apply_timeout_ms` (default 300000 = 5m; env `ARCADE_STORE_POSTGRES_SCHEMA_APPLY_TIMEOUT_MS`), documented in both example configs.
- `store.Store.EnsureIndexes` now takes `ctx` so SIGTERM can cancel a pending apply; `aerospike.New` accepts `ctx` for the same reason (its index-task wait now honors cancellation).
- Escape hatch for manual DDL drift (documented in `schema.sql`): `DELETE FROM schema_info;` forces a full idempotent reapply on next start.

## Why It Was Necessary

Every arcade service mode re-applied the full `schema.sql` on every pod boot under a hardcoded 30s deadline. `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` takes an ACCESS EXCLUSIVE lock **before** evaluating `IF NOT EXISTS`, so under DB load the (no-op) DDL queued behind long-running queries, blew the deadline, and crash-looped every replica — as seen on the arcade-v2 scale deployment during the v0.10.6 rollout (`bootstrap failed: ensuring store indexes: apply schema: context deadline exceeded`). Worse, while queued those lock requests blocked all queries behind them, so simply raising the timeout would have traded the crash-loop for stalled live traffic. Closes #278.

## Testing Performed

- New `store/postgres/schema_test.go` (`-tags=postgres`, embedded Postgres, per-test isolated databases), 7 tests including:
  - **The #278 regression test**: with the schema current, `EnsureIndexes` succeeds in ~30ms while another session holds `LOCK TABLE transactions IN ACCESS EXCLUSIVE MODE`. Red-green verified: with the checksum guards disabled it reproduces the incident (`timed out ... waiting for table locks: context deadline exceeded` after the ctx deadline).
  - Stale checksum + held lock → ≥1 lock_timeout rollback-and-retry → succeeds after release.
  - Two concurrent `EnsureIndexes` on a fresh DB (advisory-lock serialization), escape-hatch reapply, cancellation while queued on the advisory lock leaves the pool healthy.
- Full suites: `go test ./...`, `go test -tags=postgres ./store/postgres/...`, `go test -tags=smoke ./tests/smoke/` (in-process `app.Bootstrap`) — all pass. `go vet` (incl. `postgres`/`integration` tags) and `golangci-lint run` clean.
- Config validation tests for the new knob (negative rejected, 0 = default).

## Impact / Risk

- **Breaking change (Go API only)**: `store.Store.EnsureIndexes()` → `EnsureIndexes(ctx)`; `aerospike.New(cfg)` → `aerospike.New(ctx, cfg)`. No wire/config breakage; the new config key defaults sensibly.
- First deploy of this build onto an existing loaded database takes the slow path once (no `schema_info` yet) — but serialized across replicas with 10s-bounded lock waits and clean retries, strictly better than today's unconditional 30s all-or-nothing apply. Every boot after that is a single-row read.
- Mixed-version rolling deploys ping-pong the checksum and reapply idempotently under the advisory lock — bounded and correct.
- Aerospike/Pebble behavior unchanged apart from ctx cancellation support.

## Ops Notes

- **Liveness probes vs slow path**: the health server starts only after `Bootstrap` returns, and arcade-v2 liveness probes allow ~3 minutes before killing the pod. A fully-contended slow-path apply can run up to the 5m default ceiling, so a pod may be killed mid-apply — this is safe (the transaction rolls back and the advisory lock releases with the session; the next boot resumes) and converges once load eases, but deployments that want zero probe kills during a schema-change rollout under load should align `schema_apply_timeout_ms` with their probe budget.
- The advisory-lock apply path requires session-consistent connections: a transaction-pooling proxy (pgbouncer transaction mode) on the DSN is not supported (documented in `schema.go`).
- Pre-existing (not addressed here): the aerospike backend runs `EnsureIndexes` twice per boot (once inside `aerospike.New`, once from `Bootstrap`).