### PR TITLE
fix(reorg): bound the reconciler startup full-scan and stop reverting un-re-anchorable txs

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -232,9 +232,8 @@ bump_builder:
   #
   # Anchor reconciler (issue #279): heals transactions anchored to orphaned
   # blocks — re-anchors them to the active-chain block containing them (via
-  # the canonical block's stored compound BUMP) or reverts them to
-  # SEEN_ON_NETWORK, publishing corrected status events. Runs in the
-  # bump-builder mode, lease-gated across replicas.
+  # the canonical block's stored compound BUMP). Runs in the bump-builder
+  # mode, lease-gated across replicas.
   # reconciler:
   #   enabled: true
   #   interval_ms: 30000       # orphan-queue tick cadence
@@ -242,7 +241,27 @@ bump_builder:
   #   blocks_per_tick: 4       # orphaned blocks reconciled per tick
   #   neighborhood_depth: 6    # heights above an orphan searched for re-binned txs
   #   max_defer_attempts: 10   # ticks to wait for a missing canonical BUMP
-  #   startup_full_scan: true  # one-off whole-table sweep for stale anchors
+  #   startup_full_scan: true  # one-off sweep for stale anchors (bounded, see below)
+  #
+  #   # Startup full-scan horizon (issue #282). The sweep is BOUNDED so it does
+  #   # not re-orphan a long chain's entire history oldest-first (which starves
+  #   # the actual recent incident). It considers only heights within
+  #   # full_scan_depth of the active tip. Default 144 (~1 day of BSV blocks);
+  #   # a chain shorter than the horizon is swept whole (cheap).
+  #   full_scan_depth: 144
+  #   # Operator-targeted recovery: when either bound is > 0 the startup scan
+  #   # runs over the explicit [min, max] height range instead of the depth
+  #   # horizon (max 0 = up to the tip). E.g. min=760 max=770 heals just the
+  #   # height-764 incident from its already-stored canonical BUMP; min=1
+  #   # restores the legacy whole-history sweep. Both default 0.
+  #   full_scan_min_height: 0
+  #   full_scan_max_height: 0
+  #
+  #   # Fallback when a block's canonical BUMP is unavailable at the defer cap
+  #   # (issue #282). Default false: PARK the block — leave its txs MINED
+  #   # against the orphan (a later canonical BUMP re-anchors them) rather than
+  #   # un-mining them. true restores the pre-#282 revert-all-to-SEEN fallback.
+  #   revert_when_unreconcilable: false
 
 # Shared on-disk root for arcade state. Chaintracks headers default to
 # <storage_path>/chaintracks/.

--- a/config/config.go
+++ b/config/config.go
@@ -532,12 +532,43 @@ type ReconcilerConfig struct {
 	// SEEN_ON_NETWORK → MINED is lattice-legal and a late canonical
 	// redelivery re-mines via the short-circuit path. Default 10.
 	MaxDeferAttempts int `mapstructure:"max_defer_attempts"`
-	// StartupFullScan runs one pass over the whole block_processing table
-	// after startup, orphan-marking any 'active' row whose height's
-	// canonical header differs — the deep backstop that also heals
-	// incidents that predate this code (like the height-764 block on the
-	// scaling cluster). Default true.
+	// StartupFullScan runs one pass over the block_processing table after
+	// startup, orphan-marking any 'active' row whose height's canonical
+	// header differs — the deep backstop that also heals incidents that
+	// predate this code (like the height-764 block on the scaling cluster).
+	// Bounded by FullScanDepth (or the explicit FullScan{Min,Max}Height
+	// target). Default true.
 	StartupFullScan bool `mapstructure:"startup_full_scan"`
+	// FullScanDepth bounds the STARTUP full-scan to heights within this many
+	// blocks of the active tip (store.GetActiveTipBlockHeight): the sweep
+	// only considers rows with height >= tip-FullScanDepth. This stops the
+	// backstop from becoming a whole-history rewrite on a long chain — the
+	// original scan paged the ENTIRE table oldest-first and re-orphaned
+	// hundreds of historical competition losers, starving the actual recent
+	// incident (issue #282). Default 144 (~1 day on BSV; matches the
+	// watchdog's recency window). <= 0 selects the default; a chain shorter
+	// than the horizon (tip <= depth) scans unbounded, which is cheap. For
+	// deep recovery of an old incident, use the explicit target below.
+	FullScanDepth int `mapstructure:"full_scan_depth"`
+	// FullScanMinHeight / FullScanMaxHeight, when EITHER is > 0, point the
+	// startup scan at an explicit height range [min, max] (max 0 = up to the
+	// tip), OVERRIDING the FullScanDepth horizon — operator-targeted incident
+	// recovery. E.g. min=760 max=770 heals just the height-764 neighborhood
+	// from its already-stored canonical BUMP without touching the rest of the
+	// table. min=1 restores the legacy whole-history sweep as an opt-in.
+	// Both default 0 (use the depth horizon).
+	FullScanMinHeight uint64 `mapstructure:"full_scan_min_height"`
+	FullScanMaxHeight uint64 `mapstructure:"full_scan_max_height"`
+	// RevertWhenUnreconcilable controls the fallback when a block's canonical
+	// BUMP is unavailable and the defer cap is reached. Default false: PARK
+	// the block (issue #282) — leave its txs MINED against the orphan and
+	// stamp reconciled_at so it drops out of the queue (no revert, no
+	// infinite retry). A later stored/rebuilt canonical BUMP re-anchors them
+	// through the normal mine path; un-mining a tx that is almost certainly
+	// in the not-yet-fetched canonical block is a downgrade, not a repair.
+	// true restores the pre-#282 revert-all-to-SEEN_ON_NETWORK fallback as an
+	// opt-in.
+	RevertWhenUnreconcilable bool `mapstructure:"revert_when_unreconcilable"`
 }
 
 // WatchdogConfig tunes the stale-block recovery watchdog. Defaults are
@@ -965,6 +996,10 @@ func setDefaults() {
 	viper.SetDefault("bump_builder.reconciler.neighborhood_depth", 6)
 	viper.SetDefault("bump_builder.reconciler.max_defer_attempts", 10)
 	viper.SetDefault("bump_builder.reconciler.startup_full_scan", true)
+	viper.SetDefault("bump_builder.reconciler.full_scan_depth", 144)
+	viper.SetDefault("bump_builder.reconciler.full_scan_min_height", 0)
+	viper.SetDefault("bump_builder.reconciler.full_scan_max_height", 0)
+	viper.SetDefault("bump_builder.reconciler.revert_when_unreconcilable", false)
 	// Block-processing watchdog (standalone arcade service — mode=watchdog
 	// in production, in-process under mode=all): on by default. The runtime
 	// nil-guards the merkle-service client; an unconfigured deployment

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -409,7 +409,9 @@ var BumpBuilderAnchorGuardDeniedTotal = promauto.NewCounterVec(prometheus.Counte
 // canonical block), reverted (all reverted to SEEN_ON_NETWORK), mixed,
 // empty (nothing anchored to the orphan anymore), resurrected (the block is
 // active again — stale orphan mark), deferred (waiting on the canonical
-// block's BUMP), error.
+// block's BUMP), parked (canonical BUMP unavailable at the defer cap — txs
+// left MINED, NOT reverted, awaiting a later canonical BUMP; issue #282),
+// error.
 var ReconcilerBlocksTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "arcade_reconciler_blocks_total",
 	Help: "Orphaned blocks processed by the anchor reconciler, by outcome.",
@@ -427,6 +429,17 @@ var ReconcilerTxsReanchoredTotal = promauto.NewCounter(prometheus.CounterOpts{
 var ReconcilerTxsRevertedTotal = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "arcade_reconciler_txs_reverted_total",
 	Help: "Transactions reverted to SEEN_ON_NETWORK because their only block was orphaned.",
+})
+
+// ReconcilerTxsParkedTotal counts transactions left MINED against an
+// orphaned block because its canonical BUMP was unavailable at the defer cap
+// (issue #282). Parked txs are NOT reverted to SEEN_ON_NETWORK — a later
+// stored/rebuilt canonical BUMP re-anchors them through the normal mine
+// path. A steady climb here means canonical BUMPs are not arriving (see the
+// merkle-service /reprocess dependency, bsv-blockchain/merkle-service#208).
+var ReconcilerTxsParkedTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "arcade_reconciler_txs_parked_total",
+	Help: "Transactions left MINED against an orphan because no canonical BUMP was available (not reverted).",
 })
 
 // ReconcilerBlockDuration observes wall time per reconciled block.

--- a/services/bump_builder/reconciler.go
+++ b/services/bump_builder/reconciler.go
@@ -25,13 +25,24 @@ import (
 // failover window is redundant work, not corruption.
 const ReconcilerLeaseName = "anchor-reconciler"
 
+// defaultFullScanDepth bounds the startup full-scan when
+// Reconciler.FullScanDepth is unset: only rows within this many heights of
+// the active tip are considered. 144 ≈ one day of BSV blocks — the same
+// recency window the watchdog uses — and stops the deep backstop from
+// re-orphaning a long chain's entire history oldest-first (issue #282).
+const defaultFullScanDepth = 144
+
 // Reconciler heals the transactions of orphaned blocks (issue #279): for
 // every block_processing row with status='orphaned' and no reconciled_at,
 // it re-anchors the txs still MINED against the orphan to the active-chain
 // block that contains them (using the canonical block's already-stored
-// compound BUMP — no external calls in the common case), reverts the rest
-// to SEEN_ON_NETWORK, publishes corrected bulk status events, and stamps
-// reconciled_at.
+// compound BUMP — no external calls in the common case), reverts the txs
+// proven to be in no canonical block to SEEN_ON_NETWORK, publishes corrected
+// bulk status events, and stamps reconciled_at. When the canonical block's
+// BUMP is unavailable it PARKS the block instead of reverting (issue #282):
+// the txs stay MINED against the orphan until a later canonical BUMP can
+// re-anchor them — un-mining a tx that is very likely in the not-yet-fetched
+// canonical block would be a downgrade, not a repair.
 //
 // Detection is elsewhere: the chaintracks_server tracker marks blocks
 // orphaned from ReorgEvents and its tie-scan, and bump-builder's anchor
@@ -187,20 +198,33 @@ func (r *Reconciler) tick(ctx context.Context) {
 	}
 }
 
-// fullScan pages the entire block_processing table and orphan-marks every
-// 'active' row whose height is provably held by a different block on the
-// active chain. Unbounded horizon by design: this is what picks up orphans
-// that predate the detection edges (guard, tie-scan, ReorgEvents) — e.g. an
-// incident block far below the current tip. Marked rows are then consumed
-// by the normal tick.
+// fullScan pages the block_processing table and orphan-marks every 'active'
+// row whose height is provably held by a different block on the active
+// chain. It is the deep backstop that picks up orphans predating the
+// detection edges (guard, tie-scan, ReorgEvents).
+//
+// The scan is BOUNDED (issue #282): rather than re-orphaning the entire
+// history oldest-first (which on a long chain grinds through hundreds of
+// historical competition losers, starving the actual recent incident), it
+// considers only heights within FullScanDepth of the active tip — or an
+// explicit FullScan{Min,Max}Height range for operator-targeted recovery.
+// Marked rows are then consumed by the normal tick.
 func (r *Reconciler) fullScan(ctx context.Context) {
 	const page = 1000
+	minHeight, maxHeight, mode := r.fullScanBounds(ctx)
+	r.logger.Info("startup full-scan: scanning",
+		zap.String("bound_mode", mode),
+		zap.Uint64("min_height", minHeight),
+		zap.Uint64("max_height", maxHeight))
 	// A set, not a slice: the boundary-safe pager may visit a row more than
 	// once at page boundaries (see store.ForEachBlockProcessing).
 	markedSet := make(map[string]struct{})
-	err := store.ForEachBlockProcessing(ctx, r.store, 0, page, func(row *models.BlockProcessingStatus) error {
+	err := store.ForEachBlockProcessing(ctx, r.store, minHeight, page, func(row *models.BlockProcessingStatus) error {
 		if row.Status != models.BlockStatusActive || row.BlockHeight == 0 || row.BlockHeight > math.MaxUint32 {
 			return nil
+		}
+		if maxHeight > 0 && row.BlockHeight > maxHeight {
+			return nil // above the targeted range's upper bound
 		}
 		active, hdrErr := r.chainHeader.GetHeaderByHeight(ctx, uint32(row.BlockHeight))
 		if hdrErr != nil || active == nil {
@@ -232,6 +256,34 @@ func (r *Reconciler) fullScan(ctx context.Context) {
 	}
 	r.logger.Info("startup full-scan: marked off-chain blocks orphaned",
 		zap.Strings("block_hashes", marked))
+}
+
+// fullScanBounds resolves the height window the startup full-scan considers.
+// An explicit FullScan{Min,Max}Height target (either > 0) wins — operator-
+// pointed recovery, e.g. a known old incident. Otherwise the scan is bounded
+// to within FullScanDepth of the active tip (store.GetActiveTipBlockHeight).
+// Returns (0, 0) — unbounded, the pre-#282 behavior — when the tip is unknown
+// or the chain is shorter than the horizon (a short table is cheap to sweep
+// whole); this keeps the fail-open contract so a missing tip never hides an
+// incident. maxHeight 0 means "no upper bound".
+func (r *Reconciler) fullScanBounds(ctx context.Context) (minHeight, maxHeight uint64, mode string) {
+	rc := r.cfg.BumpBuilder.Reconciler
+	if rc.FullScanMinHeight > 0 || rc.FullScanMaxHeight > 0 {
+		return rc.FullScanMinHeight, rc.FullScanMaxHeight, "targeted"
+	}
+	depth := rc.FullScanDepth
+	if depth <= 0 {
+		depth = defaultFullScanDepth
+	}
+	tip, err := r.store.GetActiveTipBlockHeight(ctx)
+	if err != nil {
+		r.logger.Warn("startup full-scan: active-tip lookup failed; scanning unbounded", zap.Error(err))
+		return 0, 0, "unbounded"
+	}
+	if tip == 0 || uint64(depth) >= tip {
+		return 0, 0, "unbounded"
+	}
+	return tip - uint64(depth), 0, "horizon"
 }
 
 // reconcileBlock heals one orphaned block O and returns the metric outcome.
@@ -298,14 +350,13 @@ func (r *Reconciler) reconcileBlock(ctx context.Context, row *models.BlockProces
 		if r.deferForCanonicalBUMP(ctx, logger, orphan, canonicalHash) {
 			return "deferred"
 		}
-		logger.Warn("defer cap reached without a canonical BUMP — falling back to revert-all "+
-			"(SEEN_ON_NETWORK → MINED is lattice-legal; a late canonical redelivery re-mines them)",
-			zap.String("canonical_block_hash", canonicalHash))
 	}
 
 	// Deep-reorg neighborhood: txs re-binned into LATER canonical blocks.
 	// Only the txs still anchored to O are candidates; membership is an
-	// O(1) lookup against each neighbor's stored compound BUMP.
+	// O(1) lookup against each neighbor's stored compound BUMP. This runs
+	// regardless of the height-O canonical BUMP so we still re-anchor every
+	// tx we CAN prove before deciding the remainder's fate.
 	affected, err := r.store.GetTxIDsByBlockHash(ctx, orphan)
 	if err != nil {
 		logger.Warn("failed to read affected txids", zap.Error(err))
@@ -313,10 +364,27 @@ func (r *Reconciler) reconcileBlock(ctx context.Context, row *models.BlockProces
 	}
 	reanchored += r.reanchorNeighborhood(ctx, logger, affected, height, batchSize)
 
-	// Revert the remainder: everything still anchored to O exists in no
-	// canonical block we can prove — SEEN_ON_NETWORK puts them back in
-	// flight (rebroadcast/propagation owns them from here), and the store
-	// appends O to their orphaned-anchor history.
+	// Park vs revert for whatever is still anchored to O (issue #282). When
+	// the canonical block's BUMP was NOT available (canonicalReady == false),
+	// we have no proof of where these txs belong — the canonical block simply
+	// hasn't been fetched/rebuilt yet. Reverting them to SEEN_ON_NETWORK
+	// would UN-MINE txs that are almost certainly in that not-yet-fetched
+	// block: a downgrade, not a repair. So by default we PARK the block
+	// instead — leave the txs MINED@O and stamp reconciled_at so it drops out
+	// of the queue (bounded — the defer cap already fired; no infinite retry
+	// and no further /reprocess spam). A later stored/rebuilt canonical BUMP
+	// re-anchors them through the normal mine path (MINED@O → MINED@canonical
+	// is lattice-legal). RevertWhenUnreconcilable restores the old revert-all
+	// fallback as an opt-in.
+	if !canonicalReady && !r.cfg.BumpBuilder.Reconciler.RevertWhenUnreconcilable {
+		return r.parkBlock(ctx, logger, orphan, height, canonicalHash, reanchored)
+	}
+
+	// Revert the remainder: the canonical BUMP WAS available and these txs
+	// are provably in no canonical block (or the operator opted into the
+	// legacy fallback) — SEEN_ON_NETWORK puts them back in flight
+	// (rebroadcast/propagation owns them from here), and the store appends O
+	// to their orphaned-anchor history.
 	reverted, err := r.store.SetStatusByBlockHash(ctx, orphan, models.StatusSeenOnNetwork)
 	if err != nil {
 		logger.Warn("failed to revert remaining txs", zap.Error(err))
@@ -358,11 +426,51 @@ func (r *Reconciler) reconcileBlock(ctx context.Context, row *models.BlockProces
 	}
 }
 
+// parkBlock is the issue-#282 fallback for an orphan whose canonical BUMP is
+// unavailable at the defer cap: it takes the block off the reconcile queue
+// WITHOUT downgrading any transaction. The txs still anchored to O stay
+// MINED@O (not reverted to SEEN_ON_NETWORK) — a later stored or rebuilt
+// canonical BUMP re-anchors them through the normal mine path. STUMPs are
+// pruned and the compound BUMP retained, identical to the healed-terminal
+// path; only reconciled_at is stamped so the row leaves the queue (bounded:
+// no infinite retry, no repeated /reprocess). Returns the "parked" outcome.
+func (r *Reconciler) parkBlock(ctx context.Context, logger *zap.Logger, orphan string, height uint64, canonicalHash string, reanchored int) string {
+	// Count what remains MINED@O purely for the metric/log — the neighborhood
+	// pass already re-anchored everything it could prove, so this is the
+	// still-unresolvable set we are deliberately leaving in place.
+	parked := 0
+	if remaining, err := r.store.GetTxIDsByBlockHash(ctx, orphan); err == nil {
+		parked = len(remaining)
+	}
+
+	if err := r.store.DeleteStumpsByBlockHash(ctx, orphan); err != nil {
+		logger.Warn("failed to clean up orphan STUMPs", zap.Error(err))
+	}
+	if err := r.store.MarkBlockReconciled(ctx, orphan, r.now()); err != nil {
+		logger.Warn("failed to stamp reconciled_at on parked block", zap.Error(err))
+		return "error"
+	}
+	delete(r.defers, orphan)
+
+	metrics.ReconcilerTxsReanchoredTotal.Add(float64(reanchored))
+	metrics.ReconcilerTxsParkedTotal.Add(float64(parked))
+	logger.Warn(
+		"orphaned block parked (unreconcilable): canonical BUMP unavailable at the defer cap — "+
+			"txs left MINED against the orphan, NOT reverted; a later canonical BUMP re-anchors them (issue #282)",
+		logfields.BlockHeight(height),
+		zap.String("canonical_block_hash", canonicalHash),
+		zap.Int("txs_reanchored", reanchored),
+		zap.Int("txs_parked", parked),
+	)
+	return "parked"
+}
+
 // deferForCanonicalBUMP handles the canonical-BUMP-missing branch: while
 // under the defer cap it bumps the orphan's counter, optionally pokes
 // merkle-service /reprocess for the canonical block, and reports true
 // (caller returns "deferred" without stamping reconciled_at). At the cap it
-// reports false so the caller falls back to revert-all.
+// reports false so the caller parks the block (issue #282) — or reverts, if
+// RevertWhenUnreconcilable is set.
 func (r *Reconciler) deferForCanonicalBUMP(ctx context.Context, logger *zap.Logger, orphan, canonicalHash string) bool {
 	maxDefer := r.cfg.BumpBuilder.Reconciler.MaxDeferAttempts
 	if maxDefer <= 0 {

--- a/services/bump_builder/reconciler_test.go
+++ b/services/bump_builder/reconciler_test.go
@@ -278,9 +278,10 @@ func TestReconciler_DefersUntilCanonicalBUMPArrives(t *testing.T) {
 	}
 }
 
-// TestReconciler_DeferCapFallsBackToRevert: when the canonical BUMP never
-// arrives, the defer cap converts the orphan to revert-all — safe because
-// SEEN_ON_NETWORK → MINED is lattice-legal on a later redelivery.
+// TestReconciler_DeferCapFallsBackToRevert: the OPT-IN legacy fallback
+// (RevertWhenUnreconcilable) — when the canonical BUMP never arrives, the
+// defer cap converts the orphan to revert-all. Default behavior is now to
+// park instead (see TestReconciler_DeferCapParksByDefault, issue #282).
 func TestReconciler_DeferCapFallsBackToRevert(t *testing.T) {
 	ctx := context.Background()
 	st := newPebbleForTest(t)
@@ -292,7 +293,10 @@ func TestReconciler_DeferCapFallsBackToRevert(t *testing.T) {
 	_ = st.UpsertBlockHeaderSeen(ctx, recOrphan, 10, time.Now())
 	_ = st.MarkBlocksOrphaned(ctx, []string{recOrphan}, time.Now())
 
-	r := newTestReconciler(st, pub, stub, func(c *config.ReconcilerConfig) { c.MaxDeferAttempts = 1 })
+	r := newTestReconciler(st, pub, stub, func(c *config.ReconcilerConfig) {
+		c.MaxDeferAttempts = 1
+		c.RevertWhenUnreconcilable = true // opt into the legacy revert-all fallback
+	})
 	r.tick(ctx) // defer 1/1
 	r.tick(ctx) // cap reached → revert-all
 
@@ -301,6 +305,58 @@ func TestReconciler_DeferCapFallsBackToRevert(t *testing.T) {
 	}
 	if rows, _ := st.ListOrphanedBlocksToReconcile(ctx, 10); len(rows) != 0 {
 		t.Fatalf("orphan must be reconciled after the fallback, got %d rows", len(rows))
+	}
+}
+
+// TestReconciler_DeferCapParksByDefault: when the canonical BUMP never
+// arrives, the DEFAULT fallback is to PARK the block (issue #282) — the txs
+// stay MINED against the orphan (NOT reverted to SEEN_ON_NETWORK), no revert
+// event is published, and the block leaves the queue (bounded, no infinite
+// retry). Because the txs are left in place, a later stored/rebuilt canonical
+// BUMP re-anchors them through the normal mine path.
+func TestReconciler_DeferCapParksByDefault(t *testing.T) {
+	ctx := context.Background()
+	st := newPebbleForTest(t)
+	pub := &capturePublisher{}
+	stub := &stubChaintracks{}
+	// The canonical block at height 10 exists on-chain, but its BUMP is NOT
+	// stored — the reconciler cannot prove where the txs belong.
+	stub.setHeightHeader(10, headerWithHash(t, recCanonical, 10))
+
+	seedMined(t, st, recOrphan, 10, recShared1)
+	_ = st.UpsertBlockHeaderSeen(ctx, recOrphan, 10, time.Now())
+	_ = st.MarkBlocksOrphaned(ctx, []string{recOrphan}, time.Now())
+
+	r := newTestReconciler(st, pub, stub, func(c *config.ReconcilerConfig) { c.MaxDeferAttempts = 1 })
+	r.tick(ctx) // defer 1/1
+	r.tick(ctx) // cap reached → PARK (default)
+
+	// The tx stays MINED against the orphan — the #282 invariant: no un-mine.
+	if got := statusOf(t, st, recShared1); got.Status != models.StatusMined || got.BlockHash != recOrphan {
+		t.Fatalf("parked orphan's tx must stay MINED@orphan, got %s@%s", got.Status, got.BlockHash)
+	}
+	// No revert event published.
+	for _, ev := range pub.bulkEvents() {
+		if ev.ExtraInfo == models.ExtraInfoReorgUnmined {
+			t.Fatalf("park must not publish a revert event, got %+v", ev)
+		}
+	}
+	// Block off the queue (bounded — no infinite retry) and stamped.
+	if rows, _ := st.ListOrphanedBlocksToReconcile(ctx, 10); len(rows) != 0 {
+		t.Fatalf("parked block must leave the reconcile queue, got %d rows", len(rows))
+	}
+	bp, err := st.GetBlockProcessingStatus(ctx, recOrphan)
+	if err != nil || bp.ReconciledAt == nil {
+		t.Fatalf("parked block must be stamped reconciled_at, got %+v err=%v", bp, err)
+	}
+
+	// The txs were left in place, so once the canonical block IS processed
+	// (its BUMP stored → normal mine path), they re-anchor to canonical.
+	if _, _, err := st.SetMinedByTxIDs(ctx, recCanonical, 10, []string{recShared1}); err != nil {
+		t.Fatalf("SetMinedByTxIDs (build-path re-anchor): %v", err)
+	}
+	if got := statusOf(t, st, recShared1); got.Status != models.StatusMined || got.BlockHash != recCanonical {
+		t.Fatalf("a later canonical BUMP must re-anchor the parked tx, got %s@%s", got.Status, got.BlockHash)
 	}
 }
 
@@ -354,5 +410,49 @@ func TestReconciler_FullScanDetectsStaleAnchors(t *testing.T) {
 	}
 	if len(pub.bulkEvents()) == 0 {
 		t.Fatal("expected corrected events from the full-scan heal")
+	}
+}
+
+// TestReconciler_FullScanRespectsHorizon: the startup sweep is bounded to
+// within FullScanDepth of the active tip (issue #282) — a stale off-chain
+// row far below the tip is NOT re-orphaned by the default depth, but an
+// explicit target range picks it up. This is what stops the deep backstop
+// from grinding a long chain's whole history oldest-first and starving the
+// actual recent incident.
+func TestReconciler_FullScanRespectsHorizon(t *testing.T) {
+	ctx := context.Background()
+	st := newPebbleForTest(t)
+	pub := &capturePublisher{}
+	stub := &stubChaintracks{}
+
+	// Active tip at height 200 (on-chain → never flagged; sets GetActiveTip).
+	stub.setHeightHeader(200, headerWithHash(t, recCanonical, 200))
+	_ = st.UpsertBlockHeaderSeen(ctx, recCanonical, 200, time.Now())
+	// A stale off-chain 'active' row far below the tip: the active chain
+	// holds a DIFFERENT block at height 10.
+	stub.setHeightHeader(10, headerWithHash(t, recNeighbor, 10))
+	_ = st.UpsertBlockHeaderSeen(ctx, recOrphan, 10, time.Now())
+
+	// Default depth (144): height 10 < tip-144 (=56) ⇒ out of horizon, so it
+	// must NOT be marked.
+	r := newTestReconciler(st, pub, stub, nil)
+	r.fullScan(ctx)
+	if rows, _ := st.ListOrphanedBlocksToReconcile(ctx, 10); len(rows) != 0 {
+		t.Fatalf("horizon must skip height 10 (tip 200, depth 144), got %d queued", len(rows))
+	}
+	if bp, err := st.GetBlockProcessingStatus(ctx, recOrphan); err != nil || bp.Status != models.BlockStatusActive {
+		t.Fatalf("out-of-horizon row must stay active, got %+v err=%v", bp, err)
+	}
+
+	// An explicit target range covering height 10 overrides the depth horizon
+	// ⇒ the stale anchor is now marked orphaned and queued.
+	r2 := newTestReconciler(st, pub, stub, func(c *config.ReconcilerConfig) {
+		c.FullScanMinHeight = 1
+		c.FullScanMaxHeight = 50
+	})
+	r2.fullScan(ctx)
+	rows, err := st.ListOrphanedBlocksToReconcile(ctx, 10)
+	if err != nil || len(rows) != 1 || rows[0].BlockHash != recOrphan {
+		t.Fatalf("targeted scan must mark height 10 orphaned, got %+v err=%v", rows, err)
 	}
 }


### PR DESCRIPTION
Fixes #282

Follow-up on #279 / #280 from monitoring the `v0.11.0` rollout on the scaling cluster. The anchor reconciler deployed by #280 was **not** healing the incident it was built for and was doing collateral damage. Two design problems, fixed here.

## Part A — bound / target the startup full-scan

`Reconciler.fullScan` paged the **entire** `block_processing` table and orphan-marked every `active` row whose height is held by a different active-chain block, oldest-first. On a long, heavily-competed chain this discovers **hundreds** of *historical* competition losers (observed grinding heights **341–396** on the cluster) and starves the actual incident at height **764**, which the sweep never reaches — so the height-764 txs stay `MINED @ orphan` and the downstream client stays stuck.

The startup scan is now **bounded**:

- **Height horizon** — `full_scan_depth` (default **144** ≈ 1 day of BSV blocks, matching the watchdog's recency window). The sweep considers only rows with `height >= tip - full_scan_depth`, where the tip comes from the existing `store.GetActiveTipBlockHeight` (no new chaintracks interface surface). This alone heals the cluster incident on defaults: tip ~794 → horizon floor ~650, so 764 is marked (and heals from its stored BUMP) while 341–396 are left alone.
- **Explicit target** — `full_scan_min_height` / `full_scan_max_height` (default 0). When either is > 0 the scan runs over the explicit `[min, max]` range (`max = 0` → up to tip), **overriding** the depth horizon — operator-pointed recovery of a known old incident. `min = 1` restores the legacy whole-history sweep as an opt-in.

**Fail-open preserved:** an unknown tip, or a chain shorter than the horizon, scans unbounded (cheap) so a missing tip never hides an incident. The **live** detection edges (anchor guard, `tie_scan_depth`-bounded tie-scan, ReorgEvents) are **untouched** — only the startup full-scan is bounded.

## Part B — do not revert when re-anchor is impossible

At the defer cap with no obtainable canonical BUMP, `reconcileBlock` reverted the block's txs to `SEEN_ON_NETWORK` (observed un-mining ~49k / ~14k / ~8k txs per block on the cluster). Reverting a tx that is genuinely in the not-yet-fetched canonical block is a **downgrade, not a repair**.

Default is now to **PARK** the block:

- The still-affected txs **stay `MINED` against the orphan** — no un-mine, no revert event.
- STUMPs are pruned and the compound BUMP retained (identical to the healed-terminal path); only `reconciled_at` is stamped so the row **leaves the queue** — bounded, **no infinite retry and no `/reprocess` spam** (the defer cap already fired).
- A later stored or rebuilt canonical BUMP re-anchors those txs through the **normal mine path** (`MINED@orphan → MINED@canonical` is lattice-legal). This is the path that depends on merkle-service `/reprocess` re-delivery (bsv-blockchain/merkle-service#208) for blocks whose BUMP isn't stored — the 764 incident does **not** need it (its BUMP is stored).
- The **neighborhood** re-anchor pass still runs first, so every tx we can *prove* is moved before the remainder is parked.

New `revert_when_unreconcilable` config (default **false**) restores the pre-#282 revert-all fallback as an opt-in.

The successful re-anchor path (`remineFromStoredBUMP` / neighborhood) is **unchanged** — that heals the height-764 incident from its already-stored `12114cd0` BUMP once the bounded scan reaches it.

## Design choices

| Concern | Choice | Rationale |
|---|---|---|
| Tip source for horizon | `store.GetActiveTipBlockHeight` | Already exists (watchdog uses it); avoids widening the `ChainHeaderReader` interface. |
| `full_scan_depth` default | 144 | ≈ 1 day of BSV blocks; matches `WatchdogConfig.RecencyDepth`; heals the cluster incident on defaults while bounding a long chain. |
| Explicit target | `full_scan_min_height` / `full_scan_max_height` overriding the horizon | Lets recovery be pointed at a known incident (`min=760 max=770`) or restore a whole-history sweep (`min=1`). |
| Park mechanism | Stamp `reconciled_at` + retain BUMP, prune STUMPs, leave txs `MINED@orphan` | Drops the block from the queue (bounded, no infinite retry) without a schema migration; a later canonical BUMP re-anchors via the normal mine path. |
| Park vs revert default | Park; `revert_when_unreconcilable` opt-in | Default must never un-mine (issue #282); the old lever is kept for operators who want it. |
| Metric | `arcade_reconciler_txs_parked_total` + `parked` outcome on `arcade_reconciler_blocks_total` | Makes "canonical BUMPs aren't arriving" observable (distinct from re-anchor / revert). |

## Tests

- `TestReconciler_FullScanRespectsHorizon` — default depth skips a far-below-tip stale anchor (stays `active`, not queued); an explicit target range picks it up and queues it.
- `TestReconciler_DeferCapParksByDefault` — no canonical BUMP at the cap → tx stays `MINED@orphan`, no `reorg_unmined` event, block off the queue and stamped, then re-anchors once the canonical block is mined via the build path.
- `TestReconciler_DeferCapFallsBackToRevert` — updated to opt into `revert_when_unreconcilable` (still covers the legacy revert path).

## Verify

`go build ./...`, `go vet ./services/bump_builder/... ./config/...`, `go test ./services/bump_builder/... ./store/...`, `golangci-lint run ./...` — all green. Postgres-tagged (`-tags=postgres`) and e2e-tagged (`-tags=e2e`) packages compile. Container-gated integration/e2e tests were not executed (no infra) but the packages build.

https://claude.ai/code/session_01BvyMDBbGFAD2RDQAYhRdP3
