### PR TITLE
fix(reorg): prioritize re-anchorable orphans in the reconcile work queue

### DIFF
--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -2296,10 +2296,22 @@ func (s *Store) MarkBlockReconciled(ctx context.Context, blockHash string, at ti
 }
 
 // ListOrphanedBlocksToReconcile narrows by status='orphaned' via the secondary
-// index, then in-memory filters to rows with no reconciled_at, sorts by
-// orphaned_at ascending, and truncates to limit — the anchor reconciler's
-// durable work queue. Cardinality is bounded by unreconciled orphans, which
-// is near-zero in steady state.
+// index, then in-memory filters to rows with no reconciled_at — the anchor
+// reconciler's durable work queue. Rows that can be re-anchored RIGHT NOW —
+// the active (canonical) block at the same height already has a stored BUMP —
+// sort ahead of rows that cannot, with orphaned_at ascending WITHIN each group,
+// before truncating to limit. This mirrors the Postgres store: the reconciler
+// consumes a small LIMIT per tick, so a large backlog of orphans whose
+// canonical block has no stored BUMP (only parkable, never re-anchorable now)
+// must not starve a genuinely re-anchorable recent incident behind them.
+//
+// The re-anchorable signal mirrors reconcileBlock, which resolves the canonical
+// block at the orphan's height and re-anchors from that block's stored compound
+// BUMP; the active row at a height is the store's record of that canonical
+// block. Checking specifically the ACTIVE block's BUMP (not any BUMP at the
+// height) matters: an orphan retains its own compound BUMP, which must not
+// count. Cardinality is bounded by unreconciled orphans (near-zero in steady
+// state); the re-anchorable probe is memoized per distinct height.
 func (s *Store) ListOrphanedBlocksToReconcile(ctx context.Context, limit int) ([]*models.BlockProcessingStatus, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -2343,11 +2355,111 @@ loop:
 	if loopErr != nil {
 		return all, loopErr
 	}
-	sortByOrphanedAtAsc(all)
+
+	// Memoize the re-anchorable probe per distinct height: a backlog is mostly
+	// same-height competitions, so distinct heights are far fewer than rows.
+	reanchorableAt := make(map[uint64]bool)
+	for _, row := range all {
+		if _, done := reanchorableAt[row.BlockHeight]; done {
+			continue
+		}
+		ok, hErr := s.heightHasActiveBUMP(ctx, row.BlockHeight)
+		if hErr != nil {
+			return all, hErr
+		}
+		reanchorableAt[row.BlockHeight] = ok
+	}
+
+	sortReanchorableThenOrphanedAtAsc(all, reanchorableAt)
 	if len(all) > limit {
 		all = all[:limit]
 	}
 	return all, nil
+}
+
+// heightHasActiveBUMP reports whether the active (canonical) block at height
+// has a stored compound BUMP — the store-expressible proxy for "reconcileBlock
+// can re-anchor this orphan's txs right now". It queries the block_processing
+// rows at the height via the numeric secondary index and returns true on the
+// first active row whose block hash has a BUMP manifest.
+func (s *Store) heightHasActiveBUMP(ctx context.Context, height uint64) (bool, error) {
+	stmt := aero.NewStatement(s.namespace, setBlockProcessing)
+	_ = stmt.SetFilter(aero.NewRangeFilter(binBlockHeight, int64(height), int64(height))) //nolint:gosec // block height fits in int64
+	rs, err := s.client.Query(s.queryPolicy(ctx), stmt)
+	if rs != nil {
+		defer func() { _ = rs.Close() }()
+	}
+	if err != nil {
+		return false, fmt.Errorf("query block_processing at height %d: %w", height, err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case rec, ok := <-rs.Results():
+			if !ok {
+				return false, nil
+			}
+			if rec.Err != nil {
+				continue
+			}
+			if getString(rec.Record, binStatus) != string(models.BlockStatusActive) {
+				continue
+			}
+			if has, hErr := s.hasBUMP(ctx, getString(rec.Record, binBlockHash)); hErr != nil {
+				return false, hErr
+			} else if has {
+				return true, nil
+			}
+		}
+	}
+}
+
+// hasBUMP reports whether a compound BUMP manifest is stored for blockHash. It
+// reads only the manifest's presence (one bin) — the ordering signal mirrors
+// the Postgres EXISTS(... JOIN bumps ...) check, which is presence, not content.
+func (s *Store) hasBUMP(ctx context.Context, blockHash string) (bool, error) {
+	key, err := s.key(setBumps, blockHash)
+	if err != nil {
+		return false, err
+	}
+	rec, err := s.client.Get(s.readPolicy(ctx), key, "chunk_count")
+	if err != nil {
+		if isKeyNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("probe bump manifest %s: %w", blockHash, err)
+	}
+	return rec != nil, nil
+}
+
+// sortReanchorableThenOrphanedAtAsc orders rows re-anchorable-first (per the
+// reanchorableAt map keyed by height), then oldest orphaned_at within each
+// group, matching the Postgres ORDER BY. A nil orphaned_at sorts last.
+func sortReanchorableThenOrphanedAtAsc(rows []*models.BlockProcessingStatus, reanchorableAt map[uint64]bool) {
+	before := func(a, b *models.BlockProcessingStatus) bool {
+		ra, rb := reanchorableAt[a.BlockHeight], reanchorableAt[b.BlockHeight]
+		if ra != rb {
+			return ra // re-anchorable first
+		}
+		switch {
+		case a.OrphanedAt == nil:
+			return false
+		case b.OrphanedAt == nil:
+			return true
+		default:
+			return a.OrphanedAt.Before(*b.OrphanedAt)
+		}
+	}
+	// Insertion sort matches the other block_processing sorts — the orphan
+	// backlog is at most a handful of rows.
+	for i := 1; i < len(rows); i++ {
+		j := i
+		for j > 0 && before(rows[j], rows[j-1]) {
+			rows[j-1], rows[j] = rows[j], rows[j-1]
+			j--
+		}
+	}
 }
 
 func (s *Store) MarkBlocksParked(ctx context.Context, blockHashes []string) error {
@@ -2589,29 +2701,6 @@ func sortByHeaderSeenAsc(rows []*models.BlockProcessingStatus) {
 	for i := 1; i < len(rows); i++ {
 		j := i
 		for j > 0 && rows[j-1].HeaderSeenAt.After(rows[j].HeaderSeenAt) {
-			rows[j-1], rows[j] = rows[j], rows[j-1]
-			j--
-		}
-	}
-}
-
-func sortByOrphanedAtAsc(rows []*models.BlockProcessingStatus) {
-	// Insertion sort matches the other block_processing sorts — the orphan
-	// backlog is at most a handful of rows. A nil orphaned_at sorts last,
-	// matching Postgres's ORDER BY orphaned_at ASC NULLS LAST.
-	before := func(a, b *models.BlockProcessingStatus) bool {
-		switch {
-		case a.OrphanedAt == nil:
-			return false
-		case b.OrphanedAt == nil:
-			return true
-		default:
-			return a.OrphanedAt.Before(*b.OrphanedAt)
-		}
-	}
-	for i := 1; i < len(rows); i++ {
-		j := i
-		for j > 0 && before(rows[j], rows[j-1]) {
 			rows[j-1], rows[j] = rows[j], rows[j-1]
 			j--
 		}

--- a/store/aerospike/reorg_test.go
+++ b/store/aerospike/reorg_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+
+package aerospike
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// TestListOrphanedBlocksToReconcile_PrioritizesReanchorable pins the work-queue
+// prioritization against a live Aerospike: an orphan whose active (canonical)
+// block at the same height already has a stored BUMP — so the reconciler can
+// re-anchor it right now — surfaces AHEAD of orphans whose canonical block has
+// no BUMP, even when it was orphaned more recently, with oldest-orphaned_at
+// order preserved WITHIN the un-re-anchorable group. A BUMP stored for the
+// ORPHAN's own hash (not the active block) must NOT make it re-anchorable.
+//
+// The namespace is shared with other integration tests, so heights are chosen
+// high/unique and assertions check the RELATIVE order of this test's own rows
+// within the (totally ordered) result rather than the absolute queue contents.
+func TestListOrphanedBlocksToReconcile_PrioritizesReanchorable(t *testing.T) {
+	s := integrationStore(t)
+	ctx := context.Background()
+	t0 := time.Unix(1700000500, 0).UTC()
+
+	const base = uint64(9_000_100)
+	// Three un-re-anchorable competitions: the active block at each height has
+	// NO stored BUMP. Orphaned oldest→newest across the base+0/1/2 heights.
+	names := []string{"reanchor-A", "reanchor-B", "reanchor-C"}
+	for i, orphan := range names {
+		h := base + uint64(i)
+		active := "reanchor-act-" + orphan
+		if err := s.UpsertBlockHeaderSeen(ctx, active, h, t0); err != nil {
+			t.Fatalf("seed active %s: %v", active, err)
+		}
+		if err := s.UpsertBlockHeaderSeen(ctx, orphan, h, t0); err != nil {
+			t.Fatalf("seed orphan %s: %v", orphan, err)
+		}
+		if err := s.MarkBlocksOrphaned(ctx, []string{orphan}, t0.Add(time.Duration(i+1)*time.Minute)); err != nil {
+			t.Fatalf("orphan %s: %v", orphan, err)
+		}
+	}
+	// A BUMP stored for the ORPHAN's own hash must not count.
+	if err := s.InsertBUMP(ctx, "reanchor-A", base, []byte{0x01}); err != nil {
+		t.Fatalf("InsertBUMP reanchor-A: %v", err)
+	}
+
+	// One re-anchorable competition: the active block HAS a stored BUMP, but it
+	// was orphaned LAST (newest orphaned_at).
+	const canonHeight = base + 3
+	if err := s.UpsertBlockHeaderSeen(ctx, "reanchor-act-canon", canonHeight, t0); err != nil {
+		t.Fatalf("seed reanchor-act-canon: %v", err)
+	}
+	if err := s.UpsertBlockHeaderSeen(ctx, "reanchor-canon", canonHeight, t0); err != nil {
+		t.Fatalf("seed reanchor-canon: %v", err)
+	}
+	if err := s.MarkBlocksOrphaned(ctx, []string{"reanchor-canon"}, t0.Add(10*time.Minute)); err != nil {
+		t.Fatalf("orphan reanchor-canon: %v", err)
+	}
+	if err := s.InsertBUMP(ctx, "reanchor-act-canon", canonHeight, []byte{0xde, 0xad}); err != nil {
+		t.Fatalf("InsertBUMP reanchor-act-canon: %v", err)
+	}
+
+	rows, err := s.ListOrphanedBlocksToReconcile(ctx, 1000)
+	if err != nil {
+		t.Fatalf("ListOrphanedBlocksToReconcile: %v", err)
+	}
+
+	// Filter to this test's orphans, preserving the returned (total) order.
+	mine := map[string]bool{"reanchor-A": true, "reanchor-B": true, "reanchor-C": true, "reanchor-canon": true}
+	var got []string
+	for _, r := range rows {
+		if r.Status == models.BlockStatusOrphaned && mine[r.BlockHash] {
+			got = append(got, r.BlockHash)
+		}
+	}
+	want := []string{"reanchor-canon", "reanchor-A", "reanchor-B", "reanchor-C"}
+	if len(got) != len(want) {
+		t.Fatalf("filtered queue = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("filtered queue = %v, want %v (re-anchorable first, then oldest orphaned_at)", got, want)
+		}
+	}
+}

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -1425,8 +1425,22 @@ func (s *Store) MarkBlockReconciled(ctx context.Context, blockHash string, at ti
 }
 
 // ListOrphanedBlocksToReconcile scans the block_processing rows for
-// status='orphaned' AND reconciled_at unset, oldest orphaned_at first.
-// The table holds one row per block, so a prefix scan is cheap.
+// status='orphaned' AND reconciled_at unset. Rows that can be re-anchored
+// RIGHT NOW — the active (canonical) block at the same height already has a
+// stored BUMP — sort ahead of rows that cannot, oldest orphaned_at first
+// WITHIN each group. This mirrors the Postgres store: the reconciler consumes
+// a small LIMIT per tick, so a large backlog of orphans whose canonical block
+// has no stored BUMP (only parkable, never re-anchorable now) must not starve
+// a genuinely re-anchorable recent incident sitting behind them.
+//
+// The re-anchorable signal mirrors reconcileBlock, which resolves the canonical
+// block at the orphan's height and re-anchors from that block's stored compound
+// BUMP. The active row at a height is the store's record of that canonical
+// block, so "an active row at this height whose hash has a stored BUMP" is the
+// proxy. Checking specifically the ACTIVE block's BUMP (not any BUMP at the
+// height) matters: an orphan retains its own compound BUMP, which must not
+// count. The table holds one row per block, so the single prefix scan that
+// already backs this query also collects the active-by-height map for free.
 func (s *Store) ListOrphanedBlocksToReconcile(ctx context.Context, limit int) ([]*models.BlockProcessingStatus, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -1445,6 +1459,7 @@ func (s *Store) ListOrphanedBlocksToReconcile(ctx context.Context, limit int) ([
 	defer func() { _ = iter.Close() }()
 
 	var rows []*storedBlockProcessing
+	activeByHeight := make(map[uint64][]string)
 	for iter.First(); iter.Valid(); iter.Next() {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -1453,23 +1468,71 @@ func (s *Store) ListOrphanedBlocksToReconcile(ctx context.Context, limit int) ([
 		if err := json.Unmarshal(iter.Value(), &b); err != nil {
 			continue
 		}
-		if b.Status != string(models.BlockStatusOrphaned) || b.ReconciledAtUnixNs != 0 {
-			continue
+		switch {
+		case b.Status == string(models.BlockStatusActive):
+			activeByHeight[b.BlockHeight] = append(activeByHeight[b.BlockHeight], b.BlockHash)
+		case b.Status == string(models.BlockStatusOrphaned) && b.ReconciledAtUnixNs == 0:
+			row := b
+			rows = append(rows, &row)
 		}
-		row := b
-		rows = append(rows, &row)
 	}
-	sort.Slice(rows, func(i, j int) bool {
-		return rows[i].OrphanedAtUnixNs < rows[j].OrphanedAtUnixNs
-	})
-	if len(rows) > limit {
-		rows = rows[:limit]
+
+	// reanchorable[i] tracks whether rows[i]'s canonical block already has a
+	// stored BUMP. Memoized per height because a backlog is mostly same-height
+	// competitions, so distinct heights (and thus BUMP existence probes) are
+	// far fewer than rows.
+	reanchorableAt := make(map[uint64]bool, len(activeByHeight))
+	heightReanchorable := func(height uint64) bool {
+		if v, ok := reanchorableAt[height]; ok {
+			return v
+		}
+		v := false
+		for _, hash := range activeByHeight[height] {
+			if s.hasBUMP(hash) {
+				v = true
+				break
+			}
+		}
+		reanchorableAt[height] = v
+		return v
 	}
-	out := make([]*models.BlockProcessingStatus, len(rows))
+	reanchorable := make([]bool, len(rows))
 	for i, r := range rows {
-		out[i] = r.toModel()
+		reanchorable[i] = heightReanchorable(r.BlockHeight)
+	}
+
+	idx := make([]int, len(rows))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.SliceStable(idx, func(a, b int) bool {
+		ia, ib := idx[a], idx[b]
+		if reanchorable[ia] != reanchorable[ib] {
+			return reanchorable[ia] // re-anchorable first
+		}
+		return rows[ia].OrphanedAtUnixNs < rows[ib].OrphanedAtUnixNs
+	})
+	if len(idx) > limit {
+		idx = idx[:limit]
+	}
+	out := make([]*models.BlockProcessingStatus, len(idx))
+	for i, j := range idx {
+		out[i] = rows[j].toModel()
 	}
 	return out, nil
+}
+
+// hasBUMP reports whether a compound BUMP is stored for blockHash. It only
+// probes for key existence — the ordering signal in
+// ListOrphanedBlocksToReconcile mirrors the Postgres EXISTS(... JOIN bumps ...)
+// check, which is presence, not content.
+func (s *Store) hasBUMP(blockHash string) bool {
+	_, closer, err := s.db.Get(bumpKey(blockHash))
+	if err != nil {
+		return false
+	}
+	_ = closer.Close()
+	return true
 }
 
 func (s *Store) MarkBlocksParked(ctx context.Context, blockHashes []string) error {

--- a/store/pebble/reorg_test.go
+++ b/store/pebble/reorg_test.go
@@ -447,6 +447,80 @@ func TestMarkBlockReconciled_And_ListOrphanedBlocksToReconcile(t *testing.T) {
 	}
 }
 
+// TestListOrphanedBlocksToReconcile_PrioritizesReanchorable pins the
+// work-queue prioritization: an orphan whose active (canonical) block at the
+// same height already has a stored BUMP — so the reconciler can re-anchor it
+// right now — surfaces AHEAD of orphans whose canonical block has no BUMP,
+// even when it was orphaned more recently. Within the un-re-anchorable group
+// the original oldest-orphaned_at ordering is preserved. A BUMP stored for the
+// ORPHAN's own hash (not the active block) must NOT make it re-anchorable.
+func TestListOrphanedBlocksToReconcile_PrioritizesReanchorable(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	t0 := time.Unix(1700000500, 0).UTC()
+
+	// Three un-re-anchorable competitions: the active block at each height has
+	// NO stored BUMP. Orphaned oldest→newest across heights 100/101/102.
+	for i, h := range []uint64{100, 101, 102} {
+		active := "act-" + string(rune('A'+i))
+		orphan := "orph-" + string(rune('A'+i))
+		if err := s.UpsertBlockHeaderSeen(ctx, active, h, t0); err != nil {
+			t.Fatalf("seed active %s: %v", active, err)
+		}
+		if err := s.UpsertBlockHeaderSeen(ctx, orphan, h, t0); err != nil {
+			t.Fatalf("seed orphan %s: %v", orphan, err)
+		}
+		if err := s.MarkBlocksOrphaned(ctx, []string{orphan}, t0.Add(time.Duration(i+1)*time.Minute)); err != nil {
+			t.Fatalf("orphan %s: %v", orphan, err)
+		}
+	}
+	// A BUMP stored for the ORPHAN's own hash (orph-A) must not count — only
+	// the active block's BUMP makes a height re-anchorable.
+	if err := s.InsertBUMP(ctx, "orph-A", 100, []byte{0x01}); err != nil {
+		t.Fatalf("InsertBUMP orph-A: %v", err)
+	}
+
+	// One re-anchorable competition at height 200: the active block HAS a
+	// stored BUMP, but it was orphaned LAST (newest orphaned_at).
+	if err := s.UpsertBlockHeaderSeen(ctx, "act-canon", 200, t0); err != nil {
+		t.Fatalf("seed act-canon: %v", err)
+	}
+	if err := s.UpsertBlockHeaderSeen(ctx, "orph-canon", 200, t0); err != nil {
+		t.Fatalf("seed orph-canon: %v", err)
+	}
+	if err := s.MarkBlocksOrphaned(ctx, []string{"orph-canon"}, t0.Add(10*time.Minute)); err != nil {
+		t.Fatalf("orphan orph-canon: %v", err)
+	}
+	if err := s.InsertBUMP(ctx, "act-canon", 200, []byte{0xde, 0xad}); err != nil {
+		t.Fatalf("InsertBUMP act-canon: %v", err)
+	}
+
+	rows, err := s.ListOrphanedBlocksToReconcile(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListOrphanedBlocksToReconcile: %v", err)
+	}
+	got := hashesOf(rows)
+	want := []string{"orph-canon", "orph-A", "orph-B", "orph-C"}
+	if len(got) != len(want) {
+		t.Fatalf("queue = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("queue = %v, want %v (re-anchorable first, then oldest orphaned_at)", got, want)
+		}
+	}
+
+	// LIMIT still applies after prioritization: the re-anchorable one wins the
+	// single slot even though it is the newest orphan.
+	rows, err = s.ListOrphanedBlocksToReconcile(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].BlockHash != "orph-canon" {
+		t.Fatalf("limit=1 queue = %v, want [orph-canon]", hashesOf(rows))
+	}
+}
+
 // TestGetStatus_EnrichesOrphanedProofPaths builds a real compound BUMP for
 // the orphaned block so GetStatus can re-derive the historical anchor's
 // minimal path at read time; the extracted path must parse and compute the

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -1102,17 +1102,44 @@ func (s *Store) MarkBlockReconciled(ctx context.Context, blockHash string, at ti
 }
 
 // ListOrphanedBlocksToReconcile returns the reconciler's work queue:
-// orphaned rows not yet reconciled, oldest orphaned_at first. Served by
-// the idx_bp_orphaned_unreconciled partial index.
+// orphaned rows not yet reconciled. Rows that can be re-anchored RIGHT NOW —
+// the active (canonical) block at the same height already has a stored BUMP —
+// sort ahead of rows that cannot, with oldest orphaned_at first WITHIN each
+// group. Served by the idx_bp_orphaned_unreconciled partial index for the
+// WHERE, with idx_bp_status_height + the bumps PK serving the re-anchorable
+// probe.
+//
+// Why prioritize: the reconciler processes a small LIMIT per tick. A large
+// backlog of orphans whose canonical block has NO stored BUMP (they can only
+// be parked/deferred, never re-anchored right now) would, under a plain
+// orphaned_at ASC ordering, starve a genuinely re-anchorable recent incident
+// sitting behind them oldest-first. Ordering the re-anchorable ones first
+// guarantees the tick spends its budget on work it can actually complete.
+//
+// The re-anchorable signal mirrors reconcileBlock: it resolves the canonical
+// block at the orphan's height (chaintracks header) and re-anchors from that
+// block's stored compound BUMP. The active block_processing row at a height is
+// the store's record of that canonical block (the tie-scan/tracker keeps the
+// competition winner 'active' and marks losers 'orphaned'), so "an active row
+// at bp.block_height whose block_hash has a bumps row" is the in-SQL proxy for
+// "the canonical block's BUMP is stored". The a.status='active' filter is what
+// makes this correct: an orphan RETAINS its own compound BUMP, so a bare
+// "any bump at this height" test would falsely flag every orphan re-anchorable.
 func (s *Store) ListOrphanedBlocksToReconcile(ctx context.Context, limit int) ([]*models.BlockProcessingStatus, error) {
 	if limit <= 0 {
 		return nil, fmt.Errorf("limit must be > 0")
 	}
 	const q = `
-SELECT block_hash, block_height, header_seen_at, processed_at, bump_built_at, status, orphaned_at, reconciled_at
-FROM block_processing
-WHERE status = 'orphaned' AND reconciled_at IS NULL
-ORDER BY orphaned_at ASC NULLS LAST
+SELECT bp.block_hash, bp.block_height, bp.header_seen_at, bp.processed_at, bp.bump_built_at, bp.status, bp.orphaned_at, bp.reconciled_at
+FROM block_processing bp
+WHERE bp.status = 'orphaned' AND bp.reconciled_at IS NULL
+ORDER BY
+    EXISTS (
+        SELECT 1 FROM block_processing a
+        JOIN bumps b ON b.block_hash = a.block_hash
+        WHERE a.block_height = bp.block_height AND a.status = 'active'
+    ) DESC,
+    bp.orphaned_at ASC NULLS LAST
 LIMIT $1`
 	rows, err := s.pool.Query(ctx, q, limit)
 	if err != nil {

--- a/store/postgres/reorg_test.go
+++ b/store/postgres/reorg_test.go
@@ -444,6 +444,81 @@ func TestMarkBlockReconciled_And_ListOrphanedBlocksToReconcile(t *testing.T) {
 	}
 }
 
+// TestListOrphanedBlocksToReconcile_PrioritizesReanchorable pins the
+// work-queue prioritization: an orphan whose active (canonical) block at the
+// same height already has a stored BUMP — so the reconciler can re-anchor it
+// right now — surfaces AHEAD of orphans whose canonical block has no BUMP,
+// even when it was orphaned more recently. Within the un-re-anchorable group
+// the original oldest-orphaned_at ordering is preserved. A BUMP stored for the
+// ORPHAN's own hash (not the active block) must NOT make it re-anchorable —
+// this is the reason the EXISTS subquery filters a.status='active'.
+func TestListOrphanedBlocksToReconcile_PrioritizesReanchorable(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	t0 := time.Unix(1700000500, 0).UTC()
+
+	// Three un-re-anchorable competitions: the active block at each height has
+	// NO stored BUMP. Orphaned oldest→newest across heights 100/101/102.
+	for i, h := range []uint64{100, 101, 102} {
+		active := "act-" + string(rune('A'+i))
+		orphan := "orph-" + string(rune('A'+i))
+		if err := s.UpsertBlockHeaderSeen(ctx, active, h, t0); err != nil {
+			t.Fatalf("seed active %s: %v", active, err)
+		}
+		if err := s.UpsertBlockHeaderSeen(ctx, orphan, h, t0); err != nil {
+			t.Fatalf("seed orphan %s: %v", orphan, err)
+		}
+		if err := s.MarkBlocksOrphaned(ctx, []string{orphan}, t0.Add(time.Duration(i+1)*time.Minute)); err != nil {
+			t.Fatalf("orphan %s: %v", orphan, err)
+		}
+	}
+	// A BUMP stored for the ORPHAN's own hash (orph-A) must not count — only
+	// the active block's BUMP makes a height re-anchorable.
+	if err := s.InsertBUMP(ctx, "orph-A", 100, []byte{0x01}); err != nil {
+		t.Fatalf("InsertBUMP orph-A: %v", err)
+	}
+
+	// One re-anchorable competition at height 200: the active block HAS a
+	// stored BUMP, but it was orphaned LAST (newest orphaned_at).
+	if err := s.UpsertBlockHeaderSeen(ctx, "act-canon", 200, t0); err != nil {
+		t.Fatalf("seed act-canon: %v", err)
+	}
+	if err := s.UpsertBlockHeaderSeen(ctx, "orph-canon", 200, t0); err != nil {
+		t.Fatalf("seed orph-canon: %v", err)
+	}
+	if err := s.MarkBlocksOrphaned(ctx, []string{"orph-canon"}, t0.Add(10*time.Minute)); err != nil {
+		t.Fatalf("orphan orph-canon: %v", err)
+	}
+	if err := s.InsertBUMP(ctx, "act-canon", 200, []byte{0xde, 0xad}); err != nil {
+		t.Fatalf("InsertBUMP act-canon: %v", err)
+	}
+
+	rows, err := s.ListOrphanedBlocksToReconcile(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListOrphanedBlocksToReconcile: %v", err)
+	}
+	got := hashesOf(rows)
+	want := []string{"orph-canon", "orph-A", "orph-B", "orph-C"}
+	if len(got) != len(want) {
+		t.Fatalf("queue = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("queue = %v, want %v (re-anchorable first, then oldest orphaned_at)", got, want)
+		}
+	}
+
+	// LIMIT still applies after prioritization: the re-anchorable one wins the
+	// single slot even though it is the newest orphan.
+	rows, err = s.ListOrphanedBlocksToReconcile(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].BlockHash != "orph-canon" {
+		t.Fatalf("limit=1 queue = %v, want [orph-canon]", hashesOf(rows))
+	}
+}
+
 // TestGetStatus_EnrichesOrphanedProofPaths builds a real compound BUMP for
 // the orphaned block so GetStatus can re-derive the historical anchor's
 // minimal path at read time; the extracted path must parse and compute the


### PR DESCRIPTION
## The bug

The anchor-reconciler heals same-height block competitions (reorgs): orphaned `block_processing` rows get their txs re-anchored to the canonical block at that height using the canonical block's stored compound BUMP. Its per-tick work queue, `store.ListOrphanedBlocksToReconcile`, consumed orphaned rows **strictly oldest-first** (`ORDER BY orphaned_at ASC NULLS LAST LIMIT $1`) with **no notion of which orphans can actually be re-anchored right now.**

A regtest throughput blast on the scale-ovh cluster produced a large backlog of same-height competitions — **4,356 orphaned rows**, almost all *ancient* blocks whose canonical block has **no stored BUMP**. Those can never be re-anchored right now; the reconciler just defers each up to a cap, then parks it. Meanwhile a genuinely re-anchorable recent incident — **height 764, orphan `5a55997b`, canonical `12114cd0` which does have a stored BUMP** — sat behind thousands of those un-re-anchorable ancients and, at the small per-tick LIMIT, effectively never got processed. An operator had to manually move its `orphaned_at` to the front of the queue to heal it.

The reconciler itself is correct; the problem was purely **work-queue ordering/prioritization**.

## The fix

Re-order `ListOrphanedBlocksToReconcile` so orphans that are **re-anchorable right now** — the *active* (canonical) block at the same height already has a stored BUMP — sort **ahead** of orphans that are not, keeping `orphaned_at ASC` as the tie-breaker **within each group**.

Postgres (production) folds this into the ORDER BY:

```sql
SELECT bp.block_hash, bp.block_height, bp.header_seen_at, bp.processed_at, bp.bump_built_at, bp.status, bp.orphaned_at, bp.reconciled_at
FROM block_processing bp
WHERE bp.status = 'orphaned' AND bp.reconciled_at IS NULL
ORDER BY
    EXISTS (
        SELECT 1 FROM block_processing a
        JOIN bumps b ON b.block_hash = a.block_hash
        WHERE a.block_height = bp.block_height AND a.status = 'active'
    ) DESC,
    bp.orphaned_at ASC NULLS LAST
LIMIT $1
```

**Why the signal is correct.** `reconcileBlock` resolves the canonical block at the orphan's height (chaintracks header) and re-anchors from *that block's* stored compound BUMP (`GetBUMP(canonicalHash)`). The active `block_processing` row at a height is the store's record of that canonical block — the tie-scan/tracker keeps the competition winner `active` and marks losers `orphaned` — so "an active row at `bp.block_height` whose hash has a `bumps` row" is the in-SQL proxy for "the canonical block's BUMP is stored." The `a.status='active'` filter is **load-bearing**: an orphan retains its *own* compound BUMP, so a bare "any bump at this height" test would falsely flag every orphan as re-anchorable.

The pebble and aerospike stores mirror the same re-anchorable-first ordering for consistency (Postgres is the production backend).

## Performance

`EXPLAIN (ANALYZE, BUFFERS)` on a seeded **4,356-row** backlog (matching the live incident), LIMIT 4:

- The planner rewrites the correlated `EXISTS` into a **hashed SubPlan evaluated once** (a semi-join built from the tiny `bumps` table), not a per-row correlated scan.
- Outer scan uses the existing `idx_bp_orphaned_unreconciled` partial index; top-N heapsort to the LIMIT.
- **Execution time ~1.4 ms**, all buffers cached, at a ~30s tick cadence.

No new index was added — the existing `idx_bp_orphaned_unreconciled` (WHERE), `block_processing_pkey`, and the `bumps` PK cover the plan.

## Tests

Store-level tests in **all three backends** (postgres, pebble; aerospike under the `integration` tag) seed several un-re-anchorable competitions (active block at each height has NO bump) orphaned *earlier*, plus one re-anchorable competition (active block HAS a bump) orphaned *later*, and assert:

- the re-anchorable orphan is returned **first** despite being the newest;
- oldest-first ordering is preserved **within** the un-re-anchorable group;
- an orphan's **own** retained BUMP does **not** make it re-anchorable (pins the `a.status='active'` filter);
- `LIMIT` still applies after prioritization.

`go build ./...`, `go test ./store/... ./services/bump_builder/...` (+ `-tags=postgres` for the postgres suite) pass; `golangci-lint run ./store/... ./services/bump_builder/...` reports 0 issues.

## Follow-up (not included)

Optionally biasing the tick toward a configured `bump_builder.reconciler.full_scan_min_height`/`full_scan_max_height` window (the knobs #283 added for the scan) would require threading those params through the `ListOrphanedBlocksToReconcile` signature across the store interface and all three backends; left as a separate change. The BUMP-availability prioritization here is the required fix.

Completes the reorg-recovery line from #282 / #283 / #284.

https://claude.ai/code/session_01BvyMDBbGFAD2RDQAYhRdP3