### PR TITLE
fix(propagation): surface Teranode reject reasons from non-500 /txs responses

### DIFF
--- a/docs/sse.md
+++ b/docs/sse.md
@@ -64,6 +64,19 @@ data: {"txid":"abc...","txStatus":"MINED","timestamp":"2026-04-28T18:21:52Z","bl
 
 These three fields are omitted from non-mined frames, so pre-`MINED` frames keep the original three-field shape. On a `Last-Event-ID` reconnect, replayed `MINED` frames are enriched with `merklePath` best-effort: to keep the replay path bounded, a single reconnect enriches at most a fixed number of distinct blocks, after which replayed `MINED` frames still carry `blockHash`/`blockHeight` but omit `merklePath` — recover it with `GET /tx/{txid}`.
 
+### Rejected frames carry the reason
+
+When `txStatus` is `REJECTED`, the frame carries the same rejection detail as `GET /tx/{txid}`:
+
+```
+data: {"txid":"abc...","txStatus":"REJECTED","timestamp":"2026-08-10T09:15:02Z","status":466,"extraInfo":"UTXO_SPENT (70): ... utxo already spent by tx 7dfb...[0]"}
+```
+
+- `extraInfo` — the verbatim Teranode validator line that caused the rejection (best available line when peers disagree).
+- `status` — the ARC status code when the line maps to one (466 conflict/double-spend, 467 generic invalid, 476 not-final); omitted when no confident mapping exists.
+
+Both fields are omitted when empty, so existing consumers see no shape change. Reorg-correction frames (see `MINED`/`SEEN_ON_NETWORK` re-anchoring) reuse `extraInfo` for the `reorg_reanchor` / `reorg_unmined` markers.
+
 Every ~15 seconds the server emits a `: keepalive` comment frame so idle proxies don't kill the connection. Comment frames have no `event:` and should be ignored by clients.
 
 ## Browser (`EventSource`)

--- a/services/propagation/classify_test.go
+++ b/services/propagation/classify_test.go
@@ -68,3 +68,32 @@ func TestClassifyFailureLine(t *testing.T) {
 		})
 	}
 }
+
+// TestPreferRejectionLine ensures multi-peer aggregation keeps the best
+// wallet-facing reason rather than first-writer-wins.
+func TestPreferRejectionLine(t *testing.T) {
+	processing := "PROCESSING (4): [ProcessTransaction][ab] failed to validate transaction"
+	utxoSpent := "UTXO_SPENT (70): [ProcessTransaction][ab] utxo already spent"
+	txInvalid := "TX_INVALID (31): [ProcessTransaction][ab] bad fee"
+	opaque := "malformed peer body"
+	cases := []struct {
+		name      string
+		current   string
+		candidate string
+		want      string
+	}{
+		{name: "empty current takes candidate", current: "", candidate: processing, want: processing},
+		{name: "empty candidate keeps current", current: processing, candidate: "", want: processing},
+		{name: "UTXO_SPENT beats PROCESSING", current: processing, candidate: utxoSpent, want: utxoSpent},
+		{name: "PROCESSING beats opaque", current: opaque, candidate: processing, want: processing},
+		{name: "TX_INVALID beats PROCESSING", current: processing, candidate: txInvalid, want: txInvalid},
+		{name: "equal score keeps current", current: processing + " a", candidate: processing + " b", want: processing + " a"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := preferRejectionLine(tc.current, tc.candidate); got != tc.want {
+				t.Errorf("preferRejectionLine(%q, %q) = %q, want %q", tc.current, tc.candidate, got, tc.want)
+			}
+		})
+	}
+}

--- a/services/propagation/classify_test.go
+++ b/services/propagation/classify_test.go
@@ -45,6 +45,25 @@ func TestClassifyFailureLine(t *testing.T) {
 			wantCode: 466,
 		},
 		{
+			name:     "utxo spent maps to conflict 466",
+			line:     "UTXO_SPENT (70): [ProcessTransaction][ab12] utxo already spent by tx cd34",
+			wantCode: 466,
+		},
+		{
+			// Exact doubled-prefix shape observed on mainnet 409 responses:
+			// the code name appears twice because Teranode wraps the inner
+			// error's UserMessage. strings.Cut on the first " (" still
+			// recovers the code.
+			name:     "doubled UTXO_SPENT prefix (live 409 shape) maps to conflict 466",
+			line:     "UTXO_SPENT (70): UTXO_SPENT (70): 256f...ae43:2 utxo already spent by tx 7dfb...8489[0]",
+			wantCode: 466,
+		},
+		{
+			name:     "tx invalid double spend maps to conflict 466",
+			line:     "TX_INVALID_DOUBLE_SPEND (32): [ProcessTransaction][ab12] tx invalid double spend",
+			wantCode: 466,
+		},
+		{
 			name: "unknown code name stays uncoded",
 			line: "SOME_FUTURE_CODE (99): [ProcessTransaction][ab12] who knows",
 		},
@@ -85,8 +104,23 @@ func TestPreferRejectionLine(t *testing.T) {
 		{name: "empty current takes candidate", current: "", candidate: processing, want: processing},
 		{name: "empty candidate keeps current", current: processing, candidate: "", want: processing},
 		{name: "UTXO_SPENT beats PROCESSING", current: processing, candidate: utxoSpent, want: utxoSpent},
+		{name: "UTXO_SPENT beats TX_INVALID", current: txInvalid, candidate: utxoSpent, want: utxoSpent},
 		{name: "PROCESSING beats opaque", current: opaque, candidate: processing, want: processing},
 		{name: "TX_INVALID beats PROCESSING", current: processing, candidate: txInvalid, want: txInvalid},
+		{
+			// A code this build doesn't know is still a concrete verdict:
+			// better than the PROCESSING catch-all, worse than a known code.
+			name:      "unknown code beats PROCESSING",
+			current:   processing,
+			candidate: "SOME_FUTURE_CODE (99): [ProcessTransaction][ab] specific reason",
+			want:      "SOME_FUTURE_CODE (99): [ProcessTransaction][ab] specific reason",
+		},
+		{
+			name:      "TX_INVALID beats unknown code",
+			current:   "SOME_FUTURE_CODE (99): [ProcessTransaction][ab] specific reason",
+			candidate: txInvalid,
+			want:      txInvalid,
+		},
 		{name: "equal score keeps current", current: processing + " a", candidate: processing + " b", want: processing + " a"},
 	}
 	for _, tc := range cases {
@@ -95,5 +129,42 @@ func TestPreferRejectionLine(t *testing.T) {
 				t.Errorf("preferRejectionLine(%q, %q) = %q, want %q", tc.current, tc.candidate, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestFailureLinesForLog pins the operator-log contract: nil for empty
+// input, at most 8 lines, and most-informative-first ordering so the cap
+// drops PROCESSING catch-alls before concrete validator verdicts —
+// deterministic across map iteration order.
+func TestFailureLinesForLog(t *testing.T) {
+	if got := failureLinesForLog(nil); got != nil {
+		t.Errorf("failureLinesForLog(nil) = %v, want nil", got)
+	}
+	if got := failureLinesForLog(map[string]string{}); got != nil {
+		t.Errorf("failureLinesForLog(empty) = %v, want nil", got)
+	}
+
+	failures := make(map[string]string, 10)
+	for i := 0; i < 9; i++ {
+		key := strings.Repeat(string(rune('a'+i)), 64)
+		failures[key] = "PROCESSING (4): [ProcessTransaction][" + key + "] failed to validate transaction"
+	}
+	spentKey := strings.Repeat("f", 64)
+	spentLine := "UTXO_SPENT (70): [ProcessTransaction][" + spentKey + "] utxo already spent"
+	failures[spentKey] = spentLine
+
+	got := failureLinesForLog(failures)
+	if len(got) != 8 {
+		t.Fatalf("len=%d want 8 (cap)", len(got))
+	}
+	if got[0] != spentLine {
+		t.Errorf("got[0]=%q — the UTXO_SPENT line must survive the cap and sort first", got[0])
+	}
+	// Determinism: same input, same output, regardless of map iteration.
+	again := failureLinesForLog(failures)
+	for i := range got {
+		if got[i] != again[i] {
+			t.Fatalf("non-deterministic output at index %d: %q vs %q", i, got[i], again[i])
+		}
 	}
 }

--- a/services/propagation/health_test.go
+++ b/services/propagation/health_test.go
@@ -516,6 +516,257 @@ func TestBroadcast_422RejectionSurfacesExtraInfo(t *testing.T) {
 	}
 }
 
+// TestBroadcast_422PartialFailureList_ImplicitAccept pins the riskiest
+// semantics the status-agnostic parse enables: a single 422 whose failure
+// list names ONE tx is a whole-batch verdict — the named tx is REJECTED and
+// every unnamed tx is terminally ACCEPTED_BY_NETWORK on that peer's implicit
+// accept. Previously pinned only for HTTP 500.
+func TestBroadcast_422PartialFailureList_ImplicitAccept(t *testing.T) {
+	const (
+		txidRejected = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		txidAccepted = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte("Failed to process transactions:\n" +
+			"TX_INVALID (31): [ProcessTransaction][" + txidRejected + "] bad fee\n"))
+	}))
+	defer srv.Close()
+
+	ms := newMockStore()
+	cfg := &config.Config{}
+	cfg.Propagation.MerkleConcurrency = 10
+	tc := teranode.NewClient([]string{srv.URL}, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
+	p := New(cfg, zap.NewNop(), nil, nil, ms, nil, tc, nil)
+
+	for _, txid := range []string{txidRejected, txidAccepted} {
+		if err := p.handleMessage(context.Background(), consumerMsg(makePropMsg(txid))); err != nil {
+			t.Fatalf("handleMessage(%s): %v", txid, err)
+		}
+	}
+	if err := flushSync(t, p); err != nil {
+		t.Fatalf("flush error: %v", err)
+	}
+
+	if got := ms.lastUpdateForTxid(txidRejected); got == nil || got.Status != models.StatusRejected {
+		t.Errorf("txidRejected: got %v, want REJECTED", got)
+	}
+	if got := ms.lastUpdateForTxid(txidAccepted); got == nil || got.Status != models.StatusAcceptedByNetwork {
+		t.Errorf("txidAccepted: got %v, want ACCEPTED_BY_NETWORK", got)
+	}
+}
+
+// TestBatchBroadcastFailedLog_IncludesFailureLines pins the operator-
+// visibility half of the fix: the "batch broadcast endpoint failed" warn for
+// a peer whose response parsed into a failure list must carry
+// failure_count/failure_lines (previously the structured verdict was hidden
+// off err once parsed), while an opaque-body peer's warn must NOT grow those
+// fields.
+func TestBatchBroadcastFailedLog_IncludesFailureLines(t *testing.T) {
+	const txid = "d018bc98d7828b7f095e5d616f7ccba607fc228368e82e74b25304e37699f1e9"
+	srvVerdict := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte("Failed to process transactions:\n" +
+			"PROCESSING (4): [ProcessTransaction][" + txid + "] failed to validate transaction\n"))
+	}))
+	defer srvVerdict.Close()
+	srvOpaque := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("error code: 502\n"))
+	}))
+	defer srvOpaque.Close()
+
+	core, recorded := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core)
+
+	ms := newMockStore()
+	cfg := &config.Config{}
+	cfg.Propagation.MerkleConcurrency = 10
+	tc := teranode.NewClient([]string{srvVerdict.URL, srvOpaque.URL}, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
+	p := New(cfg, logger, nil, nil, ms, nil, tc, nil)
+
+	if err := p.handleMessage(context.Background(), consumerMsg(makePropMsg(txid))); err != nil {
+		t.Fatalf("handleMessage: %v", err)
+	}
+	if err := flushSync(t, p); err != nil {
+		t.Fatalf("flush error: %v", err)
+	}
+
+	entries := recorded.FilterMessage("batch broadcast endpoint failed").All()
+	if len(entries) != 2 {
+		t.Fatalf("want 2 'batch broadcast endpoint failed' warns, got %d", len(entries))
+	}
+	for _, e := range entries {
+		fields := make(map[string]interface{}, len(e.Context))
+		for _, f := range e.Context {
+			fields[f.Key] = f
+		}
+		endpoint := ""
+		for _, f := range e.Context {
+			if f.Key == "endpoint" {
+				endpoint = f.String
+			}
+		}
+		_, hasLines := fields["failure_lines"]
+		switch endpoint {
+		case srvVerdict.URL:
+			if !hasLines {
+				t.Errorf("verdict peer warn missing failure_lines: %+v", e.Context)
+			}
+		case srvOpaque.URL:
+			if hasLines {
+				t.Errorf("opaque peer warn must not carry failure_lines: %+v", e.Context)
+			}
+		default:
+			t.Errorf("unexpected endpoint %q in warn", endpoint)
+		}
+	}
+}
+
+// TestBroadcast_422RejectionLosesToAcceptance pins sticky acceptance across
+// the NEW parse path: a peer that 200-accepts the batch must win over a peer
+// that 422-rejects the tx with a parseable failure list. Guards against the
+// status-agnostic parse accidentally making 4xx verdicts override real
+// acceptance (rejection votes only matter when NO peer accepts).
+func TestBroadcast_422RejectionLosesToAcceptance(t *testing.T) {
+	const txid = "d018bc98d7828b7f095e5d616f7ccba607fc228368e82e74b25304e37699f1e9"
+	srvAccept := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srvAccept.Close()
+	srvReject := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte("Failed to process transactions:\n" +
+			"PROCESSING (4): [ProcessTransaction][" + txid + "] failed to validate transaction\n"))
+	}))
+	defer srvReject.Close()
+
+	ms := newMockStore()
+	cfg := &config.Config{}
+	cfg.Propagation.MerkleConcurrency = 10
+	tc := teranode.NewClient([]string{srvReject.URL, srvAccept.URL}, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
+	p := New(cfg, zap.NewNop(), nil, nil, ms, nil, tc, nil)
+
+	if err := p.handleMessage(context.Background(), consumerMsg(makePropMsg(txid))); err != nil {
+		t.Fatalf("handleMessage: %v", err)
+	}
+	if err := flushSync(t, p); err != nil {
+		t.Fatalf("flush error: %v", err)
+	}
+
+	got := ms.lastUpdateForTxid(txid)
+	if got == nil {
+		t.Fatal("no status update recorded")
+	}
+	if got.Status != models.StatusAcceptedByNetwork {
+		t.Errorf("status=%s want ACCEPTED_BY_NETWORK (acceptance is sticky; extraInfo=%q)", got.Status, got.ExtraInfo)
+	}
+}
+
+// TestBroadcast_409AlienConflict_SingleTxTerminalizes pins the mainnet
+// incident shape end to end: batch_size=1, one peer answers HTTP 409 with a
+// wrapper-less conflict verdict whose hashes name the spent OUTPOINT and the
+// competing spender — NOT the submitted txid ("UTXO_SPENT (70): UTXO_SPENT
+// (70): <outpoint>:2 utxo already spent by tx <spender>[0]"). The failure
+// map therefore keys under an alien hash. A naive "absent from map ⇒
+// accepted" read would mark the submitted tx ACCEPTED_BY_NETWORK off its own
+// rejection; the single-tx attribution rule must instead terminalize it
+// REJECTED with the conflict line as ExtraInfo and ARC 466 (StatusConflict).
+func TestBroadcast_409AlienConflict_SingleTxTerminalizes(t *testing.T) {
+	const (
+		txid     = "e3b7a2c260168429b20ad85f746ae09c2e41f6a1d79877a8810832cdf732e703"
+		outpoint = "256fc7143c6ef5436cd5258ade24b68c43d0f8268c086bd9fa90055dd5a7ae43"
+		spender  = "7dfbe0fcacf630066b23036bc007e73d58a61ab9bcb8e66f6b214f8ef5f28489"
+	)
+	conflictBody := "Failed to process transactions:\n" +
+		"UTXO_SPENT (70): UTXO_SPENT (70): " + outpoint + ":2 utxo already spent by tx " + spender + "[0]\n"
+
+	srvConflict := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(conflictBody))
+	}))
+	defer srvConflict.Close()
+	srv502 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("error code: 502\n"))
+	}))
+	defer srv502.Close()
+
+	ms := newMockStore()
+	cfg := &config.Config{}
+	cfg.Propagation.MerkleConcurrency = 10
+	tc := teranode.NewClient(
+		[]string{srv502.URL, srvConflict.URL},
+		"",
+		teranode.HealthConfig{FailureThreshold: 1 << 20},
+	)
+	p := New(cfg, zap.NewNop(), nil, nil, ms, nil, tc, nil)
+
+	if err := p.handleMessage(context.Background(), consumerMsg(makePropMsg(txid))); err != nil {
+		t.Fatalf("handleMessage: %v", err)
+	}
+	if err := flushSync(t, p); err != nil {
+		t.Fatalf("flush error: %v", err)
+	}
+
+	got := ms.lastUpdateForTxid(txid)
+	if got == nil {
+		t.Fatal("no status update recorded")
+	}
+	if got.Status != models.StatusRejected {
+		t.Fatalf("status=%s want REJECTED (extraInfo=%q)", got.Status, got.ExtraInfo)
+	}
+	if got.StatusCode != 466 {
+		t.Errorf("StatusCode=%d want 466 (ARC StatusConflict)", got.StatusCode)
+	}
+	if !strings.Contains(got.ExtraInfo, "UTXO_SPENT") || !strings.Contains(got.ExtraInfo, spender) {
+		t.Errorf("ExtraInfo=%q want the UTXO_SPENT line naming the competing spender", got.ExtraInfo)
+	}
+}
+
+// TestBroadcast_409AlienConflict_MultiTxWithholdsAccepts covers the
+// multi-tx half of the alien-line rule: a 409 failure list whose only line
+// names no submitted tx means SOME tx in the batch was rejected but we can't
+// tell which — so the peer must grant no implicit acceptance votes, and with
+// no other peer voting, both txs requeue rather than either terminalizing
+// (no fabricated ACCEPTED_BY_NETWORK, no misattributed REJECTED).
+func TestBroadcast_409AlienConflict_MultiTxWithholdsAccepts(t *testing.T) {
+	const (
+		txidA    = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		txidB    = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		outpoint = "256fc7143c6ef5436cd5258ade24b68c43d0f8268c086bd9fa90055dd5a7ae43"
+		spender  = "7dfbe0fcacf630066b23036bc007e73d58a61ab9bcb8e66f6b214f8ef5f28489"
+	)
+	srvConflict := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte("Failed to process transactions:\n" +
+			"UTXO_SPENT (70): UTXO_SPENT (70): " + outpoint + ":2 utxo already spent by tx " + spender + "[0]\n"))
+	}))
+	defer srvConflict.Close()
+
+	ms := newMockStore()
+	cfg := &config.Config{}
+	cfg.Propagation.MerkleConcurrency = 10
+	tc := teranode.NewClient([]string{srvConflict.URL}, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
+	p := New(cfg, zap.NewNop(), nil, nil, ms, nil, tc, nil)
+
+	for _, txid := range []string{txidA, txidB} {
+		if err := p.handleMessage(context.Background(), consumerMsg(makePropMsg(txid))); err != nil {
+			t.Fatalf("handleMessage(%s): %v", txid, err)
+		}
+	}
+	if err := flushSync(t, p); err != nil {
+		t.Fatalf("flush error: %v", err)
+	}
+
+	for _, txid := range []string{txidA, txidB} {
+		if got := ms.lastUpdateForTxid(txid); got != nil &&
+			(got.Status == models.StatusAcceptedByNetwork || got.Status == models.StatusRejected) {
+			t.Errorf("%s: terminalized as %s (extraInfo=%q); alien-keyed 409 must requeue, not vote", txid, got.Status, got.ExtraInfo)
+		}
+	}
+}
+
 // TestBroadcast_PerPeerAggregation_UnanimousRejection covers the other
 // half: when every peer that gave us a parseable response named the same
 // tx as failed, the tx is REJECTED. Two endpoints both 500 with the

--- a/services/propagation/health_test.go
+++ b/services/propagation/health_test.go
@@ -453,6 +453,69 @@ func TestBroadcast_PerPeerAggregation_AcceptanceWins(t *testing.T) {
 	}
 }
 
+// TestBroadcast_422RejectionSurfacesExtraInfo pins the production gap where
+// one peer returned HTTP 422 + a parseable Teranode failure list (the real
+// validator verdict for a spent-UTXO / invalid tx) while other peers returned
+// opaque gateway 502/500 with no body. Pre-fix the 422 body was discarded
+// (client only parsed status 500), so the tx either requeued forever or —
+// worse — never carried the PROCESSING/UTXO_SPENT line into GET /tx ExtraInfo.
+// Post-fix: REJECTED with the Teranode line as ExtraInfo.
+func TestBroadcast_422RejectionSurfacesExtraInfo(t *testing.T) {
+	const txid = "d018bc98d7828b7f095e5d616f7ccba607fc228368e82e74b25304e37699f1e9"
+	verdictBody := "Failed to process transactions:\n" +
+		"PROCESSING (4): [ProcessTransaction][" + txid + "] failed to validate transaction\n"
+
+	// Peer A: the only peer that actually validated — 422 + failure list.
+	srvVerdict := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(verdictBody))
+	}))
+	defer srvVerdict.Close()
+	// Peer B/C: gateway noise that must NOT become ExtraInfo and must NOT
+	// silence the 422 verdict.
+	srv502 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("error code: 502\n"))
+	}))
+	defer srv502.Close()
+	srv503 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("no available server\n"))
+	}))
+	defer srv503.Close()
+
+	ms := newMockStore()
+	cfg := &config.Config{}
+	cfg.Propagation.MerkleConcurrency = 10
+	tc := teranode.NewClient(
+		[]string{srv502.URL, srv503.URL, srvVerdict.URL},
+		"",
+		teranode.HealthConfig{FailureThreshold: 1 << 20},
+	)
+	p := New(cfg, zap.NewNop(), nil, nil, ms, nil, tc, nil)
+
+	if err := p.handleMessage(context.Background(), consumerMsg(makePropMsg(txid))); err != nil {
+		t.Fatalf("handleMessage: %v", err)
+	}
+	if err := flushSync(t, p); err != nil {
+		t.Fatalf("flush error: %v", err)
+	}
+
+	got := ms.lastUpdateForTxid(txid)
+	if got == nil {
+		t.Fatal("no status update recorded")
+	}
+	if got.Status != models.StatusRejected {
+		t.Fatalf("status=%s want REJECTED (extraInfo=%q)", got.Status, got.ExtraInfo)
+	}
+	if !strings.Contains(got.ExtraInfo, "PROCESSING (4)") {
+		t.Errorf("ExtraInfo=%q want Teranode PROCESSING line (not gateway 502/503 body)", got.ExtraInfo)
+	}
+	if strings.Contains(got.ExtraInfo, "no available server") || strings.Contains(got.ExtraInfo, "502") {
+		t.Errorf("ExtraInfo leaked opaque gateway text: %q", got.ExtraInfo)
+	}
+}
+
 // TestBroadcast_PerPeerAggregation_UnanimousRejection covers the other
 // half: when every peer that gave us a parseable response named the same
 // tx as failed, the tx is REJECTED. Two endpoints both 500 with the

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -184,15 +184,18 @@ type broadcastJob struct {
 type broadcastJobResult struct {
 	endpoint   string
 	statusCode int
-	// failures is the per-txid failure map extracted from a /txs HTTP 500
+	// failures is the per-txid failure map extracted from a non-200 /txs
 	// "Failed to process transactions:" body (Teranode upstream main, post
-	// #879). Each entry is keyed by the txid embedded in
-	// "[ProcessTransaction][<txid>]" and the value is the full error line
+	// #879; the HTTP status varies by failure class — 409/422/400/500 all
+	// carry the same shape). Each entry is keyed by the txid embedded in
+	// "[ProcessTransaction][<txid>]" when present, else the first bare
+	// 64-hex string in the line (which for conflict-family verdicts is an
+	// alien hash — see alienFailureLines); the value is the full error line
 	// verbatim (e.g. "TX_INVALID (31): [ProcessTransaction][<txid>] tx is
-	// invalid because..."). Absent here means accepted (after a peer 500).
-	// nil for 200, transport errors, and any 5xx that doesn't match the
-	// Teranode failure-list shape — those cases drive the whole-batch
-	// requeue path.
+	// invalid because..."). Absent here means accepted — but only when no
+	// alien-keyed line voids that contract for the peer. nil for 200,
+	// transport errors, and any non-200 that doesn't match the Teranode
+	// failure-list shape — those cases drive the whole-batch requeue path.
 	failures map[string]string
 	err      error
 }
@@ -1030,8 +1033,10 @@ type txResult struct {
 }
 
 // failureLinesForLog returns a stable, capped list of Teranode failure lines
-// for structured logging. Keys are ignored; order is sorted so log output is
-// deterministic across map iteration.
+// for structured logging. Keys are ignored; lines are ordered most-informative
+// first (rejectionLineScore, ties broken lexicographically) so the cap keeps
+// the concrete validator verdicts (UTXO_SPENT, TX_CONFLICTING, …) and drops
+// PROCESSING catch-alls, not the reverse. Deterministic across map iteration.
 func failureLinesForLog(failures map[string]string) []string {
 	const maxLines = 8
 	if len(failures) == 0 {
@@ -1041,7 +1046,13 @@ func failureLinesForLog(failures map[string]string) []string {
 	for _, line := range failures {
 		lines = append(lines, line)
 	}
-	sort.Strings(lines)
+	sort.Slice(lines, func(i, j int) bool {
+		si, sj := rejectionLineScore(lines[i]), rejectionLineScore(lines[j])
+		if si != sj {
+			return si > sj
+		}
+		return lines[i] < lines[j]
+	})
 	if len(lines) > maxLines {
 		lines = lines[:maxLines]
 	}
@@ -1067,6 +1078,31 @@ func preferRejectionLine(current, candidate string) string {
 	return current
 }
 
+// alienFailureLines scans one peer's parsed failure map for lines whose key
+// does not name any tx in the submitted batch, returning how many such lines
+// exist and the most informative one (preferRejectionLine ordering).
+//
+// Alien keys are expected, not a parser bug: Teranode's conflict-family
+// verdicts (UTXO_SPENT / TX_CONFLICTING / TX_INVALID_DOUBLE_SPEND, HTTP 409)
+// render the deepest public cause, whose message names the spent OUTPOINT's
+// txid and the competing spender — never the submitted txid (no
+// [ProcessTransaction][<txid>] wrapper; see teranode
+// errors/error_data_utxo_spent.go + errors.UserMessage). The parse then keys
+// the line under a hash that isn't in the batch. Any alien line voids the
+// failure map's "absent ⇒ accepted" contract for that peer: exactly one
+// submitted tx DID fail per line, we just can't tell which, so implicit
+// acceptance votes would fabricate an ACCEPTED_BY_NETWORK for the very tx
+// the peer rejected.
+func alienFailureLines(failures map[string]string, inBatch map[string]bool) (count int, best string) {
+	for key, line := range failures {
+		if !inBatch[key] {
+			count++
+			best = preferRejectionLine(best, line)
+		}
+	}
+	return count, best
+}
+
 // rejectionLineScore ranks a Teranode failure line for wallet-facing quality.
 // Higher is better. Unknown free text scores 0.
 func rejectionLineScore(line string) int {
@@ -1083,11 +1119,14 @@ func rejectionLineScore(line string) int {
 		return 30
 	case "PROCESSING":
 		// Catch-all "this tx is bad" wrapper — better than opaque infra text,
-		// worse than a specific validator code.
+		// worse than any concrete validator code.
 		return 20
 	default:
-		// Recognizable "<NAME> (n):" shape but not a known code.
-		return 10
+		// Recognizable "<NAME> (n):" shape but not a code this list knows —
+		// e.g. a Teranode code added after this build. Still a concrete
+		// verdict, so it outranks the PROCESSING catch-all but never a
+		// known code.
+		return 25
 	}
 }
 
@@ -1117,7 +1156,13 @@ func rejectionLineScore(line string) int {
 //	  peer's tip catches up) is expected to succeed, so the message gains an
 //	  explicit retryable hint. (Intake's finality gate catches most of these
 //	  against arcade's own tip; a line here means the peer's view trails.)
-//	TX_CONFLICTING (36) → 466 StatusConflict (double-spend attempt).
+//	TX_CONFLICTING (36), UTXO_SPENT (70), TX_INVALID_DOUBLE_SPEND →
+//	  466 StatusConflict (double-spend attempt / input already spent).
+//	  Teranode's own /txs handler groups exactly these under HTTP 409
+//	  Conflict (httpStatusForTxError, services/propagation/Server.go), so
+//	  the 466 mapping mirrors the upstream classification. Wallets branch
+//	  on 466 to decide "do NOT blind-release these inputs" — the outpoint
+//	  is owned by a competing/confirmed tx, not merely unaccepted.
 //	TX_INVALID (31)     → 467 StatusGeneric (wraps fee/script/policy — the
 //	  name alone can't recover which).
 //	PROCESSING (4) and everything else → 0, message verbatim.
@@ -1133,7 +1178,7 @@ func classifyFailureLine(line string) (errMsg string, arcCode int) {
 	case "TX_LOCK_TIME", "UTXO_NON_FINAL":
 		return line + " — retryable: the transaction is not final against this peer's chain view; resubmit after the locktime expires",
 			int(arcerrors.StatusNotFinal)
-	case "TX_CONFLICTING":
+	case "TX_CONFLICTING", "UTXO_SPENT", "TX_INVALID_DOUBLE_SPEND":
 		return line, int(arcerrors.StatusConflict)
 	case "TX_INVALID":
 		return line, int(arcerrors.StatusGeneric)
@@ -1608,18 +1653,26 @@ func (p *Propagator) submitBroadcastJobs(ctx context.Context, endpoints []string
 //
 //   - HTTP 200 from a peer → that peer accepted the whole batch, so
 //     every tx in the batch gets a sticky acceptance vote.
-//   - Non-2xx with a parseable "Failed to process transactions:" body
-//     (HTTP status is NOT part of the contract — Teranode often uses 500,
-//     but some deployments/proxies return 422/4xx with the same body) →
+//   - Non-200 with a parseable "Failed to process transactions:" body
+//     (HTTP status is NOT part of the contract — Teranode's own /txs
+//     handler returns 409 for the conflict family, 400/422 for policy
+//     failures, and 500 only for unclassified server faults, all with the
+//     same body shape; see httpStatusForTxError in Teranode's
+//     services/propagation/Server.go) →
 //     that peer rejected the listed txids and accepted the rest. Each
 //     accepted tx gets an acceptance vote; each rejected tx gets a
 //     rejection vote carrying the verbatim Teranode error line (this is
 //     what lands in the wallet-visible ExtraInfo / SSE payload).
-//   - Non-2xx with no parseable body (gateway 502/503 "no available
-//     server", bare 500, network error), or no healthy endpoints → no
-//     per-tx information from that peer. These must NEVER become the
-//     terminal ExtraInfo on their own — they are infra noise, not a
-//     validator verdict.
+//     Implicit acceptance is only trusted when every failure line named a
+//     submitted tx; conflict-family lines key under alien hashes (spent
+//     outpoint / competing spender — no [ProcessTransaction] wrapper), in
+//     which case the peer grants no implicit accepts, and a single-tx
+//     batch attributes the alien verdict to its only tx.
+//   - Non-200 with no parseable body (gateway 502/503 "no available
+//     server", bare 500, truncated body, network error, unexpected
+//     2xx-but-not-200), or no healthy endpoints → no per-tx information
+//     from that peer. These must NEVER become the terminal ExtraInfo on
+//     their own — they are infra noise, not a validator verdict.
 //
 // After all responses are in (or the 15s submitCtx timeout fires), each
 // tx is classified:
@@ -1634,11 +1687,16 @@ func (p *Propagator) submitBroadcastJobs(ctx context.Context, endpoints []string
 // so a returned line cannot be reliably distinguished from a transient
 // infra issue by code.
 //
-// Per-endpoint outcomes are recorded into the circuit-breaker regardless
-// of verdict so a peer returning 500 doesn't get sidelined when the
-// 500 was a per-tx verdict, not the peer's fault. The returned
-// successEndpoint is the URL of the first peer that returned HTTP 200
-// (empty when none did).
+// Per-endpoint outcomes are recorded into the circuit-breaker. A peer
+// whose non-2xx carried a per-tx verdict is shielded from sidelining only
+// when NO peer accepted (the unanimous-reject branch of
+// recordBroadcastOutcomes resets its counters); when another peer
+// 2xx-accepts the same batch, a rejecting peer still accrues
+// RecordBroadcastFailure — acceptable, since a healthy peer's next 2xx
+// resets the counter, and a peer that persistently rejects batches its
+// siblings accept is exactly the slow-track breaker's target. The
+// returned successEndpoint is the URL of the first peer that returned
+// HTTP 200 (empty when none did).
 func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]byte, batch []propagationMsg) (results []txResult, successEndpoint string) {
 	start := time.Now()
 	defer func() {
@@ -1661,10 +1719,13 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 
 	// Precompute lowercase txids so failure-map lookups against
 	// Teranode's lower-cased keys don't allocate inside the per-result
-	// loop below.
+	// loop below. inBatch answers the reverse lookup — "does this failure
+	// key name a tx we actually submitted?" — for alien-line detection.
 	lowerTxids := make([]string, len(batch))
+	inBatch := make(map[string]bool, len(batch))
 	for i, msg := range batch {
 		lowerTxids[i] = strings.ToLower(msg.TXID)
+		inBatch[lowerTxids[i]] = true
 	}
 
 	// Per-tx accumulation across every peer response. Acceptance is
@@ -1738,12 +1799,41 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 		// reject the same tx with different lines, keep the most
 		// informative one (specific Teranode codes over PROCESSING over
 		// opaque text) so GET /tx ExtraInfo is useful to wallets.
+		//
+		// The "absent from map ⇒ accepted" half of the contract only holds
+		// when every failure line named a tx we submitted. Conflict-family
+		// lines (UTXO_SPENT et al., HTTP 409) name the spent outpoint / the
+		// competing spender instead of the submitted txid, so they key
+		// under an alien hash — see alienFailureLines. One alien line means
+		// one unidentifiable submitted tx DID fail; granting implicit
+		// accepts would mark that very tx ACCEPTED_BY_NETWORK.
+		alienCount, bestAlien := alienFailureLines(result.failures, inBatch)
+		if alienCount > 0 {
+			p.logger.Warn(
+				"teranode failure lines name no submitted tx; withholding implicit accepts from this peer",
+				zap.String("endpoint", result.endpoint),
+				zap.Int("batch_size", len(batch)),
+				zap.Int("alien_line_count", alienCount),
+				zap.String("best_alien_line", bestAlien),
+			)
+		}
 		for j, lower := range lowerTxids {
 			if line, failed := result.failures[lower]; failed {
 				rejectionLine[j] = preferRejectionLine(rejectionLine[j], line)
-			} else {
+			} else if alienCount == 0 {
 				acceptedByAny[j] = true
 			}
+		}
+		// A single-tx batch has exactly one possible owner for an alien
+		// verdict — the tx itself. Terminalize it with the real reason
+		// (this is the mainnet incident shape: batch_size=1, HTTP 409,
+		// wrapper-less "UTXO_SPENT (70): <outpoint> utxo already spent by
+		// tx <spender>[0]"). Multi-tx batches can't attribute alien lines,
+		// so affected txs simply get no vote from this peer and requeue
+		// unless another peer produces a verdict — the safe pre-fix
+		// behavior, now with the alien reason visible in the Warn log.
+		if alienCount > 0 && len(batch) == 1 {
+			rejectionLine[0] = preferRejectionLine(rejectionLine[0], bestAlien)
 		}
 	}
 	recordBroadcastOutcomes(p.teranodeClient, outcomes)

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1028,6 +1029,68 @@ type txResult struct {
 	successEndpoint string
 }
 
+// failureLinesForLog returns a stable, capped list of Teranode failure lines
+// for structured logging. Keys are ignored; order is sorted so log output is
+// deterministic across map iteration.
+func failureLinesForLog(failures map[string]string) []string {
+	const maxLines = 8
+	if len(failures) == 0 {
+		return nil
+	}
+	lines := make([]string, 0, len(failures))
+	for _, line := range failures {
+		lines = append(lines, line)
+	}
+	sort.Strings(lines)
+	if len(lines) > maxLines {
+		lines = lines[:maxLines]
+	}
+	return lines
+}
+
+// preferRejectionLine chooses which peer rejection line to keep when several
+// endpoints reject the same tx. Higher score wins; equal score keeps the
+// current (first-writer) line for stability. Ranking prefers concrete
+// Teranode validator codes (UTXO_SPENT, TX_CONFLICTING, TX_INVALID, …) over
+// the PROCESSING catch-all over opaque free text, so wallet-visible ExtraInfo
+// carries the best available reason rather than whichever peer responded first.
+func preferRejectionLine(current, candidate string) string {
+	if candidate == "" {
+		return current
+	}
+	if current == "" {
+		return candidate
+	}
+	if rejectionLineScore(candidate) > rejectionLineScore(current) {
+		return candidate
+	}
+	return current
+}
+
+// rejectionLineScore ranks a Teranode failure line for wallet-facing quality.
+// Higher is better. Unknown free text scores 0.
+func rejectionLineScore(line string) int {
+	name, _, found := strings.Cut(line, " (")
+	if !found {
+		return 0
+	}
+	switch name {
+	case "UTXO_SPENT", "TX_INVALID_DOUBLE_SPEND", "TX_CONFLICTING":
+		return 40
+	case "TX_INVALID", "TX_POLICY", "TX_LOCK_TIME", "TX_MISSING_PARENT",
+		"TX_LOCKED", "TX_COINBASE_IMMATURE", "UTXO_FROZEN", "UTXO_NON_FINAL",
+		"UTXO_INVALID_SIZE", "INVALID_ARGUMENT":
+		return 30
+	case "PROCESSING":
+		// Catch-all "this tx is bad" wrapper — better than opaque infra text,
+		// worse than a specific validator code.
+		return 20
+	default:
+		// Recognizable "<NAME> (n):" shape but not a known code.
+		return 10
+	}
+}
+
 // classifyFailureLine maps one Teranode /txs failure line into a client-
 // facing message and a machine-readable ARC status code (errors/errors.go
 // taxonomy; 0 when the line has no confident ARC equivalent). The line is
@@ -1545,19 +1608,25 @@ func (p *Propagator) submitBroadcastJobs(ctx context.Context, endpoints []string
 //
 //   - HTTP 200 from a peer → that peer accepted the whole batch, so
 //     every tx in the batch gets a sticky acceptance vote.
-//   - HTTP 5xx with a parseable "Failed to process transactions:"
-//     body → that peer rejected the listed txids and accepted the
-//     rest. Each accepted tx gets an acceptance vote; each rejected
-//     tx gets a rejection vote carrying the verbatim error line.
-//   - HTTP 5xx with no parseable body, network error, or no healthy
-//     endpoints → no per-tx information from that peer.
+//   - Non-2xx with a parseable "Failed to process transactions:" body
+//     (HTTP status is NOT part of the contract — Teranode often uses 500,
+//     but some deployments/proxies return 422/4xx with the same body) →
+//     that peer rejected the listed txids and accepted the rest. Each
+//     accepted tx gets an acceptance vote; each rejected tx gets a
+//     rejection vote carrying the verbatim Teranode error line (this is
+//     what lands in the wallet-visible ExtraInfo / SSE payload).
+//   - Non-2xx with no parseable body (gateway 502/503 "no available
+//     server", bare 500, network error), or no healthy endpoints → no
+//     per-tx information from that peer. These must NEVER become the
+//     terminal ExtraInfo on their own — they are infra noise, not a
+//     validator verdict.
 //
 // After all responses are in (or the 15s submitCtx timeout fires), each
 // tx is classified:
 //
 //   - Any acceptance vote → ACCEPTED_BY_NETWORK.
 //   - Otherwise, at least one rejection vote → REJECTED with the
-//     first peer's rejection line.
+//     best (most informative) peer rejection line.
 //   - Otherwise (no information from any peer) → Requeue.
 //
 // We treat any per-tx rejection line as terminal because Teranode wraps
@@ -1631,28 +1700,47 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 			continue
 		}
 
-		p.logger.Warn(
-			"batch broadcast endpoint failed",
-			zap.String("endpoint", result.endpoint),
-			zap.Int("batch_size", len(batch)),
-			zap.Int("status_code", result.statusCode),
-			zap.Error(result.err),
-		)
+		// Always log the human-visible error. When the response carried a
+		// parseable Teranode failure-list, also log the per-txid lines —
+		// otherwise operators only see "unexpected status code 500" and
+		// cannot tell that the peer actually returned UTXO_SPENT /
+		// PROCESSING (the structured body is not on err in that case).
+		// Opaque gateway 502/503 bodies stay on err alone.
+		if n := len(result.failures); n > 0 {
+			p.logger.Warn(
+				"batch broadcast endpoint failed",
+				zap.String("endpoint", result.endpoint),
+				zap.Int("batch_size", len(batch)),
+				zap.Int("status_code", result.statusCode),
+				zap.Error(result.err),
+				zap.Int("failure_count", n),
+				zap.Strings("failure_lines", failureLinesForLog(result.failures)),
+			)
+		} else {
+			p.logger.Warn(
+				"batch broadcast endpoint failed",
+				zap.String("endpoint", result.endpoint),
+				zap.Int("batch_size", len(batch)),
+				zap.Int("status_code", result.statusCode),
+				zap.Error(result.err),
+			)
+		}
 
 		if len(result.failures) == 0 {
 			// Non-parseable failure — this peer carried no per-tx info.
 			continue
 		}
 
-		// Parseable 500: peer accepted every tx not in the failure
-		// map and rejected the listed ones. An acceptance vote from
-		// any peer makes the tx ACCEPTED; a rejection vote only
-		// matters if no peer ever accepts.
+		// Parseable failure-list body (any non-2xx status): peer accepted
+		// every tx not in the failure map and rejected the listed ones. An
+		// acceptance vote from any peer makes the tx ACCEPTED; a rejection
+		// vote only matters if no peer ever accepts. When several peers
+		// reject the same tx with different lines, keep the most
+		// informative one (specific Teranode codes over PROCESSING over
+		// opaque text) so GET /tx ExtraInfo is useful to wallets.
 		for j, lower := range lowerTxids {
 			if line, failed := result.failures[lower]; failed {
-				if rejectionLine[j] == "" {
-					rejectionLine[j] = line
-				}
+				rejectionLine[j] = preferRejectionLine(rejectionLine[j], line)
 			} else {
 				acceptedByAny[j] = true
 			}

--- a/services/sse/manager.go
+++ b/services/sse/manager.go
@@ -675,6 +675,8 @@ func buildStatusFrame(status *models.TransactionStatus) (string, error) {
 		BlockHash:   status.BlockHash,
 		BlockHeight: status.BlockHeight,
 		MerklePath:  status.MerklePath,
+		StatusCode:  status.StatusCode,
+		ExtraInfo:   status.ExtraInfo,
 	})
 	if err != nil {
 		return "", err
@@ -708,6 +710,12 @@ func writeStatusBuffered(w *sseWriter, status *models.TransactionStatus) error {
 // are the always-present legacy fields; blockHash/blockHeight/merklePath are
 // added for mined/immutable frames (omitempty keeps every other frame at the
 // original three-field shape). merklePath is a BUMP, hex-encoded like GET /tx.
+// status/extraInfo mirror the same fields on GET /tx: on REJECTED frames
+// extraInfo carries the verbatim Teranode rejection line (e.g. "UTXO_SPENT
+// (70): … utxo already spent by tx …") and status the ARC code when one maps
+// (466 conflict, 467 generic, 476 non-final) — wallets branching on the
+// reject reason no longer need a follow-up GET /tx. Reorg-correction frames
+// (issue #279) reuse extraInfo for the reorg_reanchor/reorg_unmined markers.
 type statusPayload struct {
 	TxID        string          `json:"txid"`
 	TxStatus    string          `json:"txStatus"`
@@ -715,4 +723,6 @@ type statusPayload struct {
 	BlockHash   string          `json:"blockHash,omitempty"`
 	BlockHeight uint64          `json:"blockHeight,omitempty"`
 	MerklePath  models.HexBytes `json:"merklePath,omitempty"`
+	StatusCode  int             `json:"status,omitempty"`
+	ExtraInfo   string          `json:"extraInfo,omitempty"`
 }

--- a/teranode/client.go
+++ b/teranode/client.go
@@ -927,7 +927,7 @@ func parseTxsFailures(body []byte, logger *zap.Logger) map[string]string {
 		// competing spender), so the CALLER must verify each key actually
 		// names a submitted tx before trusting the map's "absent ⇒ accepted"
 		// contract (see broadcastBatchToEndpoints).
-		txid := ""
+		var txid string
 		if m := txsWrappedTxidPattern.FindStringSubmatch(line); m != nil {
 			txid = m[1]
 		} else {

--- a/teranode/client.go
+++ b/teranode/client.go
@@ -777,26 +777,32 @@ func (c *Client) SubmitTransaction(ctx context.Context, endpoint string, rawTx [
 //
 //   - HTTP 200: every tx accepted. failures is nil so callers short-circuit
 //     without per-tx inspection.
-//   - Non-2xx + body starting "Failed to process transactions:" (Teranode
-//     upstream main #879, and some deployments/proxies that remap the HTTP
-//     status to 400/422/etc. while preserving the body): each subsequent line
-//     is one tx's error in the form "<TERANODE_CODE_NAME> (<num>): <message
-//     containing the txid via [ProcessTransaction][<txid>]>". The returned
-//     map is keyed by the extracted txid; the value is the full line verbatim
-//     so callers can surface the Teranode code in wallet-visible rows (GET
-//     /tx extraInfo, SSE, webhooks). Txs not in the map are assumed accepted
-//     by that peer.
-//   - Non-2xx without a parseable Teranode failure-list body (gateway 502/503,
-//     "no available server", echo recover panic, bare 500, transport error):
-//     failures is nil; the caller treats the response as pure infra (no
-//     per-tx vote — requeue if no peer produced a parseable verdict).
+//   - Non-200 + body starting "Failed to process transactions:" (Teranode
+//     upstream main #879): each subsequent line is one tx's error in the form
+//     "<TERANODE_CODE_NAME> (<num>): <message containing the txid via
+//     [ProcessTransaction][<txid>]>". The returned map is keyed by the
+//     extracted txid; the value is the full line verbatim so callers can
+//     surface the Teranode code in wallet-visible rows (GET /tx extraInfo,
+//     SSE, webhooks). Txs not in the map are assumed accepted by that peer.
+//   - Non-200 without a parseable Teranode failure-list body (gateway 502/503,
+//     "no available server", echo recover panic, bare 500, transport error,
+//     or an unexpected 2xx-but-not-200): failures is nil; the caller treats
+//     the response as pure infra (no per-tx vote — requeue if no peer
+//     produced a parseable verdict).
 //
 // The failure-list parse is intentionally status-agnostic: the body shape is
-// the contract, not the HTTP code. Restricting parse to 500 only silently
-// dropped real validator rejections that arrived as 422 (observed in
-// production: PROCESSING / UTXO_SPENT failures logged at Warn with the full
-// Teranode line, while GET /tx only saw an opaque peer-infra ExtraInfo from a
-// different endpoint's race).
+// the contract, not the HTTP code. This is Teranode's own contract, not proxy
+// folklore — since v0.16 the /txs handler derives the aggregate status from
+// the per-tx error class (httpStatusForTxError, services/propagation/
+// Server.go): conflict-family failures (UTXO_SPENT, TX_CONFLICTING,
+// TX_INVALID_DOUBLE_SPEND, TX_LOCKED) return 409, TX_MISSING_PARENT 422,
+// the policy family (TX_INVALID, TX_POLICY, TX_LOCK_TIME, UTXO_NON_FINAL, …)
+// 400, UTXO_FROZEN 403, and only unclassified server faults 500 — all with
+// the identical failure-list body. Restricting parse to 500 silently dropped
+// real validator rejections that arrived as 409/422 (observed in production:
+// UTXO_SPENT / PROCESSING failures visible only in propagation Warn logs
+// while the tx never terminalized — GET /tx stayed RECEIVED/requeued with no
+// reject reason).
 func (c *Client) SubmitTransactions(ctx context.Context, endpoint string, rawTxs [][]byte) (int, map[string]string, error) {
 	start := time.Now()
 	// Calculate total size for pre-allocation
@@ -831,13 +837,25 @@ func (c *Client) SubmitTransactions(ctx context.Context, endpoint string, rawTxs
 	defer drainAndClose(resp.Body)
 	defer observeRequest("submit_txs", resp.StatusCode, start)
 
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, readErr := io.ReadAll(resp.Body)
 
 	if resp.StatusCode == http.StatusOK {
+		// The 200 status line is the whole-batch acceptance verdict; the
+		// body carries no per-tx information, so a read error here doesn't
+		// invalidate the verdict.
 		return resp.StatusCode, nil, nil
 	}
 
-	// Any non-2xx may carry Teranode's failure-list body. Parse first; only
+	if readErr != nil {
+		// Truncated or aborted body (connection reset mid-transfer,
+		// unexpected EOF). A PARTIAL failure list must never be parsed:
+		// the map's "absent ⇒ accepted" contract would grant implicit
+		// acceptance to every tx whose failure line was cut off. Treat as
+		// pure infra — no per-tx vote.
+		return resp.StatusCode, nil, fmt.Errorf("%w %d: reading response body: %w", errUnexpectedStatusCode, resp.StatusCode, readErr)
+	}
+
+	// Any non-200 may carry Teranode's failure-list body. Parse first; only
 	// fall through to the opaque infra-failure path when the body is not a
 	// structured per-tx verdict. Status stays on the wire for metrics/logs.
 	if failures := parseTxsFailures(respBody, c.logger); failures != nil {
@@ -857,6 +875,15 @@ const txsFailureHeader = "Failed to process transactions:"
 // processTransactionInternal. Case-insensitive — Teranode normalizes to
 // lowercase but the regex stays defensive.
 var txsTxidPattern = regexp.MustCompile(`[0-9a-fA-F]{64}`)
+
+// txsWrappedTxidPattern extracts the txid from Teranode's
+// "[ProcessTransaction][<txid>]" wrapper. Preferred over the bare 64-hex
+// fallback because conflict-family messages embed OTHER transactions' hashes
+// before any wrapper — e.g. "UTXO_SPENT (70): <outpoint-txid>:<vout> utxo
+// already spent by tx <spender-txid>[0]" names the spent outpoint's tx and
+// the competing spender, not the submitted tx. A bare first-hex match on a
+// wrapped line that also mentions an outpoint would mis-key the failure.
+var txsWrappedTxidPattern = regexp.MustCompile(`\[ProcessTransaction\]\[([0-9a-fA-F]{64})\]`)
 
 // parseTxsFailures extracts the per-txid failure list from a /txs non-2xx
 // response body. The expected format is status-agnostic (HTTP 500, 422, 400,
@@ -892,7 +919,20 @@ func parseTxsFailures(body []byte, logger *zap.Logger) map[string]string {
 		if line == "" {
 			continue
 		}
-		txid := txsTxidPattern.FindString(line)
+		// Prefer the [ProcessTransaction][<txid>] wrapper — it names the
+		// submitted tx unambiguously. Wrapper-less lines (Teranode's
+		// UserMessage surfaces the deepest public cause, which for the
+		// conflict family carries no wrapper) fall back to the first bare
+		// 64-hex string; that may be another tx entirely (spent outpoint /
+		// competing spender), so the CALLER must verify each key actually
+		// names a submitted tx before trusting the map's "absent ⇒ accepted"
+		// contract (see broadcastBatchToEndpoints).
+		txid := ""
+		if m := txsWrappedTxidPattern.FindStringSubmatch(line); m != nil {
+			txid = m[1]
+		} else {
+			txid = txsTxidPattern.FindString(line)
+		}
 		if txid == "" {
 			// Fail-closed: an orphan line means the response isn't fully
 			// trustworthy (Teranode processOne panic, or a future format

--- a/teranode/client.go
+++ b/teranode/client.go
@@ -777,16 +777,26 @@ func (c *Client) SubmitTransaction(ctx context.Context, endpoint string, rawTx [
 //
 //   - HTTP 200: every tx accepted. failures is nil so callers short-circuit
 //     without per-tx inspection.
-//   - HTTP 500 + body starting "Failed to process transactions:" (Teranode
-//     upstream main #879): each subsequent line is one tx's error in the
-//     form "<TERANODE_CODE_NAME> (<num>): <message containing the txid via
-//     [ProcessTransaction][<txid>]>". The returned map is keyed by the
-//     extracted txid; the value is the full line verbatim so callers can
-//     surface the Teranode code in wallet-visible rows. Txs not in the map
-//     are assumed to have been accepted.
-//   - Anything else (4xx, 5xx with non-Teranode body, transport error):
-//     failures is nil; the caller treats the batch as a pure infra failure
-//     (whole batch requeued for another attempt).
+//   - Non-2xx + body starting "Failed to process transactions:" (Teranode
+//     upstream main #879, and some deployments/proxies that remap the HTTP
+//     status to 400/422/etc. while preserving the body): each subsequent line
+//     is one tx's error in the form "<TERANODE_CODE_NAME> (<num>): <message
+//     containing the txid via [ProcessTransaction][<txid>]>". The returned
+//     map is keyed by the extracted txid; the value is the full line verbatim
+//     so callers can surface the Teranode code in wallet-visible rows (GET
+//     /tx extraInfo, SSE, webhooks). Txs not in the map are assumed accepted
+//     by that peer.
+//   - Non-2xx without a parseable Teranode failure-list body (gateway 502/503,
+//     "no available server", echo recover panic, bare 500, transport error):
+//     failures is nil; the caller treats the response as pure infra (no
+//     per-tx vote — requeue if no peer produced a parseable verdict).
+//
+// The failure-list parse is intentionally status-agnostic: the body shape is
+// the contract, not the HTTP code. Restricting parse to 500 only silently
+// dropped real validator rejections that arrived as 422 (observed in
+// production: PROCESSING / UTXO_SPENT failures logged at Warn with the full
+// Teranode line, while GET /tx only saw an opaque peer-infra ExtraInfo from a
+// different endpoint's race).
 func (c *Client) SubmitTransactions(ctx context.Context, endpoint string, rawTxs [][]byte) (int, map[string]string, error) {
 	start := time.Now()
 	// Calculate total size for pre-allocation
@@ -827,15 +837,11 @@ func (c *Client) SubmitTransactions(ctx context.Context, endpoint string, rawTxs
 		return resp.StatusCode, nil, nil
 	}
 
-	// HTTP 500 with the Teranode failure-list body (#879) — extract a
-	// per-txid map. Any other 5xx/4xx (echo recover panic, gateway 502/503,
-	// proxy-injected error pages, etc.) falls through to the infra-failure
-	// path with failures==nil.
-	if resp.StatusCode == http.StatusInternalServerError {
-		failures := parseTxsFailures(respBody, c.logger)
-		if failures != nil {
-			return resp.StatusCode, failures, fmt.Errorf("%w %d", errUnexpectedStatusCode, resp.StatusCode)
-		}
+	// Any non-2xx may carry Teranode's failure-list body. Parse first; only
+	// fall through to the opaque infra-failure path when the body is not a
+	// structured per-tx verdict. Status stays on the wire for metrics/logs.
+	if failures := parseTxsFailures(respBody, c.logger); failures != nil {
+		return resp.StatusCode, failures, fmt.Errorf("%w %d", errUnexpectedStatusCode, resp.StatusCode)
 	}
 
 	return resp.StatusCode, nil, fmt.Errorf("%w %d: %s", errUnexpectedStatusCode, resp.StatusCode, string(respBody))
@@ -852,8 +858,9 @@ const txsFailureHeader = "Failed to process transactions:"
 // lowercase but the regex stays defensive.
 var txsTxidPattern = regexp.MustCompile(`[0-9a-fA-F]{64}`)
 
-// parseTxsFailures extracts the per-txid failure list from a /txs HTTP 500
-// response body. The expected format is:
+// parseTxsFailures extracts the per-txid failure list from a /txs non-2xx
+// response body. The expected format is status-agnostic (HTTP 500, 422, 400,
+// … all accepted — the body shape is the contract):
 //
 //	"Failed to process transactions:
 //	<NAME> (<num>): [ProcessTransaction][<txid>] <message>
@@ -863,7 +870,7 @@ var txsTxidPattern = regexp.MustCompile(`[0-9a-fA-F]{64}`)
 //
 // Returns a txid → full-line map naming every failed tx, or nil if the body
 // doesn't match Teranode's failure-list shape (in which case the caller
-// treats the batch as a pure infra failure). Lines whose txid couldn't be
+// treats the response as a pure infra failure). Lines whose txid couldn't be
 // extracted are dropped — the contract is "if you appear in the map you
 // failed; if you don't you're accepted," so a malformed line with no
 // recognizable txid would otherwise be silently lost. A trailing nil-map

--- a/teranode/client_test.go
+++ b/teranode/client_test.go
@@ -2,6 +2,7 @@ package teranode
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -97,10 +98,136 @@ func TestSubmitTransactions_FailureList_422(t *testing.T) {
 	testSubmitTransactionsFailureList(t, http.StatusUnprocessableEntity)
 }
 
-// TestSubmitTransactions_FailureList_400 covers another remapped status
-// that has been observed carrying the same body shape.
+// TestSubmitTransactions_FailureList_400 covers Teranode's policy-family
+// aggregate status (TX_INVALID / TX_POLICY / TX_LOCK_TIME / … →
+// httpStatusForTxError → 400).
 func TestSubmitTransactions_FailureList_400(t *testing.T) {
 	testSubmitTransactionsFailureList(t, http.StatusBadRequest)
+}
+
+// TestSubmitTransactions_FailureList_409 covers Teranode's conflict-family
+// aggregate status: since v0.16 the upstream /txs handler returns 409 for
+// UTXO_SPENT / TX_CONFLICTING / TX_INVALID_DOUBLE_SPEND / TX_LOCKED
+// (httpStatusForTxError, services/propagation/Server.go) — the exact status
+// observed on mainnet carrying the UTXO_SPENT verdict that pre-fix Arcade
+// dropped.
+func TestSubmitTransactions_FailureList_409(t *testing.T) {
+	testSubmitTransactionsFailureList(t, http.StatusConflict)
+}
+
+// TestParseTxsFailures_WrapperPreferredOverBareHex pins the txid-extraction
+// order: the [ProcessTransaction][<txid>] wrapper always wins over the first
+// bare 64-hex string in the line. Conflict-family messages embed other
+// transactions' hashes (spent outpoint, competing spender) that can precede
+// any wrapper — keying by first-hex would misattribute the failure to a
+// different tx (possibly another tx in the same batch, e.g. a same-batch
+// parent whose output the failed tx tried to spend).
+func TestParseTxsFailures_WrapperPreferredOverBareHex(t *testing.T) {
+	const (
+		submitted = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+		outpoint  = "256fc7143c6ef5436cd5258ade24b68c43d0f8268c086bd9fa90055dd5a7ae43"
+		spender   = "7dfbe0fcacf630066b23036bc007e73d58a61ab9bcb8e66f6b214f8ef5f28489"
+	)
+	body := []byte("Failed to process transactions:\n" +
+		// Bare hex (the outpoint) appears BEFORE the wrapper — wrapper must win.
+		"TX_INVALID (31): utxo " + outpoint + ":1 already spent [ProcessTransaction][" + submitted + "] tx invalid\n" +
+		// Wrapper-less conflict line — falls back to first bare hex (the
+		// outpoint), which callers must treat as an alien key (it names no
+		// submitted tx); pinned here so the fallback shape is explicit.
+		"UTXO_SPENT (70): UTXO_SPENT (70): " + outpoint + ":2 utxo already spent by tx " + spender + "[0]\n")
+
+	failures := parseTxsFailures(body, nil)
+	if len(failures) != 2 {
+		t.Fatalf("failures=%#v want 2 entries", failures)
+	}
+	if _, ok := failures[submitted]; !ok {
+		t.Errorf("wrapped line must key under the wrapper txid, got %#v", failures)
+	}
+	if _, ok := failures[outpoint]; !ok {
+		t.Errorf("wrapper-less conflict line must fall back to first bare hex, got %#v", failures)
+	}
+}
+
+// TestSubmitTransactions_TruncatedFailureList_NoPartialParse asserts that a
+// failure-list body cut off mid-transfer (Content-Length promises more than
+// arrives) is NOT parsed: a partial list that happens to truncate at a line
+// boundary would silently grant implicit acceptance to every tx whose
+// failure line was lost. The read error must route to the infra path
+// (failures nil → whole-batch requeue).
+func TestSubmitTransactions_TruncatedFailureList_NoPartialParse(t *testing.T) {
+	const (
+		txidA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		txidB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+	full := "Failed to process transactions:\n" +
+		"TX_INVALID (31): [ProcessTransaction][" + txidA + "] tx invalid\n" +
+		"TX_INVALID (31): [ProcessTransaction][" + txidB + "] tx invalid\n"
+	// Truncate exactly at the line boundary after txidA's line — the
+	// dangerous shape: the prefix alone is a well-formed one-entry list.
+	cut := strings.Index(full, txidB) - len("TX_INVALID (31): [ProcessTransaction][")
+	partial := full[:cut]
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprint(len(full)))
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(partial))
+		// Handler returns with fewer bytes than promised; the server tears
+		// the connection down and the client's io.ReadAll sees an error.
+	}))
+	defer server.Close()
+
+	client := NewClient([]string{server.URL}, "", HealthConfig{})
+	code, failures, err := client.SubmitTransactions(context.Background(), server.URL, [][]byte{{0x01}, {0x02}})
+	if err == nil {
+		t.Fatal("expected non-nil error for truncated body")
+	}
+	if code != http.StatusUnprocessableEntity {
+		t.Errorf("code=%d want 422", code)
+	}
+	if failures != nil {
+		t.Errorf("failures=%#v want nil — a truncated failure list must not be parsed", failures)
+	}
+}
+
+// TestSubmitTransactions_NonParseable4xx_NoFailureList asserts the
+// status-agnostic parse does NOT turn arbitrary 4xx error pages (auth
+// failures, proxy HTML, rate limiting, bare conflict text) into per-tx
+// verdicts. failures must stay nil so the caller treats them as infra
+// noise — otherwise a body-less 4xx would fabricate implicit ACCEPT votes
+// for every tx in the batch.
+func TestSubmitTransactions_NonParseable4xx_NoFailureList(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "401 unauthorized", status: http.StatusUnauthorized, body: "Unauthorized\n"},
+		{name: "404 html error page", status: http.StatusNotFound, body: "<html><body><h1>404 Not Found</h1></body></html>"},
+		{name: "429 rate limited", status: http.StatusTooManyRequests, body: "rate limit exceeded"},
+		{name: "409 without failure-list body", status: http.StatusConflict, body: "Conflict"},
+		{name: "503 no available server", status: http.StatusServiceUnavailable, body: "no available server\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			client := NewClient([]string{server.URL}, "", HealthConfig{})
+			code, failures, err := client.SubmitTransactions(context.Background(), server.URL, [][]byte{{0x01}, {0x02}})
+			if err == nil {
+				t.Fatalf("expected non-nil error for %d", tc.status)
+			}
+			if code != tc.status {
+				t.Errorf("code=%d want %d", code, tc.status)
+			}
+			if failures != nil {
+				t.Errorf("failures=%#v want nil (opaque %d body must not become a per-tx verdict)", failures, tc.status)
+			}
+		})
+	}
 }
 
 func testSubmitTransactionsFailureList(t *testing.T, status int) {

--- a/teranode/client_test.go
+++ b/teranode/client_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -82,6 +83,28 @@ func TestSubmitTransactions_Batch(t *testing.T) {
 // code along with an error so the caller's err != nil branch routes through
 // the per-txid classification path.
 func TestSubmitTransactions_FailureList_500(t *testing.T) {
+	testSubmitTransactionsFailureList(t, http.StatusInternalServerError)
+}
+
+// TestSubmitTransactions_FailureList_422 pins the production bug where
+// Teranode (or a gateway in front of it) returned HTTP 422 with a fully
+// parseable "Failed to process transactions:" body containing
+// PROCESSING / UTXO_SPENT lines. The old client only parsed the body on
+// HTTP 500, so the failure map was nil, the peer contributed no rejection
+// vote, and GET /tx ExtraInfo never saw the Teranode reason (only opaque
+// infra noise from other peers, if anything). Parsing is status-agnostic.
+func TestSubmitTransactions_FailureList_422(t *testing.T) {
+	testSubmitTransactionsFailureList(t, http.StatusUnprocessableEntity)
+}
+
+// TestSubmitTransactions_FailureList_400 covers another remapped status
+// that has been observed carrying the same body shape.
+func TestSubmitTransactions_FailureList_400(t *testing.T) {
+	testSubmitTransactionsFailureList(t, http.StatusBadRequest)
+}
+
+func testSubmitTransactionsFailureList(t *testing.T, status int) {
+	t.Helper()
 	const (
 		txidA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 		txidB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -90,7 +113,7 @@ func TestSubmitTransactions_FailureList_500(t *testing.T) {
 		"TX_INVALID (31): [ProcessTransaction][" + txidA + "] tx is invalid because UTXO_SPENT\n" +
 		"UTXO_SPENT (28): [ProcessTransaction][" + txidB + "] utxo already spent\n"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(status)
 		_, _ = w.Write([]byte(body))
 	}))
 	defer server.Close()
@@ -100,10 +123,10 @@ func TestSubmitTransactions_FailureList_500(t *testing.T) {
 
 	code, failures, err := client.SubmitTransactions(context.Background(), server.URL, rawTxs)
 	if err == nil {
-		t.Fatalf("expected non-nil error for 500 (caller routes off err != nil)")
+		t.Fatalf("expected non-nil error for %d (caller routes off err != nil)", status)
 	}
-	if code != http.StatusInternalServerError {
-		t.Errorf("expected 500, got %d", code)
+	if code != status {
+		t.Errorf("expected %d, got %d", status, code)
 	}
 	if len(failures) != 2 {
 		t.Fatalf("expected 2 failure entries, got %d (%#v)", len(failures), failures)
@@ -113,6 +136,40 @@ func TestSubmitTransactions_FailureList_500(t *testing.T) {
 	}
 	if _, ok := failures[txidB]; !ok {
 		t.Errorf("expected failure for txidB, got %#v", failures)
+	}
+}
+
+// TestSubmitTransactions_422_ProcessingOnly mirrors the exact live shape
+// observed when spending an already-mined UTXO: HTTP 422 with a single
+// PROCESSING catch-all line. Must still yield a one-entry failure map so
+// propagation can terminalize REJECTED with that ExtraInfo.
+func TestSubmitTransactions_422_ProcessingOnly(t *testing.T) {
+	const txid = "d018bc98d7828b7f095e5d616f7ccba607fc228368e82e74b25304e37699f1e9"
+	body := "Failed to process transactions:\n" +
+		"PROCESSING (4): [ProcessTransaction][" + txid + "] failed to validate transaction\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	client := NewClient([]string{server.URL}, "", HealthConfig{})
+	code, failures, err := client.SubmitTransactions(context.Background(), server.URL, [][]byte{{0x01}})
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if code != http.StatusUnprocessableEntity {
+		t.Errorf("code=%d want 422", code)
+	}
+	if len(failures) != 1 {
+		t.Fatalf("failures=%#v want 1 entry", failures)
+	}
+	line, ok := failures[txid]
+	if !ok {
+		t.Fatalf("missing failure for %s: %#v", txid, failures)
+	}
+	if !strings.Contains(line, "PROCESSING (4)") {
+		t.Errorf("line=%q want PROCESSING (4)", line)
 	}
 }
 


### PR DESCRIPTION
## Summary

Teranode returns **structured per-tx rejection bodies** under more HTTP status codes than 500. Arcade only parsed `Failed to process transactions:` when status was **exactly 500**, so real validator verdicts on **409 / 422 / 400** never became rejection votes or `GET /tx` `extraInfo` — while propagation **logs** still showed the body on the error string (because unparsed responses attach the body to `err`).

This is not proxy folklore: since v0.16 Teranode's own `/txs` handler derives the aggregate status from the per-tx error class (`httpStatusForTxError`, `services/propagation/Server.go`) — **conflict family** (`UTXO_SPENT`, `TX_CONFLICTING`, `TX_INVALID_DOUBLE_SPEND`, `TX_LOCKED`) → **409**, `TX_MISSING_PARENT` → **422**, policy family (`TX_INVALID`, `TX_POLICY`, `TX_LOCK_TIME`, `UTXO_NON_FINAL`, …) → **400**, `UTXO_FROZEN` → **403**, and only unclassified server faults → **500** — all with the identical failure-list body. Duplicate submissions (`TX_EXISTS`) classify as success upstream and never appear in the list.

This made production look like "peers disagree about UTXO spend," when what we often had was:

1. **Log / parse asymmetry** across status codes
2. **Gateway infra noise** (502/503/bare 500) that is *not* a UTXO acceptance
3. **One peer returning a clear `UTXO_SPENT`** that did not reliably reach the status store / API

### Changes

- **`teranode.Client.SubmitTransactions`**: parse the Teranode failure-list body for **any non-200** (body shape is the contract, not the HTTP code).
- **Propagation aggregation**: prefer the most informative rejection line across peers (`UTXO_SPENT` / `TX_CONFLICTING` > `TX_INVALID` family > unknown-but-shaped codes > `PROCESSING` > opaque text).
- **Logging**: when a peer returns a parseable failure map, log `failure_count` + `failure_lines` (most-informative-first, capped at 8).
- Tests for 400/409/422 failure lists, live-shaped 422 PROCESSING, multi-peer 422+502/503 → REJECTED with Teranode ExtraInfo, and rejection-line preference.

### Deep-review hardening (second commit, `8c19cf0`)

A deep review of the first commit found that the status-agnostic parse, as first written, **mis-handled the PR's own motivating 409 body**:

> `UTXO_SPENT (70): UTXO_SPENT (70): 256fc714…ae43:2 utxo already spent by tx 7dfbe0fc…8489[0]`

Conflict-family lines are rendered from the **deepest public cause** (`errors.UserMessage`), which carries **no `[ProcessTransaction][<txid>]` wrapper** — the hashes in the line are the **spent outpoint's txid** and the **competing spender**, never the submitted txid. The parser keyed the failure under that alien hash, the submitted tx was "absent from the failure map", and the *"absent ⇒ accepted"* contract would have terminalized the rejected tx as **ACCEPTED_BY_NETWORK** (pre-fix behavior for these statuses was a safe requeue). Fixes:

- **Wrapper-first txid extraction**: `[ProcessTransaction][<txid>]` wins over the first bare 64-hex string (also immune to a same-batch parent's hash appearing in a wrapped line before the wrapper).
- **Alien-line guard in aggregation**: any failure key that names no submitted tx voids implicit accepts from that peer; a **single-tx batch** attributes the alien verdict to its only tx — the exact mainnet incident shape now terminalizes `REJECTED` with the real `UTXO_SPENT` line, ARC `466`.
- **Truncation guard**: `io.ReadAll` errors on the response body route to the infra path — a partial failure list cut at a line boundary can no longer mint implicit accepts for txs whose lines were lost.
- **ARC mapping**: `UTXO_SPENT` / `TX_INVALID_DOUBLE_SPEND` → **466 StatusConflict** (mirrors upstream's 409 conflict class; wallets can branch "do NOT blind-release these inputs" on the code, not prose).
- **SSE parity**: `REJECTED` frames now carry `status` / `extraInfo` (omitempty — no shape change for existing consumers); `docs/sse.md` updated.
- Doc corrections: non-200 (not "non-2xx") is the parse boundary; circuit-breaker comment no longer overstates verdict-peer protection; pre-fix symptom corrected (txs **stayed RECEIVED/requeued** — the opaque-`extraInfo` claim below was wrong for this path).

## Why peers look inconsistent (production context)

### Incident logs (mainnet, single-tx batch)

```json
{"level":"debug","ts":1786386718.6865864,"logger":"propagation","caller":"propagation/propagator.go:938","msg":"registered with merkle-service","txid_count":1,"txids":["e3b7a2c260168429b20ad85f746ae09c2e41f6a1d79877a8810832cdf732e703"]}
{"level":"info","ts":1786386718.6866257,"logger":"propagation","caller":"propagation/propagator.go:1081","msg":"processing batch","txid_count":1}
{"level":"warn","ts":1786386718.7062376,"logger":"propagation","caller":"propagation/propagator.go:1491","msg":"batch broadcast endpoint failed","endpoint":"https://teranode-mainnet.orches-trator.com/api/v1","batch_size":1,"status_code":502,"error":"unexpected status code 502: error code: 502\n"}
{"level":"warn","ts":1786386718.7525613,"logger":"propagation","caller":"propagation/propagator.go:1491","msg":"batch broadcast endpoint failed","endpoint":"https://mainnet.gorillanode.io/api/v1","batch_size":1,"status_code":500,"error":"unexpected status code 500"}
{"level":"warn","ts":1786386718.7531743,"logger":"propagation","caller":"propagation/propagator.go:1491","msg":"batch broadcast endpoint failed","endpoint":"https://mainnet2.gorillanode.io/api/v1","batch_size":1,"status_code":500,"error":"unexpected status code 500"}
{"level":"warn","ts":1786386718.8100939,"logger":"propagation","caller":"propagation/propagator.go:1491","msg":"batch broadcast endpoint failed","endpoint":"https://teranode-eks-mainnet-eu-1.bsvb.tech/api/v1","batch_size":1,"status_code":500,"error":"unexpected status code 500"}
{"level":"warn","ts":1786386718.8142848,"logger":"propagation","caller":"propagation/propagator.go:1491","msg":"batch broadcast endpoint failed","endpoint":"http://bsva-ovh-teranode-eu-1.bsvb.tech:8000/api/v1","batch_size":1,"status_code":500,"error":"unexpected status code 500"}
{"level":"warn","ts":1786386718.9217396,"logger":"propagation","caller":"propagation/propagator.go:1491","msg":"batch broadcast endpoint failed","endpoint":"http://bsva-ovh-teranode-eu-2.bsvb.tech:8000/api/v1","batch_size":1,"status_code":409,"error":"unexpected status code 409: Failed to process transactions:\nUTXO_SPENT (70): UTXO_SPENT (70): 256fc7143c6ef5436cd5258ade24b68c43d0f8268c086bd9fa90055dd5a7ae43:2 utxo already spent by tx 7dfbe0fcacf630066b23036bc007e73d58a61ab9bcb8e66f6b214f8ef5f28489[0]\n"}
{"level":"debug","ts":1786386718.9217832,"logger":"propagation","caller":"propagation/propagator.go:1520","msg":"batch broadcast complete","batch_size":1,"any_success":false,"endpoint_count":6}
{"level":"info","ts":1786386718.9233756,"logger":"propagation","caller":"propagation/propagator.go:1145","msg":"batch propagated","txid_count":1,"accepted":0,"rejected":1,"requeued":0,"success_endpoints":[]}
```

### Reading those lines carefully

| Peer response | What it actually means | Pre-fix Arcade treatment |
|---|---|---|
| **502** `error code: 502` | Gateway/proxy dead — **no UTXO verdict** | No rejection vote (`failures=nil`) |
| **500** with log `unexpected status code 500` **and no body on err** | Often a **parseable** failure-list path (body stripped from `err` when parse succeeds) *or* empty body — **ambiguous in logs** | Only counted if status was 500 *and* body parsed; **lines not shown in warn log** |
| **409** + full `Failed to process transactions:` / `UTXO_SPENT (70): … already spent by tx 7dfb…` | Clear validator verdict: outpoint spent by a known miner/winner. **NB: the hashes name the outpoint and the spender, not the submitted tx** | **Dropped** (only 500 bodies were parsed) → no structured vote from the one peer that printed the truth in the log |
| **`any_success: false`** | **No peer accepted the tx** | There is **no** "some Teranodes accept a double-spend" signal in this batch |

So the right question is **not** "why do some Teranodes allow a spent UTXO?"
It is "why do only some peers return a **structured** spend-conflict, and why doesn't Arcade surface it?"

### Hypotheses for peer divergence (ordered)

1. **Status-code classing by failure family** (confirmed upstream, see Summary)
   Same class of failure returns as **500 + failure list** on older builds, **409/422/400 + failure list** on v0.16+ (`httpStatusForTxError`). Arcade only trusted 500 → silent drop of 409/422/400.

2. **Log asymmetry (looks like disagreement, isn't)**
   When parse succeeds on 500, warn logs show only `unexpected status code 500` — **not** the `UTXO_SPENT` lines. When parse fails (409/422 pre-fix), the **full body is on `error`**. Operators then conclude "only eu-2 said UTXO_SPENT" even if other peers also returned structured rejects that were hidden.

3. **Infra vs validation**
   502 / bare gateway 500 is **not** "UTXO still free." It is "this peer never returned a per-tx validation result." Aggregation correctly gives them **no vote**, not an accept.

4. **Possible true UTXO-set lag (secondary)**
   If some peers ever returned **HTTP 200** while another returned `UTXO_SPENT`, that would be real tip/UTXO divergence. **These logs show zero accepts** (`any_success: false`, `accepted: 0`), so this incident is **not** that case.

5. **Teranode message quality**
   Related earlier runs used `PROCESSING (4): failed to validate transaction` (catch-all). This run's 409 path has the **good** form: `UTXO_SPENT (70)` + outpoint + spending txid. Preferring higher-quality lines across peers helps when both shapes appear.

### Client-visible symptom (related)

- `POST /tx` → `202 RECEIVED` (intake, not verdict)
- Later `GET /tx` → **stuck `RECEIVED`** (the tx requeued forever; the reject reason lived only in propagation warn logs) — wallets polling for a verdict never got one
- Wallet reject→release then cannot distinguish "inputs free (policy fail)" vs "inputs already spent (must not re-release)" — post-fix, `GET /tx` and SSE both carry the `UTXO_SPENT` line + ARC `466`

## Test plan

- [x] `go test ./teranode/ ./services/propagation/ ./services/sse/`
- [x] Client: failure lists on 400/409/422/500; live-shaped 422 PROCESSING; non-parseable 4xx (401/404/409/429/503) stays infra; truncated body (Content-Length short-read) never parses; wrapper-preferred txid extraction
- [x] Aggregation: multi-peer 422+502/503 → REJECTED with Teranode ExtraInfo; 200-accept beats 422-reject (sticky acceptance); 422 partial list → named tx REJECTED, unnamed tx ACCEPTED; **alien-keyed 409 single-tx → REJECTED 466 with UTXO_SPENT line (mutation-tested: unguarded code marks it ACCEPTED)**; alien-keyed 409 multi-tx → requeue, no fabricated votes
- [x] classify: UTXO_SPENT/TX_INVALID_DOUBLE_SPEND → 466 incl. doubled-prefix live shape; preference tiers incl. unknown-code ordering; failureLinesForLog cap/order/determinism; warn-log failure_lines presence/absence
- [ ] After deploy: rebroadcast a known already-spent outpoint; confirm `GET /tx` ExtraInfo contains `UTXO_SPENT` (or best peer line) with `status: 466`, not gateway 502/503 text
- [ ] Confirm warn logs for structured 409/422/500 include `failure_lines`
- [ ] Confirm pure-infra batches (all 502/503, no failure list) still **requeue** rather than terminal REJECTED

## Follow-ups (out of scope)

- Emit `DOUBLE_SPEND_ATTEMPTED` + `competingTxs` when ExtraInfo/codes indicate spend conflict (wallet reject→release winner-union). The competing txid is already present verbatim in the surfaced `UTXO_SPENT` line.
- **Teranode: include the submitted txid (`[ProcessTransaction][<txid>]` wrapper) in conflict-family `/txs` failure lines** — without it, multi-tx batches cannot attribute a spend-conflict verdict to its tx and must degrade to requeue (only single-tx batches terminalize today).
- Teranode: prefer `UTXO_SPENT` over bare `PROCESSING (4)` for spent-input failures on all code paths.
- go-arcade-toolbox: do not blind-release inputs on pure `REJECTED` when ExtraInfo is spend-conflict class.
- Consider treating verdict-carrying non-2xx responses as circuit-breaker successes even when another peer accepted (today only the unanimous-reject case shields them; a persistently-stricter healthy peer can still accrue slow-track failures).
