### PR TITLE
fix(propagation): SQL-side reaper census so the scan no longer gates rebroadcast cadence

### DIFF
--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -157,6 +157,10 @@ func (m *mockStore) IterateStatusesSince(context.Context, time.Time, func(*model
 	return nil
 }
 
+func (m *mockStore) CensusStatusesSince(context.Context, time.Time, time.Time, []models.Status) (map[models.Status]store.StatusCensus, error) {
+	return map[models.Status]store.StatusCensus{}, nil
+}
+
 func (m *mockStore) SetStatusByBlockHash(context.Context, string, models.Status) ([]string, error) {
 	return nil, nil
 }

--- a/services/propagation/propagator_test.go
+++ b/services/propagation/propagator_test.go
@@ -121,6 +121,10 @@ type mockStore struct {
 	cleared        []clearedCall
 	// replayRows drives IterateStatusesSince for merkle-replay tests.
 	replayRows []*models.TransactionStatus
+	// iterated counts rows visited by IterateStatusesSince — lets a test
+	// assert the reaper walk aborts at the rebroadcast batch (issue #290)
+	// instead of scanning the whole table.
+	iterated int
 	// submissionsByTxID drives GetSubmissionsByTxID, used by the reaper's
 	// stuck-by-callback attribution. Absent txids return no submissions
 	// (attributed to the "none" host).
@@ -303,11 +307,44 @@ func (m *mockStore) IterateStatusesSince(_ context.Context, since time.Time, fn 
 		if !r.Timestamp.IsZero() && r.Timestamp.Before(since) {
 			continue
 		}
+		m.iterated++ // count rows actually visited (issue #290 early-abort test)
 		if err := fn(r); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// CensusStatusesSince mirrors the store-side aggregate the reaper now uses for
+// the stuck census (issue #290): per requested status, the count and oldest
+// timestamp of replayRows in the window [since, stuckDeadline). Zero and
+// pre-since timestamps are excluded to match the Postgres GROUP BY (rows with a
+// NULL/absent timestamp_at can't satisfy timestamp_at >= since).
+func (m *mockStore) CensusStatusesSince(_ context.Context, since, stuckDeadline time.Time, statuses []models.Status) (map[models.Status]store.StatusCensus, error) {
+	m.mu.Lock()
+	rows := append([]*models.TransactionStatus(nil), m.replayRows...)
+	m.mu.Unlock()
+	want := make(map[models.Status]struct{}, len(statuses))
+	out := make(map[models.Status]store.StatusCensus, len(statuses))
+	for _, s := range statuses {
+		want[s] = struct{}{}
+		out[s] = store.StatusCensus{}
+	}
+	for _, r := range rows {
+		if _, ok := want[r.Status]; !ok {
+			continue
+		}
+		if r.Timestamp.Before(since) || !r.Timestamp.Before(stuckDeadline) {
+			continue
+		}
+		c := out[r.Status]
+		c.Count++
+		if c.Oldest.IsZero() || r.Timestamp.Before(c.Oldest) {
+			c.Oldest = r.Timestamp
+		}
+		out[r.Status] = c
+	}
+	return out, nil
 }
 
 func (m *mockStore) updateCount() int {

--- a/services/propagation/reaper.go
+++ b/services/propagation/reaper.go
@@ -67,6 +67,13 @@ const (
 	stuckTransientAge = time.Hour
 )
 
+// errStopReaperWalk stops the IterateStatusesSince scan once the rebroadcast
+// batch is full. It is a control signal, not a failure — reapOnce filters it
+// out of the scan error check. Restoring this early stop (issue #290) is safe
+// because the stuck census no longer rides on the walk; CensusStatusesSince
+// answers it store-side, so the walk only needs a bounded rebroadcast batch.
+var errStopReaperWalk = errors.New("propagation: rebroadcast batch full")
+
 // stuckTransientStatuses are the transient statuses the stuck gauges track.
 // Both are now nudged by the rebroadcast arm below (RECEIVED past
 // staleReceivedAge, ACCEPTED_BY_NETWORK past staleAcceptedByNetworkAge); the
@@ -191,17 +198,20 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 	acceptedDeadline := now.Add(-staleAcceptedByNetworkAge)
 
 	stuckTransientDeadline := now.Add(-stuckTransientAge)
-	type transientStats struct {
-		count  int
-		oldest time.Time
-	}
-	stuckTransient := make(map[models.Status]*transientStats, len(stuckTransientStatuses))
+	// The stuck-transient census (counts + oldest age per status) is resolved
+	// store-side by CensusStatusesSince after the walk, NOT by counting inside
+	// it. Counting in the walk forced it to visit every row so the census
+	// stayed uncapped, which pinned the reaper's cadence to the full-scan time
+	// (~4 min on a ~1.6M-row store) instead of reaper_interval_ms — issue #290.
+	stuckTransientSet := make(map[models.Status]struct{}, len(stuckTransientStatuses))
 	for _, s := range stuckTransientStatuses {
-		stuckTransient[s] = &transientStats{}
+		stuckTransientSet[s] = struct{}{}
 	}
 	// txids of stuck rows to attribute to a callback host after the scan
-	// (bounded by stuckAttributionCap). Collected here — not looked up inline
-	// — so the scan itself stays free of per-row store calls.
+	// (bounded by stuckAttributionCap). Collected in the walk — not looked up
+	// inline — so the scan itself stays free of per-row store calls. Best
+	// effort: the walk stops at the rebroadcast batch, so attribution samples
+	// the leading portion of the backlog.
 	type stuckRef struct {
 		txid   string
 		status models.Status
@@ -210,25 +220,21 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 
 	stuck := make([]propagationMsg, 0, p.rebroadcastBatch)
 	err := p.store.IterateStatusesSince(ctx, since, func(st *models.TransactionStatus) error {
-		// Stuck-transient accounting runs on EVERY row (regardless of RawTx
-		// or the rebroadcast cap): the gauges must be an uncapped census of
-		// txs whose SEEN state-transfer never arrived, including
-		// ACCEPTED_BY_NETWORK rows the rebroadcast arm below never touches.
-		if ts, ok := stuckTransient[st.Status]; ok && st.Timestamp.Before(stuckTransientDeadline) {
-			ts.count++
-			if ts.oldest.IsZero() || st.Timestamp.Before(ts.oldest) {
-				ts.oldest = st.Timestamp
-			}
-			if len(attrib) < stuckAttributionCap {
-				attrib = append(attrib, stuckRef{txid: st.TxID, status: st.Status})
-			}
+		// Best-effort per-callback attribution sample (bounded by
+		// stuckAttributionCap). The census COUNTS come from
+		// CensusStatusesSince below, not from this walk.
+		if _, ok := stuckTransientSet[st.Status]; ok &&
+			st.Timestamp.Before(stuckTransientDeadline) &&
+			len(attrib) < stuckAttributionCap {
+			attrib = append(attrib, stuckRef{txid: st.TxID, status: st.Status})
 		}
 
 		if len(stuck) >= p.rebroadcastBatch {
-			// Rebroadcast batch is full — keep walking for the census, just
-			// stop collecting. (Previously the walk aborted here, which also
-			// capped any counting at the batch size.)
-			return nil
+			// Rebroadcast batch is full — stop the walk (issue #290). The
+			// census no longer needs a full scan (CensusStatusesSince does it
+			// store-side), so a large backlog drains one batch per tick at
+			// reaper_interval_ms cadence instead of a multi-minute full scan.
+			return errStopReaperWalk
 		}
 		if len(st.RawTx) == 0 {
 			// No body to rebroadcast. Pre-reaper-population rows
@@ -271,9 +277,20 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 		stuck = append(stuck, propagationMsg{TXID: st.TxID, RawTx: st.RawTx})
 		return nil
 	})
-	if err != nil && !errors.Is(err, context.Canceled) {
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, errStopReaperWalk) {
 		p.logger.Error("reaper: scan failed", zap.Error(err))
 		return
+	}
+
+	// Resolve the stuck-transient census store-side (one GROUP BY aggregate on
+	// Postgres) so the counts stay uncapped without the walk visiting every
+	// row (issue #290). A census error must not skip the rebroadcast that
+	// follows — the gauges are observability, the drain is the job — so log it
+	// and publish zeroed counts.
+	census, cerr := p.store.CensusStatusesSince(ctx, since, stuckTransientDeadline, stuckTransientStatuses)
+	if cerr != nil {
+		p.logger.Error("reaper: stuck-transient census failed", zap.Error(cerr))
+		census = nil
 	}
 
 	// Publish the post-scan depth on every tick BEFORE the early-return
@@ -298,19 +315,21 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 		zap.Int("reaper_ready_depth", len(stuck)),
 	)
 
-	// Publish the stuck-transient census the same way: every tick, zero
-	// included, so the gauges always reflect the latest completed scan.
-	for status, ts := range stuckTransient {
-		metrics.StuckTransientTxs.WithLabelValues(string(status)).Set(float64(ts.count))
+	// Publish the stuck-transient census every tick, zero included (iterate the
+	// status list, not the result map, so a drained or errored census still
+	// resets the gauges), so they always reflect the latest completed scan.
+	for _, status := range stuckTransientStatuses {
+		c := census[status] // zero value when census is nil or nothing matched
+		metrics.StuckTransientTxs.WithLabelValues(string(status)).Set(float64(c.Count))
 		age := 0.0
-		if !ts.oldest.IsZero() {
-			age = now.Sub(ts.oldest).Seconds()
+		if !c.Oldest.IsZero() {
+			age = now.Sub(c.Oldest).Seconds()
 		}
 		metrics.OldestTransientTxAge.WithLabelValues(string(status)).Set(age)
-		if ts.count > 0 {
+		if c.Count > 0 {
 			p.logger.Warn("reaper: transactions stuck in transient status past threshold",
 				logfields.Status(string(status)),
-				zap.Int("count", ts.count),
+				zap.Int64("count", c.Count),
 				zap.Float64("oldest_age_seconds", age))
 		}
 	}

--- a/services/propagation/reaper_test.go
+++ b/services/propagation/reaper_test.go
@@ -328,6 +328,50 @@ func TestReapOnce_CensusUncappedByRebroadcastBatch(t *testing.T) {
 	}
 }
 
+// TestReapOnce_WalkAbortsAtBatch_NoFullScan pins the issue #290 fix: with the
+// census resolved store-side (CensusStatusesSince), the IterateStatusesSince
+// walk stops once the rebroadcast batch is full instead of scanning the whole
+// table. It seeds far more eligible rows than the batch and asserts the walk
+// visited only ~one batch of rows — so the reaper's cadence is
+// reaper_interval_ms, not the multi-minute full-scan time it regressed to.
+func TestReapOnce_WalkAbortsAtBatch_NoFullScan(t *testing.T) {
+	now := time.Now()
+	stale := now.Add(-2 * time.Hour)
+
+	log := &eventLog{}
+	ms := newMockStore()
+	total := defaultReaperRebroadcastBatch * 4 // far more eligible rows than one batch
+	for i := 0; i < total; i++ {
+		ms.replayRows = append(ms.replayRows, &models.TransactionStatus{
+			TxID:      fmt.Sprintf("recv-%05d", i),
+			Status:    models.StatusReceived,
+			RawTx:     []byte{0x01},
+			Timestamp: stale,
+		})
+	}
+	merkleSrv := newMerkleServer(log, http.StatusOK)
+	defer merkleSrv.Close()
+	teranodeSrv := newTeranodeServer(log, http.StatusOK)
+	defer teranodeSrv.Close()
+
+	p := newPropagator(merkleSrv.URL, teranodeSrv.URL, ms)
+	p.reapOnce(context.Background())
+
+	// The walk visits one batch of rows, then aborts on the next (that row is
+	// counted before fn returns the stop sentinel) → batch+1 at most.
+	if ms.iterated > defaultReaperRebroadcastBatch+1 {
+		t.Errorf("walk visited %d rows, want <= %d (must abort at the batch, not full-scan %d)",
+			ms.iterated, defaultReaperRebroadcastBatch+1, total)
+	}
+	// Census is still uncapped (store-side aggregate sees every row).
+	if got := gaugeVal(t, metrics.StuckTransientTxs, string(models.StatusReceived)); got != float64(total) {
+		t.Errorf("stuck RECEIVED census = %v, want %d (census must be uncapped via CensusStatusesSince)", got, total)
+	}
+	if got := log.count("register:"); got != defaultReaperRebroadcastBatch {
+		t.Errorf("rebroadcast count = %d, want %d", got, defaultReaperRebroadcastBatch)
+	}
+}
+
 // TestReapOnce_RebroadcastBatchConfigurable pins the configurable per-tick
 // rebroadcast cap (the 2026-08-10 incident fix: ~178k txs stuck at RECEIVED
 // could only drain at the hardcoded 200 per tick). With

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -170,6 +170,10 @@ func (s *fakeStore) IterateStatusesSince(context.Context, time.Time, func(*model
 	return nil
 }
 
+func (s *fakeStore) CensusStatusesSince(context.Context, time.Time, time.Time, []models.Status) (map[models.Status]store.StatusCensus, error) {
+	return map[models.Status]store.StatusCensus{}, nil
+}
+
 func (s *fakeStore) SetStatusByBlockHash(context.Context, string, models.Status) ([]string, error) {
 	return nil, nil
 }

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -554,6 +554,72 @@ func (s *Store) IterateStatusesSince(ctx context.Context, _ time.Time, fn func(*
 	}
 }
 
+// CensusStatusesSince pushes the census as far into Aerospike as the client
+// allows: one secondary-index query per requested status (arcade_idx_tx_status,
+// same index GetReadyRetries uses) projecting ONLY the timestamp bin, with the
+// count/min aggregation done over that stream. No raw_tx or full-record
+// transfer, and rows outside the requested statuses are never visited — the
+// full-namespace IterateStatusesSince walk this replaces is what pinned the
+// reaper's cadence to the scan time (issue #290).
+func (s *Store) CensusStatusesSince(ctx context.Context, since, stuckDeadline time.Time, statuses []models.Status) (map[models.Status]store.StatusCensus, error) {
+	out := make(map[models.Status]store.StatusCensus, len(statuses))
+	for _, st := range statuses {
+		out[st] = store.StatusCensus{}
+	}
+	sinceMs := since.UnixMilli()
+	deadlineMs := stuckDeadline.UnixMilli()
+
+	for _, status := range statuses {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		stmt := aero.NewStatement(s.namespace, setTransactions, "timestamp")
+		_ = stmt.SetFilter(aero.NewEqualFilter("status", string(status)))
+
+		rs, err := s.client.Query(s.queryPolicy(ctx), stmt)
+		if err != nil {
+			if rs != nil {
+				_ = rs.Close()
+			}
+			return nil, fmt.Errorf("census query status %s: %w", status, err)
+		}
+
+		census := out[status]
+		var loopErr error
+	loop:
+		for {
+			select {
+			case <-ctx.Done():
+				loopErr = ctx.Err()
+				break loop
+			case rec, ok := <-rs.Results():
+				if !ok {
+					break loop
+				}
+				if rec.Err != nil {
+					loopErr = rec.Err
+					break loop
+				}
+				tsMs := getInt64(rec.Record, "timestamp")
+				if tsMs < sinceMs || tsMs >= deadlineMs {
+					continue
+				}
+				census.Count++
+				ts := time.UnixMilli(tsMs)
+				if census.Oldest.IsZero() || ts.Before(census.Oldest) {
+					census.Oldest = ts
+				}
+			}
+		}
+		_ = rs.Close()
+		if loopErr != nil {
+			return nil, loopErr
+		}
+		out[status] = census
+	}
+	return out, nil
+}
+
 // binOrphAnchors is the transactions-set bin holding the row's orphaned-anchor
 // history as JSON-encoded []orphanedAnchorRecord (Aerospike bin names are
 // capped at 15 chars, hence the abbreviation). Written by SetMinedByTxIDs

--- a/store/pebble/keys.go
+++ b/store/pebble/keys.go
@@ -55,6 +55,12 @@ func idxTxStatusKey(status, txid string) []byte {
 	return []byte(prefixIdxTxStatus + status + ":" + txid)
 }
 
+// idxTxStatusPrefix returns the prefix used to iterate every row currently at
+// one status — the census path's way of never visiting rows in other statuses.
+func idxTxStatusPrefix(status string) []byte {
+	return []byte(prefixIdxTxStatus + status + ":")
+}
+
 func idxTxBlockKey(blockHash, txid string) []byte {
 	return []byte(prefixIdxTxBlock + blockHash + ":" + txid)
 }

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -665,6 +665,55 @@ func (s *Store) IterateStatusesSince(ctx context.Context, since time.Time, fn fu
 	return nil
 }
 
+// CensusStatusesSince walks the per-status index (idx:tx:status:<status>:*)
+// for each requested status, so rows in other statuses — the overwhelming
+// majority of a mature store — are never visited. Each candidate row is read
+// via readStoredStatus (no merkle enrichment) purely for its timestamp; the
+// count/min aggregation happens in place. This replaces the reaper's in-walk
+// census over the full updated-at index (issue #290).
+func (s *Store) CensusStatusesSince(ctx context.Context, since, stuckDeadline time.Time, statuses []models.Status) (map[models.Status]store.StatusCensus, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	out := make(map[models.Status]store.StatusCensus, len(statuses))
+	sinceNs := since.UnixNano()
+	deadlineNs := stuckDeadline.UnixNano()
+
+	for _, status := range statuses {
+		census := store.StatusCensus{}
+		prefix := idxTxStatusPrefix(string(status))
+		iter, err := s.db.NewIter(&pebbledb.IterOptions{
+			LowerBound: prefix,
+			UpperBound: endOfPrefix(prefix),
+		})
+		if err != nil {
+			return nil, err
+		}
+		for iter.First(); iter.Valid(); iter.Next() {
+			if err := ctx.Err(); err != nil {
+				_ = iter.Close()
+				return nil, err
+			}
+			st, err := s.readStoredStatus(lastSegment(iter.Key()))
+			if err != nil || st == nil {
+				continue
+			}
+			if (!since.IsZero() && st.TimestampUnixNs < sinceNs) || st.TimestampUnixNs >= deadlineNs {
+				continue
+			}
+			census.Count++
+			if census.Oldest.IsZero() || st.TimestampUnixNs < census.Oldest.UnixNano() {
+				census.Oldest = time.Unix(0, st.TimestampUnixNs)
+			}
+		}
+		if err := iter.Close(); err != nil {
+			return nil, err
+		}
+		out[status] = census
+	}
+	return out, nil
+}
+
 // SetStatusByBlockHash walks idx:tx:block:<blockHash>:* and rewrites each
 // referenced row with the new status. For SEEN_ON_NETWORK transitions block
 // fields are cleared and the cleared anchor is appended to the row's

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -684,6 +684,47 @@ ORDER BY timestamp_at DESC`
 	return rows.Err()
 }
 
+// CensusStatusesSince is one aggregate round-trip: count + min(timestamp_at)
+// per status over the census window, resolved by the idx_tx_status /
+// idx_tx_updated indexes. The reaper's stuck census over a multi-million-row
+// table must never stream rows through the client (issue #290) — this query
+// is the entire point of the method.
+func (s *Store) CensusStatusesSince(ctx context.Context, since, stuckDeadline time.Time, statuses []models.Status) (map[models.Status]store.StatusCensus, error) {
+	out := make(map[models.Status]store.StatusCensus, len(statuses))
+	if len(statuses) == 0 {
+		return out, nil
+	}
+	names := make([]string, len(statuses))
+	for i, st := range statuses {
+		out[st] = store.StatusCensus{}
+		names[i] = string(st)
+	}
+
+	const q = `
+SELECT status, count(*), min(timestamp_at)
+FROM transactions
+WHERE timestamp_at >= $1 AND timestamp_at < $2 AND status = ANY($3)
+GROUP BY status`
+	rows, err := s.pool.Query(ctx, q, since, stuckDeadline, names)
+	if err != nil {
+		return nil, fmt.Errorf("census statuses since: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			name   string
+			count  int64
+			oldest time.Time
+		)
+		if err := rows.Scan(&name, &count, &oldest); err != nil {
+			return nil, err
+		}
+		out[models.Status(name)] = store.StatusCensus{Count: count, Oldest: oldest}
+	}
+	return out, rows.Err()
+}
+
 // SetStatusByBlockHash rewrites every row in the block. Block fields are
 // cleared on SEEN_ON_NETWORK transitions (reorg path) and kept otherwise —
 // matches the Aerospike / Pebble contract. IMMUTABLE rows are never touched,

--- a/store/store.go
+++ b/store/store.go
@@ -43,6 +43,14 @@ type DatahubEndpoint struct {
 	LastSeen time.Time
 }
 
+// StatusCensus is one status's aggregate in a CensusStatusesSince result:
+// how many rows sit at that status inside the census window, and the minimum
+// timestamp among them (zero when Count is 0).
+type StatusCensus struct {
+	Count  int64
+	Oldest time.Time
+}
+
 // BatchInsertResult is one entry in the result slice returned by
 // BatchGetOrInsertStatus. Inserted is true when the row was newly written by
 // this call; false when an existing row was found and Existing carries it.
@@ -125,6 +133,21 @@ type Store interface {
 	// would otherwise pin a large slice during pruning. fn returning a non-nil
 	// error stops iteration and surfaces that error to the caller.
 	IterateStatusesSince(ctx context.Context, since time.Time, fn func(*models.TransactionStatus) error) error
+
+	// CensusStatusesSince aggregates the stuck-transient census store-side:
+	// for each requested status, the number of transaction rows with
+	// timestamp >= since AND timestamp < stuckDeadline, plus the minimum
+	// timestamp among them. The returned map has exactly one entry per
+	// requested status — zero-valued when nothing matched — so callers can
+	// publish gauges without existence checks.
+	//
+	// This exists so the propagation reaper's census over a multi-million-row
+	// table never streams rows: Postgres answers it with one GROUP BY
+	// aggregate, and other backends push the status filter into their
+	// secondary indexes. Counting inside an IterateStatusesSince walk pinned
+	// the reaper's effective cadence to the full-scan time (~4 minutes on a
+	// ~1.6M-row store) instead of reaper_interval_ms — see issue #290.
+	CensusStatusesSince(ctx context.Context, since, stuckDeadline time.Time, statuses []models.Status) (map[models.Status]StatusCensus, error)
 
 	// SetStatusByBlockHash updates all transactions with the given block hash to a new status.
 	// Returns the txids that were updated. For unmined statuses (SEEN_ON_NETWORK),


### PR DESCRIPTION
Fixes #290.

## Problem

#287 made the reaper's stuck-transient census uncapped by removing the early-abort from the `IterateStatusesSince` walk — so it now streams **every row** each tick. On a ~1.6M-row store that walk takes **~4 minutes**, so the reaper's effective cadence became the scan time, not `reaper_interval_ms`. Observed live on dev-ovh-1 (v0.11.4): one `reaper: rebroadcasting stuck txs count=2000` per ~4 min (**~8 tx/s** durable drain) while the 2000-tx rebroadcast itself completed in **1.4s**. Operators had to raise `reaper_rebroadcast_batch` to 50000 to compensate (teranode-argocd-deployments #206).

## Fix

- New `Store.CensusStatusesSince(ctx, since, stuckDeadline, statuses)` returning per-status `{Count, Oldest}`. Postgres answers it with **one `SELECT status, count(*), min(timestamp_at) ... WHERE timestamp_at >= $1 AND timestamp_at < $2 AND status = ANY($3) GROUP BY status`** — the entire point. Aerospike/Pebble push the status filter into their indexes.
- `reapOnce` resolves the census store-side and **restores the walk's early-abort** at the rebroadcast batch (a sentinel `errStopReaperWalk`, filtered out of the scan error check). The census stays uncapped and exact; the walk visits at most one batch of rows again, so the reaper ticks at `reaper_interval_ms` regardless of table size.

## Behavior preserved

Identical `StuckTransientTxs` / `OldestTransientTxAge` gauges, the "transactions stuck in transient status past threshold" warn, and the `reaper: propagation backlog depth` line. Per-callback attribution is now a bounded best-effort sample of the leading batch (was already capped at `stuckAttributionCap`). A census error logs and publishes zeroed gauges — the rebroadcast still runs (drain is the job).

## Tests

- Existing `TestReapOnce_StuckTransientCensus`, `_ZeroesWhenClear`, `_CensusUncappedByRebroadcastBatch`, `_RebroadcastBatch*` pass unchanged.
- New `TestReapOnce_WalkAbortsAtBatch_NoFullScan`: seeds 4× the batch of eligible rows, asserts the walk visits ≤ batch+1 rows (no full scan) while the census gauge still equals the full total.
- `mockStore.CensusStatusesSince` mirrors the SQL window `[since, stuckDeadline)`.
- `make test` + `make lint` green (CGO/gobdk).

## Deploy note

After this ships (v0.11.5), `reaper_rebroadcast_batch` can be dialed back from the 50000 workaround to ~2000.

Full incident context: go-arcade-toolbox `docs/benchmarks/20260810-three-phase-1500tps-and-ceiling.md`.