### PR TITLE
fix(propagation): attribute conflict verdicts and bound requeue so a poison batch cannot wedge the consumer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -357,10 +357,34 @@ type TelemetryConfig struct {
 
 type PropagationConfig struct {
 	MerkleConcurrency int `mapstructure:"merkle_concurrency"`
-	RetryMaxAttempts  int `mapstructure:"retry_max_attempts"`
-	RetryBackoffMs    int `mapstructure:"retry_backoff_ms"`
-	ReaperIntervalMs  int `mapstructure:"reaper_interval_ms"`
-	ReaperBatchSize   int `mapstructure:"reaper_batch_size"`
+	// RetryMaxAttempts bounds how many times the propagator will push a
+	// transaction back through the in-memory requeue loop when a broadcast
+	// produced no per-tx verdict (no healthy peer, body-less 5xx, merkle
+	// /watch blip, or a conflict-family 409 whose lines could not be
+	// attributed to any submitted tx). After the budget is spent the tx is
+	// parked at PENDING_RETRY, which releases the dispatcher's in-flight
+	// entry so the Kafka commit watermark can advance; the reaper then owns
+	// the durable retry.
+	//
+	// The bound is not a nicety. On 2026-08-11 (dev-ovh-1, arcade v0.11.5) a
+	// 21-tx batch of stale transactions drew a permanent HTTP 409 from
+	// Teranode — 21 "UTXO_SPENT (70): <outpoint>:<vout> utxo already spent by
+	// tx <spender>[n]" lines, all keyed by the spent outpoint rather than by
+	// any submitted txid. With no attributable verdict every tx fell to the
+	// requeue arm and looped forever: ~2,410 409s in two minutes, 42 of 43
+	// batches requeued, 4,679 transactions pinned in the dispatcher's
+	// inFlight map and therefore 337,247 messages of Kafka lag frozen on the
+	// single-partition arcade.propagation topic while the leader burned 4.2
+	// cores. Nothing new could propagate until operators seeked the consumer
+	// group past the backlog by hand.
+	//
+	// Defaults to 5 (matching the shipped viper default). Non-positive values
+	// fall back to the default rather than disabling the bound — an unbounded
+	// requeue is the failure mode this exists to prevent.
+	RetryMaxAttempts int `mapstructure:"retry_max_attempts"`
+	RetryBackoffMs   int `mapstructure:"retry_backoff_ms"`
+	ReaperIntervalMs int `mapstructure:"reaper_interval_ms"`
+	ReaperBatchSize  int `mapstructure:"reaper_batch_size"`
 	// ReaperRebroadcastBatch caps how many stuck transactions the reaper's
 	// durable-rebroadcast backstop pushes back through the register+broadcast
 	// pipeline per tick (reapOnce collects at most this many stale RECEIVED /

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -225,6 +225,50 @@ var PropagationInflightDepth = promauto.NewGauge(prometheus.GaugeOpts{
 	Help: "Transactions in the dispatcher's in-flight set (admitted but not yet terminal); each pins an uncommitted Kafka offset.",
 })
 
+// PropagationConflictAttributionTotal counts conflict-family ("alien") Teranode
+// failure lines by whether arcade could resolve them back to a submitted tx.
+//
+// Teranode renders the conflict family (UTXO_SPENT / TX_CONFLICTING /
+// TX_INVALID_DOUBLE_SPEND, HTTP 409) as the deepest public cause, which names
+// the SPENT OUTPOINT and the competing spender — never the submitted txid — so
+// the line keys under a hash that is not in the batch. arcade holds the
+// submitted raw transactions, so it can usually match "<outpoint>:<vout>"
+// against a submitted tx's inputs and attribute the verdict (result=attributed
+// → terminal REJECTED). result=unattributable means the outpoint matched no
+// submitted input, or matched more than one (an intra-batch double spend), so
+// the verdict is deliberately NOT guessed: implicit accepts stay withheld and
+// the affected txs fall to the bounded requeue.
+//
+// A sustained unattributable rate is the signal that Teranode changed the
+// conflict-line format (or is reporting on outpoints arcade never submitted) —
+// exactly the shape that wedged the dev-ovh-1 propagation consumer on
+// 2026-08-11 at 337,247 frozen messages of Kafka lag.
+var PropagationConflictAttributionTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_propagation_conflict_attribution_total",
+	Help: "Conflict-family Teranode failure lines by whether the spent outpoint resolved to a submitted transaction.",
+}, []string{"result"}) // attributed, unattributable
+
+// PropagationRequeueExhaustedTotal counts transactions parked at PENDING_RETRY
+// because they burned their whole in-memory requeue budget
+// (propagation.retry_max_attempts) without ever producing a network verdict.
+//
+// This is the poison-batch escape hatch. Before it existed a batch that
+// permanently failed with no attributable per-tx verdict requeued forever:
+// every tx stayed in the dispatcher's inFlight map, so its Kafka offset kept
+// pinning LowestUnfinished() and the single-partition arcade.propagation topic
+// could not commit. Observed live on dev-ovh-1 (2026-08-11, arcade v0.11.5):
+// 337,247 messages of lag frozen for minutes, 4,679 txs in-flight, ~2,410
+// UTXO_SPENT 409s in two minutes across 43 batches of which 42 requeued, while
+// the leader pod burned 4.2 cores achieving nothing.
+//
+// Any non-zero rate here is worth an alert: it means transactions are getting
+// no verdict from any peer. They are NOT lost — the row keeps its raw bytes and
+// the reaper rebroadcasts PENDING_RETRY rows — but the fast path has given up.
+var PropagationRequeueExhaustedTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "arcade_propagation_requeue_exhausted_total",
+	Help: "Transactions parked at PENDING_RETRY after exhausting the in-memory requeue budget with no network verdict.",
+})
+
 // APITxsSubmittedTotal counts individual transactions submitted through the
 // API, by route and dedup result. Unlike the HTTP request histogram (one
 // sample per request), this counts PER TRANSACTION — the /txs batch route

--- a/services/propagation/dispatcher.go
+++ b/services/propagation/dispatcher.go
@@ -434,11 +434,27 @@ func handleRequeue(
 // releases direct waiters whose other-parent set has also cleared —
 // each released waiter goes into pendingMsgs (and its own waiters
 // stay held until IT terminalizes; no recursive cascade). REJECTED
-// recursively cascade-rejects every descendant.
+// recursively cascade-rejects every descendant. PENDING_RETRY (the
+// requeue-budget escape) behaves structurally like REJECTED.
 //
-// Both branches mark the txid's offset Done on the tracker (and every
+// All three branches mark the txid's offset Done on the tracker (and every
 // cascaded descendant's offset too) so the Kafka commit watermark can
 // advance past them.
+//
+// PENDING_RETRY is included precisely BECAUSE it is not a verdict. A tx that
+// burned its whole requeue budget without an answer from any peer must still
+// stop pinning its Kafka offset — otherwise it keeps LowestUnfinished()
+// frozen and, on a single-partition topic, blocks every message behind it.
+// That is the 2026-08-11 dev-ovh-1 wedge in one sentence: 4,679 no-verdict
+// txs held 337,247 messages of lag stationary because nothing ever released
+// their in-flight entries. The tx is not abandoned — the reaper rebroadcasts
+// PENDING_RETRY rows from the store, off the Kafka offset path entirely.
+//
+// Held descendants are cascaded (not released into pendingMsgs) for the same
+// reason they are on the REJECTED branch: their parent never reached
+// ACCEPTED, so broadcasting them now would just draw TX_MISSING_PARENT. They
+// ride the same durable reaper retry as their parked ancestor — the CALLER
+// writes PENDING_RETRY rows for them, not REJECTED (see persistCascade).
 func handleTerminal(
 	ev terminalEvent,
 	inFlight map[string]int64,
@@ -456,7 +472,7 @@ func handleTerminal(
 		releaseWaiters(ev.txid, inFlight, waiters, heldMsgs, pendingMsgs)
 		return terminalResult{}
 
-	case models.StatusRejected:
+	case models.StatusRejected, models.StatusPendingRetry:
 		if offset, ok := inFlight[ev.txid]; ok {
 			tracker.Done(offset)
 		}

--- a/services/propagation/poison_batch_test.go
+++ b/services/propagation/poison_batch_test.go
@@ -1,0 +1,567 @@
+package propagation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/script"
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/kafka"
+	"github.com/bsv-blockchain/arcade/metrics"
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
+	"github.com/bsv-blockchain/arcade/teranode"
+)
+
+// These tests reproduce the 2026-08-11 dev-ovh-1 propagation wedge (arcade
+// v0.11.5) and pin both halves of the fix.
+//
+// The incident: Teranode answered a 21-tx batch of stale transactions with
+// HTTP 409 and 21 conflict lines shaped
+//
+//	UTXO_SPENT (70): <outpoint_txid>:<vout> utxo already spent by tx <spender>[n]
+//
+// Those lines key under the SPENT OUTPOINT, never under a submitted txid (no
+// [ProcessTransaction][<txid>] wrapper), so alienFailureLines correctly
+// withheld implicit accepts (#292) — but with no attributable rejection
+// either, every tx fell to the `default: txResultClassRequeue` arm and went
+// round again into the identical 409. ~2,410 failures in two minutes, 42 of 43
+// batches requeued, 4,679 txs stuck in the dispatcher's inFlight map pinning
+// Kafka offsets, and 337,247 messages of lag on the single-partition
+// arcade.propagation topic completely stationary while the leader pod burned
+// 4.2 CPU cores. Nothing new could propagate.
+//
+// Fix 1 (attribution): the conflict line's outpoint is matched against the
+// submitted transactions' own inputs, so the verdict lands on the tx that
+// actually spends it — REJECTED / ARC 466 instead of an eternal requeue.
+// Fix 2 (bounded requeue): anything still unattributable is parked at
+// PENDING_RETRY after propagation.retry_max_attempts, which releases the
+// dispatcher in-flight entry so the commit watermark can advance.
+
+// --- fixtures ------------------------------------------------------------
+
+// outpointRef renders an outpoint the way Teranode renders it inside a
+// conflict-family failure line.
+func outpointRef(txid string, vout uint32) string {
+	return fmt.Sprintf("%s:%d", txid, vout)
+}
+
+// spendingTx builds a parseable transaction that spends exactly the named
+// outpoint. nonce varies the locktime so two txs spending different outpoints
+// (or the same one) still hash differently. Returns the display-form txid and
+// the serialized bytes the propagation envelope carries.
+//
+// Real bytes matter here: outpoint attribution deliberately re-parses RawTx
+// rather than trusting propagationMsg.InputTXIDs, because InputTXIDs carries
+// parent txids only and an outpoint needs the vout to be unambiguous.
+func spendingTx(t *testing.T, sourceTxIDHex string, vout, nonce uint32) (txid string, raw []byte) {
+	t.Helper()
+	source, err := chainhash.NewHashFromHex(sourceTxIDHex)
+	if err != nil {
+		t.Fatalf("NewHashFromHex(%s): %v", sourceTxIDHex, err)
+	}
+	tx := sdkTx.NewTransaction()
+	tx.LockTime = nonce
+	tx.Inputs = append(tx.Inputs, &sdkTx.TransactionInput{
+		SourceTXID:       source,
+		SourceTxOutIndex: vout,
+		UnlockingScript:  &script.Script{},
+		SequenceNumber:   0xffffffff,
+	})
+	return tx.TxID().String(), tx.Bytes()
+}
+
+// realPropMsg is makePropMsg with genuine transaction bytes, so the
+// attribution path has inputs to match against.
+func realPropMsg(t *testing.T, txid string, rawTx []byte) []byte {
+	t.Helper()
+	b, err := json.Marshal(propagationMsg{TXID: txid, RawTx: rawTx})
+	if err != nil {
+		t.Fatalf("marshal propagation msg: %v", err)
+	}
+	return b
+}
+
+// conflictBody renders the exact wrapper-less UTXO_SPENT body Teranode
+// returned during the incident, one line per named outpoint.
+func conflictBody(outpoints []string, spender string) string {
+	var sb strings.Builder
+	sb.WriteString("Failed to process transactions:\n")
+	for i, op := range outpoints {
+		fmt.Fprintf(&sb, "UTXO_SPENT (70): UTXO_SPENT (70): %s utxo already spent by tx %s[%d]\n", op, spender, i)
+	}
+	return sb.String()
+}
+
+// conflictServer answers every POST /txs with HTTP 409 and the supplied body,
+// counting calls so a test can prove the retry loop is bounded.
+func conflictServer(log *eventLog, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		log.add("broadcast")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// opaqueConflictBody is a 409 whose body does NOT match Teranode's failure-list
+// shape, so parseTxsFailures returns nil and the peer contributes no per-tx
+// information at all. This is the oldest form of the poison batch and it
+// predates #292 entirely: teranode/client.go used to parse ONLY status 500, so
+// every 409 produced failures = nil and the caller "treats the batch as a pure
+// infra failure (whole batch requeued for another attempt)" — forever, if the
+// 409 was permanent. #292 made the verdicts visible for the parseable shape;
+// it neither created nor fixed the unbounded loop.
+const opaqueConflictBody = "409 Conflict: transaction rejected\n"
+
+// opaqueConflictServer answers every POST /txs with a permanent, unparseable
+// 409. Batch-size independent, which keeps the bounded-requeue tests free of
+// any dependency on how the dispatcher happened to group messages.
+func opaqueConflictServer(log *eventLog) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		log.add("broadcast")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(opaqueConflictBody))
+	}))
+}
+
+// waitForPending blocks until the dispatcher is holding at least want messages
+// in its pending accumulator, i.e. a delayed requeue has landed and the next
+// flush would pick it up.
+func waitForPending(t *testing.T, p *Propagator, want int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.pendingDepth.Load() >= int64(want) {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("dispatcher never accumulated %d pending msgs (have %d); the requeue never landed", want, p.pendingDepth.Load())
+}
+
+// poisonPropagator wires a Propagator with no merkle client (so registerBatch
+// is a pass-through), a compressed requeue delay, and an explicit retry
+// budget.
+func poisonPropagator(teranodeURL string, st store.Store, maxAttempts int, delay time.Duration) *Propagator {
+	cfg := &config.Config{}
+	cfg.Propagation.MerkleConcurrency = 10
+	cfg.Propagation.RetryMaxAttempts = maxAttempts
+	tc := teranode.NewClient([]string{teranodeURL}, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
+	p := New(cfg, zap.NewNop(), nil, nil, st, nil, tc, nil)
+	p.requeueDelay = delay
+	return p
+}
+
+// --- fix 1: attribute conflict verdicts by outpoint ----------------------
+
+// TestBroadcast_409ConflictLines_AttributedToSubmittedInputs is the incident
+// shape at batch scale. Teranode 409s a multi-tx batch with one wrapper-less
+// UTXO_SPENT line per genuinely double-spent tx, each keyed by the spent
+// outpoint rather than by the submitted txid. Every named tx must terminalize
+// REJECTED with the real UTXO_SPENT verdict and ARC 466 (StatusConflict) —
+// pre-fix all of them fell to the requeue arm and looped forever, which is
+// what froze 337,247 messages of Kafka lag.
+//
+// The batch deliberately also contains a tx whose outpoint is NOT named. The
+// peer answered 409, so it has told us nothing good about that tx: it must
+// NOT be fabricated as ACCEPTED_BY_NETWORK. The #292 withholding rule still
+// applies to the whole peer response regardless of how many lines resolved.
+func TestBroadcast_409ConflictLines_AttributedToSubmittedInputs(t *testing.T) {
+	const (
+		outA    = "256fc7143c6ef5436cd5258ade24b68c43d0f8268c086bd9fa90055dd5a7ae43"
+		outB    = "9d2c1f0e7b5a48361c0e7f2d6b48a91c33e0f8261c086bd9fa90055dd5a7bb11"
+		outC    = "11223344556677889900aabbccddeeff11223344556677889900aabbccddeeff"
+		spender = "7dfbe0fcacf630066b23036bc007e73d58a61ab9bcb8e66f6b214f8ef5f28489"
+	)
+	txidA, rawA := spendingTx(t, outA, 2, 1)
+	txidB, rawB := spendingTx(t, outB, 0, 2)
+	txidC, rawC := spendingTx(t, outC, 7, 3)
+
+	// Only A's and B's outpoints appear in the failure list.
+	body := conflictBody([]string{outpointRef(outA, 2), outpointRef(outB, 0)}, spender)
+	srv := conflictServer(&eventLog{}, body)
+	defer srv.Close()
+
+	ms := newMockStore()
+	p := poisonPropagator(srv.URL, ms, 5, time.Hour)
+
+	for _, tx := range []struct {
+		txid string
+		raw  []byte
+	}{{txidA, rawA}, {txidB, rawB}, {txidC, rawC}} {
+		if err := p.handleMessage(context.Background(), consumerMsg(realPropMsg(t, tx.txid, tx.raw))); err != nil {
+			t.Fatalf("handleMessage(%s): %v", tx.txid, err)
+		}
+	}
+	if err := flushSync(t, p); err != nil {
+		t.Fatalf("flush error: %v", err)
+	}
+
+	for _, txid := range []string{txidA, txidB} {
+		got := ms.lastUpdateForTxid(txid)
+		if got == nil {
+			t.Fatalf("%s: no status update recorded; the conflict line naming its outpoint must terminalize it (pre-fix it requeued forever)", txid)
+		}
+		if got.Status != models.StatusRejected {
+			t.Errorf("%s: status=%s want REJECTED (extraInfo=%q)", txid, got.Status, got.ExtraInfo)
+		}
+		if got.StatusCode != 466 {
+			t.Errorf("%s: StatusCode=%d want 466 (ARC StatusConflict)", txid, got.StatusCode)
+		}
+		if !strings.Contains(got.ExtraInfo, "UTXO_SPENT") || !strings.Contains(got.ExtraInfo, spender) {
+			t.Errorf("%s: ExtraInfo=%q want the verbatim UTXO_SPENT line naming the competing spender", txid, got.ExtraInfo)
+		}
+	}
+
+	// Attribution must not have leaked into a fabricated acceptance for the
+	// tx nobody named. This is the #292 property; a 409 peer grants no
+	// implicit accepts even when every one of its lines resolved.
+	if got := ms.lastUpdateForTxid(txidC); got != nil {
+		t.Errorf("%s: terminalized as %s (extraInfo=%q); an unnamed tx in a 409 batch must get no vote at all", txidC, got.Status, got.ExtraInfo)
+	}
+
+	// A and B must carry each other's verdicts correctly, not the same line
+	// twice — attribution is per-outpoint, not best-effort broadcast.
+	gotA := ms.lastUpdateForTxid(txidA)
+	gotB := ms.lastUpdateForTxid(txidB)
+	if gotA != nil && gotB != nil && gotA.ExtraInfo == gotB.ExtraInfo {
+		t.Errorf("both txs got the same line %q; each conflict line must attribute to the single tx that spends its outpoint", gotA.ExtraInfo)
+	}
+	if gotA != nil && !strings.Contains(gotA.ExtraInfo, outpointRef(outA, 2)) {
+		t.Errorf("txidA ExtraInfo=%q want the line naming its own outpoint %s", gotA.ExtraInfo, outpointRef(outA, 2))
+	}
+	if gotB != nil && !strings.Contains(gotB.ExtraInfo, outpointRef(outB, 0)) {
+		t.Errorf("txidB ExtraInfo=%q want the line naming its own outpoint %s", gotB.ExtraInfo, outpointRef(outB, 0))
+	}
+}
+
+// TestBroadcast_409UnattributableConflict_WithholdsAcceptsAndRejects is the
+// no-fabrication guard from #292, re-pinned against the attribution path so
+// the new code cannot regress it. The 409 names an outpoint no submitted tx
+// spends: arcade knows SOMETHING failed but not what, so it must invent
+// neither an ACCEPTED_BY_NETWORK nor a REJECTED for anyone. Both txs stay
+// non-terminal and fall to the (now bounded) requeue.
+func TestBroadcast_409UnattributableConflict_WithholdsAcceptsAndRejects(t *testing.T) {
+	const (
+		outA     = "256fc7143c6ef5436cd5258ade24b68c43d0f8268c086bd9fa90055dd5a7ae43"
+		outB     = "9d2c1f0e7b5a48361c0e7f2d6b48a91c33e0f8261c086bd9fa90055dd5a7bb11"
+		stranger = "cafebabe00000000000000000000000000000000000000000000000000001234"
+		spender  = "7dfbe0fcacf630066b23036bc007e73d58a61ab9bcb8e66f6b214f8ef5f28489"
+	)
+	txidA, rawA := spendingTx(t, outA, 1, 11)
+	txidB, rawB := spendingTx(t, outB, 1, 12)
+
+	// The named outpoint belongs to neither submitted tx.
+	body := conflictBody([]string{outpointRef(stranger, 3)}, spender)
+	srv := conflictServer(&eventLog{}, body)
+	defer srv.Close()
+
+	ms := newMockStore()
+	p := poisonPropagator(srv.URL, ms, 5, time.Hour)
+
+	for _, tx := range []struct {
+		txid string
+		raw  []byte
+	}{{txidA, rawA}, {txidB, rawB}} {
+		if err := p.handleMessage(context.Background(), consumerMsg(realPropMsg(t, tx.txid, tx.raw))); err != nil {
+			t.Fatalf("handleMessage(%s): %v", tx.txid, err)
+		}
+	}
+	if err := flushSync(t, p); err != nil {
+		t.Fatalf("flush error: %v", err)
+	}
+
+	for _, txid := range []string{txidA, txidB} {
+		if got := ms.lastUpdateForTxid(txid); got != nil {
+			t.Errorf("%s: terminalized as %s (extraInfo=%q); an unattributable alien 409 line must produce no vote — no fabricated accept, no guessed reject",
+				txid, got.Status, got.ExtraInfo)
+		}
+	}
+}
+
+// TestAttributeConflictLines_AmbiguousOutpointDeclines pins the one case
+// where arcade holds enough information to name a tx but must refuse to: two
+// submitted txs spend the SAME outpoint (an intra-batch double spend), so
+// Teranode's single conflict line cannot say which one lost. Guessing would
+// terminally reject a transaction that may well be the winner.
+func TestAttributeConflictLines_AmbiguousOutpointDeclines(t *testing.T) {
+	const (
+		shared  = "256fc7143c6ef5436cd5258ade24b68c43d0f8268c086bd9fa90055dd5a7ae43"
+		spender = "7dfbe0fcacf630066b23036bc007e73d58a61ab9bcb8e66f6b214f8ef5f28489"
+	)
+	txidA, rawA := spendingTx(t, shared, 0, 21)
+	txidB, rawB := spendingTx(t, shared, 0, 22)
+	if txidA == txidB {
+		t.Fatal("fixture bug: the two competing txs must differ")
+	}
+
+	batch := []propagationMsg{{TXID: txidA, RawTx: rawA}, {TXID: txidB, RawTx: rawB}}
+	owners := buildSubmittedOutpointIndex(batch)
+	if got := owners[strings.ToLower(outpointRef(shared, 0))]; got != outpointOwnerAmbiguous {
+		t.Fatalf("owners[%s]=%d want outpointOwnerAmbiguous (%d)", outpointRef(shared, 0), got, outpointOwnerAmbiguous)
+	}
+
+	line := fmt.Sprintf("UTXO_SPENT (70): %s utxo already spent by tx %s[0]", outpointRef(shared, 0), spender)
+	failures := map[string]string{strings.ToLower(shared): line}
+	inBatch := map[string]bool{strings.ToLower(txidA): true, strings.ToLower(txidB): true}
+
+	if got := attributeConflictLines(failures, inBatch, owners); len(got) != 0 {
+		t.Errorf("attributed %v; an outpoint spent by two submitted txs must attribute to neither", got)
+	}
+}
+
+// --- fix 2: bounded requeue with a terminal escape -----------------------
+
+// TestPoisonBatch_MultiTxConflict409_ParksInsteadOfLoopingForever is the
+// incident in its exact shape: a MULTI-tx batch that permanently draws an
+// HTTP 409 whose conflict line names an outpoint none of the submitted txs
+// spend. Nothing is attributable, no peer accepts, so every tx lands on the
+// `default: txResultClassRequeue` arm — which pre-fix meant "again, forever".
+//
+// The batch has to be multi-tx to reproduce it: for a single-tx batch #292's
+// len(batch) == 1 rule already attributes the alien verdict to the only
+// possible owner, so the loop never forms. That is exactly why the live
+// incident was a 21-tx batch.
+//
+// Driven through the test-mode dispatcher (nil claim ⇒ no 50ms flush ticker),
+// so batching is decided by this test's explicit flushSync calls and the two
+// txs provably stay in one batch across every retry round.
+func TestPoisonBatch_MultiTxConflict409_ParksInsteadOfLoopingForever(t *testing.T) {
+	const (
+		outA     = "256fc7143c6ef5436cd5258ade24b68c43d0f8268c086bd9fa90055dd5a7ae43"
+		outB     = "9d2c1f0e7b5a48361c0e7f2d6b48a91c33e0f8261c086bd9fa90055dd5a7bb11"
+		stranger = "deadbeef00000000000000000000000000000000000000000000000000009999"
+		spender  = "7dfbe0fcacf630066b23036bc007e73d58a61ab9bcb8e66f6b214f8ef5f28489"
+	)
+	txidA, rawA := spendingTx(t, outA, 0, 31)
+	txidB, rawB := spendingTx(t, outB, 0, 32)
+
+	broadcasts := &eventLog{}
+	srv := conflictServer(broadcasts, conflictBody([]string{outpointRef(stranger, 1)}, spender))
+	defer srv.Close()
+
+	const maxAttempts = 2
+	ms := newMockStore()
+	p := poisonPropagator(srv.URL, ms, maxAttempts, 10*time.Millisecond)
+
+	exhaustedBefore := testutil.ToFloat64(metrics.PropagationRequeueExhaustedTotal)
+
+	for _, tx := range []struct {
+		txid string
+		raw  []byte
+	}{{txidA, rawA}, {txidB, rawB}} {
+		if err := p.handleMessage(context.Background(), consumerMsg(realPropMsg(t, tx.txid, tx.raw))); err != nil {
+			t.Fatalf("handleMessage(%s): %v", tx.txid, err)
+		}
+	}
+
+	// One initial flush plus maxAttempts requeued flushes is the entire budget.
+	// Waiting for the requeue to land between rounds is what proves the loop
+	// really is running, not just failing to start.
+	for round := 0; round <= maxAttempts; round++ {
+		if round > 0 {
+			waitForPending(t, p, 2)
+		}
+		if err := flushSync(t, p); err != nil {
+			t.Fatalf("round %d flush error: %v", round, err)
+		}
+	}
+
+	// Give any surviving requeue a generous window to come back around; the
+	// budget is spent, so nothing more may reach the peer.
+	time.Sleep(150 * time.Millisecond)
+	if got := broadcasts.count("broadcast"); got != maxAttempts+1 {
+		t.Errorf("broadcast attempts=%d want %d (1 initial + %d requeues); the poison batch is still looping",
+			got, maxAttempts+1, maxAttempts)
+	}
+
+	for _, txid := range []string{txidA, txidB} {
+		got := ms.lastUpdateForTxid(txid)
+		if got == nil {
+			t.Fatalf("%s: no status update — an exhausted tx must reach a state that releases its in-flight entry", txid)
+		}
+		if got.Status != models.StatusPendingRetry {
+			t.Errorf("%s: status=%s want PENDING_RETRY — the escape must not invent a verdict (extraInfo=%q)", txid, got.Status, got.ExtraInfo)
+		}
+		if !strings.Contains(got.ExtraInfo, "no network verdict") {
+			t.Errorf("%s: ExtraInfo=%q want an operator-legible park reason", txid, got.ExtraInfo)
+		}
+		// The in-flight entry is genuinely released, not merely status-flipped:
+		// a re-admission comes back as a fresh admit rather than the duplicate
+		// a still-in-flight entry would produce.
+		if res := p.admitToDispatcher(propagationMsg{TXID: txid, RawTx: []byte{0x01}}, 90); !res.admitted {
+			t.Errorf("%s: re-admit got %+v, want admitted — a parked tx must have left the dispatcher's in-flight set", txid, res)
+		}
+	}
+
+	if d := testutil.ToFloat64(metrics.PropagationRequeueExhaustedTotal) - exhaustedBefore; d != 2 {
+		t.Errorf("requeue-exhausted counter delta=%v want 2", d)
+	}
+}
+
+// TestRunDispatcher_PoisonBatch_ExhaustsRetriesAndAdvancesWatermark asserts the
+// property that actually unwedges the consumer: claim.MarkMessage — the Kafka
+// commit signal — must eventually fire for a transaction that never gets a
+// verdict.
+//
+// The peer here answers a permanent 409 with an unparseable body, so it
+// contributes no per-tx information at all. That is the oldest form of the
+// poison batch and it long predates #292: teranode/client.go used to parse
+// only status 500, so ANY persistent non-500 produced failures = nil and the
+// whole batch requeued for another attempt, forever. Pre-fix the tx stayed in
+// inFlight, its offset kept pinning offsetTracker.LowestUnfinished(),
+// advanceMarks never marked it, and on the single-partition
+// arcade.propagation topic every later message queued behind it — 337,247 of
+// them, stationary, on dev-ovh-1.
+func TestRunDispatcher_PoisonBatch_ExhaustsRetriesAndAdvancesWatermark(t *testing.T) {
+	const out = "256fc7143c6ef5436cd5258ade24b68c43d0f8268c086bd9fa90055dd5a7ae43"
+	txid, raw := spendingTx(t, out, 0, 41)
+
+	broadcasts := &eventLog{}
+	srv := opaqueConflictServer(broadcasts)
+	defer srv.Close()
+
+	const maxAttempts = 2
+	ms := newMockStore()
+	p := poisonPropagator(srv.URL, ms, maxAttempts, 20*time.Millisecond)
+
+	exhaustedBefore := testutil.ToFloat64(metrics.PropagationRequeueExhaustedTotal)
+
+	claim, stop := runDispatcherWithClaim(t, p)
+	defer stop()
+
+	claim.ch <- &kafka.Message{Offset: 41, Value: realPropMsg(t, txid, raw)}
+	waitForMark(t, claim, 41,
+		"a permanently unresolvable batch must exhaust its retry budget and release the offset; without the bound the commit watermark pins forever and the whole partition wedges")
+
+	got := ms.lastUpdateForTxid(txid)
+	if got == nil {
+		t.Fatal("no status update recorded for the parked tx")
+	}
+	if got.Status != models.StatusPendingRetry {
+		t.Errorf("status=%s want PENDING_RETRY — the escape must not invent a verdict (extraInfo=%q)", got.Status, got.ExtraInfo)
+	}
+	if !strings.Contains(got.ExtraInfo, "no network verdict") {
+		t.Errorf("ExtraInfo=%q want an operator-legible park reason", got.ExtraInfo)
+	}
+	if d := testutil.ToFloat64(metrics.PropagationRequeueExhaustedTotal) - exhaustedBefore; d != 1 {
+		t.Errorf("requeue-exhausted counter delta=%v want 1", d)
+	}
+
+	// Bounded, not merely eventually-terminal: nothing may reach the peer once
+	// the budget is spent.
+	settled := broadcasts.count("broadcast")
+	if settled != maxAttempts+1 {
+		t.Errorf("broadcast attempts=%d want %d (1 initial + %d requeues)", settled, maxAttempts+1, maxAttempts)
+	}
+	time.Sleep(150 * time.Millisecond) // ≫ requeueDelay: a surviving loop would fire several more times
+	if again := broadcasts.count("broadcast"); again != settled {
+		t.Errorf("broadcasts kept firing after the park (%d → %d); the requeue loop is still alive", settled, again)
+	}
+
+	// The in-flight entry is genuinely gone, not just offset-marked.
+	if res := p.admitToDispatcher(propagationMsg{TXID: txid, RawTx: raw}, 42); !res.admitted {
+		t.Errorf("re-admit got %+v, want admitted — the parked tx must have left the dispatcher's in-flight set", res)
+	}
+}
+
+// TestRequeueBudget_ConfigurableAndDefault pins both halves of "configurable
+// with a sensible default": the propagation.retry_max_attempts value is
+// honored verbatim, and an unset (or nonsensical) value falls back to
+// defaultRetryMaxAttempts rather than to "unbounded" — an unbounded requeue is
+// the failure this budget exists to prevent, so it must not be configurable
+// away.
+func TestRequeueBudget_ConfigurableAndDefault(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		for _, configured := range []int{0, -1} {
+			cfg := &config.Config{}
+			cfg.Propagation.RetryMaxAttempts = configured
+			p := New(cfg, zap.NewNop(), nil, nil, newMockStore(), nil, nil, nil)
+			if p.retryMaxAttempts != defaultRetryMaxAttempts {
+				t.Errorf("retry_max_attempts=%d → budget %d, want the default %d", configured, p.retryMaxAttempts, defaultRetryMaxAttempts)
+			}
+			if p.requeueDelay != defaultRequeueDelay {
+				t.Errorf("requeueDelay=%v want %v", p.requeueDelay, defaultRequeueDelay)
+			}
+		}
+		if defaultRetryMaxAttempts != 5 {
+			t.Errorf("defaultRetryMaxAttempts=%d; it must stay equal to the shipped propagation.retry_max_attempts viper default (5)", defaultRetryMaxAttempts)
+		}
+	})
+
+	// Behavioral half: the configured budget, not a hardcoded constant, decides
+	// how many broadcasts a poison tx gets before it is parked.
+	t.Run("configured budget bounds the broadcast count", func(t *testing.T) {
+		for _, maxAttempts := range []uint32{1, 3} {
+			t.Run(fmt.Sprintf("max=%d", maxAttempts), func(t *testing.T) {
+				const out = "256fc7143c6ef5436cd5258ade24b68c43d0f8268c086bd9fa90055dd5a7ae43"
+				txid, raw := spendingTx(t, out, 0, 100+maxAttempts)
+
+				broadcasts := &eventLog{}
+				srv := opaqueConflictServer(broadcasts)
+				defer srv.Close()
+
+				ms := newMockStore()
+				p := poisonPropagator(srv.URL, ms, int(maxAttempts), 10*time.Millisecond)
+				if p.retryMaxAttempts != int(maxAttempts) {
+					t.Fatalf("configured budget not honored: got %d want %d", p.retryMaxAttempts, maxAttempts)
+				}
+
+				claim, stop := runDispatcherWithClaim(t, p)
+				defer stop()
+
+				claim.ch <- &kafka.Message{Offset: 61, Value: realPropMsg(t, txid, raw)}
+				waitForMark(t, claim, 61, "the poison tx must park and release its offset")
+
+				if got := broadcasts.count("broadcast"); got != int(maxAttempts)+1 {
+					t.Errorf("broadcast attempts=%d want %d (1 initial + %d requeues)", got, maxAttempts+1, maxAttempts)
+				}
+				if got := ms.lastUpdateForTxid(txid); got == nil || got.Status != models.StatusPendingRetry {
+					t.Errorf("final status=%v want PENDING_RETRY", got)
+				}
+			})
+		}
+	})
+}
+
+// TestHandleTerminal_PendingRetry_ReleasesOffsetAndCascades is the
+// dispatcher-level contract behind the escape hatch, asserted in isolation:
+// a park must Done the tx's offset (so LowestUnfinished stops pinning) and
+// must also release every held descendant's offset. Missing either one leaves
+// the commit watermark exactly as frozen as the unbounded requeue did.
+func TestHandleTerminal_PendingRetry_ReleasesOffsetAndCascades(t *testing.T) {
+	s := newDispatcherState()
+
+	if r := s.admit("parent", 1); !r.admitted {
+		t.Fatalf("parent should admit; got %+v", r)
+	}
+	s.pendingMsgs = nil
+	if r := s.admit("child", 2, "parent"); !r.held {
+		t.Fatalf("child should be held behind parent; got %+v", r)
+	}
+
+	res := s.terminal("parent", models.StatusPendingRetry)
+	if len(res.cascaded) != 1 || res.cascaded[0] != "child" {
+		t.Fatalf("parking a parent must cascade its held descendants; got %v", res.cascaded)
+	}
+	if !s.tracker.Empty() {
+		t.Fatal("PENDING_RETRY must Done the parked tx's offset AND every cascaded descendant's; tracker should be empty")
+	}
+	if _, ok := s.inFlight["parent"]; ok {
+		t.Error("parked tx must leave the in-flight set")
+	}
+	if _, ok := s.inFlight["child"]; ok {
+		t.Error("cascaded descendant must leave the in-flight set")
+	}
+}

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -9,12 +9,15 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -63,6 +66,17 @@ type propagationMsg struct {
 	// processBatch to link the batch's "propagation.broadcast" span back to
 	// each tx's originating producer span — see startBroadcastSpan.
 	spanCtx trace.SpanContext
+	// retryCount is how many times this tx has already been pushed back
+	// through requeueAfterDelay on THIS claim. Like spanCtx it is process-
+	// local and deliberately not serialized: a tx re-read from Kafka after a
+	// restart or rebalance is a fresh attempt against (probably) a different
+	// downstream state, so its budget resets. requeueAfterDelay increments it
+	// and parks the tx at PENDING_RETRY once it exceeds
+	// Propagator.retryMaxAttempts — without that ceiling a batch that can
+	// never succeed loops forever and its in-flight entries freeze the Kafka
+	// commit watermark (the 2026-08-11 dev-ovh-1 wedge: 337,247 messages of
+	// lag stationary behind 4,679 in-flight txs).
+	retryCount int
 }
 
 type Propagator struct {
@@ -105,6 +119,18 @@ type Propagator struct {
 	maxParallelChunks int
 	holderID          string
 	leaseTTL          time.Duration
+	// retryMaxAttempts is the per-claim in-memory requeue budget
+	// (propagation.retry_max_attempts, default defaultRetryMaxAttempts). See
+	// requeueAfterDelay / parkExhaustedRequeues for what happens when it runs
+	// out, and config.PropagationConfig.RetryMaxAttempts for the incident that
+	// motivated bounding it at all.
+	retryMaxAttempts int
+	// requeueDelay is the flat wait before a requeue lands back on the
+	// dispatcher. Initialized to defaultRequeueDelay; carried as a field
+	// rather than referenced as a constant so tests can compress the
+	// retry loop to milliseconds instead of spending
+	// retryMaxAttempts × 2s of wall time per case.
+	requeueDelay time.Duration
 
 	// broadcastJobs feeds the persistent worker pool that runs every
 	// per-endpoint POST /txs call. Replaces the previous per-broadcast
@@ -244,6 +270,17 @@ const defaultBroadcastWorkers = 256
 // defaultMaxParallelChunks × len(endpoints).
 const defaultMaxParallelChunks = 4
 
+// defaultRetryMaxAttempts is the in-memory requeue budget applied when
+// propagation.retry_max_attempts is unset or non-positive. Kept equal to the
+// shipped viper default (config.setDefaults) so the code and the config file
+// can never disagree about what "unset" means.
+//
+// Five attempts × defaultRequeueDelay is ~10s of fast-path retry, which
+// comfortably rides out the blips the requeue arm was built for (a peer
+// restarting, a merkle-service hiccup) while guaranteeing a permanently
+// unresolvable batch reaches its terminal escape in seconds rather than never.
+const defaultRetryMaxAttempts = 5
+
 // New constructs a Propagator. leaser may be nil, in which case the reaper
 // runs unguarded — appropriate for tests and single-process deployments that
 // don't need coordination. In production every replica should receive a
@@ -295,6 +332,13 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 	if maxParallelChunks <= 0 {
 		maxParallelChunks = defaultMaxParallelChunks
 	}
+	// A non-positive retry_max_attempts falls back to the default rather than
+	// meaning "unlimited": an unbounded requeue loop is precisely the failure
+	// this budget exists to prevent, so there is no way to configure it away.
+	retryMaxAttempts := cfg.Propagation.RetryMaxAttempts
+	if retryMaxAttempts <= 0 {
+		retryMaxAttempts = defaultRetryMaxAttempts
+	}
 	p := &Propagator{
 		cfg:               cfg,
 		logger:            logger.Named("propagation"),
@@ -314,6 +358,8 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 		maxParallelChunks: maxParallelChunks,
 		holderID:          newHolderID(),
 		leaseTTL:          leaseTTL,
+		retryMaxAttempts:  retryMaxAttempts,
+		requeueDelay:      defaultRequeueDelay,
 		broadcastJobs:     make(chan broadcastJob, broadcastJobBuffer),
 		processBatchSem:   make(chan struct{}, maxConcurrentBatches),
 		admitCh:           make(chan admitRequest, dispatcherChannelBuffer),
@@ -381,9 +427,18 @@ func (p *Propagator) Name() string { return "propagation" }
 
 // applyTerminalStatuses persists the per-tx terminal statuses produced by
 // processBatch in one BatchUpdateStatusReturning call, observes the
-// RECEIVED→{ACCEPTED_BY_NETWORK,REJECTED} transition age, emits one
-// PublishBulk per terminal status, and notifies the dispatcher so it can
+// RECEIVED→{ACCEPTED_BY_NETWORK,REJECTED,PENDING_RETRY} transition age, emits
+// one PublishBulk per status, and notifies the dispatcher so it can
 // release/cascade waiters and mark the Kafka offset Done.
+//
+// "Terminal" here means terminal FOR THE DISPATCHER — the point at which a tx
+// stops pinning its Kafka offset — not terminal for the client. Three statuses
+// qualify: ACCEPTED_BY_NETWORK, REJECTED, and PENDING_RETRY (the requeue-budget
+// escape, see parkExhaustedRequeues). Routing the park through this one
+// function is deliberate: it is the only place that both persists a status and
+// tells the dispatcher to release the in-flight entry, and a park that failed
+// to release would leave the consumer exactly as wedged as the unbounded
+// requeue loop it replaced.
 //
 // It walks the batch with two deliberately separate accounting passes:
 //
@@ -422,14 +477,16 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 		// be released even when the store write failed.
 	}
 
-	// terminalAccepted/terminalRejected drive the dispatcher notification:
-	// every terminalized tx, unconditionally.
+	// terminalAccepted/terminalRejected/terminalParked drive the dispatcher
+	// notification: every terminalized tx, unconditionally.
 	terminalAccepted := make([]string, 0, accepted)
 	terminalRejected := make([]string, 0, rejected)
-	// publishedAccepted/publishedRejected drive the bulk publish: only
-	// rows whose store status actually transitioned.
+	var terminalParked []string
+	// published* drive the bulk publish: only rows whose store status
+	// actually transitioned.
 	publishedAccepted := make([]string, 0, accepted)
 	publishedRejected := make([]string, 0, rejected)
+	var publishedParked []string
 	now := time.Now()
 	for i, st := range terminalStatuses {
 		var prev *models.TransactionStatus
@@ -437,14 +494,16 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 			prev = prevs[i]
 		}
 
-		// Dispatcher accounting — unconditional. processBatch only routes
-		// ACCEPTED_BY_NETWORK and REJECTED into terminalStatuses; the
-		// defensive default keeps the switch exhaustive.
+		// Dispatcher accounting — unconditional. Callers only route
+		// ACCEPTED_BY_NETWORK, REJECTED and PENDING_RETRY into
+		// terminalStatuses; the defensive default keeps the switch exhaustive.
 		switch st.Status {
 		case models.StatusAcceptedByNetwork:
 			terminalAccepted = append(terminalAccepted, st.TxID)
 		case models.StatusRejected:
 			terminalRejected = append(terminalRejected, st.TxID)
+		case models.StatusPendingRetry:
+			terminalParked = append(terminalParked, st.TxID)
 		default:
 		}
 
@@ -474,6 +533,8 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 				zap.String("reason", st.ExtraInfo),
 				logfields.Stage(logfields.StageNetwork),
 			)
+		case models.StatusPendingRetry:
+			publishedParked = append(publishedParked, st.TxID)
 		default:
 		}
 	}
@@ -498,6 +559,7 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 
 	p.publishBulkStatus(ctx, models.StatusAcceptedByNetwork, publishedAccepted, now)
 	p.publishBulkStatus(ctx, models.StatusRejected, publishedRejected, now)
+	p.publishBulkStatus(ctx, models.StatusPendingRetry, publishedParked, now)
 
 	// Notify the dispatcher ONLY when the batch status write fully
 	// succeeded. BatchUpdateStatusReturning surfaces per-row failures as
@@ -520,74 +582,116 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 	// dispatcher's pendingMsgs). REJECTED returns cascaded
 	// descendants we write REJECTED rows for; the cascade reason names
 	// the rejected ancestor but never its cause — see
-	// persistCascadeRejections.
-	var allCascaded []cascadeRejection
+	// persistCascade.
+	//
+	// PENDING_RETRY behaves like REJECTED structurally (offset released,
+	// held descendants collected) but the descendants are parked, not
+	// rejected: their ancestor produced NO verdict, so condemning them would
+	// invent one. They ride the same durable reaper retry as the parked
+	// ancestor.
+	var allRejectCascaded, allParkCascaded []cascadeRejection
 	for _, txid := range terminalAccepted {
 		p.notifyTerminalToDispatcher(ctx, txid, models.StatusAcceptedByNetwork)
 	}
 	for _, txid := range terminalRejected {
 		r := p.notifyTerminalToDispatcher(ctx, txid, models.StatusRejected)
 		for _, child := range r.cascaded {
-			allCascaded = append(allCascaded, cascadeRejection{txid: child, ancestor: txid})
+			allRejectCascaded = append(allRejectCascaded, cascadeRejection{txid: child, ancestor: txid})
 		}
 	}
-	if len(allCascaded) > 0 {
-		p.persistCascadeRejections(ctx, allCascaded, now)
+	for _, txid := range terminalParked {
+		r := p.notifyTerminalToDispatcher(ctx, txid, models.StatusPendingRetry)
+		for _, child := range r.cascaded {
+			allParkCascaded = append(allParkCascaded, cascadeRejection{txid: child, ancestor: txid})
+		}
+	}
+	if len(allRejectCascaded) > 0 {
+		p.persistCascade(ctx, allRejectCascaded, models.StatusRejected, now)
+	}
+	if len(allParkCascaded) > 0 {
+		p.persistCascade(ctx, allParkCascaded, models.StatusPendingRetry, now)
 	}
 }
 
-// cascadeRejection pairs a cascade-rejected tx with the terminal-rejected
-// ancestor whose verdict condemned it, so the persisted reason can name the
-// row a client should look at (and resubmit first).
+// cascadeRejection pairs a cascade-terminalized tx with the ancestor whose
+// outcome condemned (REJECTED) or parked (PENDING_RETRY) it, so the persisted
+// reason can name the row a client should look at (and resubmit first).
 type cascadeRejection struct {
 	txid     string
 	ancestor string
 }
 
-// persistCascadeRejections writes terminal REJECTED rows for txs the
-// dep cascade rejected without ever broadcasting them, then emits one
+// cascadeReason renders the ExtraInfo for a tx that inherited its ancestor's
+// outcome without ever being broadcast itself.
+//
+// "parent rejected" is kept as the stable prefix existing consumers match on.
+// Both variants state the recovery path explicitly, because neither is a
+// verdict about this tx's bytes — it is a consequence of queue state, so once
+// the ancestor clears, a resubmission re-runs the pipeline (intake re-validates
+// and re-broadcasts REJECTED rows).
+func cascadeReason(status models.Status, ancestor string) string {
+	if status == models.StatusPendingRetry {
+		return fmt.Sprintf(
+			"parent parked for durable retry (ancestor %s): retryable — the ancestor got no network verdict; both are rebroadcast by the reaper",
+			ancestor,
+		)
+	}
+	return fmt.Sprintf(
+		"parent rejected (ancestor %s): retryable — resubmit after the ancestor is accepted",
+		ancestor,
+	)
+}
+
+// persistCascade writes rows for txs the dep cascade terminalized without ever
+// broadcasting them — REJECTED when their ancestor was rejected, PENDING_RETRY
+// when their ancestor was parked by the requeue-budget escape — then emits one
 // bulk publish so SSE/webhook subscribers learn about the outcome.
 // Best-effort: a store write failure is logged but doesn't undo the
 // in-memory cascade state (the dispatcher has already terminalized
 // them; we'd be reconciling at restart via Kafka replay anyway).
-func (p *Propagator) persistCascadeRejections(ctx context.Context, cascaded []cascadeRejection, now time.Time) {
+func (p *Propagator) persistCascade(ctx context.Context, cascaded []cascadeRejection, status models.Status, now time.Time) {
 	statuses := make([]*models.TransactionStatus, len(cascaded))
 	txids := make([]string, len(cascaded))
 	for i, cr := range cascaded {
 		txids[i] = cr.txid
-		// "parent rejected" (kept as the stable prefix existing consumers
-		// match on) is the only structural reason that applies to a
-		// cascaded child — it didn't fail for any reason of its own. The
-		// suffix names the rejected ancestor whose row carries the actual
-		// cause, and states the recovery path: this rejection is a
-		// consequence of queue state, not a verdict about this tx's bytes,
-		// so once the ancestor is accepted a resubmission re-runs the
-		// pipeline (intake re-validates and re-broadcasts REJECTED rows).
-		reason := fmt.Sprintf(
-			"parent rejected (ancestor %s): retryable — resubmit after the ancestor is accepted",
-			cr.ancestor,
-		)
+		// The cascaded child didn't fail for any reason of its own; the
+		// reason names the ancestor whose row carries the actual cause.
+		reason := cascadeReason(status, cr.ancestor)
 		statuses[i] = &models.TransactionStatus{
 			TxID:      cr.txid,
-			Status:    models.StatusRejected,
+			Status:    status,
 			Timestamp: now,
 			ExtraInfo: reason,
 		}
-		p.logger.Info(
-			"transaction rejected",
-			logfields.TxID(cr.txid),
-			zap.String("reason", reason),
-			logfields.Stage(logfields.StageCascade),
+		// One line per cascade-REJECTED tx preserves the existing searchable
+		// "transaction rejected" record. The parked cascade gets a single
+		// bounded line below instead — a park is not a verdict, and an
+		// upstream outage can cascade a lot of them at once.
+		if status == models.StatusRejected {
+			p.logger.Info(
+				"transaction rejected",
+				logfields.TxID(cr.txid),
+				zap.String("reason", reason),
+				logfields.Stage(logfields.StageCascade),
+			)
+		}
+	}
+	if status == models.StatusPendingRetry {
+		parkFields := append(
+			[]zap.Field{logfields.Stage(logfields.StageCascade)},
+			logfields.TxIDBatch(txids)...,
 		)
+		p.logger.Warn("transactions parked behind an ancestor with no network verdict", parkFields...)
 	}
 	if _, err := p.store.BatchUpdateStatusReturning(ctx, statuses); err != nil {
 		p.logger.Warn(
-			"cascade rejection write failed",
+			"cascade status write failed",
+			logfields.Status(string(status)),
 			zap.Int("count", len(cascaded)),
 			zap.Error(err),
 		)
 	}
-	p.publishBulkStatus(ctx, models.StatusRejected, txids, now)
+	p.publishBulkStatus(ctx, status, txids, now)
 }
 
 // publishBulkStatus fans a post-broadcast batch status update onto the
@@ -1103,6 +1207,135 @@ func alienFailureLines(failures map[string]string, inBatch map[string]bool) (cou
 	return count, best
 }
 
+// outpointRefPattern matches an "<txid>:<vout>" outpoint reference anywhere in
+// a Teranode failure line. The conflict family renders the spent outpoint in
+// exactly this form — "UTXO_SPENT (70): <outpoint_txid>:<vout> utxo already
+// spent by tx <spender_txid>[n]" — and, crucially, renders the COMPETING
+// SPENDER with a bracketed index instead ("...[0]"), so a colon-anchored match
+// can never pick up the spender by accident. Case-insensitive because Teranode
+// lowercases but the regex stays defensive, exactly like txsTxidPattern.
+var outpointRefPattern = regexp.MustCompile(`[0-9a-fA-F]{64}:[0-9]{1,10}`)
+
+// outpointOwnerAmbiguous marks an outpoint spent by more than one tx in the
+// same submitted batch — an intra-batch double spend. Teranode's single
+// conflict line cannot say which of them lost, so such an outpoint attributes
+// to nobody (see attributeConflictLines).
+const outpointOwnerAmbiguous = -1
+
+// buildSubmittedOutpointIndex maps every outpoint spent by the batch to the
+// index of the single tx that spends it, or outpointOwnerAmbiguous when
+// several do. Keys are lowercase "<txid>:<vout>" so they compare directly
+// against what outpointRefPattern lifts out of a Teranode failure line.
+//
+// The raw bytes are re-parsed here rather than read off propagationMsg —
+// InputTXIDs carries parent txids only, and an outpoint needs the vout to be
+// unambiguous (two inputs of the same batch can spend two different outputs of
+// the same parent). Parsing is confined to the failure path: the caller only
+// builds the index when a peer actually returned alien lines, and builds it at
+// most once per batch no matter how many peers do.
+//
+// Unparseable raw bytes are skipped, not fatal — a tx we cannot parse simply
+// owns no outpoints and therefore attracts no attribution.
+func buildSubmittedOutpointIndex(batch []propagationMsg) map[string]int {
+	owners := make(map[string]int, len(batch))
+	for i, msg := range batch {
+		tx, err := sdkTx.NewTransactionFromBytes(msg.RawTx)
+		if err != nil || tx == nil {
+			continue
+		}
+		for _, in := range tx.Inputs {
+			if in == nil || in.SourceTXID == nil {
+				continue
+			}
+			key := strings.ToLower(in.SourceTXID.String()) + ":" + strconv.FormatUint(uint64(in.SourceTxOutIndex), 10)
+			if prev, seen := owners[key]; seen && prev != i {
+				owners[key] = outpointOwnerAmbiguous
+				continue
+			}
+			owners[key] = i
+		}
+	}
+	return owners
+}
+
+// attributeConflictLines resolves alien (outpoint-keyed) failure lines back to
+// the submitted transactions they actually condemn, returning batch-index →
+// line for every line it could place.
+//
+// This is the fix for the common case behind the 2026-08-11 wedge. Teranode's
+// conflict verdicts name the spent outpoint rather than the submitted txid, so
+// #292 could tell that SOMETHING in the batch had failed but not what — and a
+// tx with neither an accept vote nor an attributable rejection falls to
+// requeue, forever. arcade does hold the submitted raw transactions, so for
+// the overwhelmingly common shape (one line per genuinely double-spent tx) it
+// can simply look up which submitted tx spends that outpoint and terminalize
+// it REJECTED with the real verdict.
+//
+// The safety property from #292 is preserved verbatim: attribution only ever
+// ADDS rejection votes, and only on an exact outpoint match against a
+// submitted input. A line whose outpoint matches nothing, or matches more than
+// one submitted tx, is left alone — nothing is guessed, and no acceptance is
+// ever fabricated. Callers keep withholding implicit accepts for the peer
+// regardless of how many lines were attributed.
+//
+// Iteration is over sorted keys so a batch that draws two attributable lines
+// for the same tx resolves to the same ExtraInfo on every run, independent of
+// Go's map iteration order.
+func attributeConflictLines(failures map[string]string, inBatch map[string]bool, owners map[string]int) map[int]string {
+	if len(failures) == 0 || len(owners) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(failures))
+	for key := range failures {
+		if !inBatch[key] {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	var attributed map[int]string
+	for _, key := range keys {
+		line := failures[key]
+		idx, ok := attributeOneConflictLine(line, owners)
+		if !ok {
+			metrics.PropagationConflictAttributionTotal.WithLabelValues("unattributable").Inc()
+			continue
+		}
+		metrics.PropagationConflictAttributionTotal.WithLabelValues("attributed").Inc()
+		if attributed == nil {
+			attributed = make(map[int]string, len(keys))
+		}
+		attributed[idx] = preferRejectionLine(attributed[idx], line)
+	}
+	return attributed
+}
+
+// attributeOneConflictLine finds the submitted tx a single failure line
+// condemns by matching every "<txid>:<vout>" the line mentions against the
+// batch's spent outpoints. Returns the batch index and true only when the line
+// resolves to exactly one submitted tx.
+func attributeOneConflictLine(line string, owners map[string]int) (int, bool) {
+	matches := outpointRefPattern.FindAllString(line, -1)
+	found := -1
+	for _, ref := range matches {
+		idx, ok := owners[strings.ToLower(ref)]
+		if !ok || idx == outpointOwnerAmbiguous {
+			continue
+		}
+		if found >= 0 && found != idx {
+			// The line names spent outpoints belonging to two different
+			// submitted txs. Nothing about that shape tells us which one the
+			// verdict is about, so decline rather than guess.
+			return 0, false
+		}
+		found = idx
+	}
+	if found < 0 {
+		return 0, false
+	}
+	return found, true
+}
+
 // rejectionLineScore ranks a Teranode failure line for wallet-facing quality.
 // Higher is better. Unknown free text scores 0.
 func rejectionLineScore(line string) int {
@@ -1389,16 +1622,24 @@ func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) {
 	)
 }
 
-// requeueDelay is the flat wait before a requeue lands back on the
+// defaultRequeueDelay is the flat wait before a requeue lands back on the
 // dispatcher. Long enough to ride out a brief upstream blip; short
 // enough that submitter-visible latency stays acceptable. Tunable if
-// observed retry traffic suggests a different cadence works better.
-const requeueDelay = 2 * time.Second
+// observed retry traffic suggests a different cadence works better; carried
+// on the Propagator as requeueDelay so tests can compress it.
+const defaultRequeueDelay = 2 * time.Second
 
 // requeueAfterDelay schedules a delayed requeue of msgs through the
-// dispatcher. Spawns a goroutine that sleeps requeueDelay then sends
+// dispatcher. Spawns a goroutine that sleeps p.requeueDelay then sends
 // each msg to requeueCh. The goroutine bails on ctx cancellation so
 // claim revocation and shutdown don't hold txs in limbo.
+//
+// Every requeue costs the tx one unit of its retry budget
+// (propagation.retry_max_attempts). Txs whose budget is spent do NOT go
+// round again: they are parked at PENDING_RETRY by parkExhaustedRequeues,
+// which releases their dispatcher in-flight entry so the Kafka commit
+// watermark can advance. That ceiling is the whole reason this function
+// splits its input — see the incident write-up on parkExhaustedRequeues.
 //
 // Bailing on ctx.Done is safe for at-least-once delivery: a requeue
 // dropped here leaves the tx in the dispatcher's inFlight set with its
@@ -1419,6 +1660,10 @@ func (p *Propagator) requeueAfterDelay(ctx context.Context, msgs []propagationMs
 	// minus the 2s of parked goroutines per aborted batch a rebalance used
 	// to accumulate. Also skips the "transactions requeued for retry" Info,
 	// which would be a lie: nothing is being requeued.
+	//
+	// Checked BEFORE the budget is charged: a claim revocation is not an
+	// attempt, and charging for it would let a rebalance storm park txs that
+	// were never actually broadcast.
 	if ctx.Err() != nil {
 		p.logger.Debug(
 			"requeue dropped before delay elapsed; txs left uncommitted for replay",
@@ -1426,6 +1671,15 @@ func (p *Propagator) requeueAfterDelay(ctx context.Context, msgs []propagationMs
 		)
 		return
 	}
+
+	msgs, exhausted := p.chargeRetryBudget(msgs)
+	if len(exhausted) > 0 {
+		p.parkExhaustedRequeues(ctx, exhausted)
+	}
+	if len(msgs) == 0 {
+		return
+	}
+
 	requeueTxIDs := make([]string, len(msgs))
 	for i, m := range msgs {
 		requeueTxIDs[i] = m.TXID
@@ -1447,7 +1701,7 @@ func (p *Propagator) requeueAfterDelay(ctx context.Context, msgs []propagationMs
 	go func(msgs []propagationMsg) {
 		defer metrics.PropagationPendingRequeues.Dec()
 		select {
-		case <-time.After(requeueDelay):
+		case <-time.After(p.requeueDelay):
 		case <-ctx.Done():
 			p.logger.Debug(
 				"requeue dropped before delay elapsed; txs left uncommitted for replay",
@@ -1468,6 +1722,94 @@ func (p *Propagator) requeueAfterDelay(ctx context.Context, msgs []propagationMs
 			}
 		}
 	}(msgs)
+}
+
+// chargeRetryBudget debits one attempt from every msg and splits the batch
+// into the txs that may go round again and the txs whose budget is spent.
+// The increment is on the local copy of each msg, which is exactly right:
+// requeueToDispatcher sends the value on to the dispatcher, which stores it
+// verbatim in pendingMsgs/heldMsgs, so the count rides with the tx through
+// every subsequent flush on this claim.
+func (p *Propagator) chargeRetryBudget(msgs []propagationMsg) (retry, exhausted []propagationMsg) {
+	retry = make([]propagationMsg, 0, len(msgs))
+	for _, m := range msgs {
+		m.retryCount++
+		if m.retryCount > p.retryMaxAttempts {
+			exhausted = append(exhausted, m)
+			continue
+		}
+		retry = append(retry, m)
+	}
+	return retry, exhausted
+}
+
+// parkExhaustedRequeues is the poison-batch escape hatch: it moves txs that
+// spent their whole requeue budget without ever drawing a network verdict to
+// PENDING_RETRY, which releases their dispatcher in-flight entry and lets the
+// Kafka commit watermark advance past them.
+//
+// WHY this has to exist. Before it, "no verdict" meant "requeue", full stop,
+// and a batch that could never succeed simply went round forever. On
+// 2026-08-11 (dev-ovh-1, arcade v0.11.5) Teranode answered a 21-tx batch of
+// stale transactions with HTTP 409 and 21 conflict lines of the form
+// "UTXO_SPENT (70): <outpoint>:<vout> utxo already spent by tx <spender>[n]".
+// Those lines key under the spent outpoint, not the submitted txid, so
+// alienFailureLines correctly withheld implicit accepts (#292) and — with no
+// attributable rejection either — every tx fell to the requeue arm. Result:
+// ~2,410 409s in two minutes, 42 of 43 batches requeued, 4,679 txs stuck in
+// the dispatcher's inFlight map pinning offsets, and 337,247 messages of lag
+// on the single-partition arcade.propagation topic frozen solid while the
+// leader pod burned 4.2 CPU cores. Every newly submitted transaction sat at
+// RECEIVED until operators hand-seeked the consumer group past the backlog.
+//
+// WHY PENDING_RETRY and not REJECTED. The requeue arm covers genuine infra
+// failure too (no healthy peer, body-less 5xx, merkle /watch blip). Rejecting
+// on a ~10s budget would turn a brief Teranode outage into a wave of false
+// terminal REJECTEDs. PENDING_RETRY is honest — "no verdict yet" — keeps the
+// row's raw bytes, and hands ownership to the reaper, which rebroadcasts
+// PENDING_RETRY rows on its own (much slower, offset-free) cadence. Nothing is
+// dropped; only the fast path gives up.
+//
+// The write goes through applyTerminalStatuses precisely because that is the
+// one path that both persists the status AND notifies the dispatcher. A park
+// that skipped the notify would leave the in-flight entry — and therefore the
+// wedge — exactly as it was.
+func (p *Propagator) parkExhaustedRequeues(ctx context.Context, msgs []propagationMsg) {
+	now := time.Now()
+	txids := make([]string, len(msgs))
+	statuses := make([]*models.TransactionStatus, len(msgs))
+	reason := fmt.Sprintf(
+		"no network verdict after %d propagation attempts: retryable — parked for durable rebroadcast by the propagation reaper",
+		p.retryMaxAttempts,
+	)
+	for i, m := range msgs {
+		txids[i] = m.TXID
+		statuses[i] = &models.TransactionStatus{
+			TxID:      m.TXID,
+			Status:    models.StatusPendingRetry,
+			Timestamp: now,
+			ExtraInfo: reason,
+		}
+	}
+
+	metrics.PropagationRequeueExhaustedTotal.Add(float64(len(msgs)))
+	// ERROR, not Warn: reaching this line means transactions got no answer
+	// from any peer across the entire fast-path budget. It is always worth
+	// waking someone up, and the bounded txid list is what an operator needs
+	// to reproduce the failing submit against Teranode by hand.
+	parkFields := append(
+		[]zap.Field{
+			zap.Int("attempts", p.retryMaxAttempts),
+			logfields.Stage(logfields.StageNetwork),
+		},
+		logfields.TxIDBatch(txids)...,
+	)
+	p.logger.Error(
+		"propagation retry budget exhausted with no network verdict; parking txs at PENDING_RETRY so the Kafka commit watermark can advance",
+		parkFields...,
+	)
+
+	p.applyTerminalStatuses(ctx, statuses, 0, 0)
 }
 
 // Per-batch chunk parallelism is now config-driven via
@@ -1666,8 +2008,12 @@ func (p *Propagator) submitBroadcastJobs(ctx context.Context, endpoints []string
 //     Implicit acceptance is only trusted when every failure line named a
 //     submitted tx; conflict-family lines key under alien hashes (spent
 //     outpoint / competing spender — no [ProcessTransaction] wrapper), in
-//     which case the peer grants no implicit accepts, and a single-tx
-//     batch attributes the alien verdict to its only tx.
+//     which case the peer grants no implicit accepts. Alien lines are then
+//     re-attributed by OUTPOINT (attributeConflictLines): the spent
+//     "<txid>:<vout>" the line names is looked up against the inputs of the
+//     submitted raw transactions, and a unique match rejects that tx with the
+//     real verdict. A single-tx batch attributes any leftover alien verdict to
+//     its only tx.
 //   - Non-200 with no parseable body (gateway 502/503 "no available
 //     server", bare 500, truncated body, network error, unexpected
 //     2xx-but-not-200), or no healthy endpoints → no per-tx information
@@ -1736,6 +2082,12 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 	outcomes := make([]endpointOutcome, 0, submitted)
 	acceptedByAny := make([]bool, len(batch))
 	rejectionLine := make([]string, len(batch))
+	// outpointOwners is the batch's spent-outpoint → tx index map used to
+	// attribute conflict-family lines back to submitted txs. Built lazily and
+	// at most once: it costs a full parse of every raw tx in the batch, which
+	// is pure waste on the (overwhelmingly common) path where no peer returns
+	// an alien-keyed failure line. nil means "not built yet".
+	var outpointOwners map[string]int
 	anySuccess := false
 	for i := 0; i < submitted; i++ {
 		result := <-resultCh
@@ -1808,12 +2160,32 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 		// one unidentifiable submitted tx DID fail; granting implicit
 		// accepts would mark that very tx ACCEPTED_BY_NETWORK.
 		alienCount, bestAlien := alienFailureLines(result.failures, inBatch)
+		// Alien lines are not a dead end. arcade holds the submitted raw
+		// transactions, so the spent "<outpoint>:<vout>" a conflict line names
+		// can be matched against the batch's own inputs and the verdict handed
+		// to the tx that actually spends it. This is what stops the incident
+		// shape from looping: on 2026-08-11 a 21-tx batch drew 21 UTXO_SPENT
+		// 409 lines and, with no attributable verdict, requeued forever
+		// (2,410 failures in two minutes, 42 of 43 batches requeued, 337,247
+		// messages of Kafka lag frozen behind 4,679 in-flight txs).
+		//
+		// Attribution only ever ADDS rejection votes on an exact outpoint
+		// match. The #292 rule is untouched: alienCount > 0 still withholds
+		// every implicit accept from this peer, whether or not the lines could
+		// be placed — a peer that answered 409 has not told us the unnamed txs
+		// are good.
+		var attributed map[int]string
 		if alienCount > 0 {
+			if outpointOwners == nil {
+				outpointOwners = buildSubmittedOutpointIndex(batch)
+			}
+			attributed = attributeConflictLines(result.failures, inBatch, outpointOwners)
 			p.logger.Warn(
 				"teranode failure lines name no submitted tx; withholding implicit accepts from this peer",
 				zap.String("endpoint", result.endpoint),
 				zap.Int("batch_size", len(batch)),
 				zap.Int("alien_line_count", alienCount),
+				zap.Int("attributed_by_outpoint", len(attributed)),
 				zap.String("best_alien_line", bestAlien),
 			)
 		}
@@ -1824,14 +2196,16 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 				acceptedByAny[j] = true
 			}
 		}
+		for idx, line := range attributed {
+			rejectionLine[idx] = preferRejectionLine(rejectionLine[idx], line)
+		}
 		// A single-tx batch has exactly one possible owner for an alien
 		// verdict — the tx itself. Terminalize it with the real reason
 		// (this is the mainnet incident shape: batch_size=1, HTTP 409,
 		// wrapper-less "UTXO_SPENT (70): <outpoint> utxo already spent by
-		// tx <spender>[0]"). Multi-tx batches can't attribute alien lines,
-		// so affected txs simply get no vote from this peer and requeue
-		// unless another peer produces a verdict — the safe pre-fix
-		// behavior, now with the alien reason visible in the Warn log.
+		// tx <spender>[0]"). Kept as the backstop for the case outpoint
+		// attribution can't cover — a conflict line about an outpoint the tx
+		// doesn't visibly spend, or raw bytes we failed to parse.
 		if alienCount > 0 && len(batch) == 1 {
 			rejectionLine[0] = preferRejectionLine(rejectionLine[0], bestAlien)
 		}

--- a/services/propagation/reaper.go
+++ b/services/propagation/reaper.go
@@ -43,6 +43,16 @@ import (
 // result is a store no-op: the stuck gauge drains only when the tx genuinely
 // reaches SEEN/MINED/REJECTED, never via a spurious timestamp refresh.
 //
+// stalePendingRetryAge: a row parked at PENDING_RETRY by the propagation
+// requeue-budget escape (parkExhaustedRequeues) got no verdict from any peer
+// across its whole fast-path budget, so its dispatcher in-flight entry was
+// released to free the Kafka commit watermark and the reaper inherited the
+// retry. Much shorter than the other thresholds — the row is not "stuck", it
+// is explicitly queued for another attempt, and the failure that parked it
+// (a peer outage, a conflict line arcade could not attribute) typically
+// clears in minutes. Long enough that a tx cannot bounce between the
+// fast path and the reaper faster than the fast path's own budget.
+//
 // staleScanLookback bounds how far back IterateStatusesSince walks. Rows
 // older than this are assumed permanently stuck and outside the reaper's
 // responsibility.
@@ -50,6 +60,7 @@ const (
 	staleSeenOnNetworkAge     = time.Hour
 	staleReceivedAge          = time.Hour
 	staleAcceptedByNetworkAge = time.Hour
+	stalePendingRetryAge      = 5 * time.Minute
 	staleScanLookback         = 24 * time.Hour
 
 	// defaultReaperRebroadcastBatch is the per-tick rebroadcast cap applied
@@ -176,10 +187,13 @@ func (p *Propagator) tryReap(ctx context.Context) {
 // requeue was lost, or an intake Kafka-publish failure the submitter never
 // retried), and ACCEPTED_BY_NETWORK past staleAcceptedByNetworkAge (accepted
 // into a mempool but the SEEN state-transfer from merkle-service never
-// arrived — re-register + re-broadcast to nudge it toward SEEN). All carry
-// RawTx and are validated txs we accepted responsibility to propagate, so
-// rebroadcasting self-heals a transient downstream outage. Recent rows (still
-// in the normal intake/requeue path) and body-less rows are left alone.
+// arrived — re-register + re-broadcast to nudge it toward SEEN), and
+// PENDING_RETRY past stalePendingRetryAge (parked by the propagation
+// requeue-budget escape after getting no verdict from any peer; the reaper is
+// its only remaining retry path). All carry RawTx and are validated txs we
+// accepted responsibility to propagate, so rebroadcasting self-heals a
+// transient downstream outage. Recent rows (still in the normal intake/requeue
+// path) and body-less rows are left alone.
 //
 // Rebroadcasts go through the same registerBatch + broadcastInChunks +
 // applyTerminalStatuses pipeline as processBatch but bypass the
@@ -196,6 +210,7 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 	seenDeadline := now.Add(-staleSeenOnNetworkAge)
 	receivedDeadline := now.Add(-staleReceivedAge)
 	acceptedDeadline := now.Add(-staleAcceptedByNetworkAge)
+	pendingRetryDeadline := now.Add(-stalePendingRetryAge)
 
 	stuckTransientDeadline := now.Add(-stuckTransientAge)
 	// The stuck-transient census (counts + oldest age per status) is resolved
@@ -268,10 +283,22 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 			if !st.Timestamp.Before(acceptedDeadline) {
 				return nil
 			}
+		case models.StatusPendingRetry:
+			// Parked by parkExhaustedRequeues: the fast path spent its whole
+			// requeue budget without a verdict and released the tx's Kafka
+			// offset so the consumer could keep moving. The reaper is now the
+			// ONLY thing that will retry it, so this arm is what makes the
+			// poison-batch escape a park rather than a drop. A successful
+			// rebroadcast lifts the row straight to ACCEPTED_BY_NETWORK /
+			// REJECTED (the lattice permits both from PENDING_RETRY); another
+			// no-verdict result leaves it here for the next tick.
+			if !st.Timestamp.Before(pendingRetryDeadline) {
+				return nil
+			}
 		default:
 			// Terminal statuses (REJECTED, DOUBLE_SPEND_ATTEMPTED, MINED,
-			// IMMUTABLE) and transient in-between states are not the
-			// reaper's job to rebroadcast.
+			// IMMUTABLE) and the remaining transient in-between states are
+			// not the reaper's job to rebroadcast.
 			return nil
 		}
 		stuck = append(stuck, propagationMsg{TXID: st.TxID, RawTx: st.RawTx})


### PR DESCRIPTION
## The incident (dev-ovh-1, 2026-08-11, arcade v0.11.5)

The propagation consumer **wedged completely**. `arcade.propagation` — a
single-partition topic — sat at **337,247 messages of Kafka lag, frozen**: the
lag did not move at all over 40+ seconds while the leader pod burned **4.2 CPU
cores**. Nothing new could propagate; every newly submitted transaction sat at
`RECEIVED` indefinitely. Operators unblocked the environment by **seeking the
consumer group past the stale backlog** by hand.

The cause was an unresolvable batch retried forever:

* Teranode returned **HTTP 409** for a batch of 21 stale transactions, with 21
  body lines shaped
  `UTXO_SPENT (70): <outpoint_txid>:<vout> utxo already spent by tx <spender_txid>[n]`
  — genuine, permanent double-spend rejections.
* Conflict-family lines are keyed by the **spent outpoint / competing spender
  hash**, not by the submitted txid (there is no `[ProcessTransaction][<txid>]`
  wrapper), so `alienFailureLines` flags them "alien" and **withholds implicit
  accepts** for that peer. That behavior is from #292 and is **correct** —
  without it arcade fabricates `ACCEPTED_BY_NETWORK` for transactions the peer
  just rejected.
* But with no accept vote and no *attributable* rejection line, every tx in the
  batch fell to the `default: txResultClassRequeue` arm.
* Requeue → retry → identical 409 → requeue. Observed: **~2,410**
  `batch broadcast endpoint failed` (409) and **~2,410**
  `teranode failure lines name no submitted tx; withholding implicit accepts
  from this peer` in **two minutes**, across 43 batches of which **42 requeued**.
* Those txs stayed in the dispatcher's `inFlight` map (**4,679** of them), so
  their Kafka offsets kept pinning `offsetTracker.LowestUnfinished()`,
  `advanceMarks` never called `claim.MarkMessage`, and the entire
  single-partition topic queued behind a batch that could never succeed.

### This predates #292 — verified

I checked, and the report's caveat is right. Before #292, `teranode/client.go`
parsed the failure-list body **only for status 500**; its doc said every other
status yields `failures = nil` and "the caller treats the batch as a pure infra
failure (whole batch requeued for another attempt)". A *persistent* 409
therefore looped forever back then too — with no verdict visible anywhere.
**#292 did not create the loop and did not fix it; it only made the verdicts
visible.** The unbounded requeue has been the standing gap the whole time.
There is a dedicated regression test for exactly that older shape
(`opaqueConflictServer`: a permanent 409 with an unparseable body).

## Fix 1 — attribute conflict verdicts to the submitted transactions

arcade holds the submitted raw transactions, so it can usually resolve a
conflict line on its own: parse each submitted tx's inputs and match the
`<outpoint_txid>:<vout>` the line names against them. A unique match attributes
the line to that tx and terminalizes it **REJECTED** with the real verdict and
the existing ARC 409-conflict mapping (**466 `StatusConflict`**, via the
untouched `classifyFailureLine`) instead of requeueing it.

* `buildSubmittedOutpointIndex` maps every spent outpoint in the batch to the
  single tx that spends it. Built **lazily and at most once per batch**, only
  when a peer actually returned alien lines — the happy path pays nothing.
* `attributeConflictLines` walks the alien lines in **sorted key order** so the
  result is deterministic across Go's map iteration.
* `attributeOneConflictLine` declines whenever the answer isn't unique: an
  outpoint no submitted tx spends, an outpoint spent by **two** submitted txs
  (intra-batch double spend), or a line naming outpoints of two different txs.
  Nothing is guessed.
* The `<spender_txid>[n]` half of the message can't be mistaken for the
  outpoint: the spender is rendered with a **bracketed** index, the outpoint
  with a **colon**, and the pattern is colon-anchored.

**The #292 safety property is preserved verbatim.** Attribution only ever *adds
rejection votes*. `alienCount > 0` still withholds every implicit accept from
that peer, whether or not the lines resolved — a peer that answered 409 has told
us nothing good about the txs it didn't name. The single-tx-batch attribution
rule from #292 is kept as the backstop for lines outpoint matching can't cover.

## Fix 2 — bounded requeue with a terminal escape

A transaction can no longer be requeued forever.

* Every requeue debits one unit of **`propagation.retry_max_attempts`** —
  previously declared, defaulted (5) in viper, and *never read by any
  production code*. Non-positive values fall back to the default rather than
  meaning "unlimited": unbounded requeue is the failure this exists to prevent,
  so it isn't configurable away. The counter (`propagationMsg.retryCount`) is
  process-local like `spanCtx`, so a Kafka replay after a restart/rebalance is
  a fresh attempt.
* A tx that spends its budget with no verdict is **parked at `PENDING_RETRY`**
  by `parkExhaustedRequeues`, which writes through **`applyTerminalStatuses`** —
  the one path that both persists the status *and* notifies the dispatcher.
  `handleTerminal` gained `PENDING_RETRY` alongside `REJECTED`: it Dones the
  offset, drops the tx from `inFlight`, and cascades held descendants (which the
  caller then persists as `PENDING_RETRY`, not `REJECTED` — their ancestor
  produced no verdict, so condemning them would invent one).
* **Why `PENDING_RETRY` and not `REJECTED`/DLQ:** the requeue arm also covers
  genuine infra failure (no healthy peer, body-less 5xx, merkle `/watch` blip).
  Rejecting on a ~10s budget would turn a brief Teranode outage into a wave of
  false terminal rejections. `PENDING_RETRY` is honest ("no verdict yet"), keeps
  the row's raw bytes, and hands ownership to the reaper — which gained a
  `PENDING_RETRY` rebroadcast arm (`stalePendingRetryAge` = 5m) so parked txs
  are genuinely retried, off the Kafka offset path entirely. Nothing is dropped;
  only the fast path gives up.
* **Loud:** an `ERROR` naming the txids (bounded via `logfields.TxIDBatch`) plus
  `arcade_propagation_requeue_exhausted_total`.

Also adds `arcade_propagation_conflict_attribution_total{result="attributed"|"unattributable"}`
so a future Teranode conflict-line format drift surfaces as a rising
unattributable rate rather than as another silent wedge.

## Tests

New `services/propagation/poison_batch_test.go`, following the existing
harnesses (`mockStore`, `newTeranodeServer`/httptest, `flushSync`, `fakeClaim`,
`runDispatcherWithClaim`, `classify_test.go`/`health_test.go` style). Fixtures
build **real transactions** with known inputs so attribution has something to
match.

| Test | Pins |
|---|---|
| `TestBroadcast_409ConflictLines_AttributedToSubmittedInputs` | Multi-tx 409 with outpoint-keyed `UTXO_SPENT` lines → each named tx REJECTED / ARC 466 / verbatim line; **plus a tx in the same batch whose outpoint is not named must NOT be fabricated as accepted** |
| `TestBroadcast_409UnattributableConflict_WithholdsAcceptsAndRejects` | The #292 no-fabrication guard: an unattributable alien line yields **no** accept and **no** guessed reject |
| `TestAttributeConflictLines_AmbiguousOutpointDeclines` | Two submitted txs spending the same outpoint → attribute to neither |
| `TestPoisonBatch_MultiTxConflict409_ParksInsteadOfLoopingForever` | The incident's exact shape (multi-tx, alien-keyed 409): bounded broadcast count, both txs parked at `PENDING_RETRY`, **in-flight entries released** (re-admit returns `admitted`, not `duplicate`) |
| `TestRunDispatcher_PoisonBatch_ExhaustsRetriesAndAdvancesWatermark` | Real dispatcher + `fakeClaim`: **`claim.MarkMessage` fires** — the commit watermark advances. That is the property that actually unwedges the consumer |
| `TestRequeueBudget_ConfigurableAndDefault` | Budget honored verbatim (broadcasts == `max+1` for max ∈ {1,3}); unset/negative falls back to `defaultRetryMaxAttempts` = 5, matching the viper default |
| `TestHandleTerminal_PendingRetry_ReleasesOffsetAndCascades` | Dispatcher unit: a park Dones its own offset *and* every cascaded descendant's |

### Verified to fail without the fix

Each test was run against a temporarily reverted build; the failure message is
the right one in every case.

* **Attribution disabled** → `TestBroadcast_409ConflictLines_AttributedToSubmittedInputs`:
  `no status update recorded; the conflict line naming its outpoint must terminalize it (pre-fix it requeued forever)`
* **Unsafe variant** (restore implicit accepts once all alien lines resolve) →
  same test: `terminalized as ACCEPTED_BY_NETWORK ...; an unnamed tx in a 409 batch must get no vote at all` — the no-fabrication guard is genuinely load-bearing
* **Retry bound removed** (`if false` in `chargeRetryBudget`) →
  `TestRunDispatcher_PoisonBatch_...`: `offset 41 was never MarkMessage'd: ... without the bound the commit watermark pins forever and the whole partition wedges`;
  `TestPoisonBatch_MultiTx...`: `no status update — an exhausted tx must reach a state that releases its in-flight entry`;
  `TestRequeueBudget_.../max=1` and `/max=3`: `offset 61 was never MarkMessage'd`
* **`PENDING_RETRY` removed from `handleTerminal`** →
  `TestHandleTerminal_PendingRetry_...`: `parking a parent must cascade its held descendants; got []`, and
  `TestPoisonBatch_MultiTx...`: `re-admit got {admitted:false held:false duplicate:true}` — proving the status write alone is not what releases the in-flight entry

`make test` and `make lint` pass (CGO on, gobdk linked). Both were also verified
green on `origin/main` first — **no pre-existing failures**. The propagation
package is additionally clean under `go test -race -count=3`.

## Follow-ups (not in this PR)

* `propagation.retry_backoff_ms` is still unread; `requeueDelay` stays at its
  historical flat 2s (now a field so tests can compress it). Wiring the config
  would silently change production cadence to 500ms, which didn't belong in a
  fix PR.
* `BumpRetryCount` / `SetPendingRetryFields` / `GetReadyRetries` remain unwired.
  The park writes go through the existing **batched** `BatchUpdateStatusReturning`
  because those APIs are per-tx — a 4,679-tx exhaustion would be 4,679 round
  trips. The reaper drains `PENDING_RETRY` off `IterateStatusesSince` instead of
  `GetReadyRetries`; switching to the purpose-built API (and persisting
  `retry_count`/`next_retry_at`) is a reasonable follow-up.
* Reaper drain rate for a mass park is `reaper_rebroadcast_batch` per tick
  (200 / 30s by default). Fine for the incident's scale, worth raising if a
  long outage parks six figures of transactions.
* `arcade_propagation_outcome_total{outcome="skipped"}` still counts parked txs
  as "skipped"; a dedicated label would read better on dashboards.

https://claude.ai/code/session_01QMqfayz1Uon8apbfccGa97
