### PR TITLE
feat(propagation): make the reaper rebroadcast batch size configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -361,6 +361,17 @@ type PropagationConfig struct {
 	RetryBackoffMs    int `mapstructure:"retry_backoff_ms"`
 	ReaperIntervalMs  int `mapstructure:"reaper_interval_ms"`
 	ReaperBatchSize   int `mapstructure:"reaper_batch_size"`
+	// ReaperRebroadcastBatch caps how many stuck transactions the reaper's
+	// durable-rebroadcast backstop pushes back through the register+broadcast
+	// pipeline per tick (reapOnce collects at most this many stale RECEIVED /
+	// ACCEPTED_BY_NETWORK / SEEN rows). During the 2026-08-10 requeue-spiral
+	// incident ~178k txs were stranded at RECEIVED with the reaper as their
+	// only drain path; the then-hardcoded 200-per-tick cap at the default 30s
+	// interval drained ~6.7 tx/s (~7.4h to clear), forcing operators to crank
+	// reaper_interval_ms down instead. Raise this to drain a large backlog
+	// faster without touching the tick interval. Defaults to 200 (the
+	// historical hardcoded cap) when unset or non-positive.
+	ReaperRebroadcastBatch int `mapstructure:"reaper_rebroadcast_batch"`
 	// LeaseTTLMs bounds how long the reaper lease remains valid without a
 	// renewal. Set to at least 2–3× reaper_interval_ms so a missed tick
 	// doesn't trigger a false-positive failover. Defaults to 3× interval.
@@ -934,6 +945,7 @@ func setDefaults() {
 	viper.SetDefault("propagation.retry_backoff_ms", 500)
 	viper.SetDefault("propagation.reaper_interval_ms", 30000)
 	viper.SetDefault("propagation.reaper_batch_size", 500)
+	viper.SetDefault("propagation.reaper_rebroadcast_batch", 200)
 	// 0 keeps New()'s 3×reaper_interval default, so changing reaper_interval
 	// automatically moves the lease TTL unless the operator opts into a fixed value.
 	viper.SetDefault("propagation.lease_ttl_ms", 0)

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -95,6 +95,10 @@ type Propagator struct {
 	merkleConcurrency int
 	reaperInterval    time.Duration
 	reaperBatchSize   int
+	// rebroadcastBatch caps stuck-tx rebroadcasts per reaper tick
+	// (propagation.reaper_rebroadcast_batch, default
+	// defaultReaperRebroadcastBatch). See reapOnce.
+	rebroadcastBatch  int
 	teranodeBatchCap  int
 	broadcastWorkers  int
 	maxParallelChunks int
@@ -259,6 +263,10 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 	if reaperBatch <= 0 {
 		reaperBatch = 500
 	}
+	rebroadcastBatch := cfg.Propagation.ReaperRebroadcastBatch
+	if rebroadcastBatch <= 0 {
+		rebroadcastBatch = defaultReaperRebroadcastBatch
+	}
 	leaseTTL := time.Duration(cfg.Propagation.LeaseTTLMs) * time.Millisecond
 	if leaseTTL <= 0 {
 		leaseTTL = 3 * reaperInterval
@@ -296,6 +304,7 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 		merkleConcurrency: merkleConcurrency,
 		reaperInterval:    reaperInterval,
 		reaperBatchSize:   reaperBatch,
+		rebroadcastBatch:  rebroadcastBatch,
 		teranodeBatchCap:  teranodeBatchCap,
 		broadcastWorkers:  broadcastWorkers,
 		maxParallelChunks: maxParallelChunks,

--- a/services/propagation/reaper.go
+++ b/services/propagation/reaper.go
@@ -51,7 +51,13 @@ const (
 	staleReceivedAge          = time.Hour
 	staleAcceptedByNetworkAge = time.Hour
 	staleScanLookback         = 24 * time.Hour
-	reaperRebroadcastBatch    = 200
+
+	// defaultReaperRebroadcastBatch is the per-tick rebroadcast cap applied
+	// when propagation.reaper_rebroadcast_batch is unset or non-positive —
+	// the source of truth for the historical hardcoded 200. See
+	// config.PropagationConfig.ReaperRebroadcastBatch for the incident
+	// rationale behind making it configurable.
+	defaultReaperRebroadcastBatch = 200
 
 	// stuckTransientAge is the threshold for the StuckTransientTxs /
 	// OldestTransientTxAge gauges: a tx sitting in RECEIVED or
@@ -174,7 +180,8 @@ func (p *Propagator) tryReap(ctx context.Context) {
 // resulting terminal status notifies the dispatcher via applyTerminalStatuses
 // only as a no-op for offset bookkeeping.
 //
-// Bounded by reaperRebroadcastBatch per tick so a backlog can't pin the
+// Bounded by p.rebroadcastBatch (propagation.reaper_rebroadcast_batch,
+// default defaultReaperRebroadcastBatch) per tick so a backlog can't pin the
 // reaper into a single multi-minute call.
 func (p *Propagator) reapOnce(ctx context.Context) {
 	now := time.Now()
@@ -201,7 +208,7 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 	}
 	attrib := make([]stuckRef, 0, stuckAttributionCap)
 
-	stuck := make([]propagationMsg, 0, reaperRebroadcastBatch)
+	stuck := make([]propagationMsg, 0, p.rebroadcastBatch)
 	err := p.store.IterateStatusesSince(ctx, since, func(st *models.TransactionStatus) error {
 		// Stuck-transient accounting runs on EVERY row (regardless of RawTx
 		// or the rebroadcast cap): the gauges must be an uncapped census of
@@ -217,7 +224,7 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 			}
 		}
 
-		if len(stuck) >= reaperRebroadcastBatch {
+		if len(stuck) >= p.rebroadcastBatch {
 			// Rebroadcast batch is full — keep walking for the census, just
 			// stop collecting. (Previously the walk aborted here, which also
 			// capped any counting at the batch size.)

--- a/services/propagation/reaper_test.go
+++ b/services/propagation/reaper_test.go
@@ -296,14 +296,14 @@ func TestReapOnce_StuckTransientCensus_ZeroesWhenClear(t *testing.T) {
 
 // TestReapOnce_CensusUncappedByRebroadcastBatch: the census must keep
 // counting past the rebroadcast batch cap (the old walk aborted at
-// reaperRebroadcastBatch, silently truncating any census).
+// the batch cap, silently truncating any census).
 func TestReapOnce_CensusUncappedByRebroadcastBatch(t *testing.T) {
 	now := time.Now()
 	stale := now.Add(-2 * time.Hour)
 
 	log := &eventLog{}
 	ms := newMockStore()
-	total := reaperRebroadcastBatch + 50
+	total := defaultReaperRebroadcastBatch + 50
 	for i := 0; i < total; i++ {
 		ms.replayRows = append(ms.replayRows, &models.TransactionStatus{
 			TxID:      fmt.Sprintf("recv-%04d", i),
@@ -323,8 +323,58 @@ func TestReapOnce_CensusUncappedByRebroadcastBatch(t *testing.T) {
 	if got := gaugeVal(t, metrics.StuckTransientTxs, string(models.StatusReceived)); got != float64(total) {
 		t.Errorf("stuck RECEIVED = %v, want %d (census must not be capped at the rebroadcast batch)", got, total)
 	}
-	if got := log.count("register:"); got != reaperRebroadcastBatch {
-		t.Errorf("rebroadcast count = %d, want %d (batch cap unchanged)", got, reaperRebroadcastBatch)
+	if got := log.count("register:"); got != defaultReaperRebroadcastBatch {
+		t.Errorf("rebroadcast count = %d, want %d (batch cap unchanged)", got, defaultReaperRebroadcastBatch)
+	}
+}
+
+// TestReapOnce_RebroadcastBatchConfigurable pins the configurable per-tick
+// rebroadcast cap (the 2026-08-10 incident fix: ~178k txs stuck at RECEIVED
+// could only drain at the hardcoded 200 per tick). With
+// propagation.reaper_rebroadcast_batch set to 5 and 8 eligible stuck rows
+// seeded, one reapOnce rebroadcasts exactly 5.
+func TestReapOnce_RebroadcastBatchConfigurable(t *testing.T) {
+	stale := time.Now().Add(-2 * time.Hour)
+
+	log := &eventLog{}
+	ms := newMockStore()
+	for i := 0; i < 8; i++ {
+		ms.replayRows = append(ms.replayRows, &models.TransactionStatus{
+			TxID:      fmt.Sprintf("recv-%02d", i),
+			Status:    models.StatusReceived,
+			RawTx:     []byte{0x01},
+			Timestamp: stale,
+		})
+	}
+
+	merkleSrv := newMerkleServer(log, http.StatusOK)
+	defer merkleSrv.Close()
+	teranodeSrv := newTeranodeServer(log, http.StatusOK)
+	defer teranodeSrv.Close()
+
+	cfg := &config.Config{CallbackURL: "http://localhost:8080/callback"}
+	cfg.Propagation.MerkleConcurrency = 10
+	cfg.Propagation.ReaperRebroadcastBatch = 5
+	mc := merkleservice.NewClient(merkleSrv.URL, "", 5*time.Second)
+	tc := teranode.NewClient([]string{teranodeSrv.URL}, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
+	p := New(cfg, zap.NewNop(), nil, nil, ms, nil, tc, mc)
+
+	p.reapOnce(context.Background())
+
+	if got := log.count("register:"); got != 5 {
+		t.Errorf("rebroadcast count = %d, want 5 (configured reaper_rebroadcast_batch)", got)
+	}
+}
+
+// TestNew_ReaperRebroadcastBatchDefault: leaving
+// propagation.reaper_rebroadcast_batch unset (zero) resolves to the historical
+// hardcoded cap, so behavior at default config is byte-identical to before the
+// knob existed.
+func TestNew_ReaperRebroadcastBatchDefault(t *testing.T) {
+	p := newPropagator("", "http://localhost:0", newMockStore())
+	if p.rebroadcastBatch != defaultReaperRebroadcastBatch {
+		t.Errorf("rebroadcastBatch = %d, want %d (code default when config is unset)",
+			p.rebroadcastBatch, defaultReaperRebroadcastBatch)
 	}
 }
 

--- a/services/webhook/reaper.go
+++ b/services/webhook/reaper.go
@@ -15,7 +15,7 @@ import (
 const webhookReaperLeaseName = "webhook-reaper"
 
 // webhookReaperBatch caps how many submissions a single tick re-fires. Same
-// shape as propagation's reaperRebroadcastBatch — bounded so a backlog can't
+// shape as propagation's rebroadcast batch cap — bounded so a backlog can't
 // pin the reaper into a multi-minute call, and so a too-broad scan doesn't
 // hold the worker pool against a sudden burst of new deliveries.
 const webhookReaperBatch = 200


### PR DESCRIPTION
## Problem

During the 2026-08-10 requeue-spiral incident (fixed separately in #287), ~178,000 transactions were left stuck at RECEIVED having lost Kafka replayability. Their only drain path is the reaper's durable-rebroadcast backstop in `services/propagation/reaper.go`, which rebroadcasts a **hardcoded 200 txs per tick** (`reaperRebroadcastBatch`). At the default 30s tick that is ~6.7 tx/s — a 178k backlog needs ~7.4 hours to clear even though every rebroadcast batch succeeded (200/200 accepted).

Operators mitigated live by dropping `reaper_interval_ms` to 2000 (argocd PR #204), which is a blunt instrument: it speeds up every reaper concern (lease churn, full census scans, backlog log lines) just to raise the rebroadcast rate. The right knob is the per-tick rebroadcast batch itself.

## Change

- `config/config.go`: new `propagation.reaper_rebroadcast_batch` (`ReaperRebroadcastBatch`) on `PropagationConfig`, documented with the incident rationale; viper default 200 alongside the other propagation defaults.
- `services/propagation/propagator.go`: `New` resolves the value with the standard code-fallback pattern (`<= 0` → 200) and stores it on the `Propagator` as `rebroadcastBatch`.
- `services/propagation/reaper.go`: `reapOnce` uses the configured field; the constant is renamed to `defaultReaperRebroadcastBatch` and remains the default's source of truth.
- `services/webhook/reaper.go`: one comment touch-up (it referenced the old constant name).

**Default-preserving:** with the key unset (or non-positive) the resolved cap is the historical 200, so behavior at default config is byte-identical to today.

## Deploy guidance

For backlog-drain scenarios like the incident, set `propagation.reaper_rebroadcast_batch: 2000` and relax `reaper_interval_ms` back toward 30000 (reverting the argocd PR #204 mitigation). That yields ~66 tx/s of backstop drain without running the lease/census machinery 15× more often.

## Tests

- `TestReapOnce_RebroadcastBatchConfigurable`: 8 eligible stuck RECEIVED rows seeded, `ReaperRebroadcastBatch: 5` configured → one `reapOnce` rebroadcasts exactly 5 (asserted via the recorded merkle test server).
- `TestNew_ReaperRebroadcastBatchDefault`: field unset (0) → resolved cap is `defaultReaperRebroadcastBatch` (200).
- `TestReapOnce_CensusUncappedByRebroadcastBatch` updated for the constant rename; still pins the default 200 cap with >200 seeded rows.
- `go test ./services/propagation/...`, `make test` (CGO), and `make lint` all pass locally.

Full run analysis: go-arcade-toolbox docs/benchmarks/20260810-three-phase-1500tps-and-ceiling.md