### PR TITLE
fix(reorg): gate reconciler startup full-scan on chaintracks readiness

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -574,6 +574,19 @@ type ReconcilerConfig struct {
 	// true restores the pre-#282 revert-all-to-SEEN_ON_NETWORK fallback as an
 	// opt-in.
 	RevertWhenUnreconcilable bool `mapstructure:"revert_when_unreconcilable"`
+	// FullScanChaintracksReadyTimeoutMs bounds how long Start waits, before the
+	// FIRST startup full-scan attempt, for the chain-header source to sync up
+	// to the store's active tip. The bump-builder pod runs an EMBEDDED
+	// chaintracks with ephemeral storage, so every deploy wipes its headers and
+	// it resyncs from genesis (height 0); a scan fired before it catches up
+	// sees GetHeaderByHeight return nil for every height, fails open on every
+	// row, and heals nothing — silently breaking reorg recovery in exactly the
+	// window it is needed (right after a deploy). The wait uses bounded backoff
+	// and respects context cancellation. On timeout the scan is NOT abandoned:
+	// it re-runs on a later tick once chaintracks is ready (self-healing across
+	// the resync), so a slow catch-up is never fatal. Default 120000 (2 min);
+	// <= 0 selects the default.
+	FullScanChaintracksReadyTimeoutMs int `mapstructure:"full_scan_chaintracks_ready_timeout_ms"`
 }
 
 // WatchdogConfig tunes the stale-block recovery watchdog. Defaults are
@@ -1006,6 +1019,7 @@ func setDefaults() {
 	viper.SetDefault("bump_builder.reconciler.full_scan_min_height", 0)
 	viper.SetDefault("bump_builder.reconciler.full_scan_max_height", 0)
 	viper.SetDefault("bump_builder.reconciler.revert_when_unreconcilable", false)
+	viper.SetDefault("bump_builder.reconciler.full_scan_chaintracks_ready_timeout_ms", 120000)
 	// Block-processing watchdog (standalone arcade service — mode=watchdog
 	// in production, in-process under mode=all): on by default. The runtime
 	// nil-guards the merkle-service client; an unconfigured deployment

--- a/services/bump_builder/builder_test.go
+++ b/services/bump_builder/builder_test.go
@@ -1611,6 +1611,11 @@ type stubChaintracks struct {
 	byHeight map[uint32]*chaintrackslib.BlockHeader
 	err      error
 	lookups  int
+	// unready simulates an embedded chaintracks still resyncing from genesis:
+	// every GetHeaderByHeight returns (nil, nil) regardless of what is set,
+	// exactly as the real one does before it reaches the tip. Toggle with
+	// setUnready/setReady. Default false ⇒ existing tests are unaffected.
+	unready bool
 }
 
 func (s *stubChaintracks) GetHeaderByHash(_ context.Context, h *chainhash.Hash) (*chaintrackslib.BlockHeader, error) {
@@ -1631,7 +1636,22 @@ func (s *stubChaintracks) GetHeaderByHeight(_ context.Context, height uint32) (*
 	if s.err != nil {
 		return nil, s.err
 	}
+	if s.unready {
+		return nil, nil //nolint:nilnil // (nil,nil) is the ChainHeaderReader "cannot judge this height" contract
+	}
 	return s.byHeight[height], nil
+}
+
+func (s *stubChaintracks) setUnready() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.unready = true
+}
+
+func (s *stubChaintracks) setReady() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.unready = false
 }
 
 func (s *stubChaintracks) setHeightHeader(height uint32, header *chaintrackslib.BlockHeader) {

--- a/services/bump_builder/reconciler.go
+++ b/services/bump_builder/reconciler.go
@@ -32,6 +32,14 @@ const ReconcilerLeaseName = "anchor-reconciler"
 // re-orphaning a long chain's entire history oldest-first (issue #282).
 const defaultFullScanDepth = 144
 
+// defaultFullScanChaintracksReadyTimeout bounds the initial wait for the
+// chain-header source to sync up to the store's active tip before the startup
+// full-scan runs, when Reconciler.FullScanChaintracksReadyTimeoutMs is unset.
+// The embedded chaintracks resyncs from genesis on every deploy; two minutes
+// covers a typical catch-up while never blocking startup indefinitely — a
+// slower resync self-heals through the tick loop instead.
+const defaultFullScanChaintracksReadyTimeout = 2 * time.Minute
+
 // Reconciler heals the transactions of orphaned blocks (issue #279): for
 // every block_processing row with status='orphaned' and no reconciled_at,
 // it re-anchors the txs still MINED against the orphan to the active-chain
@@ -65,6 +73,15 @@ type Reconciler struct {
 	// the worst case is a bounded number of duplicate /reprocess calls —
 	// the same trade-off the watchdog makes with its attempt state.
 	defers map[string]int
+
+	// startupScanDone flips true only after a startup full-scan that ran while
+	// the chain-header source was synced to the store's active tip. Until then
+	// the tick loop keeps re-attempting it (lease-gated) so the deep backstop
+	// eventually runs once even if chaintracks was mid-resync at process start
+	// and the initial readiness wait timed out. In-memory by design: a restart
+	// re-arms the one-shot, which is idempotent (fullScan only marks, and marks
+	// are convergent).
+	startupScanDone bool
 
 	now    func() time.Time
 	cancel context.CancelFunc
@@ -113,7 +130,11 @@ func NewReconciler(
 func (r *Reconciler) Name() string { return "anchor-reconciler" }
 
 // Start runs the reconcile loop until ctx is canceled. The optional startup
-// full-scan runs once (lease-gated) before the first tick.
+// full-scan runs once (lease-gated), but only after the chain-header source
+// has synced up to the store's active tip — see waitForChaintracksReady. If it
+// is still catching up when the bounded wait elapses, the scan is deferred to a
+// later tick rather than run against a header source that would fail open on
+// every row (issue #279 follow-up).
 func (r *Reconciler) Start(ctx context.Context) error {
 	ctx, r.cancel = context.WithCancel(ctx)
 	defer close(r.done)
@@ -124,7 +145,14 @@ func (r *Reconciler) Start(ctx context.Context) error {
 	}
 
 	if r.cfg.BumpBuilder.Reconciler.StartupFullScan && r.acquireLease(ctx) {
-		r.fullScan(ctx)
+		if r.waitForChaintracksReady(ctx) {
+			r.fullScan(ctx)
+			r.startupScanDone = true
+		} else {
+			r.logger.Warn("startup full-scan: chain-header source not ready within timeout; "+
+				"deferring to a later tick (self-heals once chaintracks catches up to the active tip)",
+				zap.Int("timeout_ms", r.cfg.BumpBuilder.Reconciler.FullScanChaintracksReadyTimeoutMs))
+		}
 	}
 	r.tick(ctx)
 
@@ -177,6 +205,17 @@ func (r *Reconciler) acquireLease(ctx context.Context) bool {
 func (r *Reconciler) tick(ctx context.Context) {
 	if ctx.Err() != nil || !r.acquireLease(ctx) {
 		return
+	}
+	// Self-heal the startup full-scan: if it was deferred because the embedded
+	// chaintracks was still resyncing from genesis at process start (its
+	// storage is ephemeral, so every deploy wipes headers), run it now that the
+	// lease is held and chaintracks has caught up to the active tip. Guarded by
+	// startupScanDone so it runs at most once successfully; short-circuits
+	// before the readiness probe once done or when the scan is disabled, so
+	// steady-state ticks pay nothing.
+	if r.cfg.BumpBuilder.Reconciler.StartupFullScan && !r.startupScanDone && r.chaintracksReady(ctx) {
+		r.fullScan(ctx)
+		r.startupScanDone = true
 	}
 	blocksPerTick := r.cfg.BumpBuilder.Reconciler.BlocksPerTick
 	if blocksPerTick <= 0 {
@@ -284,6 +323,86 @@ func (r *Reconciler) fullScanBounds(ctx context.Context) (minHeight, maxHeight u
 		return 0, 0, "unbounded"
 	}
 	return tip - uint64(depth), 0, "horizon"
+}
+
+// chaintracksReady reports whether the chain-header source has caught up to the
+// store's active tip — the precondition for a MEANINGFUL startup full-scan. In
+// the bump-builder deployment r.chainHeader is an embedded chaintracks with
+// ephemeral storage that resyncs from genesis on every deploy; until it reaches
+// the tip, GetHeaderByHeight returns nil for every height and the scan would
+// fail open on every row (marking nothing) — silently breaking reorg recovery.
+//
+// Readiness is TRIVIALLY satisfied when the active tip is unknown/zero (nothing
+// to compare against — preserves the pre-gate behavior on an empty table) or
+// when the tip lookup fails (the scan itself still fails open per-row, so a
+// store hiccup never blocks it forever). Otherwise chaintracks is ready exactly
+// when it can return a non-nil, non-error header at the tip height.
+func (r *Reconciler) chaintracksReady(ctx context.Context) bool {
+	tip, err := r.store.GetActiveTipBlockHeight(ctx)
+	if err != nil {
+		// A canceled/expired context is shutdown, not evidence — report
+		// not-ready so a cancellation mid-wait never masquerades as "ready"
+		// and triggers a scan on the way down. A genuine store error still
+		// fails open (treat as ready; the scan itself fails open per-row).
+		if ctx.Err() != nil {
+			return false
+		}
+		r.logger.Warn("chaintracks readiness: active-tip lookup failed; treating as ready", zap.Error(err))
+		return true
+	}
+	if tip == 0 || tip > math.MaxUint32 {
+		return true
+	}
+	hdr, err := r.chainHeader.GetHeaderByHeight(ctx, uint32(tip))
+	return err == nil && hdr != nil
+}
+
+// waitForChaintracksReady blocks — with bounded exponential backoff — until
+// chaintracksReady reports true or the configured timeout elapses, whichever
+// comes first. Returns true if chaintracks became ready, false on timeout or
+// context cancellation. It NEVER blocks indefinitely: a false return is the
+// caller's signal to defer the startup scan to the tick-loop self-heal rather
+// than run it against a not-yet-synced header source.
+func (r *Reconciler) waitForChaintracksReady(ctx context.Context) bool {
+	timeout := time.Duration(r.cfg.BumpBuilder.Reconciler.FullScanChaintracksReadyTimeoutMs) * time.Millisecond
+	if timeout <= 0 {
+		timeout = defaultFullScanChaintracksReadyTimeout
+	}
+	const (
+		initialBackoff = 250 * time.Millisecond
+		maxBackoff     = 5 * time.Second
+	)
+	deadline := time.Now().Add(timeout)
+	backoff := initialBackoff
+	for {
+		if ctx.Err() != nil {
+			return false
+		}
+		if r.chaintracksReady(ctx) {
+			return true
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return false
+		}
+		wait := backoff
+		if wait > remaining {
+			wait = remaining
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return false
+		case <-timer.C:
+		}
+		if backoff < maxBackoff {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
 }
 
 // reconcileBlock heals one orphaned block O and returns the metric outcome.

--- a/services/bump_builder/reconciler_test.go
+++ b/services/bump_builder/reconciler_test.go
@@ -456,3 +456,144 @@ func TestReconciler_FullScanRespectsHorizon(t *testing.T) {
 		t.Fatalf("targeted scan must mark height 10 orphaned, got %+v err=%v", rows, err)
 	}
 }
+
+// TestReconciler_StartupScanDeferredUntilChaintracksReady pins the fix: the
+// startup full-scan must not run while the embedded chaintracks is still
+// resyncing from genesis (every GetHeaderByHeight returns nil), because it
+// would fail open on every row and heal nothing. It must instead self-heal on
+// a later tick once chaintracks catches up to the active tip — and run at most
+// once (startupScanDone). Covers (a) unready ⇒ marks nothing, (b) ready ⇒
+// scans + reconciles, (d) one-shot idempotency.
+func TestReconciler_StartupScanDeferredUntilChaintracksReady(t *testing.T) {
+	ctx := context.Background()
+	st := newPebbleForTest(t)
+	pub := &capturePublisher{}
+	stub := &stubChaintracks{}
+	stub.setUnready()                                             // resyncing from genesis
+	stub.setHeightHeader(10, headerWithHash(t, recCanonical, 10)) // the real header, revealed once ready
+
+	// Same shape as the plain full-scan test: a stale 'active' row at height 10
+	// whose canonical competitor holds the height, canonical BUMP stored so the
+	// heal can re-anchor. Both rows active ⇒ active tip is 10.
+	seedMined(t, st, recOrphan, 10, recShared1)
+	_ = st.InsertBUMP(ctx, recCanonical, 10, makeCompoundForTest(t, 10, recShared1))
+	_ = st.UpsertBlockHeaderSeen(ctx, recOrphan, 10, time.Now())
+	_ = st.UpsertBlockHeaderSeen(ctx, recCanonical, 10, time.Now())
+
+	r := newTestReconciler(st, pub, stub, func(c *config.ReconcilerConfig) {
+		c.StartupFullScan = true
+		c.FullScanChaintracksReadyTimeoutMs = 50
+	})
+
+	// (a) While chaintracks is unready the startup scan marks nothing.
+	r.tick(ctx)
+	if got := statusOf(t, st, recShared1); got.BlockHash != recOrphan {
+		t.Fatalf("unready: stale anchor must be untouched, got %s@%s", got.Status, got.BlockHash)
+	}
+	if rows, _ := st.ListOrphanedBlocksToReconcile(ctx, 10); len(rows) != 0 {
+		t.Fatalf("unready: nothing may be orphaned, got %d queued", len(rows))
+	}
+	if r.startupScanDone {
+		t.Fatal("unready: startupScanDone must stay false")
+	}
+
+	// (b) Once chaintracks catches up, a later tick runs the deferred scan
+	// (marking the off-chain block) and the same tick reconciles it as usual.
+	stub.setReady()
+	r.tick(ctx)
+	if got := statusOf(t, st, recShared1); got.Status != models.StatusMined || got.BlockHash != recCanonical {
+		t.Fatalf("ready: stale anchor must heal to canonical, got %s@%s", got.Status, got.BlockHash)
+	}
+	if !r.startupScanDone {
+		t.Fatal("ready: startupScanDone must be set after a successful scan")
+	}
+	if len(pub.bulkEvents()) == 0 {
+		t.Fatal("ready: expected corrected events from the heal")
+	}
+
+	// (d) One-shot: a NEW stale row introduced afterwards is NOT swept, because
+	// the startup full-scan does not re-run once startupScanDone is set.
+	_ = st.UpsertBlockHeaderSeen(ctx, recNeighbor, 11, time.Now())
+	stub.setHeightHeader(11, headerWithHash(t, recCanonical, 11)) // height 11 held by a DIFFERENT block
+	r.tick(ctx)
+	if bp, err := st.GetBlockProcessingStatus(ctx, recNeighbor); err != nil || bp.Status != models.BlockStatusActive {
+		t.Fatalf("one-shot: post-scan stale row must stay active (scan must not re-run), got %+v err=%v", bp, err)
+	}
+	if !r.startupScanDone {
+		t.Fatal("one-shot: startupScanDone must remain true")
+	}
+}
+
+// TestReconciler_StartupScanReadinessWaitIsBounded covers (c): with chaintracks
+// never becoming ready the readiness wait returns false without hanging, ctx
+// cancellation aborts it, Start logs the timeout path and enters its loop
+// without blocking or marking anything, and the deferred scan still self-heals
+// once chaintracks finally catches up.
+func TestReconciler_StartupScanReadinessWaitIsBounded(t *testing.T) {
+	ctx := context.Background()
+	st := newPebbleForTest(t)
+	pub := &capturePublisher{}
+	stub := &stubChaintracks{}
+	stub.setUnready() // never becomes ready during the wait phase
+
+	// Active tip at 10 so readiness is a real comparison (unready ⇒ nil header).
+	seedMined(t, st, recOrphan, 10, recShared1)
+	_ = st.UpsertBlockHeaderSeen(ctx, recOrphan, 10, time.Now())
+	stub.setHeightHeader(10, headerWithHash(t, recCanonical, 10))
+
+	r := newTestReconciler(st, pub, stub, func(c *config.ReconcilerConfig) {
+		c.StartupFullScan = true
+		c.FullScanChaintracksReadyTimeoutMs = 100
+	})
+
+	// The wait is bounded: never-ready ⇒ false, and it does not hang.
+	start := time.Now()
+	if r.waitForChaintracksReady(ctx) {
+		t.Fatal("wait must report not-ready when chaintracks never syncs")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("readiness wait must be bounded, took %s", elapsed)
+	}
+
+	// ctx cancellation short-circuits the wait.
+	cctx, cancel := context.WithCancel(ctx)
+	cancel()
+	if r.waitForChaintracksReady(cctx) {
+		t.Fatal("canceled ctx must abort the wait as not-ready")
+	}
+
+	// A timed-out initial wait is NOT fatal: Start logs and enters its loop
+	// without hanging, and marks nothing while chaintracks stays unready.
+	runCtx, runCancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() { done <- r.Start(runCtx) }()
+	time.Sleep(300 * time.Millisecond) // well past the 100ms readiness timeout
+	runCancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after ctx cancel — the readiness wait hung")
+	}
+	if r.startupScanDone {
+		t.Fatal("scan must not have run while chaintracks stayed unready")
+	}
+	if rows, _ := st.ListOrphanedBlocksToReconcile(ctx, 10); len(rows) != 0 {
+		t.Fatalf("nothing may be orphaned while unready, got %d queued", len(rows))
+	}
+
+	// Self-heal: once chaintracks catches up a later tick runs the deferred
+	// scan exactly once and heals.
+	_ = st.InsertBUMP(ctx, recCanonical, 10, makeCompoundForTest(t, 10, recShared1))
+	_ = st.UpsertBlockHeaderSeen(ctx, recCanonical, 10, time.Now())
+	stub.setReady()
+	r.tick(ctx)
+	if !r.startupScanDone {
+		t.Fatal("self-heal: startupScanDone must be set once the deferred scan runs")
+	}
+	if got := statusOf(t, st, recShared1); got.Status != models.StatusMined || got.BlockHash != recCanonical {
+		t.Fatalf("self-heal: deferred scan must eventually heal, got %s@%s", got.Status, got.BlockHash)
+	}
+}


### PR DESCRIPTION
## The bug

The anchor-reconciler's **startup full-scan** (`services/bump_builder/reconciler.go`) is the deep backstop that detects same-height block competitions (reorgs) predating the live detection edges: it finds `block_processing` rows whose stored block is no longer the active-chain block at that height, marks them orphaned, and lets the tick loop re-anchor their txs to the canonical block.

`Start()` ran `fullScan(ctx)` **once, immediately at process start, with no wait for the chain-header source to be ready**.

In the bump-builder deployment `r.chainHeader` is an **embedded chaintracks whose storage is ephemeral** (the pod mounts only its ConfigMap — no PVC), so **every deploy wipes its headers and it resyncs from genesis (height 0)**. At the instant the scan ran, `GetHeaderByHeight` returned nil for every height, so the scan **fail-opened on every row** (per its "never orphan on absence of evidence" contract) and **marked nothing**. Chaintracks caught up to the tip minutes later, but the one-shot scan had already run and never re-ran. Reorg recovery was therefore silently broken in exactly the situation it is needed: right after a deploy.

Confirmed live on the scale-ovh cluster: after the v0.11.1 deploy the embedded chaintracks resynced 0→805 about 10 min after start, but the startup scan at t=0 had already fail-opened. The height-764 incident (orphan `5a55997b…` vs canonical `12114cd0…`) was never marked orphaned, leaving ~92,700 txs stuck MINED against the orphan.

(`fullScanBounds()` uses `store.GetActiveTipBlockHeight`, which reads PG `block_processing` and returns the correct tip — that part was never the bug.)

## The fix

Gate the startup full-scan on the header source having synced up to the store's active tip, and make it **self-healing** so a slow resync is never fatal.

- **`chaintracksReady`** — ready iff `GetHeaderByHeight(tip)` returns a non-nil, non-error header. Trivially ready when the tip is unknown/zero (nothing to compare — preserves prior behavior) or on a genuine store error (fail-open); a canceled context reports **not**-ready so a shutdown mid-wait never masquerades as ready.
- **`waitForChaintracksReady`** — bounded exponential backoff up to the new timeout knob, respecting `ctx` cancellation; never blocks indefinitely.
- **`Start`** waits for readiness before the first scan attempt; on timeout it logs a WARN and defers to a later tick rather than crashing or hanging.
- **`startupScanDone` one-shot** — the tick loop re-runs the scan (lease-gated) once chaintracks catches up, so a timed-out initial wait self-heals across the resync and the scan still runs **exactly once** successfully.

### New config knob

`bump_builder.reconciler.full_scan_chaintracks_ready_timeout_ms` — default **120000** (2 min). `<= 0` selects the default.

Preserved unchanged: lease-gating (`acquireLease`), the `StartupFullScan` flag, the per-row fail-open contract during the scan itself, single-replica (nil leaser) vs multi-replica semantics, and crash-resume idempotency.

## Test coverage

`services/bump_builder/reconciler_test.go` (+ a readiness toggle on the shared `stubChaintracks` double):

- `TestReconciler_StartupScanDeferredUntilChaintracksReady` — (a) while chaintracks is unready the scan marks nothing; (b) once it becomes ready on a later tick the scan runs and the off-chain block is marked orphaned and reconciled; (d) one-shot: a new stale row added afterwards is not swept (scan does not re-run).
- `TestReconciler_StartupScanReadinessWaitIsBounded` — (c) the wait is bounded (never-ready ⇒ false without hanging), ctx cancellation aborts it, `Start` logs the timeout path and enters its loop without blocking or marking anything, and the deferred scan still self-heals once chaintracks catches up.

All existing reconciler tests remain green. `go build ./...`, `go test ./services/bump_builder/... ./config/...` (incl. `-race`), and `golangci-lint run` all pass.

Completes the reorg-recovery line from #282 / #283.

https://claude.ai/code/session_01BvyMDBbGFAD2RDQAYhRdP3