### PR TITLE
fix(sse): mid-stream catchup when a client's buffer overflows

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -670,6 +670,15 @@ type SSEConfig struct {
 	// non-blocking, so overflow is lost, not backpressured). Default
 	// DefaultSSEClientBuffer. A value <= 0 selects the default.
 	ClientBufferSize int `mapstructure:"client_buffer_size"`
+	// CatchupOnDrop enables mid-stream store-backed catchup for token-scoped
+	// clients whose send channel overflowed: instead of losing the dropped
+	// events until the client reconnects with Last-Event-ID, the connection's
+	// writer replays them from the store as soon as it drains its backlog.
+	// Replay may duplicate frames the client already received (clients dedupe
+	// by txid+status). Default true; false restores the previous drop-only
+	// behavior. Tokenless (firehose) clients always keep drop-only behavior —
+	// the store catchup source is token-scoped.
+	CatchupOnDrop bool `mapstructure:"catchup_on_drop"`
 }
 
 // WebhookConfig tunes the HTTP webhook delivery service. The service
@@ -1045,6 +1054,7 @@ func setDefaults() {
 	viper.SetDefault("sse.host", "0.0.0.0")
 	viper.SetDefault("sse.port", 8082)
 	viper.SetDefault("sse.client_buffer_size", DefaultSSEClientBuffer)
+	viper.SetDefault("sse.catchup_on_drop", true)
 
 	// chaintracks standalone service: enabled by default. The bind port
 	// must differ from api.port and sse.port in single-binary deployments

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -540,6 +540,27 @@ var APISSEDroppedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "SSE fan-out events dropped without delivery, by reason.",
 }, []string{"reason"}) // slow_client, client_gone
 
+// SSEMidstreamCatchupsTotal counts store-backed catchup rounds run on a LIVE
+// /events connection after fan-out overflowed the client's send channel
+// (reason="slow_client" drops above). One drop episode can take several
+// rounds (each bounded by the per-round frame cap), so this counts rounds,
+// not episodes. A sustained rate means a consumer chronically drains slower
+// than the publish rate and is being served store-paced replay instead of
+// live frames.
+var SSEMidstreamCatchupsTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "arcade_sse_midstream_catchups_total",
+	Help: "Mid-stream SSE catchup rounds run after a client's send buffer overflowed.",
+})
+
+// SSEMidstreamCatchupFramesTotal counts frames replayed from the store by
+// mid-stream catchup rounds. Includes duplicates of frames the client already
+// received live (the replay window is deliberately rewound past the drop
+// boundary; clients dedupe by txid+status).
+var SSEMidstreamCatchupFramesTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "arcade_sse_midstream_catchup_frames_total",
+	Help: "Frames replayed from the store by mid-stream SSE catchup rounds.",
+})
+
 // EventsSubscriberDroppedTotal counts events.Publisher.Subscribe channel
 // drops, labeled by which caller's channel filled. The publisher emits a
 // drop when the per-subscriber buffer is at capacity and the kafka handler

--- a/services/bump_builder/builder.go
+++ b/services/bump_builder/builder.go
@@ -408,11 +408,25 @@ func setMinedAndPublish(
 		if end > len(publishTxIDs) {
 			end = len(publishTxIDs)
 		}
+		// Stamp the event with the STORE's MINED transition timestamp (mined
+		// is parallel to minedTxIDs, and every row of one SetMinedByTxIDs call
+		// shares it), not a fresh time.Now(). The SSE event id is this
+		// timestamp, and SSE catchup (Last-Event-ID reconnect and mid-stream
+		// drop recovery) queries the store strictly-after timestamp_at — a
+		// publish-time stamp sits seconds AFTER timestamp_at for a big block
+		// (the 40k-row UPDATE + chunked logging run in between), so a client
+		// resuming from a live event id would silently skip the whole block's
+		// rows. Keeping the id in the timestamp_at domain makes the resume
+		// watermark exact.
+		ts := mined[start].Timestamp
+		if ts.IsZero() {
+			ts = time.Now()
+		}
 		template := &models.TransactionStatus{
 			Status:      models.StatusMined,
 			BlockHash:   blockHash,
 			BlockHeight: blockHeight,
-			Timestamp:   time.Now(),
+			Timestamp:   ts,
 			TxIDs:       publishTxIDs[start:end],
 			ExtraInfo:   extraInfo,
 		}

--- a/services/sse/manager.go
+++ b/services/sse/manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"sync"
@@ -15,7 +16,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/bsv-blockchain/arcade/events"
-	"github.com/bsv-blockchain/arcade/logfields"
 	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/store"
@@ -43,6 +43,31 @@ type Client struct {
 	// long-lived cancellation handles owned by a registry entry.
 	Ctx    context.Context    //nolint:containedctx // see comment above
 	Cancel context.CancelFunc //nolint:containedctx // paired with Ctx above
+
+	// The fields below are the mid-stream catchup delivery state. They are
+	// raced between the manager's fan-out goroutine (recordDrop) and the
+	// per-connection writer goroutine (handleEvents / midstreamCatchup),
+	// hence atomics.
+
+	// lastDelivered is the Timestamp.UnixNano() of the last frame (live or
+	// catchup) the writer goroutine successfully wrote to this client. It is
+	// the resume watermark for capped mid-stream catchup rounds. Written only
+	// by the writer goroutine.
+	lastDelivered atomic.Int64
+	// dropped is set by fanOut's drop arm when this client's channel
+	// overflowed; the writer goroutine clears it and runs a store-backed
+	// catchup. recordDrop writes droppedFloor BEFORE setting this flag, so a
+	// writer that observes the flag also observes the floor.
+	dropped atomic.Bool
+	// droppedFloor is the minimum Timestamp.UnixNano() among events dropped
+	// since the writer last consumed it (math.MaxInt64 = none). It bounds the
+	// mid-stream catchup replay window from below.
+	droppedFloor atomic.Int64
+	// dropsSinceLog and lastDropLog implement the rate-limited aggregate
+	// drop Warn (at most one line per dropLogInterval per client) — a big
+	// block's burst used to emit one Warn PER dropped event.
+	dropsSinceLog atomic.Int64
+	lastDropLog   atomic.Int64
 }
 
 // Manager owns the per-pod registry of SSE clients listening on
@@ -77,6 +102,13 @@ type Manager struct {
 	// defaultClientBuffer.
 	clientBufferSize int
 
+	// catchupOnDrop gates mid-stream store-backed catchup for token-scoped
+	// clients whose channel overflowed. Wired from
+	// config.SSEConfig.CatchupOnDrop by the Service at startup; newManager
+	// initializes it to true so tests constructing the manager directly get
+	// the production default.
+	catchupOnDrop bool
+
 	mu      sync.RWMutex
 	clients map[int64]*Client
 }
@@ -97,11 +129,12 @@ func newManager(ctx context.Context, publisher events.Publisher, st store.Store,
 		return nil, nil //nolint:nilnil // intentional: nil manager means "no fan-out wired"
 	}
 	m := &Manager{
-		publisher: publisher,
-		store:     st,
-		logger:    logger.Named("sse"),
-		parentCtx: ctx,
-		clients:   make(map[int64]*Client),
+		publisher:     publisher,
+		store:         st,
+		logger:        logger.Named("sse"),
+		parentCtx:     ctx,
+		catchupOnDrop: true,
+		clients:       make(map[int64]*Client),
 	}
 	ch, err := publisher.Subscribe(ctx, "sse")
 	if err != nil {
@@ -196,13 +229,48 @@ func (m *Manager) fanOut(ctx context.Context, status *models.TransactionStatus) 
 			metrics.APISSEDroppedTotal.WithLabelValues("client_gone").Inc()
 		default:
 			metrics.APISSEDroppedTotal.WithLabelValues("slow_client").Inc()
-			m.logger.Warn(
-				"dropping update for slow SSE client",
-				zap.Int64("client_id", c.ID),
-				logfields.TxID(status.TxID),
-			)
+			m.recordDrop(c, status)
 		}
 	}
+}
+
+// dropLogInterval rate-limits the aggregate slow-client drop Warn: at most
+// one line per client per interval, carrying the count of drops folded into
+// it. A ≥20k-tx block used to emit ~12-22k per-event Warn lines per slow
+// client.
+const dropLogInterval = time.Second
+
+// recordDrop notes one fan-out drop on a slow client: it arms the mid-stream
+// catchup state read by the client's writer goroutine and folds the event
+// into the rate-limited aggregate Warn. Runs on the manager's single fan-out
+// goroutine; the writer goroutine concurrently consumes the state, hence the
+// atomics.
+func (m *Manager) recordDrop(c *Client, status *models.TransactionStatus) {
+	// Track the earliest dropped timestamp since the writer last consumed the
+	// floor: it lower-bounds the catchup replay window. The floor MUST be
+	// written before the dropped flag so a writer that observes the flag also
+	// observes the floor (it consumes them in the opposite order).
+	ts := status.Timestamp.UnixNano()
+	for {
+		cur := c.droppedFloor.Load()
+		if ts >= cur || c.droppedFloor.CompareAndSwap(cur, ts) {
+			break
+		}
+	}
+	c.dropped.Store(true)
+
+	c.dropsSinceLog.Add(1)
+	now := time.Now().UnixNano()
+	last := c.lastDropLog.Load()
+	if now-last < int64(dropLogInterval) || !c.lastDropLog.CompareAndSwap(last, now) {
+		return
+	}
+	m.logger.Warn(
+		"dropped events for slow SSE client; will catch up mid-stream",
+		zap.Int64("client_id", c.ID),
+		zap.Int64("dropped", c.dropsSinceLog.Swap(0)),
+		zap.Bool("catchup_eligible", m.catchupOnDrop && c.Token != ""),
+	)
 }
 
 // txBelongsToToken reports whether txid was submitted with the given
@@ -267,13 +335,15 @@ func (m *Manager) NewClient(token string) *Client {
 	if size <= 0 {
 		size = defaultClientBuffer
 	}
-	return &Client{
+	c := &Client{
 		ID:     m.nextClientID.Add(1),
 		Token:  token,
 		Ch:     make(chan *models.TransactionStatus, size),
 		Ctx:    ctx,
 		Cancel: cancel,
 	}
+	c.droppedFloor.Store(math.MaxInt64)
+	return c
 }
 
 // handleEvents serves GET /events?callbackToken=<token>. Streams
@@ -313,7 +383,11 @@ func (s *Service) handleEvents(c *gin.Context) {
 				since = time.Unix(0, ns)
 			}
 		}
-		s.sendCatchup(ctx, writer, token, since)
+		// The pre-stream catchup threads the client through so lastDelivered
+		// is initialized from the replayed history — a later mid-stream
+		// catchup then resumes from a fresh watermark instead of replaying
+		// from zero.
+		s.sendCatchup(ctx, writer, token, since, client, false)
 	}
 
 	keepalive := time.NewTicker(15 * time.Second)
@@ -328,6 +402,7 @@ func (s *Service) handleEvents(c *gin.Context) {
 				if err := writeStatusBuffered(writer, status); err != nil {
 					return
 				}
+				client.lastDelivered.Store(status.Timestamp.UnixNano())
 			}
 			// Coalesce the rest of this burst: drain everything already
 			// buffered on the channel (the default arm breaks the loop once
@@ -344,6 +419,7 @@ func (s *Service) handleEvents(c *gin.Context) {
 					if err := writeStatusBuffered(writer, s); err != nil {
 						return
 					}
+					client.lastDelivered.Store(s.Timestamp.UnixNano())
 				default:
 					break drain
 				}
@@ -351,8 +427,18 @@ func (s *Service) handleEvents(c *gin.Context) {
 			if err := writer.flush(); err != nil {
 				return
 			}
+			if !s.midstreamCatchup(ctx, writer, client) {
+				return
+			}
 		case <-keepalive.C:
 			if err := writer.write(": keepalive\n\n"); err != nil {
+				return
+			}
+			// Also heal on the keepalive tick: a drop can land just after the
+			// writer's post-drain check (the flag is set by the concurrent
+			// fan-out goroutine), and if the stream then goes quiet no further
+			// drain cycle would notice it.
+			if !s.midstreamCatchup(ctx, writer, client) {
 				return
 			}
 		}
@@ -381,6 +467,31 @@ const catchupBlockBudget = 64
 // Internal sentinel, never surfaced to the client.
 var errCatchupCapped = errors.New("sse catchup frame cap reached")
 
+// midstreamCatchupSlack widens the mid-stream replay window below the
+// earliest dropped event's timestamp. Bulk MINED events carry the store's
+// timestamp_at verbatim (see setMinedAndPublish), so for the dominant burst
+// source the floor is exact; other publish paths (propagation, api-server)
+// stamp events with a publish-time time.Now() taken shortly AFTER the store
+// row's timestamp_at, and the store filter is strictly-after — the slack
+// covers that skew. Cost of the rewind is only duplicate frames, which the
+// catchup contract already allows.
+const midstreamCatchupSlack = 2 * time.Second
+
+// catchupResult reports one sendCatchup pass.
+type catchupResult struct {
+	// frames is how many status frames were written.
+	frames int
+	// lastTS is the Timestamp.UnixNano() of the last frame written (0 when
+	// frames == 0).
+	lastTS int64
+	// capped is true when the pass stopped at the frame cap with more
+	// matching history remaining beyond lastTS.
+	capped bool
+	// err is any non-cap error: a write error (connection dead) or a store
+	// iteration error.
+	err error
+}
+
 // sendCatchup replays persisted statuses for txids registered under the
 // supplied token. When `since` is non-zero, every status with a timestamp
 // strictly after `since` is emitted (the Last-Event-ID reconnect contract —
@@ -398,18 +509,36 @@ var errCatchupCapped = errors.New("sse catchup frame cap reached")
 // frames on a Last-Event-ID reconnect are enriched best-effort, bounded by
 // catchupBlockBudget distinct blocks. Fresh connects replay only non-terminal
 // statuses, so the enrichment branch never fires there.
-func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, since time.Time) {
+//
+// client, when non-nil, has its lastDelivered watermark advanced per written
+// frame so mid-stream catchup can resume from where any earlier pass ended.
+//
+// midstream=true adapts the pass for the live-loop caller: the frame cap
+// becomes "soft" at a timestamp boundary — once the cap is reached the pass
+// keeps writing while the timestamp stays EQUAL to the last written frame's.
+// The store's since-filter is strictly-after, so a timestamp-cursor cannot
+// resume mid-way through an equal-timestamp run (SetMinedByTxIDs stamps a
+// whole block's rows with one timestamp_at); stopping inside one would
+// strand the remainder forever. Draining the tie bounds the overshoot by the
+// largest same-timestamp batch, and guarantees `capped` passes always end on
+// a boundary the next round can resume from strictly-after.
+func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, since time.Time, client *Client, midstream bool) catchupResult {
 	var only []models.Status
 	if since.IsZero() {
 		only = models.NonTerminalStatuses()
 	}
-	frames := 0
+	var res catchupResult
 	enrichedBlocks := make(map[string]struct{})
 	err := s.store.IterateStatusesByToken(ctx, token, since, only, func(status *models.TransactionStatus) error {
-		if frames >= catchupMaxFrames {
-			return errCatchupCapped
+		ts := status.Timestamp.UnixNano()
+		if res.frames >= catchupMaxFrames {
+			if !midstream || ts != res.lastTS {
+				res.capped = true
+				return errCatchupCapped
+			}
+			// midstream: same-timestamp tie with the frame that hit the cap —
+			// finish the tie (see the function comment).
 		}
-		frames++
 		if status.Status == models.StatusMined || status.Status == models.StatusImmutable {
 			_, seen := enrichedBlocks[status.BlockHash]
 			if status.BlockHash != "" && (seen || len(enrichedBlocks) < catchupBlockBudget) {
@@ -420,13 +549,104 @@ func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, s
 				}
 			}
 		}
-		return writeStatus(w, status)
+		if err := writeStatus(w, status); err != nil {
+			return err
+		}
+		res.frames++
+		res.lastTS = ts
+		if client != nil {
+			client.lastDelivered.Store(ts)
+		}
+		return nil
 	})
-	if errors.Is(err, errCatchupCapped) {
+	switch {
+	case err == nil:
+	case errors.Is(err, errCatchupCapped):
+		if midstream {
+			// Expected multi-round pagination for the live loop, not a
+			// truncation — the caller resumes from lastTS.
+			break
+		}
 		s.logger.Warn("sse catchup truncated at frame cap",
 			zap.Int("cap", catchupMaxFrames),
 			zap.Bool("fresh_connect", since.IsZero()))
+	default:
+		res.err = err
 	}
+	return res
+}
+
+// midstreamCatchup heals a live token-scoped connection after fanOut dropped
+// events on channel overflow: it replays the missed window from the store
+// (the same engine as Last-Event-ID reconnect catchup) without forcing a
+// reconnect. Returns false when the connection is no longer writable and the
+// handler must exit.
+//
+// Replay window: from min(earliest dropped timestamp - slack, resume point of
+// a previous capped round). Frames the client already holds may be replayed
+// again — duplicates across the drop/catchup boundary are the documented
+// catchup semantics (clients dedupe by txid+status). Rounds loop while more
+// drops land or a capped round leaves history unreplayed; each capped round
+// ends on a timestamp boundary strictly above the previous one, so the loop
+// always progresses and terminates once it overtakes the live stream. Under
+// sustained overload the connection degrades to store-paced replay, which is
+// exactly the at-least-once contract.
+//
+// Tokenless (firehose) clients keep the historical drop-only behavior — the
+// catchup source is store.IterateStatusesByToken, which is token-scoped;
+// there is no bounded store query that reconstructs the unfiltered stream.
+// They keep the drop metric and the aggregate Warn.
+func (s *Service) midstreamCatchup(ctx context.Context, w *sseWriter, client *Client) bool {
+	if client.Token == "" || !s.manager.catchupOnDrop {
+		return true
+	}
+	resume := int64(-1) // lastTS of a capped round; -1 = no round pending
+	for client.dropped.Load() || resume >= 0 {
+		// Consume the flag BEFORE the floor: recordDrop writes the floor
+		// before setting the flag, so this order can at worst yield one
+		// spurious extra round, never a missed floor.
+		client.dropped.Store(false)
+		floor := client.droppedFloor.Swap(math.MaxInt64)
+
+		sinceNS := int64(math.MaxInt64)
+		if floor != math.MaxInt64 {
+			sinceNS = floor - int64(midstreamCatchupSlack)
+		}
+		if resume >= 0 && resume < sinceNS {
+			sinceNS = resume
+		}
+		if sinceNS == math.MaxInt64 {
+			// Spurious flag: its floor was consumed (and covered) by the
+			// previous round, and no capped round is pending.
+			break
+		}
+
+		metrics.SSEMidstreamCatchupsTotal.Inc()
+		res := s.sendCatchup(ctx, w, client.Token, time.Unix(0, sinceNS), client, true)
+		metrics.SSEMidstreamCatchupFramesTotal.Add(float64(res.frames))
+		if res.err != nil {
+			// Either the connection is dead (write error) or the store
+			// iteration failed mid-window. Both ways the safe move is to end
+			// the stream: the client reconnects with Last-Event-ID and the
+			// reconnect catchup re-covers the window.
+			s.logger.Warn("sse mid-stream catchup aborted",
+				zap.Int64("client_id", client.ID),
+				zap.Int("frames", res.frames),
+				zap.Error(res.err))
+			return false
+		}
+		s.logger.Info("sse mid-stream catchup round",
+			zap.Int64("client_id", client.ID),
+			zap.Int("frames", res.frames),
+			zap.Bool("capped", res.capped),
+			zap.Time("since", time.Unix(0, sinceNS)))
+		if res.capped {
+			resume = res.lastTS
+		} else {
+			resume = -1
+		}
+	}
+	return true
 }
 
 // enrichMerklePath attaches the merkle proof to a mined/immutable status before

--- a/services/sse/service.go
+++ b/services/sse/service.go
@@ -72,6 +72,7 @@ func (s *Service) Start(ctx context.Context) error {
 	// treats as "use defaultClientBuffer".
 	if mgr != nil {
 		mgr.clientBufferSize = s.cfg.SSE.ClientBufferSize
+		mgr.catchupOnDrop = s.cfg.SSE.CatchupOnDrop
 	}
 	s.manager = mgr
 

--- a/services/sse/sse_test.go
+++ b/services/sse/sse_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/bsv-blockchain/arcade/config"
 	"github.com/bsv-blockchain/arcade/metrics"
@@ -425,11 +426,14 @@ func TestSSECatchupFrameCap(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	w := &sseWriter{w: rec, f: nopFlusher{rec}}
-	svc.sendCatchup(t.Context(), w, "tok-big", time.Time{})
+	res := svc.sendCatchup(t.Context(), w, "tok-big", time.Time{}, nil, false)
 
 	frames := strings.Count(rec.Body.String(), "\nevent: status\n")
 	if frames != catchupMaxFrames {
 		t.Errorf("catchup frames = %d, want cap %d", frames, catchupMaxFrames)
+	}
+	if !res.capped || res.frames != catchupMaxFrames {
+		t.Errorf("result = %+v, want capped at %d frames", res, catchupMaxFrames)
 	}
 }
 
@@ -599,6 +603,339 @@ func TestSSEFanOutClientGoneDrops(t *testing.T) {
 	after := testutil.ToFloat64(metrics.APISSEDroppedTotal.WithLabelValues("client_gone"))
 	if got := after - before; got < 1 {
 		t.Errorf("client_gone drops = %v, want >= 1", got)
+	}
+}
+
+// TestSSEMidstreamCatchupDeliversDroppedEvents is the end-to-end contract of
+// the mid-stream self-healing path: a token-scoped client whose channel is
+// overflowed by fanOut still receives EVERY status (at-least-once) on the
+// SAME connection, served from the store, and the catchup-round counter
+// increments.
+func TestSSEMidstreamCatchupDeliversDroppedEvents(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	const nTx = 5
+	subs := make([]*models.Submission, 0, nTx)
+	statuses := make([]*models.TransactionStatus, 0, nTx)
+	statusByTx := make(map[string]*models.TransactionStatus, nTx)
+	for i := 0; i < nTx; i++ {
+		txid := fmt.Sprintf("drop-%d", i)
+		st := &models.TransactionStatus{
+			TxID:      txid,
+			Status:    models.StatusMined,
+			Timestamp: now.Add(time.Duration(i) * time.Millisecond),
+		}
+		subs = append(subs, &models.Submission{TxID: txid, CallbackToken: tokA})
+		statuses = append(statuses, st)
+		statusByTx[txid] = st
+	}
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{tokA: subs},
+		statusByTx:  statusByTx,
+	}
+	svc, router, _, cancel := setupSSEService(t, st)
+	defer cancel()
+	mgr := svc.manager
+	// A one-slot buffer makes fanOut overflow immediately once the writer
+	// goroutine lags a single frame behind.
+	mgr.clientBufferSize = 1
+
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	catchupsBefore := testutil.ToFloat64(metrics.SSEMidstreamCatchupsTotal)
+	dropsBefore := testutil.ToFloat64(metrics.APISSEDroppedTotal.WithLabelValues("slow_client"))
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/events?callbackToken="+tokA, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /events: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Wait for the connection's client to register.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mgr.mu.RLock()
+		n := len(mgr.clients)
+		mgr.mu.RUnlock()
+		if n == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("client never registered")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Fan the statuses out until at least one is dropped on the full channel.
+	deadline = time.Now().Add(2 * time.Second)
+	for i := 0; testutil.ToFloat64(metrics.APISSEDroppedTotal.WithLabelValues("slow_client")) == dropsBefore; i++ {
+		if time.Now().After(deadline) {
+			t.Fatal("fanOut never dropped despite 1-slot buffer")
+		}
+		mgr.fanOut(t.Context(), statuses[i%nTx])
+	}
+
+	// Nudge the stream while collecting: each delivered frame triggers a
+	// drain cycle whose post-flush check runs the mid-stream catchup (the
+	// 15s keepalive would eventually do it too; nudging keeps the test fast).
+	nudgeDone := make(chan struct{})
+	defer close(nudgeDone)
+	go func() {
+		tick := time.NewTicker(50 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-nudgeDone:
+				return
+			case <-tick.C:
+				mgr.fanOut(context.Background(), statuses[nTx-1])
+			}
+		}
+	}()
+
+	want := make(map[string]bool, nTx)
+	for _, s := range statuses {
+		want[s.TxID] = true
+	}
+	if err := readSSEUntilTxIDs(resp.Body, want, 10*time.Second); err != nil {
+		t.Fatalf("stream did not deliver every status: %v", err)
+	}
+	// The dropped flag is armed, so the writer's next drain cycle (the nudger
+	// keeps producing them) MUST run a catchup round — but it may not have
+	// happened yet when the reader finishes (every status can also arrive
+	// live because the drop-forcing loop cycles them). Poll.
+	deadline = time.Now().Add(5 * time.Second)
+	for testutil.ToFloat64(metrics.SSEMidstreamCatchupsTotal)-catchupsBefore < 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("arcade_sse_midstream_catchups_total never incremented after a drop")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestSSEMidstreamCatchupTokenlessKeepsDropOnly verifies the firehose
+// (tokenless) client keeps the historical behavior: drops are counted, but no
+// store-backed catchup runs — the catchup source is token-scoped.
+func TestSSEMidstreamCatchupTokenlessKeepsDropOnly(t *testing.T) {
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{},
+		statusByTx:  map[string]*models.TransactionStatus{},
+	}
+	svc, _, _, cancel := setupSSEService(t, st)
+	defer cancel()
+	mgr := svc.manager
+
+	client := mgr.NewClient("")
+	mgr.Register(client)
+	defer mgr.Unregister(client.ID)
+
+	for i := 0; i < cap(client.Ch); i++ {
+		client.Ch <- &models.TransactionStatus{TxID: "filler", Timestamp: time.Now()}
+	}
+	dropsBefore := testutil.ToFloat64(metrics.APISSEDroppedTotal.WithLabelValues("slow_client"))
+	mgr.fanOut(t.Context(), &models.TransactionStatus{TxID: "lost", Status: models.StatusMined, Timestamp: time.Now()})
+	if got := testutil.ToFloat64(metrics.APISSEDroppedTotal.WithLabelValues("slow_client")) - dropsBefore; got != 1 {
+		t.Fatalf("slow_client drops = %v, want 1", got)
+	}
+	if !client.dropped.Load() {
+		t.Fatal("dropped flag not set by fanOut drop arm")
+	}
+
+	catchupsBefore := testutil.ToFloat64(metrics.SSEMidstreamCatchupsTotal)
+	rec := httptest.NewRecorder()
+	w := &sseWriter{w: rec, f: nopFlusher{rec}}
+	if ok := svc.midstreamCatchup(t.Context(), w, client); !ok {
+		t.Fatal("midstreamCatchup reported a dead connection")
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("tokenless client received catchup frames: %q", rec.Body.String())
+	}
+	if got := testutil.ToFloat64(metrics.SSEMidstreamCatchupsTotal) - catchupsBefore; got != 0 {
+		t.Errorf("catchup rounds ran for tokenless client: %v", got)
+	}
+}
+
+// TestSSEFanOutDropLogAggregation verifies the drop Warn is aggregated and
+// rate-limited per client instead of logged once per dropped event.
+func TestSSEFanOutDropLogAggregation(t *testing.T) {
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{},
+		statusByTx:  map[string]*models.TransactionStatus{},
+	}
+	core, logs := observer.New(zap.WarnLevel)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	mgr, err := newManager(ctx, &fakePublisher{}, st, zap.New(core))
+	if err != nil {
+		t.Fatalf("newManager: %v", err)
+	}
+
+	client := mgr.NewClient("")
+	mgr.Register(client)
+	defer mgr.Unregister(client.ID)
+	for i := 0; i < cap(client.Ch); i++ {
+		client.Ch <- &models.TransactionStatus{TxID: "filler", Timestamp: time.Now()}
+	}
+
+	const drops = 100
+	for i := 0; i < drops; i++ {
+		mgr.fanOut(ctx, &models.TransactionStatus{TxID: "burst", Status: models.StatusMined, Timestamp: time.Now()})
+	}
+
+	warns := logs.FilterMessage("dropped events for slow SSE client; will catch up mid-stream").Len()
+	// 100 back-to-back drops land inside one dropLogInterval on any sane
+	// machine, so one aggregate line is expected; tolerate a second in case
+	// the loop straddles an interval boundary. The old code logged all 100.
+	if warns < 1 || warns > 2 {
+		t.Errorf("aggregate drop warns = %d, want 1 (2 tolerated), not one per %d drops", warns, drops)
+	}
+}
+
+// TestSSEMidstreamCatchupCappedRoundsProgress verifies the multi-round loop:
+// a replay window larger than catchupMaxFrames is delivered across capped
+// rounds whose `since` watermark strictly advances.
+func TestSSEMidstreamCatchupCappedRoundsProgress(t *testing.T) {
+	n := catchupMaxFrames + 500
+	subs := make([]*models.Submission, 0, n)
+	statusByTx := make(map[string]*models.TransactionStatus, n)
+	base := time.Now().UTC().Add(-time.Hour)
+	for i := 0; i < n; i++ {
+		txid := fmt.Sprintf("prog-%06d", i)
+		subs = append(subs, &models.Submission{TxID: txid, CallbackToken: "tok-prog"})
+		statusByTx[txid] = &models.TransactionStatus{
+			TxID:      txid,
+			Status:    models.StatusMined,
+			Timestamp: base.Add(time.Duration(i) * time.Millisecond),
+		}
+	}
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{"tok-prog": subs},
+		statusByTx:  statusByTx,
+	}
+	svc, _, _, cancel := setupSSEService(t, st)
+	defer cancel()
+
+	client := svc.manager.NewClient("tok-prog")
+	// Simulate fanOut having dropped events starting at the first status.
+	client.droppedFloor.Store(base.UnixNano())
+	client.dropped.Store(true)
+
+	catchupsBefore := testutil.ToFloat64(metrics.SSEMidstreamCatchupsTotal)
+	framesBefore := testutil.ToFloat64(metrics.SSEMidstreamCatchupFramesTotal)
+	rec := httptest.NewRecorder()
+	w := &sseWriter{w: rec, f: nopFlusher{rec}}
+	if ok := svc.midstreamCatchup(t.Context(), w, client); !ok {
+		t.Fatal("midstreamCatchup reported a dead connection")
+	}
+
+	if frames := strings.Count(rec.Body.String(), "\nevent: status\n"); frames != n {
+		t.Errorf("frames written = %d, want %d (every status, across rounds)", frames, n)
+	}
+	if got := testutil.ToFloat64(metrics.SSEMidstreamCatchupsTotal) - catchupsBefore; got != 2 {
+		t.Errorf("catchup rounds = %v, want 2 (capped round + resumed round)", got)
+	}
+	if got := testutil.ToFloat64(metrics.SSEMidstreamCatchupFramesTotal) - framesBefore; got != float64(n) {
+		t.Errorf("replayed frames metric delta = %v, want %d", got, n)
+	}
+	wantLast := statusByTx[fmt.Sprintf("prog-%06d", n-1)].Timestamp.UnixNano()
+	if got := client.lastDelivered.Load(); got != wantLast {
+		t.Errorf("lastDelivered = %d, want %d (watermark advanced to the final frame)", got, wantLast)
+	}
+}
+
+// TestSSEMidstreamCatchupSameTimestampGlut verifies the soft frame cap: when
+// an equal-timestamp run (one SetMinedByTxIDs batch) straddles the cap, the
+// round finishes the tie instead of stranding the remainder — a timestamp
+// cursor cannot resume mid-tie because the store filter is strictly-after.
+func TestSSEMidstreamCatchupSameTimestampGlut(t *testing.T) {
+	n := catchupMaxFrames + 500
+	subs := make([]*models.Submission, 0, n)
+	statusByTx := make(map[string]*models.TransactionStatus, n)
+	ts := time.Now().UTC().Add(-time.Hour)
+	for i := 0; i < n; i++ {
+		txid := fmt.Sprintf("glut-%06d", i)
+		subs = append(subs, &models.Submission{TxID: txid, CallbackToken: "tok-glut"})
+		statusByTx[txid] = &models.TransactionStatus{
+			TxID:      txid,
+			Status:    models.StatusMined,
+			Timestamp: ts, // the whole set shares ONE timestamp
+		}
+	}
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{"tok-glut": subs},
+		statusByTx:  statusByTx,
+	}
+	svc, _, _, cancel := setupSSEService(t, st)
+	defer cancel()
+
+	client := svc.manager.NewClient("tok-glut")
+	client.droppedFloor.Store(ts.UnixNano())
+	client.dropped.Store(true)
+
+	catchupsBefore := testutil.ToFloat64(metrics.SSEMidstreamCatchupsTotal)
+	rec := httptest.NewRecorder()
+	w := &sseWriter{w: rec, f: nopFlusher{rec}}
+	if ok := svc.midstreamCatchup(t.Context(), w, client); !ok {
+		t.Fatal("midstreamCatchup reported a dead connection")
+	}
+
+	if frames := strings.Count(rec.Body.String(), "\nevent: status\n"); frames != n {
+		t.Errorf("frames written = %d, want %d (tie drained past the cap)", frames, n)
+	}
+	if got := testutil.ToFloat64(metrics.SSEMidstreamCatchupsTotal) - catchupsBefore; got != 1 {
+		t.Errorf("catchup rounds = %v, want 1 (single round drains the tie)", got)
+	}
+}
+
+// readSSEUntilTxIDs consumes SSE frames from r until every txid in want has
+// been seen at least once (duplicates allowed) or the timeout elapses.
+func readSSEUntilTxIDs(r io.Reader, want map[string]bool, timeout time.Duration) error {
+	var mu sync.Mutex
+	seen := make(map[string]bool, len(want))
+	done := make(chan error, 1)
+	go func() {
+		br := bufio.NewReader(r)
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				done <- fmt.Errorf("read: %w", err)
+				return
+			}
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			var payload struct {
+				TxID string `json:"txid"`
+			}
+			if err := json.Unmarshal([]byte(strings.TrimPrefix(strings.TrimSpace(line), "data: ")), &payload); err != nil {
+				continue
+			}
+			mu.Lock()
+			if want[payload.TxID] {
+				seen[payload.TxID] = true
+			}
+			complete := len(seen) == len(want)
+			mu.Unlock()
+			if complete {
+				done <- nil
+				return
+			}
+		}
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		mu.Lock()
+		defer mu.Unlock()
+		missing := make([]string, 0, len(want))
+		for txid := range want {
+			if !seen[txid] {
+				missing = append(missing, txid)
+			}
+		}
+		return fmt.Errorf("timeout; missing txids: %v", missing)
 	}
 }
 


### PR DESCRIPTION
## Problem

In the 2026-08-10 load test, a healthy SSE client draining ~2.4-6k events/s **measurably lost 30-55% of every ≥20k-tx block's MINED burst** (blocks ≤8.5k txs delivered 100%). A big block also flooded the log with **~12-22k Warn lines** — one per dropped event.

Dropped events are only recoverable today via `Last-Event-ID` catchup on **reconnect** — which never happens on a healthy connection, so the loss is silent and permanent for a well-behaved client.

## Root cause

bump-builder publishes an entire block's MINED set to Kafka at once (~40,000 events within ~1ms). The SSE manager's single fan-out goroutine (`run`) unfans the bulk event per-txid into every client's buffered channel, and the per-connection send (`fanOut`) has a non-blocking `default:` arm that drops on overflow beyond `sse.client_buffer_size` (8192, #277). No consumer drains 40k events in the milliseconds the burst takes to unfan, so everything past the buffer is lost — and each loss logs its own Warn.

## Fix

**Self-healing mid-stream catchup for token-scoped clients** (`services/sse/manager.go`):

- `Client` gains atomic delivery state (fan-out and writer goroutines race on it): a `lastDelivered` watermark (updated after each successfully written live/catchup frame), a `dropped` flag, and a `droppedFloor` — the earliest dropped event timestamp since the writer last consumed it.
- `fanOut`'s drop arm keeps `arcade_api_sse_dropped_total{slow_client}`, arms the flag/floor, and replaces the per-event Warn with a **rate-limited aggregate** (at most one line per second per client, carrying the count dropped since the last line).
- The writer loop checks the flag after each drain+flush cycle (and on keepalive ticks, closing the burst-then-quiet race) and replays the missed window from the store through the **existing catchup engine** (`sendCatchup` → `IterateStatusesByToken`), looping while more drops land or a capped round leaves history unreplayed. `since` strictly advances every round, so the loop always terminates; under sustained overload the connection degrades to store-paced replay, which is the at-least-once contract.
- Tokenless (firehose) clients keep today's drop-only behavior — the store catchup source is token-scoped; there is no bounded query that reconstructs the unfiltered stream.

**Two correctness details a naive "resume from the last delivered event id" would get wrong** (this is why the diff touches `bump_builder/builder.go` and adds a soft cap):

1. **Timestamp-domain alignment.** The catchup query is strictly-after `timestamp_at`, but bulk MINED events were stamped with a publish-time `time.Now()` taken seconds AFTER the store's `SetMinedByTxIDs` timestamp (the 40k-row UPDATE + chunked logging run in between). A watermark taken from live event ids therefore sits past the whole block's `timestamp_at` and would replay **zero** of the dropped rows. Bulk MINED events now carry the store's transition timestamp verbatim (`setMinedAndPublish` uses the timestamps `SetMinedByTxIDs` returns), which also makes `Last-Event-ID` reconnect resume exact for MINED. The mid-stream replay floor is additionally rewound by a 2s slack to cover the smaller skew on non-aligned publish paths (propagation, api-server).
2. **Equal-timestamp runs vs the frame cap.** One `SetMinedByTxIDs` call stamps every row of a block with ONE `timestamp_at`, and a timestamp cursor cannot resume mid-run (strictly-after would strand the remainder forever). Mid-stream rounds treat `catchupMaxFrames` (10k) as a **soft cap that finishes an equal-timestamp run** before stopping, so rounds always end on a boundary the next round resumes strictly-after. Pre-stream/reconnect catchup keeps the exact hard cap; `catchupBlockBudget` applies per round as before.

**Metrics:** `arcade_sse_midstream_catchups_total` (rounds) and `arcade_sse_midstream_catchup_frames_total` (replayed frames).
**Config:** `sse.catchup_on_drop` (bool, default **true**) alongside `sse.client_buffer_size`; false restores the previous drop-only behavior.

## Duplicate frames

Duplicate frames across the drop/catchup boundary (and from the floor slack) are possible and acceptable — same semantics as the existing reconnect catchup: clients dedupe by txid+status.

## Tests

- `TestSSEMidstreamCatchupDeliversDroppedEvents` — end-to-end over a real HTTP stream: a token client with a 1-slot buffer is overflowed by `fanOut` while the stub store holds all statuses; the stream receives EVERY status (at-least-once) and `arcade_sse_midstream_catchups_total` increments (`prometheus/testutil`). Ran 200x under `-race`, 0 failures.
- `TestSSEMidstreamCatchupTokenlessKeepsDropOnly` — tokenless client: drop counted, no catchup round, no frames.
- `TestSSEFanOutDropLogAggregation` — 100 back-to-back drops produce 1 aggregate Warn (zap observer), not 100.
- `TestSSEMidstreamCatchupCappedRoundsProgress` — a window of `catchupMaxFrames+500` distinct-timestamp statuses is fully delivered across 2 rounds; the watermark strictly advances; frame/round counters match.
- `TestSSEMidstreamCatchupSameTimestampGlut` — `catchupMaxFrames+500` statuses sharing ONE timestamp are fully delivered in a single soft-capped round.
- Existing suite updated for the `sendCatchup` signature; `TestSSEFanOutSlowClientDrops`, catchup, frame-cap, and merkle-path e2e tests unchanged in behavior and green.

`go test -race ./services/sse/...`, `make test` (full suite, CGO/gobdk), and `make lint` (`golangci-lint`, 0 issues) all pass on this branch. No pre-existing failures observed.

Full run analysis: go-arcade-toolbox docs/benchmarks/20260810-three-phase-1500tps-and-ceiling.md