### PR TITLE
chore(bump-builder): keep INFO volume flat on large mined batches

### DIFF
--- a/services/bump_builder/builder.go
+++ b/services/bump_builder/builder.go
@@ -369,14 +369,25 @@ func setMinedAndPublish(
 	for i, st := range mined {
 		minedTxIDs[i] = st.TxID
 	}
-	// Full-searchability MINED line(s): every txid appears in the log stream
-	// (chunked, never capped) so a txid or block_hash search in Coralogix
-	// finds the MINED transition regardless of block size. A 14k-tx block
-	// produces ~14 lines at maxTxIDsPerLine=1000 — intended. Independent of
-	// b.publisher wiring below, since this is the lifecycle log, not the
-	// downstream fan-out.
+	// MINED line, split by level. Info gets ONE bounded line per block:
+	// TxIDBatch caps the list at maxTxIDsPerLine but txid_count always
+	// carries the TRUE total, so Info-level volume stays flat regardless of
+	// block size (a 40k-tx block previously chunked into ~41 Info lines,
+	// ~2.7 MB per block). Independent of the publisher wiring below, since
+	// this is the lifecycle log, not the downstream fan-out.
+	logger.Info(
+		"transactions mined",
+		append(
+			[]zap.Field{logfields.BlockHash(blockHash), logfields.BlockHeight(blockHeight)},
+			logfields.TxIDBatch(minedTxIDs)...,
+		)...,
+	)
+	// Debug, not Info, for full searchability: every txid appears in the log
+	// stream (chunked, never capped) so a txid or block_hash search in
+	// Coralogix still finds the MINED transition regardless of block size
+	// when debug logging is enabled, while Info-level volume stays flat.
 	logfields.ForEachTxIDChunk(minedTxIDs, func(chunk []string, chunkIdx, totalChunks int) {
-		logger.Info(
+		logger.Debug(
 			"transactions mined",
 			logfields.BlockHash(blockHash),
 			logfields.BlockHeight(blockHeight),

--- a/services/bump_builder/lifecycle_log_test.go
+++ b/services/bump_builder/lifecycle_log_test.go
@@ -10,17 +10,20 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-// TestMarkMinedAndPublish_LogsTransactionsMinedChunked closes the MINED log
-// gap: markMinedAndPublish must emit an Info "transactions mined" line per
-// maxTxIDsPerLine-sized chunk (from package logfields) so a block larger
-// than one chunk still surfaces every txid somewhere in the log stream —
-// each line also carries block_hash/block_height and the TRUE total
-// txid_count (not the chunk size), plus its position in the chunk sequence.
-func TestMarkMinedAndPublish_LogsTransactionsMinedChunked(t *testing.T) {
+// TestMarkMinedAndPublish_LogsTransactionsMinedLevelSplit pins the MINED log
+// split: markMinedAndPublish must emit exactly ONE Info "transactions mined"
+// line per block — the txid list capped at maxTxIDsPerLine (from package
+// logfields) but txid_count carrying the TRUE total, so Info-level volume
+// stays flat regardless of block size — plus one Debug line per chunk so a
+// block larger than one chunk still surfaces every txid somewhere in the log
+// stream. Each Debug line also carries block_hash/block_height, the TRUE
+// total txid_count (not the chunk size), and its position in the chunk
+// sequence.
+func TestMarkMinedAndPublish_LogsTransactionsMinedLevelSplit(t *testing.T) {
 	ms := newMockStore()
 	b := newTestBuilder(ms, "http://unused.invalid")
 
-	core, recorded := observer.New(zapcore.InfoLevel)
+	core, recorded := observer.New(zapcore.DebugLevel)
 	logger := zap.New(core)
 
 	// 2500 spans logfields.maxTxIDsPerLine (1000) twice over plus a
@@ -34,13 +37,39 @@ func TestMarkMinedAndPublish_LogsTransactionsMinedChunked(t *testing.T) {
 
 	b.markMinedAndPublish(context.Background(), logger, "block-hash-mined-test", 777, txids)
 
-	entries := recorded.FilterMessage("transactions mined").All()
-	if len(entries) != wantChunks {
-		t.Fatalf("expected %d 'transactions mined' log lines, got %d", wantChunks, len(entries))
+	// Info: exactly one bounded line, TRUE total in txid_count, list capped.
+	infoEntries := recorded.FilterMessage("transactions mined").
+		FilterLevelExact(zapcore.InfoLevel).All()
+	if len(infoEntries) != 1 {
+		t.Fatalf("expected exactly 1 Info 'transactions mined' line, got %d", len(infoEntries))
+	}
+	infoFields := infoEntries[0].ContextMap()
+	if got, _ := infoFields["block_hash"].(string); got != "block-hash-mined-test" {
+		t.Errorf("Info: block_hash = %q, want %q", got, "block-hash-mined-test")
+	}
+	if got, _ := infoFields["block_height"].(uint64); got != 777 {
+		t.Errorf("Info: block_height = %v, want 777", infoFields["block_height"])
+	}
+	if got, _ := infoFields["txid_count"].(int64); got != int64(n) {
+		t.Errorf("Info: txid_count = %v, want %d (true total, not the capped list length)", infoFields["txid_count"], n)
+	}
+	infoTxIDs, ok := infoFields["txids"].([]interface{})
+	if !ok {
+		t.Fatalf("Info: txids field missing or wrong type: %#v", infoFields["txids"])
+	}
+	if len(infoTxIDs) != 1000 {
+		t.Errorf("Info: txids list length = %d, want 1000 (capped at maxTxIDsPerLine)", len(infoTxIDs))
+	}
+
+	// Debug: one line per chunk, full coverage across the union.
+	debugEntries := recorded.FilterMessage("transactions mined").
+		FilterLevelExact(zapcore.DebugLevel).All()
+	if len(debugEntries) != wantChunks {
+		t.Fatalf("expected %d Debug 'transactions mined' chunk lines, got %d", wantChunks, len(debugEntries))
 	}
 
 	seen := make(map[string]bool, n)
-	for i, e := range entries {
+	for i, e := range debugEntries {
 		fields := e.ContextMap()
 		if got, _ := fields["block_hash"].(string); got != "block-hash-mined-test" {
 			t.Errorf("entry %d: block_hash = %q, want %q", i, got, "block-hash-mined-test")
@@ -78,27 +107,38 @@ func TestMarkMinedAndPublish_LogsTransactionsMinedChunked(t *testing.T) {
 }
 
 // TestMarkMinedAndPublish_LogsTransactionsMinedSingleChunk pins the common
-// case (a block small enough for one chunk) to exactly one log line, so the
-// chunked path doesn't accidentally fragment small blocks.
+// case (a block small enough for one chunk) to exactly one Info line and one
+// Debug line, so the level split doesn't accidentally fragment or duplicate
+// small blocks.
 func TestMarkMinedAndPublish_LogsTransactionsMinedSingleChunk(t *testing.T) {
 	ms := newMockStore()
 	b := newTestBuilder(ms, "http://unused.invalid")
 
-	core, recorded := observer.New(zapcore.InfoLevel)
+	core, recorded := observer.New(zapcore.DebugLevel)
 	logger := zap.New(core)
 
 	txids := []string{"tx-a", "tx-b", "tx-c"}
 	b.markMinedAndPublish(context.Background(), logger, "block-hash-small", 42, txids)
 
-	entries := recorded.FilterMessage("transactions mined").All()
-	if len(entries) != 1 {
-		t.Fatalf("expected exactly 1 'transactions mined' log line, got %d", len(entries))
+	infoEntries := recorded.FilterMessage("transactions mined").
+		FilterLevelExact(zapcore.InfoLevel).All()
+	if len(infoEntries) != 1 {
+		t.Fatalf("expected exactly 1 Info 'transactions mined' line, got %d", len(infoEntries))
 	}
-	fields := entries[0].ContextMap()
+	fields := infoEntries[0].ContextMap()
 	if got, _ := fields["txid_count"].(int64); got != 3 {
-		t.Errorf("txid_count = %v, want 3", fields["txid_count"])
+		t.Errorf("Info: txid_count = %v, want 3", fields["txid_count"])
 	}
-	if got, _ := fields["chunk_total"].(int64); got != 1 {
-		t.Errorf("chunk_total = %v, want 1", fields["chunk_total"])
+	if got, ok := fields["txids"].([]interface{}); !ok || len(got) != 3 {
+		t.Errorf("Info: txids = %#v, want the full 3-element list (under the cap)", fields["txids"])
+	}
+
+	debugEntries := recorded.FilterMessage("transactions mined").
+		FilterLevelExact(zapcore.DebugLevel).All()
+	if len(debugEntries) != 1 {
+		t.Fatalf("expected exactly 1 Debug 'transactions mined' chunk line, got %d", len(debugEntries))
+	}
+	if got, _ := debugEntries[0].ContextMap()["chunk_total"].(int64); got != 1 {
+		t.Errorf("Debug: chunk_total = %v, want 1", debugEntries[0].ContextMap()["chunk_total"])
 	}
 }


### PR DESCRIPTION
## Problem

`setMinedAndPublish` (services/bump_builder/builder.go) logged `transactions mined` at **Info** once per 1000-txid chunk via `logfields.ForEachTxIDChunk`, with every line carrying the full-block `txid_count` plus a 1000-txid list. In the 2026-08-10 load test, a 40,005-tx block produced **41 Info lines x ~67 KB ≈ 2.7 MB of Info logging per block**. The full-coverage intent (txid searchability in Coralogix) is valid, but it doesn't belong at Info.

## Fix

Split the line by level, following the existing precedent in `services/propagation/propagator.go` ("Keeps Info-level volume flat while still making the registration searchable by txid when debug logging is enabled"):

- **One bounded Info line per block**: `logfields.TxIDBatch` carries the TRUE total in `txid_count` with the txid list capped at `maxTxIDsPerLine` (1000), plus `block_hash`/`block_height`.
- **Full-coverage chunk lines demoted to Debug**: the `ForEachTxIDChunk` loop is unchanged (same fields incl. `chunk_index`/`chunk_total`), so every txid still appears in the log stream when debug logging is enabled.
- Comment updated to document the split. No other behavior changed.

## Tests

- Rewrote `services/bump_builder/lifecycle_log_test.go` (zap `observer` harness, as before): a 2,500-txid batch now asserts **exactly one** Info `transactions mined` line (`txid_count` = 2500, list capped at 1000) plus **3** Debug chunk lines whose union covers every txid exactly once; single-chunk case pinned to 1 Info + 1 Debug line.
- `go test ./services/bump_builder/... ./logfields/...` — pass.
- `make test` (CGO) — all packages pass.
- `make lint` — 0 issues.

Full run analysis: go-arcade-toolbox docs/benchmarks/20260810-three-phase-1500tps-and-ceiling.md