### PR TITLE
fix(propagation): fail fast on revoked claim and expose real backlog depth

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -199,6 +199,32 @@ var PropagationReaperReadyDepth = promauto.NewGauge(prometheus.GaugeOpts{
 	Help: "Number of stale SEEN_ON_NETWORK rows ready for rebroadcast at the last reaper tick.",
 })
 
+// PropagationClaimRevokedBatchesTotal counts processBatch pipelines aborted
+// because their Kafka claim context was already canceled — the broker revoked
+// the partition claim mid-batch (consumer-group rebalance) or the service is
+// shutting down. Aborting is the durable path: nothing in the batch has been
+// marked on the revoked claim's offset tracker, so every tx replays under the
+// next claim. An occasional tick during a rolling restart is normal; a
+// sustained rate means macro-batch cycles are overrunning the consumer-group
+// session timeout and the group is thrashing.
+var PropagationClaimRevokedBatchesTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "arcade_propagation_claim_revoked_batches_total",
+	Help: "Propagation batches aborted mid-pipeline because the Kafka claim was revoked; their txs stay uncommitted for replay.",
+})
+
+// PropagationInflightDepth gauges the dispatcher's full in-flight census:
+// every tx admitted from Kafka that has not yet reached a terminal verdict —
+// pending flush, mid-broadcast, held behind an in-flight parent, or parked in
+// a delayed requeue. Unlike PropagationPendingDepth, which admission
+// backpressure caps at max_pending, this gauge is uncapped, so it is the one
+// that shows a real backlog growing. Each in-flight entry pins its Kafka
+// offset below the commit watermark, so this depth also approximates the
+// uncommitted-offset backlog on the current claim.
+var PropagationInflightDepth = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "arcade_propagation_inflight_depth",
+	Help: "Transactions in the dispatcher's in-flight set (admitted but not yet terminal); each pins an uncommitted Kafka offset.",
+})
+
 // APITxsSubmittedTotal counts individual transactions submitted through the
 // API, by route and dedup result. Unlike the HTTP request histogram (one
 // sample per request), this counts PER TRANSACTION — the /txs batch route

--- a/services/propagation/dispatcher.go
+++ b/services/propagation/dispatcher.go
@@ -148,13 +148,26 @@ func (p *Propagator) runDispatcher(ctx context.Context, claim kafka.Claim, cfg d
 	}
 
 	for {
-		// Keep the pending-depth gauge in sync at the top of every
-		// iteration. Every branch below that mutates pendingMsgs
+		// Keep the depth gauges in sync at the top of every iteration.
+		// Every branch below that mutates pendingMsgs or inFlight
 		// (handleAdmit, handleRequeue, handleTerminal, drain, flush)
 		// is observed exactly once before the next select fires.
-		// One atomic write per iteration is negligible vs the throughput
-		// the dispatcher handles.
+		// A few atomic writes per iteration are negligible vs the
+		// throughput the dispatcher handles.
+		//
+		// inFlight is the REAL backlog: every admitted-or-held tx whose
+		// Kafka offset is pinned below the commit watermark but which
+		// hasn't reached a terminal verdict. The pending gauge alone is
+		// misleading under load — admission backpressure caps it at
+		// maxPending, so during the 2026-08-10 load test a ~466k-tx
+		// uncommitted-offset backlog was invisible behind a flat pending
+		// depth. The Propagator-level atomics mirror the gauges so the
+		// reaper's per-tick backlog log line can read them without a
+		// Prometheus read API.
 		metrics.PropagationPendingDepth.Set(float64(len(pendingMsgs)))
+		p.pendingDepth.Store(int64(len(pendingMsgs)))
+		metrics.PropagationInflightDepth.Set(float64(len(inFlight)))
+		p.inflightDepth.Store(int64(len(inFlight)))
 
 		// Backpressure: nil-channel trick excludes incoming-message
 		// sources from the select when pendingMsgs is at cap. Both

--- a/services/propagation/dispatcher_test.go
+++ b/services/propagation/dispatcher_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/bsv-blockchain/arcade/kafka"
+	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
 )
 
@@ -357,6 +361,135 @@ func TestRunDispatcher_ReapedRowTerminal_AdvancesCommitWatermark(t *testing.T) {
 	claim.ch <- &kafka.Message{Offset: 5, Value: makePropMsg("reaped-row-tx")}
 	waitForMark(t, claim, 5,
 		"a terminal for a reaped (nil-prev) row must still notify the dispatcher")
+}
+
+// --- claim revocation: fail fast, leave the batch uncommitted ------------
+
+// TestRunDispatcher_ClaimRevokedMidBatch_FailsFastAndLeavesUncommitted pins
+// the fail-fast contract from the 2026-08-10 load test (>1,900 TPS macro-
+// batch cycles overran the consumer-group session and the broker revoked the
+// claim mid-batch): when the claim ctx dies while a batch is mid-pipeline,
+// the batch must stop where it stands — no teranode submit under the dead
+// ctx, no 2s-parked requeue goroutine, no store writes — and the tx's Kafka
+// offset must stay unmarked so the next claim replays it. Pre-fix the batch
+// dragged the dead ctx through register → requeue → broadcast: every /watch
+// "failure" counted as register_error (39,189 in one observed batch), the
+// requeue parked 2s and dropped, and retry batches logged a misleading
+// "batch propagated" accepted=0.
+func TestRunDispatcher_ClaimRevokedMidBatch_FailsFastAndLeavesUncommitted(t *testing.T) {
+	// A merkle server that parks the first /watch call until released lets
+	// the test revoke the claim while the batch is provably mid-
+	// registerBatch. The cancel aborts the ctx-bound client call with
+	// context.Canceled even though the handler stays parked.
+	registerStarted := make(chan struct{})
+	var startedOnce sync.Once
+	release := make(chan struct{})
+	merkleSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		startedOnce.Do(func() { close(registerStarted) })
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer merkleSrv.Close()
+
+	teranodeLog := &eventLog{}
+	teranodeSrv := newTeranodeServer(teranodeLog, http.StatusOK)
+	defer teranodeSrv.Close()
+
+	ms := newMockStore()
+	p := newPropagator(merkleSrv.URL, teranodeSrv.URL, ms)
+
+	revokedBefore := testutil.ToFloat64(metrics.PropagationClaimRevokedBatchesTotal)
+	requeuesBefore := testutil.ToFloat64(metrics.PropagationPendingRequeues)
+	claimRevokedBefore := testutil.ToFloat64(metrics.PropagationMerkleRegisterFailures.WithLabelValues("claim_revoked"))
+	registerErrBefore := testutil.ToFloat64(metrics.PropagationMerkleRegisterFailures.WithLabelValues("register_error"))
+
+	claim, stop := runDispatcherWithClaim(t, p)
+	claim.ch <- &kafka.Message{Offset: 21, Value: makePropMsg("revoked-mid-batch-tx")}
+
+	select {
+	case <-registerStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("batch never reached merkle /watch")
+	}
+
+	// Revoke the claim while /watch is in flight. stop() cancels claimCtx,
+	// waits for the dispatcher loop to exit AND for the processBatch
+	// goroutine to unwind (WaitForBatches), so every assertion below runs
+	// against a fully-settled aborted batch.
+	stop()
+	close(release) // unpark the handler so merkleSrv.Close() doesn't hang
+
+	if got := teranodeLog.count("broadcast"); got != 0 {
+		t.Errorf("no teranode submit may run under a revoked claim; got %d", got)
+	}
+	if claim.isMarked(21) {
+		t.Error("the tx's offset must stay unmarked so the next claim replays it")
+	}
+	if got := ms.updateCount(); got != 0 {
+		t.Errorf("no status writes may land for an aborted batch; got %d", got)
+	}
+	if got := ms.markCount(); got != 0 {
+		t.Errorf("no merkle-registered marks may be written for an aborted batch; got %d", got)
+	}
+	if d := testutil.ToFloat64(metrics.PropagationClaimRevokedBatchesTotal) - revokedBefore; d != 1 {
+		t.Errorf("claim-revoked batch counter delta = %v, want 1", d)
+	}
+	if d := testutil.ToFloat64(metrics.PropagationMerkleRegisterFailures.WithLabelValues("claim_revoked")) - claimRevokedBefore; d != 1 {
+		t.Errorf("claim_revoked register-failure delta = %v, want 1 (the parked /watch collapsed with context canceled)", d)
+	}
+	if d := testutil.ToFloat64(metrics.PropagationMerkleRegisterFailures.WithLabelValues("register_error")) - registerErrBefore; d != 0 {
+		t.Errorf("a rebalance must not pollute register_error; delta = %v", d)
+	}
+	if d := testutil.ToFloat64(metrics.PropagationPendingRequeues) - requeuesBefore; d != 0 {
+		t.Errorf("no delayed-requeue goroutine may park under a revoked claim; gauge delta = %v", d)
+	}
+}
+
+// TestProcessBatch_ClaimRevokedBeforeStart_NoSideEffects covers the other
+// revocation window: the dispatcher's flush tick detaches the processBatch
+// goroutine, so the claim can already be dead before the batch STARTS. The
+// entry checkpoint must stop it before any merkle /watch or teranode submit
+// is even attempted, leaving the store untouched and the offsets uncommitted
+// for replay.
+func TestProcessBatch_ClaimRevokedBeforeStart_NoSideEffects(t *testing.T) {
+	httpLog := &eventLog{}
+	merkleSrv := newMerkleServer(httpLog, http.StatusOK)
+	defer merkleSrv.Close()
+	teranodeSrv := newTeranodeServer(httpLog, http.StatusOK)
+	defer teranodeSrv.Close()
+
+	ms := newMockStore()
+	p := newPropagator(merkleSrv.URL, teranodeSrv.URL, ms)
+
+	revokedBefore := testutil.ToFloat64(metrics.PropagationClaimRevokedBatchesTotal)
+	requeuesBefore := testutil.ToFloat64(metrics.PropagationPendingRequeues)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the claim died before the detached batch goroutine ran
+
+	p.processBatch(ctx, []propagationMsg{
+		{TXID: "revoked-1", RawTx: []byte{0x01}},
+		{TXID: "revoked-2", RawTx: []byte{0x02}},
+	})
+
+	if got := httpLog.count("register:"); got != 0 {
+		t.Errorf("no merkle /watch call may run under a revoked claim; got %d", got)
+	}
+	if got := httpLog.count("broadcast"); got != 0 {
+		t.Errorf("no teranode submit may run under a revoked claim; got %d", got)
+	}
+	if got := ms.updateCount(); got != 0 {
+		t.Errorf("store must stay untouched (txs left for replay); got %d status writes", got)
+	}
+	if got := ms.markCount(); got != 0 {
+		t.Errorf("no merkle-registered marks may be written; got %d", got)
+	}
+	if d := testutil.ToFloat64(metrics.PropagationClaimRevokedBatchesTotal) - revokedBefore; d != 1 {
+		t.Errorf("claim-revoked batch counter delta = %v, want 1", d)
+	}
+	if d := testutil.ToFloat64(metrics.PropagationPendingRequeues) - requeuesBefore; d != 0 {
+		t.Errorf("no delayed-requeue goroutine may park; gauge delta = %v", d)
+	}
 }
 
 // --- store-error guard: offsets must not release on a failed write ------

--- a/services/propagation/lifecycle_log_test.go
+++ b/services/propagation/lifecycle_log_test.go
@@ -7,12 +7,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/merkleservice"
+	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/teranode"
 )
 
@@ -98,6 +100,85 @@ func TestRequeueAfterDelay_LogsRequeueForRetry(t *testing.T) {
 	}
 	if got, _ := fields["txid_count"].(int64); got != 2 {
 		t.Errorf("txid_count = %d, want 2", got)
+	}
+}
+
+// TestRequeueAfterDelay_RevokedClaim_DropsImmediatelyWithoutParking pins the
+// requeueAfterDelay entry fast-path: under an already-dead ctx (claim revoked
+// or shutdown) the requeue must drop NOW — same Debug line as the in-goroutine
+// ctx.Done drop, no "transactions requeued for retry" Info (nothing is being
+// requeued), and no goroutine parked on the PropagationPendingRequeues gauge
+// for the 2s delay it could only ever abandon.
+func TestRequeueAfterDelay_RevokedClaim_DropsImmediatelyWithoutParking(t *testing.T) {
+	core, recorded := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+	cfg := &config.Config{}
+	tc := teranode.NewClient(nil, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
+	p := New(cfg, logger, nil, nil, newMockStore(), nil, tc, nil)
+	defer func() {
+		if p.dispatcherCancel != nil {
+			p.dispatcherCancel()
+			if p.dispatcherDone != nil {
+				<-p.dispatcherDone
+			}
+		}
+	}()
+
+	requeuesBefore := testutil.ToFloat64(metrics.PropagationPendingRequeues)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // claim already revoked when the requeue is scheduled
+
+	p.requeueAfterDelay(ctx, []propagationMsg{{TXID: "dead-1"}, {TXID: "dead-2"}})
+
+	entries := recorded.FilterMessage("requeue dropped before delay elapsed; txs left uncommitted for replay").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 'requeue dropped' log line, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.DebugLevel {
+		t.Errorf("expected Debug level, got %v", entries[0].Level)
+	}
+	if got, _ := entries[0].ContextMap()["dropped"].(int64); got != 2 {
+		t.Errorf("dropped = %d, want 2", got)
+	}
+	if n := len(recorded.FilterMessage("transactions requeued for retry").All()); n != 0 {
+		t.Errorf("no 'transactions requeued for retry' Info may fire for a dropped requeue; got %d", n)
+	}
+	if d := testutil.ToFloat64(metrics.PropagationPendingRequeues) - requeuesBefore; d != 0 {
+		t.Errorf("no goroutine may park on the pending-requeues gauge; delta = %v", d)
+	}
+}
+
+// TestRegisterBatch_ClaimRevoked_SuppressesPartialFailureWarn: when every
+// registration "failure" in a batch is a context cancellation (claim revoked),
+// the "merkle-service /watch partial/all failure; requeueing failed subset"
+// WARN must not fire — nothing is requeued (processBatch aborts at its
+// post-register checkpoint) and the single "claim revoked mid-batch" Info
+// already covers the event. Pre-fix a rebalance emitted this WARN claiming a
+// 39k-tx requeue that never happened.
+func TestRegisterBatch_ClaimRevoked_SuppressesPartialFailureWarn(t *testing.T) {
+	merkleSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer merkleSrv.Close()
+
+	core, recorded := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+
+	cfg := &config.Config{CallbackURL: "http://arcade/cb", CallbackToken: "tok"}
+	cfg.Propagation.MerkleConcurrency = 4
+	mc := merkleservice.NewClient(merkleSrv.URL, "", 5*time.Second)
+	p := New(cfg, logger, nil, nil, newMockStore(), nil, nil, mc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, failed := p.registerBatch(ctx, []propagationMsg{{TXID: "w1"}, {TXID: "w2"}})
+	if len(failed) != 2 {
+		t.Fatalf("expected both txs in the failed subset, got %d", len(failed))
+	}
+	if n := len(recorded.FilterMessage("merkle-service /watch partial/all failure; requeueing failed subset").All()); n != 0 {
+		t.Errorf("partial-failure WARN must be suppressed for cancellation-only failures; got %d", n)
 	}
 }
 

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -125,6 +125,14 @@ type Propagator struct {
 	// worker pool so an in-flight batch doesn't lose its broadcast
 	// results to a closed jobs channel.
 	inflightBatches sync.WaitGroup
+	// pendingDepth / inflightDepth mirror the PropagationPendingDepth /
+	// PropagationInflightDepth gauges as plain atomics so non-dispatcher
+	// goroutines (the reaper's per-tick backlog log line) can read the
+	// current depths without a Prometheus read API or a round-trip onto the
+	// dispatcher's channels. Written only by the dispatcher loop.
+	pendingDepth  atomic.Int64
+	inflightDepth atomic.Int64
+
 	// backgroundWG tracks the long-running Start-spawned goroutines —
 	// runReaper, runMerkleReplay — so Stop can wait for them to exit
 	// before the surrounding app cleanup closes the store backing them.
@@ -891,6 +899,7 @@ func (p *Propagator) registerBatch(ctx context.Context, batch []propagationMsg) 
 	successTxIDs := make([]string, 0, len(batch))
 	var sampleErr, sampleAuthErr error
 	authFailures := 0
+	canceledFailures := 0
 	for i, err := range errs {
 		if err == nil {
 			registered = append(registered, batch[i])
@@ -903,6 +912,21 @@ func (p *Propagator) registerBatch(ctx context.Context, batch []propagationMsg) 
 		// offset / in-flight bookkeeping (a diverted tx would strand its Kafka
 		// offset and freeze the commit watermark — see handleAdmit).
 		failed = append(failed, batch[i])
+		// Context cancellation isn't a merkle-service failure at all: the
+		// claim was revoked (consumer-group rebalance) or the service is
+		// shutting down, and every in-flight /watch call collapsed at once.
+		// Classify it under the distinct "claim_revoked" label — one
+		// rebalance used to pump tens of thousands of bogus "register_error"
+		// counts into the metric (2026-08-10: 39,189 in one batch) — and
+		// keep it out of sampleErr so the partial-failure WARN below fires
+		// only for real /watch errors. ctx.Err() is checked alongside the
+		// error chain because a call raced by the cancel can surface
+		// transport wrappers that don't unwrap to context.Canceled.
+		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+			canceledFailures++
+			metrics.PropagationMerkleRegisterFailures.WithLabelValues("claim_revoked").Inc()
+			continue
+		}
 		// But classify the reason: a 401/403 is an auth rejection
 		// (merkle_service.auth_token missing or wrong — issue #269), not a
 		// transient blip. Surface it under its own metric label + a distinct
@@ -932,7 +956,12 @@ func (p *Propagator) registerBatch(ctx context.Context, batch []propagationMsg) 
 	default:
 		metrics.PropagationMerkleRegisterBatchOutcomeTotal.WithLabelValues("partial").Inc()
 	}
-	if len(failed) > 0 {
+	// Cancellation-only failures don't warn here: nothing will be requeued
+	// (processBatch aborts the batch at its post-register checkpoint) and the
+	// caller's single "claim revoked mid-batch" Info line already covers the
+	// event — a 39k-line-equivalent WARN claiming "requeueing failed subset"
+	// during a rebalance was pure noise.
+	if len(failed) > canceledFailures {
 		p.logger.Warn(
 			"merkle-service /watch partial/all failure; requeueing failed subset",
 			zap.Int("batch_size", len(batch)),
@@ -1083,6 +1112,35 @@ func (p *Propagator) startBroadcastSpan(ctx context.Context, batch []propagation
 	return spanCtx, func() { span.End() }
 }
 
+// abortBatchOnRevokedClaim reports whether the batch's claim context is
+// already dead — the broker revoked the partition claim mid-batch (consumer-
+// group rebalance) or the service is shutting down. When it is, the caller
+// must stop the batch where it stands: every downstream stage (merkle /watch,
+// teranode /txs, the delayed requeue) would run against a born-canceled
+// context, instantly "failing" tens of thousands of txs into requeue
+// goroutines that park 2s and drop. Observed live at >1,900 TPS (2026-08-10):
+// 39,189 of a 53,269-tx batch "failed" registration with context canceled
+// after a claim revocation, then a 14,080-tx retry batch logged "batch
+// propagated" accepted=0 in 12ms because every SubmitTransactions returned
+// instantly under the dead ctx.
+//
+// Stopping IS the durable path: nothing in the batch has been marked on the
+// revoked claim's offsetTracker, so every tx's Kafka offset stays uncommitted
+// and the NEW claim replays the whole batch (at-least-once). One Info line +
+// one counter tick per aborted batch keeps the event visible without the log
+// storm the dead-ctx spiral used to produce.
+func (p *Propagator) abortBatchOnRevokedClaim(ctx context.Context, txCount int) bool {
+	if ctx.Err() == nil {
+		return false
+	}
+	metrics.PropagationClaimRevokedBatchesTotal.Inc()
+	p.logger.Info(
+		"claim revoked mid-batch; leaving txs uncommitted for replay",
+		logfields.TxIDCount(txCount),
+	)
+	return true
+}
+
 // processBatch handles one drained batch:
 //  1. Register every tx with merkle-service. Txs whose /watch failed are
 //     requeued through the dispatcher after a short flat wait.
@@ -1095,10 +1153,28 @@ func (p *Propagator) startBroadcastSpan(ctx context.Context, batch []propagation
 //     reachable, per-slot infra code). The Kafka offset stays pinned via
 //     the existing inFlight entry.
 //
+// The claim context is checked between stages (abortBatchOnRevokedClaim): a
+// batch whose claim was revoked stops immediately and leaves its txs
+// uncommitted for the next claim to replay, rather than dragging a dead ctx
+// through register/broadcast/requeue.
+//
 // Failure paths are absorbed internally — there's no caller that reacts
 // to an aggregate error here, so the function returns void.
 func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) {
+	// The dispatcher detaches this goroutine (see flushBatch / the flush
+	// tick), so the claim can be revoked before the batch even starts.
+	if p.abortBatchOnRevokedClaim(ctx, len(batch)) {
+		return
+	}
 	registered, failedRegister := p.registerBatch(ctx, batch)
+	// A claim revoked DURING registerBatch has already collapsed some or all
+	// /watch calls with context canceled — those "failures" are not merkle-
+	// service verdicts, and broadcasting the survivors under the dead ctx
+	// would only produce born-canceled submits. Stop before touching the
+	// requeue or broadcast stages.
+	if p.abortBatchOnRevokedClaim(ctx, len(batch)) {
+		return
+	}
 	if len(failedRegister) > 0 {
 		p.requeueAfterDelay(ctx, failedRegister)
 	}
@@ -1170,6 +1246,16 @@ func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) {
 
 	p.applyTerminalStatuses(ctx, terminalStatuses, accepted, rejected)
 	if len(toRequeue) > 0 {
+		// A claim revoked during broadcast classifies every no-verdict tx
+		// as Requeue (born-canceled submitCtx → instant SubmitTransactions
+		// returns). Requeueing them under the dead ctx would only park a
+		// goroutine that drops them 2s later, and the "batch propagated"
+		// line below would report accepted=0 requeued=N for a batch that
+		// never really broadcast. Stop here instead; any verdicts that DID
+		// land before the revocation were already applied above.
+		if p.abortBatchOnRevokedClaim(ctx, len(toRequeue)) {
+			return
+		}
 		p.requeueAfterDelay(ctx, toRequeue)
 	}
 	metrics.PropagationOutcomeTotal.WithLabelValues("accepted").Add(float64(accepted))
@@ -1207,6 +1293,20 @@ const requeueDelay = 2 * time.Second
 // visible in the operator's logs rather than looking like lost work.
 func (p *Propagator) requeueAfterDelay(ctx context.Context, msgs []propagationMsg) {
 	if len(msgs) == 0 {
+		return
+	}
+	// Already-dead ctx (claim revoked / shutdown): drop NOW rather than park
+	// a goroutine for requeueDelay that can only ever hit the ctx.Done arm
+	// below. Same at-least-once contract and same Debug line as that arm —
+	// the txs' offsets stay uncommitted and the next claim replays them —
+	// minus the 2s of parked goroutines per aborted batch a rebalance used
+	// to accumulate. Also skips the "transactions requeued for retry" Info,
+	// which would be a lie: nothing is being requeued.
+	if ctx.Err() != nil {
+		p.logger.Debug(
+			"requeue dropped before delay elapsed; txs left uncommitted for replay",
+			zap.Int("dropped", len(msgs)),
+		)
 		return
 	}
 	requeueTxIDs := make([]string, len(msgs))

--- a/services/propagation/propagator_test.go
+++ b/services/propagation/propagator_test.go
@@ -703,6 +703,47 @@ func TestRegisterBatch_AuthFailureClassifiedAndRequeued(t *testing.T) {
 	}
 }
 
+// TestRegisterBatch_ClaimRevokedClassifiedDistinctly pins the rebalance-noise
+// fix from the 2026-08-10 load test: when the claim ctx is dead, every /watch
+// "failure" is a context cancellation, not a merkle-service verdict. Those
+// must count under the distinct "claim_revoked" label — a single revocation
+// used to pump 39,189 bogus register_error counts into the metric — while
+// F-024 still routes every tx to the failed subset (the caller's post-register
+// checkpoint aborts the batch; nothing is broadcast).
+func TestRegisterBatch_ClaimRevokedClassifiedDistinctly(t *testing.T) {
+	httpLog := &eventLog{}
+	merkleSrv := newMerkleServer(httpLog, http.StatusOK)
+	defer merkleSrv.Close()
+
+	ms := newMockStore()
+	cfg := &config.Config{CallbackURL: "http://arcade/cb", CallbackToken: "tok"}
+	cfg.Propagation.MerkleConcurrency = 4
+	mc := merkleservice.NewClient(merkleSrv.URL, "", 5*time.Second)
+	p := New(cfg, zap.NewNop(), nil, nil, ms, nil, nil, mc)
+
+	revokedBefore := testutil.ToFloat64(metrics.PropagationMerkleRegisterFailures.WithLabelValues("claim_revoked"))
+	genBefore := testutil.ToFloat64(metrics.PropagationMerkleRegisterFailures.WithLabelValues("register_error"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // claim revoked before the register fan-out runs
+
+	batch := []propagationMsg{{TXID: "tx1"}, {TXID: "tx2"}, {TXID: "tx3"}}
+	registered, failed := p.registerBatch(ctx, batch)
+
+	if len(registered) != 0 {
+		t.Errorf("F-024 violated: %d txs marked registered under a revoked claim", len(registered))
+	}
+	if len(failed) != len(batch) {
+		t.Errorf("every tx must stay in the failed subset (offset bookkeeping): failed=%d want %d", len(failed), len(batch))
+	}
+	if d := testutil.ToFloat64(metrics.PropagationMerkleRegisterFailures.WithLabelValues("claim_revoked")) - revokedBefore; int(d) != len(batch) {
+		t.Errorf("claim_revoked metric delta=%v want %d", d, len(batch))
+	}
+	if d := testutil.ToFloat64(metrics.PropagationMerkleRegisterFailures.WithLabelValues("register_error")) - genBefore; d != 0 {
+		t.Errorf("register_error must not increment on a claim revocation: delta=%v", d)
+	}
+}
+
 // replayPropagator builds a Propagator wired to the supplied merkle server,
 // with all the knobs replay tests care about pre-populated. Keeps the
 // per-test setup boilerplate small.

--- a/services/propagation/reaper.go
+++ b/services/propagation/reaper.go
@@ -276,6 +276,21 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 	// backlog drains, which used to make the metric misleading.
 	metrics.PropagationReaperReadyDepth.Set(float64(len(stuck)))
 
+	// One-line backlog snapshot per tick (~reaperInterval, leader only):
+	// pending is the dispatcher's next-flush accumulator (capped at
+	// max_pending by admission backpressure), inflight is its full
+	// admitted-but-not-terminal census (uncapped — each entry pins an
+	// uncommitted Kafka offset, so this is the log-visible proxy for the
+	// replay backlog), and reaper_ready is this scan's stale-row batch.
+	// During the 2026-08-10 load test a ~466k-tx uncommitted-offset backlog
+	// was invisible without a DB/Kafka query; this line makes growth
+	// visible in plain logs.
+	p.logger.Info("reaper: propagation backlog depth",
+		zap.Int64("pending_depth", p.pendingDepth.Load()),
+		zap.Int64("inflight_depth", p.inflightDepth.Load()),
+		zap.Int("reaper_ready_depth", len(stuck)),
+	)
+
 	// Publish the stuck-transient census the same way: every tick, zero
 	// included, so the gauges always reflect the latest completed scan.
 	for status, ts := range stuckTransient {

--- a/services/propagation/reaper_test.go
+++ b/services/propagation/reaper_test.go
@@ -9,9 +9,15 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/merkleservice"
 	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/teranode"
 )
 
 // TestReapOnce_RebroadcastsStaleReceived is the issue #83 / F-025 regression:
@@ -319,5 +325,77 @@ func TestReapOnce_CensusUncappedByRebroadcastBatch(t *testing.T) {
 	}
 	if got := log.count("register:"); got != reaperRebroadcastBatch {
 		t.Errorf("rebroadcast count = %d, want %d (batch cap unchanged)", got, reaperRebroadcastBatch)
+	}
+}
+
+// TestReapOnce_LogsBacklogDepth pins the per-tick backlog snapshot line (the
+// 2026-08-10 load-test gap: a ~466k-tx uncommitted-offset backlog was
+// invisible in logs because the pending gauge is capped at max_pending and
+// the in-flight set was ungauged). reapOnce must emit exactly one Info line
+// per tick carrying the dispatcher's pending depth, its uncapped in-flight
+// depth, and this scan's reaper-ready depth.
+func TestReapOnce_LogsBacklogDepth(t *testing.T) {
+	now := time.Now()
+	stale := now.Add(-2 * time.Hour)
+
+	httpLog := &eventLog{}
+	ms := newMockStore()
+	ms.replayRows = []*models.TransactionStatus{
+		{TxID: "reap-ready", Status: models.StatusReceived, RawTx: []byte{0x01}, Timestamp: stale},
+	}
+
+	merkleSrv := newMerkleServer(httpLog, http.StatusOK)
+	defer merkleSrv.Close()
+	teranodeSrv := newTeranodeServer(httpLog, http.StatusOK)
+	defer teranodeSrv.Close()
+
+	core, recorded := observer.New(zapcore.InfoLevel)
+	cfg := &config.Config{CallbackURL: "http://localhost:8080/callback"}
+	cfg.Propagation.MerkleConcurrency = 10
+	mc := merkleservice.NewClient(merkleSrv.URL, "", 5*time.Second)
+	tc := teranode.NewClient([]string{teranodeSrv.URL}, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
+	p := New(cfg, zap.New(core), nil, nil, ms, nil, tc, mc)
+
+	// Seed dispatcher state: two admitted txs, the first drained into a
+	// "mid-broadcast" batch — in-flight counts both, pending only the second.
+	if res := p.admitToDispatcher(propagationMsg{TXID: "inflight-a", RawTx: []byte{0x0a}}, 1); !res.admitted {
+		t.Fatalf("admit inflight-a: %+v", res)
+	}
+	_ = p.drainPending()
+	if res := p.admitToDispatcher(propagationMsg{TXID: "inflight-b", RawTx: []byte{0x0b}}, 2); !res.admitted {
+		t.Fatalf("admit inflight-b: %+v", res)
+	}
+
+	// The dispatcher publishes the depth mirrors at the top of its next
+	// loop iteration — poll briefly rather than assuming scheduling order.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.inflightDepth.Load() == 2 && p.pendingDepth.Load() == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := p.inflightDepth.Load(); got != 2 {
+		t.Fatalf("inflightDepth mirror = %d, want 2 (admitted a + b, neither terminal)", got)
+	}
+	if got := testutil.ToFloat64(metrics.PropagationInflightDepth); got != 2 {
+		t.Fatalf("PropagationInflightDepth gauge = %v, want 2", got)
+	}
+
+	p.reapOnce(context.Background())
+
+	entries := recorded.FilterMessage("reaper: propagation backlog depth").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 backlog-depth line per tick, got %d", len(entries))
+	}
+	fields := entries[0].ContextMap()
+	if got, _ := fields["pending_depth"].(int64); got != 1 {
+		t.Errorf("pending_depth = %d, want 1", got)
+	}
+	if got, _ := fields["inflight_depth"].(int64); got != 2 {
+		t.Errorf("inflight_depth = %d, want 2", got)
+	}
+	if got, _ := fields["reaper_ready_depth"].(int64); got != 1 {
+		t.Errorf("reaper_ready_depth = %d, want 1 (the stale RECEIVED row)", got)
 	}
 }


### PR DESCRIPTION
## Problem

During the 2026-08-10 load test, sustained >1,900 TPS made the propagation service's Kafka macro-batch cycle overrun the consumer-group session; the broker revoked the partition claim mid-batch. The claim context (created in `handleClaim`, canceled when `claim.Context()` closes) is passed into **detached** `processBatch` goroutines, which kept running under the dead ctx:

- `registerBatch` failed every tx with `context canceled` — **39,189 of a 53,269-tx batch** — all counted under `register_error` and all warned as "merkle-service /watch partial/all failure; requeueing failed subset".
- Both `requeueAfterDelay` calls ran with the dead ctx: the requeue goroutines parked 2s, then dropped ("requeue dropped before delay elapsed").
- Retry batches that reached broadcast derived born-canceled contexts (`submitCtx` / `broadcastCtx`), so every `SubmitTransactions` returned instantly, every tx classified as Requeue, and the service logged a misleading `Info "batch propagated" accepted=0 requeued=N success_endpoints=[]` — one observed **14,080-tx batch "propagated" with accepted=0 in 12ms**.
- Meanwhile the real backlog (**~466k txs as uncommitted Kafka offsets**) was invisible: `PropagationPendingDepth` is capped at `max_pending` by admission backpressure, and the dispatcher's `inFlight` map was ungauged.

## Root cause

Claim revocation → detached batch goroutines continue under the dead claim ctx → every stage (register, requeue, broadcast) "runs" against a born-canceled context, producing bogus failures, parked-then-dropped requeues, and misleading success logs. This was **not** the reaper lease — the durability model was already correct: offsets stay unmarked, so a new claim replays the txs. The batch just needed to stop cleanly instead of spiraling.

## Fix

**Fail fast on a revoked claim** (`services/propagation/propagator.go`):
- `processBatch` now checks `ctx.Err()` at entry, after `registerBatch` (before requeue/broadcast), and before the post-broadcast requeue. A dead ctx aborts the batch with **one** Info line — `"claim revoked mid-batch; leaving txs uncommitted for replay"` (`txid_count`) — and one tick on the new counter `arcade_propagation_claim_revoked_batches_total`. Verdicts that landed before the revocation are still applied; non-canceled paths are unchanged.
- `requeueAfterDelay` returns immediately at entry when ctx is already dead (same Debug line as the existing in-goroutine drop path) instead of parking a goroutine for the 2s delay it could only abandon.
- `registerBatch` classifies cancellation failures under a distinct `claim_revoked` label on `arcade_propagation_merkle_register_failures_total` (instead of `register_error`), and suppresses the partial-failure WARN when every failure is a cancellation — so a rebalance no longer pumps tens of thousands of bogus register-error counts and log lines.

**Backlog observability**:
- New gauge `arcade_propagation_inflight_depth` = `len(inFlight)`, set in the dispatcher loop alongside `PropagationPendingDepth`. Unlike the pending gauge it is uncapped, and each in-flight entry pins an uncommitted Kafka offset, so it is the metric that shows a real backlog growing.
- One-line Info per reaper tick (`"reaper: propagation backlog depth"`) with `pending_depth`, `inflight_depth`, and `reaper_ready_depth`, so a growing backlog is visible in plain logs without DB/Kafka queries.

## Tests

- `TestRunDispatcher_ClaimRevokedMidBatch_FailsFastAndLeavesUncommitted` — runs the real `runDispatcher` under a `fakeClaim`, parks the batch mid-`/watch`, cancels the claim ctx: asserts no teranode submit, offset left unmarked (replay), no store writes, revocation counter +1, `claim_revoked` (not `register_error`) counted, no 2s-parked requeue goroutine.
- `TestProcessBatch_ClaimRevokedBeforeStart_NoSideEffects` — claim dead before the detached batch starts: zero `/watch` calls, zero submits, store untouched.
- `TestRegisterBatch_ClaimRevokedClassifiedDistinctly`, `TestRegisterBatch_ClaimRevoked_SuppressesPartialFailureWarn` — metric-label and WARN-suppression contracts (mirror of the issue #269 auth-classification test).
- `TestRequeueAfterDelay_RevokedClaim_DropsImmediatelyWithoutParking` — entry fast-path: Debug drop line, no misleading "requeued for retry" Info, gauge untouched.
- `TestReapOnce_LogsBacklogDepth` — seeds dispatcher state (1 pending, 2 in-flight) + a stale row, calls `reapOnce` directly: exactly one backlog line with `pending_depth=1 inflight_depth=2 reaper_ready_depth=1`, and the `arcade_propagation_inflight_depth` gauge set.

`go test ./services/propagation/...` (also with `-race`), `make test`, and `make lint` all pass (CGO/gobdk build).

Full run analysis: go-arcade-toolbox docs/benchmarks/20260810-three-phase-1500tps-and-ceiling.md