### PR TITLE
fix(sse): resolve fan-out token membership per event, not per client

### DIFF
--- a/docs/sse.md
+++ b/docs/sse.md
@@ -39,13 +39,13 @@ You may also set `X-CallbackUrl` to additionally receive status updates as outbo
 ```
 id: 1745870456123456789
 event: status
-data: {"txid":"abc...","txStatus":"SEEN_ON_NETWORK","timestamp":"2026-04-28T18:20:56Z"}
+data: {"txid":"abc...","txStatus":"SEEN_ON_NETWORK","timestamp":"2026-04-28T18:20:56.123456789Z"}
 
 ```
 
 - `id` is a Unix nanosecond timestamp. Clients should remember the most recent `id` and send it back as `Last-Event-ID` on reconnect (browser `EventSource` does this automatically).
 - `event: status` is the only event type emitted for transaction updates.
-- `data` is one JSON object per frame. Every frame carries `txid`, `txStatus`, and `timestamp` (RFC 3339).
+- `data` is one JSON object per frame. Every frame carries `txid`, `txStatus`, and `timestamp` (RFC 3339, with fractional seconds when the event has sub-second precision — the same instant as `id`, so latency can be measured from the payload alone). Fractional seconds are optional in RFC 3339; a whole-second timestamp is still rendered as `2026-04-28T18:20:56Z`.
 - A blank line terminates each frame.
 
 ### Mined frames carry the merkle proof
@@ -55,7 +55,7 @@ When `txStatus` is `MINED` (or `IMMUTABLE`), the frame additionally carries the 
 ```
 id: 1745870512987654321
 event: status
-data: {"txid":"abc...","txStatus":"MINED","timestamp":"2026-04-28T18:21:52Z","blockHash":"0000...","blockHeight":870123,"merklePath":"<BUMP hex>"}
+data: {"txid":"abc...","txStatus":"MINED","timestamp":"2026-04-28T18:21:52.987654321Z","blockHash":"0000...","blockHeight":870123,"merklePath":"<BUMP hex>"}
 
 ```
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -597,18 +597,74 @@ var APIRequestBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
 
 // APISSEDroppedTotal counts SSE fan-out events that were dropped without
 // being delivered to a client. Reasons:
-//   - "slow_client": the client's send buffer was full (the consumer goroutine
-//     wasn't draining it fast enough).
+//   - "slow_client": the client's send buffer was full. The label name is
+//     historical and is KEPT for dashboard/alert compatibility, but it is NOT
+//     a diagnosis — the buffer fills whenever production outruns drain, and
+//     the fan-out goroutine itself has been the producer-side bottleneck.
+//     Read it together with SSEFanoutDuration (is fan-out itself slow?) and
+//     SSEConnectedClients before attributing fault to a consumer.
 //   - "client_gone": the client was unregistering concurrently and its context
 //     had already been canceled by the time fan-out reached it.
 //
-// A non-zero "client_gone" rate is normal under churn; a sustained
-// "slow_client" rate indicates a consumer that can't keep up with the publish
-// rate and may need a larger buffer or a backpressure strategy.
+// A non-zero "client_gone" rate is normal under churn.
 var APISSEDroppedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "arcade_api_sse_dropped_total",
 	Help: "SSE fan-out events dropped without delivery, by reason.",
 }, []string{"reason"}) // slow_client, client_gone
+
+// SSEFanoutDuration measures how long the manager's single fan-out goroutine
+// spends on one event, split by kind:
+//   - "single": one per-tx status event.
+//   - "bulk": one bulk event (a block's MINED unfan), covering the batched
+//     token resolution AND every per-tx delivery it expands to.
+//
+// This is THE signal for the fan-out's own throughput ceiling: the goroutine
+// is serial, so sustained 1/p50 below the publish rate means events are
+// queueing upstream and will eventually be dropped — regardless of how fast
+// any consumer drains. It is the metric that was missing when 1.6M drops were
+// attributed to a "slow SSE client" that was idle.
+var SSEFanoutDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "arcade_sse_fanout_duration_seconds",
+	Help:    "Time the SSE fan-out goroutine spent dispatching one event, by kind.",
+	Buckets: latencyBuckets,
+}, []string{"kind"}) // single, bulk
+
+// SSEConnectedClients tracks how many /events connections are registered on
+// this pod. Fan-out cost per event scales with this, and it disambiguates
+// "one chronically slow consumer" from "many consumers".
+var SSEConnectedClients = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "arcade_sse_connected_clients",
+	Help: "SSE /events clients currently registered on this pod.",
+})
+
+// SSETokenCacheTotal counts txid→token-set cache outcomes on the fan-out
+// path ("hit" / "miss"). Each miss is one store round-trip on the serial
+// fan-out goroutine, so the miss rate multiplied by SSETokenLookupDuration is
+// the store's contribution to fan-out latency. Bulk events bypass the cache
+// by design and are not counted here.
+var SSETokenCacheTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_sse_token_cache_total",
+	Help: "SSE fan-out txid→token-set cache lookups, by result.",
+}, []string{"result"}) // hit, miss
+
+// SSETokenCacheEntries reports the cache's resident entry count. Sitting at
+// the entry cap means the working set is larger than the cache and hits are
+// being lost to eviction; sitting well below it while the byte budget binds
+// means unusually large token strings.
+var SSETokenCacheEntries = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "arcade_sse_token_cache_entries",
+	Help: "Entries resident in the SSE fan-out txid→token-set cache.",
+})
+
+// SSETokenLookupDuration measures one Store.TokensForTxIDs call from the
+// fan-out path, by kind ("single" for a cache miss on one txid, "batch" for a
+// bulk event's chunked resolution). This is the per-event probe latency that
+// had to be measured out-of-band before.
+var SSETokenLookupDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "arcade_sse_token_lookup_duration_seconds",
+	Help:    "Store.TokensForTxIDs latency from the SSE fan-out path, by kind.",
+	Buckets: latencyBuckets,
+}, []string{"kind"}) // single, batch
 
 // SSEMidstreamCatchupsTotal counts store-backed catchup rounds run on a LIVE
 // /events connection after fan-out overflowed the client's send channel

--- a/openapi/arcade.openapi.yaml
+++ b/openapi/arcade.openapi.yaml
@@ -611,7 +611,10 @@ paths:
         "200":
           description: |
             An event stream of status updates. Every frame carries
-            txid/txStatus/timestamp. MINED (and IMMUTABLE) frames additionally
+            txid/txStatus/timestamp; timestamp is RFC 3339 and carries
+            fractional seconds when the event has sub-second precision, so it
+            denotes the same instant as the frame id. MINED (and IMMUTABLE)
+            frames additionally
             carry blockHash, blockHeight, and merklePath (the transaction's BUMP,
             hex-encoded) — the same proof GET /tx/{txid} and the webhook callback
             return, so push-only clients need not poll. Those three fields are
@@ -625,11 +628,11 @@ paths:
               example: |
                 id: 1716205200123456789
                 event: status
-                data: {"txid":"<hex>","txStatus":"SEEN_ON_NETWORK","timestamp":"2026-05-20T12:00:00Z"}
+                data: {"txid":"<hex>","txStatus":"SEEN_ON_NETWORK","timestamp":"2026-05-20T12:00:00.123456789Z"}
 
                 id: 1716205260987654321
                 event: status
-                data: {"txid":"<hex>","txStatus":"MINED","timestamp":"2026-05-20T12:01:00Z","blockHash":"<hex>","blockHeight":870123,"merklePath":"<BUMP hex>"}
+                data: {"txid":"<hex>","txStatus":"MINED","timestamp":"2026-05-20T12:01:00.987654321Z","blockHash":"<hex>","blockHeight":870123,"merklePath":"<BUMP hex>"}
 
                 : keepalive
 

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -204,8 +204,8 @@ func (m *mockStore) IterateStatusesByToken(context.Context, string, time.Time, [
 	return nil
 }
 
-func (m *mockStore) TokenHasSubmissionForTx(context.Context, string, string) (bool, error) {
-	return false, nil
+func (m *mockStore) TokensForTxIDs(context.Context, []string) (map[string][]string, error) {
+	return map[string][]string{}, nil
 }
 
 func (m *mockStore) UpdateDeliveryStatus(context.Context, string, models.Status, int, *time.Time) error {

--- a/services/sse/fanout_test.go
+++ b/services/sse/fanout_test.go
@@ -1,0 +1,398 @@
+package sse
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/metrics"
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// newFanOutFixture builds a manager whose store has `txids` transactions, each
+// registered under every token in `tokens`. Returns the manager, the store stub
+// and a cancel for the manager goroutine.
+func newFanOutFixture(t testing.TB, tokens, txids []string) (*Manager, *sseStoreStub, context.CancelFunc) {
+	t.Helper()
+	subsByToken := make(map[string][]*models.Submission, len(tokens))
+	for _, token := range tokens {
+		subs := make([]*models.Submission, 0, len(txids))
+		for _, txid := range txids {
+			subs = append(subs, &models.Submission{TxID: txid, CallbackToken: token})
+		}
+		subsByToken[token] = subs
+	}
+	st := &sseStoreStub{
+		subsByToken: subsByToken,
+		statusByTx:  map[string]*models.TransactionStatus{},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	mgr, err := newManager(ctx, &fakePublisher{}, st, zap.NewNop())
+	if err != nil {
+		cancel()
+		t.Fatalf("newManager: %v", err)
+	}
+	return mgr, st, cancel
+}
+
+func makeTxIDs(prefix string, n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = fmt.Sprintf("%s-%06d", prefix, i)
+	}
+	return out
+}
+
+// TestFanOutResolvesTokensOncePerEvent is the regression test for the fan-out
+// throughput ceiling.
+//
+// Fan-out used to ask the store "does this txid belong to this token" once per
+// (event, CLIENT), so store round-trips scaled with the number of connected
+// clients. On the manager's single fan-out goroutine, with a 0.583 ms probe
+// against a 4.5M-row submissions table, that capped delivery at ~1.6k
+// events/s while 1,000 TPS demanded ~4k.
+//
+// The invariant now: store round-trips scale with EVENTS, never with clients.
+func TestFanOutResolvesTokensOncePerEvent(t *testing.T) {
+	const events = 50
+	tokens := []string{"tok-1", "tok-2", "tok-3", "tok-4"}
+	txids := makeTxIDs("once", events)
+	mgr, st, cancel := newFanOutFixture(t, tokens, txids)
+	defer cancel()
+
+	// Two clients per token: eight token-scoped consumers of every event.
+	clients := make([]*Client, 0, 2*len(tokens))
+	for range 2 {
+		for _, token := range tokens {
+			c := mgr.NewClient(token)
+			mgr.Register(c)
+			defer mgr.Unregister(c.ID)
+			clients = append(clients, c)
+		}
+	}
+
+	for _, txid := range txids {
+		mgr.fanOut(context.Background(), &models.TransactionStatus{
+			TxID:      txid,
+			Status:    models.StatusSeenOnNetwork,
+			Timestamp: time.Now(),
+		})
+	}
+
+	calls, resolved := st.storeCounters()
+	if calls != events {
+		t.Errorf("store round-trips = %d, want %d (one per EVENT, not per event×client)", calls, events)
+	}
+	if resolved != events {
+		t.Errorf("txids resolved = %d, want %d", resolved, events)
+	}
+	// The saving must not have cost correctness: every client still gets
+	// every event.
+	for _, c := range clients {
+		if got := len(c.Ch); got != events {
+			t.Errorf("client %d (token %s) received %d frames, want %d", c.ID, c.Token, got, events)
+		}
+	}
+}
+
+// TestFanOutBulkResolvesWholeBatchInOneQuery covers the block-burst path. A
+// bulk MINED event used to be unfanned into N synthetic per-tx statuses, each
+// running a full fan-out pass with its own per-client probe — the reason block
+// bursts pushed emit→applied p95 to 21.6 s. The whole txid list now resolves
+// in one batch before the unfan loop.
+func TestFanOutBulkResolvesWholeBatchInOneQuery(t *testing.T) {
+	const batch = 500
+	txids := makeTxIDs("bulk", batch)
+	mgr, st, cancel := newFanOutFixture(t, []string{tokA}, txids)
+	defer cancel()
+
+	clients := make([]*Client, 0, 3)
+	for range 3 {
+		c := mgr.NewClient(tokA)
+		mgr.Register(c)
+		defer mgr.Unregister(c.ID)
+		clients = append(clients, c)
+	}
+
+	mgr.fanOutBulk(context.Background(), &models.TransactionStatus{
+		Status:      models.StatusMined,
+		BlockHash:   "block-1",
+		BlockHeight: 42,
+		Timestamp:   time.Now(),
+		TxIDs:       txids,
+	})
+
+	calls, resolved := st.storeCounters()
+	if calls != 1 {
+		t.Errorf("store round-trips for one bulk event = %d, want 1", calls)
+	}
+	if resolved != batch {
+		t.Errorf("txids resolved = %d, want %d", resolved, batch)
+	}
+	for _, c := range clients {
+		if got := len(c.Ch); got != batch {
+			t.Errorf("client %d received %d frames, want %d", c.ID, got, batch)
+		}
+	}
+}
+
+// TestFanOutCachesTokenSetAcrossTransitions covers the LRU: a transaction
+// emits several live transitions, and only the first may reach the store.
+func TestFanOutCachesTokenSetAcrossTransitions(t *testing.T) {
+	txid := "cached-tx"
+	mgr, st, cancel := newFanOutFixture(t, []string{tokA}, []string{txid})
+	defer cancel()
+
+	c := mgr.NewClient(tokA)
+	mgr.Register(c)
+	defer mgr.Unregister(c.ID)
+
+	hitsBefore := testutil.ToFloat64(metrics.SSETokenCacheTotal.WithLabelValues("hit"))
+	transitions := []models.Status{
+		models.StatusAcceptedByNetwork,
+		models.StatusSeenOnNetwork,
+		models.StatusSeenMultipleNodes,
+	}
+	for _, status := range transitions {
+		mgr.fanOut(context.Background(), &models.TransactionStatus{
+			TxID:      txid,
+			Status:    status,
+			Timestamp: time.Now(),
+		})
+	}
+
+	if calls, _ := st.storeCounters(); calls != 1 {
+		t.Errorf("store round-trips = %d, want 1 (later transitions served from cache)", calls)
+	}
+	if got := testutil.ToFloat64(metrics.SSETokenCacheTotal.WithLabelValues("hit")) - hitsBefore; got != float64(len(transitions)-1) {
+		t.Errorf("cache hits = %v, want %d", got, len(transitions)-1)
+	}
+	if got := len(c.Ch); got != len(transitions) {
+		t.Errorf("client received %d frames, want %d", got, len(transitions))
+	}
+}
+
+// TestFanOutSkipsStoreWhenNoClientFiltersByToken guards the firehose case: an
+// unfiltered consumer needs no membership answer, so the store must not be
+// touched at all.
+func TestFanOutSkipsStoreWhenNoClientFiltersByToken(t *testing.T) {
+	mgr, st, cancel := newFanOutFixture(t, []string{tokA}, []string{"fire-1"})
+	defer cancel()
+
+	c := mgr.NewClient("") // firehose
+	mgr.Register(c)
+	defer mgr.Unregister(c.ID)
+
+	mgr.fanOut(context.Background(), &models.TransactionStatus{
+		TxID: "fire-1", Status: models.StatusSeenOnNetwork, Timestamp: time.Now(),
+	})
+	mgr.fanOutBulk(context.Background(), &models.TransactionStatus{
+		Status: models.StatusMined, Timestamp: time.Now(), TxIDs: []string{"fire-1", "fire-2"},
+	})
+
+	if calls, _ := st.storeCounters(); calls != 0 {
+		t.Errorf("store round-trips = %d, want 0 for a tokenless client", calls)
+	}
+	if got := len(c.Ch); got != 3 {
+		t.Errorf("firehose client received %d frames, want 3", got)
+	}
+}
+
+// TestFanOutRecordsObservability covers the signals that were missing when
+// 1.6M drops were blamed on a "slow SSE client": a fan-out duration histogram
+// and a connected-clients gauge.
+func TestFanOutRecordsObservability(t *testing.T) {
+	mgr, _, cancel := newFanOutFixture(t, []string{tokA}, []string{"obs-1"})
+	defer cancel()
+
+	c := mgr.NewClient(tokA)
+	mgr.Register(c)
+	if got := testutil.ToFloat64(metrics.SSEConnectedClients); got != 1 {
+		t.Errorf("connected-clients gauge = %v after Register, want 1", got)
+	}
+
+	mgr.fanOut(context.Background(), &models.TransactionStatus{
+		TxID: "obs-1", Status: models.StatusSeenOnNetwork, Timestamp: time.Now(),
+	})
+	if got := testutil.CollectAndCount(metrics.SSEFanoutDuration); got == 0 {
+		t.Error("fan-out duration histogram has no series")
+	}
+	if mgr.fanoutEvents != 1 || mgr.fanoutEWMA <= 0 {
+		t.Errorf("fan-out stats = (%d events, %v ewma), want a positive sample", mgr.fanoutEvents, mgr.fanoutEWMA)
+	}
+
+	mgr.Unregister(c.ID)
+	if got := testutil.ToFloat64(metrics.SSEConnectedClients); got != 0 {
+		t.Errorf("connected-clients gauge = %v after Unregister, want 0", got)
+	}
+}
+
+// BenchmarkFanOut reports the store round-trips fan-out costs per event.
+// queries/event is the number that mattered: it used to equal the connected
+// token-client count, which is what made the serial fan-out goroutine the
+// system's throughput ceiling. It is now 1 regardless of client count, and 0
+// for events whose txid is already cached.
+func BenchmarkFanOut(b *testing.B) {
+	for _, clients := range []int{1, 4, 16} {
+		b.Run(fmt.Sprintf("clients=%d", clients), func(b *testing.B) {
+			txids := makeTxIDs("bench", b.N)
+			tokens := make(map[string][]string, b.N)
+			for _, txid := range txids {
+				tokens[txid] = []string{tokA}
+			}
+			st := &tokenStoreStub{tokens: tokens}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			mgr, err := newManager(ctx, &fakePublisher{}, st, zap.NewNop())
+			if err != nil {
+				b.Fatalf("newManager: %v", err)
+			}
+			for range clients {
+				c := mgr.NewClient(tokA)
+				// A generous buffer keeps the benchmark measuring fan-out
+				// rather than the drop path.
+				c.Ch = make(chan *models.TransactionStatus, b.N+1)
+				mgr.Register(c)
+			}
+
+			status := &models.TransactionStatus{Status: models.StatusSeenOnNetwork, Timestamp: time.Now()}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				status.TxID = txids[i]
+				mgr.fanOut(ctx, status)
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(st.calls)/float64(b.N), "queries/event")
+		})
+	}
+}
+
+// TestMidstreamCatchupRateMatchesLiveStream is the regression test for the
+// drop→catchup→drop livelock.
+//
+// A mid-stream round runs on the connection's writer goroutine — the same
+// goroutine that drains the client's send channel — so nothing consumes live
+// frames while a round replays. With the old shared 10,000-frame budget
+// against the default 8,192-slot buffer, a single capped round was guaranteed
+// to overflow the buffer it was healing and re-arm its own drop flag. A
+// production stream logged 34 rounds and 570 drop lines in ten minutes with
+// the load generator stopped.
+//
+// The invariant now: a round is bounded by the client's buffer, and the live
+// channel is drained between rounds.
+func TestMidstreamCatchupRateMatchesLiveStream(t *testing.T) {
+	const bufferSize = 512
+	base := time.Now().UTC().Add(-time.Hour)
+	// Three rounds' worth of replayable history.
+	n := 3 * (bufferSize / 2)
+	subs := make([]*models.Submission, 0, n)
+	statusByTx := make(map[string]*models.TransactionStatus, n)
+	for i := range n {
+		txid := fmt.Sprintf("replay-%06d", i)
+		subs = append(subs, &models.Submission{TxID: txid, CallbackToken: tokA})
+		statusByTx[txid] = &models.TransactionStatus{
+			TxID:      txid,
+			Status:    models.StatusMined,
+			Timestamp: base.Add(time.Duration(i) * time.Millisecond),
+		}
+	}
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{tokA: subs},
+		statusByTx:  statusByTx,
+	}
+	svc, _, _, cancel := setupSSEService(t, st)
+	defer cancel()
+	svc.manager.clientBufferSize = bufferSize
+
+	client := svc.manager.NewClient(tokA)
+	budget := midstreamRoundFrames(client)
+	if budget > cap(client.Ch) {
+		t.Fatalf("round budget %d exceeds the client buffer %d it must not outrun", budget, cap(client.Ch))
+	}
+
+	// A live frame is already queued when the healing starts — exactly the
+	// state a real connection is in, since fan-out keeps producing.
+	live := &models.TransactionStatus{TxID: "live-frame", Status: models.StatusSeenOnNetwork, Timestamp: time.Now().UTC()}
+	client.Ch <- live
+	client.droppedFloor.Store(base.UnixNano())
+	client.dropped.Store(true)
+
+	rec := httptest.NewRecorder()
+	w := &sseWriter{w: rec, f: nopFlusher{rec}}
+	if ok := svc.midstreamCatchup(t.Context(), w, client); !ok {
+		t.Fatal("midstreamCatchup reported a dead connection")
+	}
+
+	body := rec.Body.String()
+	livePos := strings.Index(body, fmt.Sprintf("id: %d\n", live.Timestamp.UnixNano()))
+	if livePos < 0 || !strings.Contains(body, `"txid":"live-frame"`) {
+		t.Fatal("live frame was never written: the replay loop starved the channel it was healing")
+	}
+	// The live frame is written by the first inter-round drain, so exactly one
+	// round's budget of replay frames precedes it.
+	if got := strings.Count(body[:livePos], "\nevent: status\n"); got != budget {
+		t.Errorf("replay frames before the live frame = %d, want one round's budget %d", got, budget)
+	}
+	if got := strings.Count(body, "\nevent: status\n"); got != n+1 {
+		t.Errorf("total frames = %d, want %d replayed + 1 live", got, n+1)
+	}
+	if len(client.Ch) != 0 {
+		t.Errorf("%d live frames left buffered after catchup", len(client.Ch))
+	}
+}
+
+// TestStatusFrameTimestampCarriesSubSecondPrecision covers the payload
+// timestamp resolution. The frame `id` has always been nanoseconds; the
+// payload was RFC3339 (whole seconds), so any consumer measuring latency from
+// `data` saw up to ±1 s of error against the same frame's own id.
+func TestStatusFrameTimestampCarriesSubSecondPrecision(t *testing.T) {
+	ts := time.Unix(1700000000, 123456789).UTC()
+	frame, err := buildStatusFrame(&models.TransactionStatus{
+		TxID: "nanos", Status: models.StatusSeenOnNetwork, Timestamp: ts,
+	})
+	if err != nil {
+		t.Fatalf("buildStatusFrame: %v", err)
+	}
+	_, data, ok := strings.Cut(frame, "data: ")
+	if !ok {
+		t.Fatalf("no data field in frame %q", frame)
+	}
+	var payload struct {
+		Timestamp string `json:"timestamp"`
+	}
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSuffix(data, "\n\n")), &payload); jsonErr != nil {
+		t.Fatalf("unmarshal data: %v", jsonErr)
+	}
+	got, err := time.Parse(time.RFC3339, payload.Timestamp)
+	if err != nil {
+		t.Fatalf("payload timestamp %q is not RFC 3339: %v", payload.Timestamp, err)
+	}
+	// The payload must agree with the frame id to the nanosecond.
+	if !got.Equal(ts) {
+		t.Errorf("payload timestamp = %s (%d ns), want %s (%d ns)",
+			payload.Timestamp, got.UnixNano(), ts.Format(time.RFC3339Nano), ts.UnixNano())
+	}
+}
+
+// TestStatusFrameTimestampWholeSecondsUnchanged is the compatibility half of
+// the change: RFC3339Nano elides trailing zeros, so a whole-second timestamp
+// still renders exactly as it did before.
+func TestStatusFrameTimestampWholeSecondsUnchanged(t *testing.T) {
+	ts := time.Unix(1700000000, 0).UTC()
+	frame, err := buildStatusFrame(&models.TransactionStatus{
+		TxID: "whole", Status: models.StatusSeenOnNetwork, Timestamp: ts,
+	})
+	if err != nil {
+		t.Fatalf("buildStatusFrame: %v", err)
+	}
+	if want := `"timestamp":"2023-11-14T22:13:20Z"`; !strings.Contains(frame, want) {
+		t.Errorf("frame %q does not contain %s", frame, want)
+	}
+}

--- a/services/sse/manager.go
+++ b/services/sse/manager.go
@@ -79,14 +79,28 @@ type Client struct {
 // client missed while disconnected is served from the store by sendCatchup
 // via Last-Event-ID, never by Kafka replay.
 //
-// Token-based filtering happens in the fan-out path: every event is
-// checked against each client's token via the indexed existence probe
-// store.TokenHasSubmissionForTx — O(1)-ish per (event, client). Nothing on
-// this path may materialize a token's full submission list (see #237/#238).
+// Token-based filtering happens in the fan-out path, but the store is asked
+// once per EVENT, not once per (event, client): tokenIndex resolves a txid's
+// subscribed token set — batched for bulk events, LRU-cached for live ones —
+// and each client is then matched against that set in memory. Nothing on this
+// path may materialize a token's full submission list (see #237/#238).
 type Manager struct {
 	publisher events.Publisher
 	store     store.Store
 	logger    *zap.Logger
+
+	// tokens resolves txid → subscribed callback tokens for fan-out. Owned
+	// by the fan-out goroutine (the index is itself lock-guarded).
+	tokens *tokenIndex
+
+	// fanoutEWMA is an exponentially-weighted mean of per-event fan-out
+	// duration in nanoseconds, and fanoutEvents the lifetime event count.
+	// Both are written and read ONLY on the single fan-out goroutine (fanOut
+	// → deliver → recordDrop), so they need no synchronization; they exist to
+	// put the dispatcher's own cost into the drop warning, which used to name
+	// only the client.
+	fanoutEWMA   float64
+	fanoutEvents int64
 
 	// parentCtx is the long-lived context that owns the manager
 	// goroutine. Per-client contexts are derived from it so canceling
@@ -128,10 +142,12 @@ func newManager(ctx context.Context, publisher events.Publisher, st store.Store,
 	if publisher == nil {
 		return nil, nil //nolint:nilnil // intentional: nil manager means "no fan-out wired"
 	}
+	named := logger.Named("sse")
 	m := &Manager{
 		publisher:     publisher,
 		store:         st,
-		logger:        logger.Named("sse"),
+		logger:        named,
+		tokens:        newTokenIndex(st, named),
 		parentCtx:     ctx,
 		catchupOnDrop: true,
 		clients:       make(map[int64]*Client),
@@ -168,48 +184,104 @@ func (m *Manager) run(ctx context.Context, in <-chan *models.TransactionStatus) 
 				m.fanOut(ctx, status)
 				continue
 			}
-			for _, txid := range status.TxIDs {
-				perTx := *status
-				perTx.TxID = txid
-				perTx.TxIDs = nil
-				m.fanOut(ctx, &perTx)
-			}
+			m.fanOutBulk(ctx, status)
 		}
 	}
 }
 
-// fanOut delivers a status update to every interested client. A
-// non-empty client.Token causes a per-client check that the txid
-// actually belongs to a submission registered under that token. Sends
-// are non-blocking — slow consumers drop the event and recover via
-// Last-Event-ID catchup on reconnect.
-//
-// Concurrency contract (F-020): we snapshot the client list under
-// RLock and release the lock before sending. A client may unregister
-// between the snapshot and the send. Each client owns a context that
-// unregister cancels; the send selects on Ctx.Done() so a
-// canceled-and-gone client takes the drop arm instead of blocking or
-// panicking. The send channel is never closed by the manager — closing
-// would race this exact send.
-func (m *Manager) fanOut(ctx context.Context, status *models.TransactionStatus) {
+// snapshot copies the client registry. Callers send AFTER releasing the lock
+// (F-020) — see deliver for the concurrency contract that makes that safe.
+func (m *Manager) snapshot() []*Client {
 	m.mu.RLock()
+	defer m.mu.RUnlock()
 	clients := make([]*Client, 0, len(m.clients))
 	for _, c := range m.clients {
 		clients = append(clients, c)
 	}
-	m.mu.RUnlock()
+	return clients
+}
 
-	if len(clients) == 0 {
-		return // nobody listening — skip the token probes and enrichment
+// tokenScoped reports whether any snapshotted client filters by token. When
+// none does, fan-out skips token resolution entirely — a firehose-only pod
+// never touches the store.
+func tokenScoped(clients []*Client) bool {
+	for _, c := range clients {
+		if c.Token != "" {
+			return true
+		}
 	}
+	return false
+}
 
+// fanOut delivers ONE per-tx status update. The txid's subscribed token set
+// is resolved once (cache, else a single store lookup) and every client is
+// then matched against it in memory — the store is never asked per client.
+func (m *Manager) fanOut(ctx context.Context, status *models.TransactionStatus) {
+	start := time.Now()
+	clients := m.snapshot()
+	if len(clients) == 0 {
+		return // nobody listening — skip token resolution and enrichment
+	}
+	var tokens tokenSet
+	if tokenScoped(clients) {
+		tokens = m.tokens.lookup(ctx, status.TxID)
+	}
+	m.deliver(ctx, clients, status, tokens)
+	m.observeFanout("single", start)
+}
+
+// fanOutBulk unfans a bulk event (a block's MINED burst, or a reorg revert)
+// into per-tx frames.
+//
+// The whole txid list is resolved in ONE batched store call before the unfan
+// loop. Previously each synthetic per-tx status ran a full fan-out pass with
+// its own per-client store probe, so a 570k-transaction block cost 570k
+// probes per connected token client on a serial goroutine — the reason
+// block bursts pushed emit→applied p95 to 21.6 s.
+//
+// The client registry is snapshotted once for the whole bulk event rather
+// than per txid: a bulk event unfans in milliseconds, and a client that
+// connects mid-burst is served the same window by its connect-time catchup.
+func (m *Manager) fanOutBulk(ctx context.Context, status *models.TransactionStatus) {
+	start := time.Now()
+	clients := m.snapshot()
+	if len(clients) == 0 {
+		return
+	}
+	var resolved map[string]tokenSet
+	if tokenScoped(clients) {
+		resolved = m.tokens.resolveBatch(ctx, status.TxIDs)
+	}
+	for _, txid := range status.TxIDs {
+		perTx := *status
+		perTx.TxID = txid
+		perTx.TxIDs = nil
+		m.deliver(ctx, clients, &perTx, resolved[txid])
+	}
+	m.observeFanout("bulk", start)
+}
+
+// deliver pushes one status to every client subscribed to it. tokens is the
+// txid's already-resolved subscriber set; a client with a non-empty Token
+// receives the frame only if the set contains it. Sends are non-blocking —
+// an overflowing client drops the event and recovers via mid-stream catchup
+// or a Last-Event-ID reconnect.
+//
+// Concurrency contract (F-020): the caller snapshotted the client list under
+// RLock and released the lock before we send. A client may unregister
+// between the snapshot and the send. Each client owns a context that
+// unregister cancels; the send selects on Ctx.Done() so a canceled-and-gone
+// client takes the drop arm instead of blocking or panicking. The send
+// channel is never closed by the manager — closing would race this exact
+// send.
+func (m *Manager) deliver(ctx context.Context, clients []*Client, status *models.TransactionStatus, tokens tokenSet) {
 	enriched := false
 	for _, c := range clients {
 		if c.Ctx.Err() != nil {
 			metrics.APISSEDroppedTotal.WithLabelValues("client_gone").Inc()
 			continue
 		}
-		if c.Token != "" && !m.txBelongsToToken(ctx, status.TxID, c.Token) {
+		if c.Token != "" && !tokens.has(c.Token) {
 			continue
 		}
 		// This client will receive the frame, so attach the merkle proof — once
@@ -232,6 +304,25 @@ func (m *Manager) fanOut(ctx context.Context, status *models.TransactionStatus) 
 			m.recordDrop(c, status)
 		}
 	}
+}
+
+// fanoutEWMAAlpha weights the newest sample in the fan-out duration mean.
+// 1/64 smooths per-event jitter while still tracking a sustained stall within
+// a second or so of events.
+const fanoutEWMAAlpha = 1.0 / 64.0
+
+// observeFanout records one completed fan-out pass: the Prometheus histogram
+// plus the goroutine-local mean the drop warning quotes. Runs on the single
+// fan-out goroutine, which is what makes the unsynchronized fields safe.
+func (m *Manager) observeFanout(kind string, start time.Time) {
+	d := time.Since(start)
+	metrics.SSEFanoutDuration.WithLabelValues(kind).Observe(d.Seconds())
+	m.fanoutEvents++
+	if m.fanoutEWMA == 0 {
+		m.fanoutEWMA = float64(d)
+		return
+	}
+	m.fanoutEWMA += fanoutEWMAAlpha * (float64(d) - m.fanoutEWMA)
 }
 
 // dropLogInterval rate-limits the aggregate slow-client drop Warn: at most
@@ -265,41 +356,39 @@ func (m *Manager) recordDrop(c *Client, status *models.TransactionStatus) {
 	if now-last < int64(dropLogInterval) || !c.lastDropLog.CompareAndSwap(last, now) {
 		return
 	}
+	// The message deliberately names the BUFFER, not the client. This line
+	// previously read "dropped events for slow SSE client" and was emitted
+	// 1.6M times during a benchmark whose consumer was idle at 6 of 32 cores:
+	// the actual producer-side bottleneck was this manager's own fan-out. The
+	// fan-out cost travels with the warning so the two sides can be told
+	// apart at a glance — a fanout_avg near or above the inter-event interval
+	// means the dispatcher is the limit, not the consumer.
 	m.logger.Warn(
-		"dropped events for slow SSE client; will catch up mid-stream",
+		"sse fan-out could not enqueue events: client send buffer full; will catch up mid-stream",
 		zap.Int64("client_id", c.ID),
 		zap.Int64("dropped", c.dropsSinceLog.Swap(0)),
+		zap.Int("buffer_cap", cap(c.Ch)),
+		zap.Duration("fanout_avg", time.Duration(m.fanoutEWMA)),
+		zap.Int64("fanout_events", m.fanoutEvents),
+		zap.Int("clients", m.clientCount()),
 		zap.Bool("catchup_eligible", m.catchupOnDrop && c.Token != ""),
 	)
 }
 
-// txBelongsToToken reports whether txid was submitted with the given
-// callback token. Runs once per event per token-filtered client, so it
-// uses the store's indexed by-txid existence probe. It MUST NOT load the
-// token's submission list: a token can hold millions of submissions, and
-// materializing them per event is what OOM-killed this service the
-// moment a mega-token client survived catchup into fan-out.
-func (m *Manager) txBelongsToToken(ctx context.Context, txid, token string) bool {
-	if m.store == nil {
-		return false
-	}
-	ok, err := m.store.TokenHasSubmissionForTx(ctx, token, txid)
-	if err != nil {
-		m.logger.Warn(
-			"submission lookup failed",
-			zap.String("token", token),
-			zap.Error(err),
-		)
-		return false
-	}
-	return ok
+// clientCount reports how many clients are registered.
+func (m *Manager) clientCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.clients)
 }
 
 // Register adds a client to the registry.
 func (m *Manager) Register(c *Client) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.clients[c.ID] = c
+	n := len(m.clients)
+	m.mu.Unlock()
+	metrics.SSEConnectedClients.Set(float64(n))
 }
 
 // Unregister removes a client and signals any in-flight fan-out send to
@@ -314,7 +403,9 @@ func (m *Manager) Unregister(id int64) {
 	if ok {
 		delete(m.clients, id)
 	}
+	n := len(m.clients)
 	m.mu.Unlock()
+	metrics.SSEConnectedClients.Set(float64(n))
 	if ok {
 		c.Cancel()
 	}
@@ -387,7 +478,7 @@ func (s *Service) handleEvents(c *gin.Context) {
 		// is initialized from the replayed history — a later mid-stream
 		// catchup then resumes from a fresh watermark instead of replaying
 		// from zero.
-		s.sendCatchup(ctx, writer, token, since, client, false)
+		s.sendCatchup(ctx, writer, token, since, client, false, catchupMaxFrames)
 	}
 
 	keepalive := time.NewTicker(15 * time.Second)
@@ -404,25 +495,11 @@ func (s *Service) handleEvents(c *gin.Context) {
 				}
 				client.lastDelivered.Store(status.Timestamp.UnixNano())
 			}
-			// Coalesce the rest of this burst: drain everything already
-			// buffered on the channel (the default arm breaks the loop once
-			// the channel is empty, so this only ever writes what's ready and
-			// can't spin) and flush once. A bulk-unfan of one Kafka message
-			// lands ~50 frames here; without coalescing we'd flush per frame.
-		drain:
-			for {
-				select {
-				case s := <-client.Ch:
-					if s == nil {
-						continue
-					}
-					if err := writeStatusBuffered(writer, s); err != nil {
-						return
-					}
-					client.lastDelivered.Store(s.Timestamp.UnixNano())
-				default:
-					break drain
-				}
+			// Coalesce the rest of this burst and flush once. A bulk-unfan of
+			// one Kafka message lands ~50 frames here; without coalescing we'd
+			// flush per frame.
+			if _, err := drainLive(writer, client); err != nil {
+				return
 			}
 			if err := writer.flush(); err != nil {
 				return
@@ -463,7 +540,35 @@ const catchupMaxFrames = 10_000
 // GET /tx/:id.
 const catchupBlockBudget = 64
 
-// errCatchupCapped stops the catchup iteration at catchupMaxFrames.
+// midstreamRoundFrames bounds ONE mid-stream catchup round for a client.
+//
+// This is the fix for a self-sustaining drop/catchup loop. A mid-stream round
+// runs on the connection's writer goroutine, which is the same goroutine that
+// drains client.Ch — so for the whole round nothing consumes the live
+// channel. With the shared catchupMaxFrames (10,000) budget and the default
+// 8,192-slot client buffer, a single capped round was GUARANTEED to overflow
+// the buffer if fan-out was producing at all, which re-armed the drop flag
+// and started another round. A production stream logged 34 rounds and 570
+// drop lines in ten minutes while the load generator was stopped, alternating
+// "catchup round frames:11818 capped:true" with "dropped:3919".
+//
+// Half the buffer leaves headroom for what fan-out enqueues during the round;
+// the caller then drains the live channel before the next round, so replay
+// and live delivery interleave instead of starving each other.
+func midstreamRoundFrames(c *Client) int {
+	budget := cap(c.Ch) / 2
+	if budget < minMidstreamRoundFrames {
+		budget = minMidstreamRoundFrames
+	}
+	return min(budget, catchupMaxFrames)
+}
+
+// minMidstreamRoundFrames keeps rounds from degenerating into per-frame
+// queries when a client is configured with a tiny buffer: a round must make
+// enough progress to outpace the store query it costs.
+const minMidstreamRoundFrames = 256
+
+// errCatchupCapped stops the catchup iteration at the pass's frame budget.
 // Internal sentinel, never surfaced to the client.
 var errCatchupCapped = errors.New("sse catchup frame cap reached")
 
@@ -522,7 +627,12 @@ type catchupResult struct {
 // strand the remainder forever. Draining the tie bounds the overshoot by the
 // largest same-timestamp batch, and guarantees `capped` passes always end on
 // a boundary the next round can resume from strictly-after.
-func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, since time.Time, client *Client, midstream bool) catchupResult {
+//
+// maxFrames is the pass's frame budget: catchupMaxFrames for connect-time
+// replay, and the smaller midstreamRoundFrames(client) for live rounds, which
+// must not outrun the client's send buffer while the writer goroutine is busy
+// replaying.
+func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, since time.Time, client *Client, midstream bool, maxFrames int) catchupResult {
 	var only []models.Status
 	if since.IsZero() {
 		only = models.NonTerminalStatuses()
@@ -531,7 +641,7 @@ func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, s
 	enrichedBlocks := make(map[string]struct{})
 	err := s.store.IterateStatusesByToken(ctx, token, since, only, func(status *models.TransactionStatus) error {
 		ts := status.Timestamp.UnixNano()
-		if res.frames >= catchupMaxFrames {
+		if res.frames >= maxFrames {
 			if !midstream || ts != res.lastTS {
 				res.capped = true
 				return errCatchupCapped
@@ -568,7 +678,7 @@ func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, s
 			break
 		}
 		s.logger.Warn("sse catchup truncated at frame cap",
-			zap.Int("cap", catchupMaxFrames),
+			zap.Int("cap", maxFrames),
 			zap.Bool("fresh_connect", since.IsZero()))
 	default:
 		res.err = err
@@ -596,10 +706,18 @@ func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, s
 // catchup source is store.IterateStatusesByToken, which is token-scoped;
 // there is no bounded store query that reconstructs the unfiltered stream.
 // They keep the drop metric and the aggregate Warn.
+//
+// Rounds are rate-matched to the connection rather than run back to back:
+// each round is bounded by midstreamRoundFrames (a fraction of the client's
+// send buffer) and the live channel is drained between rounds. Replaying
+// occupies this same goroutine, so an unbounded round guaranteed the buffer
+// it was healing overflowed again mid-replay — the drop→catchup→drop loop
+// that kept a stream in permanent recovery.
 func (s *Service) midstreamCatchup(ctx context.Context, w *sseWriter, client *Client) bool {
 	if client.Token == "" || !s.manager.catchupOnDrop {
 		return true
 	}
+	roundFrames := midstreamRoundFrames(client)
 	resume := int64(-1) // lastTS of a capped round; -1 = no round pending
 	for client.dropped.Load() || resume >= 0 {
 		// Consume the flag BEFORE the floor: recordDrop writes the floor
@@ -622,7 +740,7 @@ func (s *Service) midstreamCatchup(ctx context.Context, w *sseWriter, client *Cl
 		}
 
 		metrics.SSEMidstreamCatchupsTotal.Inc()
-		res := s.sendCatchup(ctx, w, client.Token, time.Unix(0, sinceNS), client, true)
+		res := s.sendCatchup(ctx, w, client.Token, time.Unix(0, sinceNS), client, true, roundFrames)
 		metrics.SSEMidstreamCatchupFramesTotal.Add(float64(res.frames))
 		if res.err != nil {
 			// Either the connection is dead (write error) or the store
@@ -635,9 +753,24 @@ func (s *Service) midstreamCatchup(ctx context.Context, w *sseWriter, client *Cl
 				zap.Error(res.err))
 			return false
 		}
+		// Rate-match: hand the live channel back the goroutine before the next
+		// round. Without this the replay loop starves the very buffer it is
+		// healing and re-arms its own drop flag. Live frames are newer than
+		// what the round just replayed, so ids move forward again here —
+		// non-monotonic ids across a drop/catchup boundary are already part of
+		// the catchup contract.
+		live, err := drainLive(w, client)
+		if err != nil {
+			return false
+		}
+		if err := w.flush(); err != nil {
+			return false
+		}
 		s.logger.Info("sse mid-stream catchup round",
 			zap.Int64("client_id", client.ID),
 			zap.Int("frames", res.frames),
+			zap.Int("round_cap", roundFrames),
+			zap.Int("live_frames", live),
 			zap.Bool("capped", res.capped),
 			zap.Time("since", time.Unix(0, sinceNS)))
 		if res.capped {
@@ -647,6 +780,29 @@ func (s *Service) midstreamCatchup(ctx context.Context, w *sseWriter, client *Cl
 		}
 	}
 	return true
+}
+
+// drainLive writes every frame already buffered on the client's send channel
+// WITHOUT flushing, returning how many it wrote. The default arm exits once
+// the channel is empty, so it only ever writes what is ready and cannot spin.
+// Callers flush once afterwards.
+func drainLive(w *sseWriter, client *Client) (int, error) {
+	written := 0
+	for {
+		select {
+		case status := <-client.Ch:
+			if status == nil {
+				continue
+			}
+			if err := writeStatusBuffered(w, status); err != nil {
+				return written, err
+			}
+			client.lastDelivered.Store(status.Timestamp.UnixNano())
+			written++
+		default:
+			return written, nil
+		}
+	}
 }
 
 // enrichMerklePath attaches the merkle proof to a mined/immutable status before
@@ -667,11 +823,20 @@ func (m *Manager) enrichMerklePath(ctx context.Context, status *models.Transacti
 // buildStatusFrame renders one status as an SSE frame. Event id is the
 // timestamp in nanoseconds so clients can use it as Last-Event-ID on
 // reconnect.
+//
+// The payload timestamp is RFC3339Nano, not RFC3339: the frame id already
+// carries nanoseconds, so a second-resolution payload left any consumer
+// measuring latency from `data` with up to ±1 s of error against the same
+// event's own id. RFC3339Nano is a strict superset of the previous output —
+// it elides trailing zeros, so a whole-second timestamp still renders
+// byte-identically — and fractional seconds are optional in RFC 3339, so
+// conformant parsers (Go's time.RFC3339, JavaScript's Date, Python's
+// datetime.fromisoformat) accept both spellings unchanged.
 func buildStatusFrame(status *models.TransactionStatus) (string, error) {
 	data, err := json.Marshal(statusPayload{
 		TxID:        status.TxID,
 		TxStatus:    string(status.Status),
-		Timestamp:   status.Timestamp.UTC().Format(time.RFC3339),
+		Timestamp:   status.Timestamp.UTC().Format(time.RFC3339Nano),
 		BlockHash:   status.BlockHash,
 		BlockHeight: status.BlockHeight,
 		MerklePath:  status.MerklePath,

--- a/services/sse/sse_test.go
+++ b/services/sse/sse_test.go
@@ -67,8 +67,8 @@ func (p *fakePublisher) Subscribe(_ context.Context, _ string) (<-chan *models.T
 func (p *fakePublisher) Close() error { return nil }
 
 // sseStoreStub is a minimum-surface fake. The SSE service only touches
-// GetSubmissionsByToken, GetStatus, and IterateStatusesByToken on the
-// Store; embed the interface so every other method panics if
+// GetSubmissionsByToken, GetStatus, TokensForTxIDs and IterateStatusesByToken
+// on the Store; embed the interface so every other method panics if
 // accidentally called.
 type sseStoreStub struct {
 	store.Store
@@ -76,6 +76,12 @@ type sseStoreStub struct {
 	mu          sync.RWMutex
 	subsByToken map[string][]*models.Submission
 	statusByTx  map[string]*models.TransactionStatus
+
+	// tokenCalls counts TokensForTxIDs round-trips and tokenTxIDs the txids
+	// they carried — the fan-out's store cost, which is what
+	// TestFanOutResolvesTokensOncePerEvent asserts on.
+	tokenCalls int
+	tokenTxIDs int
 }
 
 func (s *sseStoreStub) GetSubmissionsByToken(_ context.Context, token string) ([]*models.Submission, error) {
@@ -130,16 +136,37 @@ func (s *sseStoreStub) IterateStatusesByToken(_ context.Context, token string, s
 	return nil
 }
 
-// TokenHasSubmissionForTx mirrors the real backends' membership probe.
-func (s *sseStoreStub) TokenHasSubmissionForTx(_ context.Context, token, txid string) (bool, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	for _, sub := range s.subsByToken[token] {
-		if sub.TxID == txid {
-			return true, nil
+// TokensForTxIDs mirrors the real backends' membership resolution and records
+// what fan-out asked of the store.
+func (s *sseStoreStub) TokensForTxIDs(_ context.Context, txids []string) (map[string][]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tokenCalls++
+	s.tokenTxIDs += len(txids)
+
+	want := make(map[string]struct{}, len(txids))
+	for _, txid := range txids {
+		want[txid] = struct{}{}
+	}
+	out := make(map[string][]string)
+	for token, subs := range s.subsByToken {
+		for _, sub := range subs {
+			if _, ok := want[sub.TxID]; !ok {
+				continue
+			}
+			if !slices.Contains(out[sub.TxID], token) {
+				out[sub.TxID] = append(out[sub.TxID], token)
+			}
 		}
 	}
-	return false, nil
+	return out, nil
+}
+
+// storeCounters snapshots the fan-out's store usage.
+func (s *sseStoreStub) storeCounters() (calls, txids int) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.tokenCalls, s.tokenTxIDs
 }
 
 func (s *sseStoreStub) setStatus(txid string, status *models.TransactionStatus) {
@@ -426,7 +453,7 @@ func TestSSECatchupFrameCap(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	w := &sseWriter{w: rec, f: nopFlusher{rec}}
-	res := svc.sendCatchup(t.Context(), w, "tok-big", time.Time{}, nil, false)
+	res := svc.sendCatchup(t.Context(), w, "tok-big", time.Time{}, nil, false, catchupMaxFrames)
 
 	frames := strings.Count(rec.Body.String(), "\nevent: status\n")
 	if frames != catchupMaxFrames {
@@ -783,7 +810,7 @@ func TestSSEFanOutDropLogAggregation(t *testing.T) {
 		mgr.fanOut(ctx, &models.TransactionStatus{TxID: "burst", Status: models.StatusMined, Timestamp: time.Now()})
 	}
 
-	warns := logs.FilterMessage("dropped events for slow SSE client; will catch up mid-stream").Len()
+	warns := logs.FilterMessage("sse fan-out could not enqueue events: client send buffer full; will catch up mid-stream").Len()
 	// 100 back-to-back drops land inside one dropLogInterval on any sane
 	// machine, so one aggregate line is expected; tolerate a second in case
 	// the loop straddles an interval boundary. The old code logged all 100.
@@ -793,8 +820,8 @@ func TestSSEFanOutDropLogAggregation(t *testing.T) {
 }
 
 // TestSSEMidstreamCatchupCappedRoundsProgress verifies the multi-round loop:
-// a replay window larger than catchupMaxFrames is delivered across capped
-// rounds whose `since` watermark strictly advances.
+// a replay window larger than one round's frame budget is delivered across
+// capped rounds whose `since` watermark strictly advances.
 func TestSSEMidstreamCatchupCappedRoundsProgress(t *testing.T) {
 	n := catchupMaxFrames + 500
 	subs := make([]*models.Submission, 0, n)
@@ -832,8 +859,12 @@ func TestSSEMidstreamCatchupCappedRoundsProgress(t *testing.T) {
 	if frames := strings.Count(rec.Body.String(), "\nevent: status\n"); frames != n {
 		t.Errorf("frames written = %d, want %d (every status, across rounds)", frames, n)
 	}
-	if got := testutil.ToFloat64(metrics.SSEMidstreamCatchupsTotal) - catchupsBefore; got != 2 {
-		t.Errorf("catchup rounds = %v, want 2 (capped round + resumed round)", got)
+	// Rounds are bounded by the client's send-buffer budget, not by
+	// catchupMaxFrames, so the window pages across ceil(n/budget) rounds.
+	budget := midstreamRoundFrames(client)
+	wantRounds := float64((n + budget - 1) / budget)
+	if got := testutil.ToFloat64(metrics.SSEMidstreamCatchupsTotal) - catchupsBefore; got != wantRounds {
+		t.Errorf("catchup rounds = %v, want %v (capped rounds of %d frames + resumed round)", got, wantRounds, budget)
 	}
 	if got := testutil.ToFloat64(metrics.SSEMidstreamCatchupFramesTotal) - framesBefore; got != float64(n) {
 		t.Errorf("replayed frames metric delta = %v, want %d", got, n)

--- a/services/sse/tokenindex.go
+++ b/services/sse/tokenindex.go
@@ -1,0 +1,246 @@
+package sse
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/logfields"
+	"github.com/bsv-blockchain/arcade/metrics"
+	"github.com/bsv-blockchain/arcade/store"
+)
+
+// tokenSet is the set of callback tokens subscribed to one txid. It is a
+// slice, not a map: a txid carries a handful of tokens and a fan-out asks
+// "does THIS client's token belong" a handful of times per event, so a linear
+// scan beats a map on both speed and — at tens of thousands of cached
+// entries — resident bytes. Treat it as immutable once published: fan-out
+// reads it without holding the index lock.
+type tokenSet []string
+
+// has reports whether token is subscribed to the txid this set describes.
+func (s tokenSet) has(token string) bool { return slices.Contains(s, token) }
+
+// Cache bounds. The index is a pure accelerator — every miss is answered by
+// the store — so the bounds are chosen for a small, predictable resident set
+// rather than for completeness. The SSE pod runs with a 256Mi limit and has
+// been OOM-killed before (#237/#238), so entries are bounded TWO ways, the
+// same dual-bound discipline as store/bumpcache: a hard entry cap AND a
+// resident-cost budget, because token strings are caller-supplied and a
+// count-based limit alone says nothing about bytes.
+const (
+	// maxTokenCacheEntries hard-caps entry count.
+	maxTokenCacheEntries = 65536
+	// maxTokenCacheBytes budgets estimated resident bytes (see entryCost).
+	// At the ~280 B/entry a 64-hex txid plus one token costs, 16 MiB is
+	// reached around 60k entries — roughly a minute of unique txids at
+	// 1,000 TPS, which spans the ACCEPTED → SEEN_ON_NETWORK →
+	// SEEN_IN_ORPHAN_MEMPOOL window that supplies the hits.
+	maxTokenCacheBytes = 16 << 20
+	// tokenCacheTTL bounds how stale a cached set may be. A txid's token set
+	// only changes if a further submission is registered for the SAME txid
+	// under a DIFFERENT token, which is rare — but a cached set is used to
+	// SUPPRESS delivery, so it must not be able to suppress forever.
+	tokenCacheTTL = 2 * time.Minute
+	// entryOverhead approximates the fixed per-entry heap cost the LRU pays
+	// on top of the key and token bytes: list node, map bucket slot, slice
+	// and string headers. Deliberately generous — under-counting is how a
+	// "bounded" cache OOMs a pod.
+	entryOverhead = 160
+	// tokenOverhead is the per-token string header cost inside a set.
+	tokenOverhead = 16
+)
+
+// cacheEntry is one txid's resolved token set plus its expiry.
+type cacheEntry struct {
+	tokens    tokenSet
+	expiresAt time.Time
+}
+
+// entryCost estimates an entry's resident bytes for the budget.
+func entryCost(txid string, tokens tokenSet) int {
+	cost := entryOverhead + len(txid)
+	for _, t := range tokens {
+		cost += tokenOverhead + len(t)
+	}
+	return cost
+}
+
+// tokenIndex answers "which callback tokens are subscribed to this txid" for
+// the SSE fan-out.
+//
+// It exists because fan-out used to ask the store that question once per
+// (event, client) via an EXISTS probe. Measured against a 4.5M-row
+// submissions table under load that probe cost 0.583 ms, and since the
+// manager fans out on exactly ONE goroutine it capped delivery at ~1.6k
+// events/s — against ~4k events/s of demand at 1,000 TPS (four transitions
+// per transaction). Two changes remove the cap:
+//
+//   - resolve ONCE per event, then answer every client from the set in
+//     memory, so query volume stops scaling with client count; and
+//   - resolve a bulk event's whole txid list in one batch, so a block's MINED
+//     unfan costs a handful of round-trips instead of one per transaction.
+//
+// A bounded LRU then absorbs the repeat lookups: a transaction emits several
+// live transitions within a short window, and only the first has to reach the
+// store.
+//
+// Concurrency: the index is mutex-guarded so it is safe to share, but the
+// production caller is the manager's single fan-out goroutine. That is also
+// why there is deliberately NO singleflight here (unlike store/bumpcache,
+// which is hit concurrently by fan-out, webhook workers and GET /tx): with
+// one caller there are no concurrent misses to collapse, and the group would
+// be pure overhead on the hot path.
+type tokenIndex struct {
+	store  store.Store
+	logger *zap.Logger
+	now    func() time.Time // injectable for tests
+
+	maxBytes int
+	ttl      time.Duration
+
+	// mu guards lru and bytes. The LRU's evict callback adjusts bytes and
+	// runs synchronously inside mutations, so it MUST NOT take mu itself —
+	// every call site below already holds it.
+	mu    sync.Mutex
+	lru   *simplelru.LRU[string, cacheEntry]
+	bytes int
+}
+
+// newTokenIndex constructs the index with the package's production bounds.
+func newTokenIndex(st store.Store, logger *zap.Logger) *tokenIndex {
+	return newTokenIndexWithLimits(st, logger, maxTokenCacheEntries, maxTokenCacheBytes, tokenCacheTTL)
+}
+
+// newTokenIndexWithLimits is the constructor proper, split out so tests can
+// exercise eviction and expiry without building 60k-entry working sets.
+func newTokenIndexWithLimits(st store.Store, logger *zap.Logger, entries, bytes int, ttl time.Duration) *tokenIndex {
+	ti := &tokenIndex{
+		store:    st,
+		logger:   logger,
+		now:      time.Now,
+		maxBytes: bytes,
+		ttl:      ttl,
+	}
+	l, err := simplelru.NewLRU(entries, func(k string, v cacheEntry) {
+		ti.bytes -= entryCost(k, v.tokens)
+	})
+	if err != nil {
+		// Unreachable: NewLRU only fails for a non-positive size and every
+		// caller passes a positive constant.
+		panic(err)
+	}
+	ti.lru = l
+	return ti
+}
+
+// lookup returns the tokens subscribed to txid, consulting the cache first
+// and falling back to a single-txid store batch. A store error yields an
+// empty set: fan-out then withholds the frame, exactly as the probe it
+// replaced did, and the client recovers it via catchup.
+func (t *tokenIndex) lookup(ctx context.Context, txid string) tokenSet {
+	if t.store == nil || txid == "" {
+		return nil
+	}
+	if tokens, ok := t.cached(txid); ok {
+		metrics.SSETokenCacheTotal.WithLabelValues("hit").Inc()
+		return tokens
+	}
+	metrics.SSETokenCacheTotal.WithLabelValues("miss").Inc()
+
+	resolved, err := t.query(ctx, []string{txid}, "single")
+	if err != nil {
+		t.logger.Warn("submission token lookup failed", logfields.TxID(txid), zap.Error(err))
+		return nil
+	}
+	tokens := tokenSet(resolved[txid])
+	// Only NON-EMPTY sets are cached. An empty answer can be a race rather
+	// than a fact: the api-server records submissions asynchronously, so a
+	// status event can overtake its own submission row by a few
+	// milliseconds. Caching that emptiness would suppress every later
+	// transition of the transaction for the whole TTL; re-asking costs one
+	// query and is what the old probe did on every event anyway.
+	if len(tokens) > 0 {
+		t.add(txid, tokens)
+	}
+	return tokens
+}
+
+// resolveBatch resolves a bulk event's whole txid list in one store batch.
+// txids absent from the result have no subscriber.
+//
+// It deliberately neither reads nor writes the LRU. A bulk event is a block's
+// MINED (or a reorg revert) burst: up to 5,000 terminal-state txids with no
+// locality against the live working set, so admitting them would evict the
+// entries that actually produce hits, and consulting the cache would only add
+// variance to a query count that is already one per chunk.
+func (t *tokenIndex) resolveBatch(ctx context.Context, txids []string) map[string]tokenSet {
+	if t.store == nil || len(txids) == 0 {
+		return nil
+	}
+	resolved, err := t.query(ctx, txids, "batch")
+	if err != nil {
+		t.logger.Warn("submission token batch lookup failed",
+			logfields.TxIDCount(len(txids)), zap.Error(err))
+		return nil
+	}
+	out := make(map[string]tokenSet, len(resolved))
+	for txid, tokens := range resolved {
+		out[txid] = tokens
+	}
+	return out
+}
+
+// query runs one store resolution and records its latency under kind.
+func (t *tokenIndex) query(ctx context.Context, txids []string, kind string) (map[string][]string, error) {
+	start := t.now()
+	resolved, err := t.store.TokensForTxIDs(ctx, txids)
+	metrics.SSETokenLookupDuration.WithLabelValues(kind).Observe(t.now().Sub(start).Seconds())
+	return resolved, err
+}
+
+// cached returns a live entry's tokens. An expired entry is dropped and
+// reported as a miss.
+func (t *tokenIndex) cached(txid string) (tokenSet, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	entry, ok := t.lru.Get(txid)
+	if !ok {
+		return nil, false
+	}
+	if t.now().After(entry.expiresAt) {
+		t.lru.Remove(txid)
+		return nil, false
+	}
+	return entry.tokens, true
+}
+
+// add inserts an entry and enforces the byte budget. Replacing an existing key
+// removes it first so the evict callback keeps the byte count exact (the LRU's
+// in-place update path skips the callback).
+func (t *tokenIndex) add(txid string, tokens tokenSet) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lru.Remove(txid)
+	t.lru.Add(txid, cacheEntry{tokens: tokens, expiresAt: t.now().Add(t.ttl)})
+	t.bytes += entryCost(txid, tokens)
+	// Unlike bumpcache there is no "keep the newest even alone over budget"
+	// exception: a token set is tiny, so the budget can always accommodate at
+	// least one entry, and stopping at Len() > 1 keeps eviction terminating
+	// if a pathological entry ever exceeded the budget on its own.
+	for t.bytes > t.maxBytes && t.lru.Len() > 1 {
+		t.lru.RemoveOldest()
+	}
+	metrics.SSETokenCacheEntries.Set(float64(t.lru.Len()))
+}
+
+// len reports the current entry count. Exposed for tests.
+func (t *tokenIndex) len() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.lru.Len()
+}

--- a/services/sse/tokenindex_test.go
+++ b/services/sse/tokenindex_test.go
@@ -1,0 +1,221 @@
+package sse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
+)
+
+// tokenStoreStub is a programmable Store for the index's unit tests: it
+// records every batch it was asked for and can fail on demand.
+type tokenStoreStub struct {
+	store.Store
+
+	tokens map[string][]string
+	err    error
+
+	calls   int
+	batches [][]string
+}
+
+// EnrichMerklePath is a no-op: these tests never exercise BUMP extraction, but
+// it must exist so fan-out enrichment doesn't dereference the nil embedded
+// store.Store.
+func (s *tokenStoreStub) EnrichMerklePath(_ context.Context, _ *models.TransactionStatus) {}
+
+func (s *tokenStoreStub) TokensForTxIDs(_ context.Context, txids []string) (map[string][]string, error) {
+	s.calls++
+	s.batches = append(s.batches, slices.Clone(txids))
+	if s.err != nil {
+		return nil, s.err
+	}
+	out := make(map[string][]string)
+	for _, txid := range txids {
+		if tokens, ok := s.tokens[txid]; ok {
+			out[txid] = tokens
+		}
+	}
+	return out, nil
+}
+
+func newTestIndex(t *testing.T, st store.Store, entries, bytes int, ttl time.Duration) *tokenIndex {
+	t.Helper()
+	return newTokenIndexWithLimits(st, zap.NewNop(), entries, bytes, ttl)
+}
+
+// TestTokenIndexCachesPositiveResults is the base case: a resolved token set
+// answers every later lookup for the same txid without touching the store.
+func TestTokenIndexCachesPositiveResults(t *testing.T) {
+	st := &tokenStoreStub{tokens: map[string][]string{"tx-1": {tokA}}}
+	idx := newTestIndex(t, st, 16, 1<<20, time.Minute)
+
+	for range 5 {
+		if got := idx.lookup(context.Background(), "tx-1"); !got.has(tokA) {
+			t.Fatalf("lookup = %v, want the set to contain %s", got, tokA)
+		}
+	}
+	if st.calls != 1 {
+		t.Errorf("store calls = %d, want 1", st.calls)
+	}
+}
+
+// TestTokenIndexDoesNotCacheEmptyResults is a correctness guard, not an
+// optimisation. The api-server records submissions asynchronously, so a status
+// event can overtake its own submission row by a few milliseconds. Caching
+// "no subscriber" would then suppress every later transition of that
+// transaction for the whole TTL — a silent delivery hole.
+func TestTokenIndexDoesNotCacheEmptyResults(t *testing.T) {
+	st := &tokenStoreStub{tokens: map[string][]string{}}
+	idx := newTestIndex(t, st, 16, 1<<20, time.Minute)
+
+	if got := idx.lookup(context.Background(), "tx-late"); len(got) != 0 {
+		t.Fatalf("lookup = %v, want empty", got)
+	}
+	if got := idx.lookup(context.Background(), "tx-late"); len(got) != 0 {
+		t.Fatalf("second lookup = %v, want empty", got)
+	}
+	if st.calls != 2 {
+		t.Errorf("store calls = %d, want 2 (an empty answer is never cached)", st.calls)
+	}
+	if idx.len() != 0 {
+		t.Errorf("cache holds %d entries, want 0", idx.len())
+	}
+
+	// The submission lands late; the very next event must see it.
+	st.tokens["tx-late"] = []string{tokA}
+	if got := idx.lookup(context.Background(), "tx-late"); !got.has(tokA) {
+		t.Errorf("lookup after late submission = %v, want it to contain %s", got, tokA)
+	}
+}
+
+// TestTokenIndexWithholdsOnStoreError: a failed lookup must behave like the
+// probe it replaced — withhold the frame (the client recovers via catchup) and
+// cache nothing, so the next event retries.
+func TestTokenIndexWithholdsOnStoreError(t *testing.T) {
+	st := &tokenStoreStub{err: errors.New("boom")}
+	idx := newTestIndex(t, st, 16, 1<<20, time.Minute)
+
+	if got := idx.lookup(context.Background(), "tx-err"); len(got) != 0 {
+		t.Errorf("lookup on store error = %v, want empty", got)
+	}
+	if idx.len() != 0 {
+		t.Errorf("cache holds %d entries after an error, want 0", idx.len())
+	}
+	_ = idx.lookup(context.Background(), "tx-err")
+	if st.calls != 2 {
+		t.Errorf("store calls = %d, want 2 (errors are not cached)", st.calls)
+	}
+}
+
+// TestTokenIndexExpiresEntries covers the TTL: a cached set is used to
+// SUPPRESS delivery, so it must not be able to suppress indefinitely if a
+// second submission registers the same txid under another token.
+func TestTokenIndexExpiresEntries(t *testing.T) {
+	st := &tokenStoreStub{tokens: map[string][]string{"tx-ttl": {tokA}}}
+	idx := newTestIndex(t, st, 16, 1<<20, time.Minute)
+	now := time.Now()
+	idx.now = func() time.Time { return now }
+
+	_ = idx.lookup(context.Background(), "tx-ttl")
+	now = now.Add(30 * time.Second)
+	_ = idx.lookup(context.Background(), "tx-ttl")
+	if st.calls != 1 {
+		t.Fatalf("store calls before TTL = %d, want 1", st.calls)
+	}
+
+	st.tokens["tx-ttl"] = []string{tokA, "tok-B"}
+	now = now.Add(time.Minute)
+	got := idx.lookup(context.Background(), "tx-ttl")
+	if st.calls != 2 {
+		t.Errorf("store calls after TTL = %d, want 2", st.calls)
+	}
+	if !got.has("tok-B") {
+		t.Errorf("post-expiry lookup = %v, want it to pick up tok-B", got)
+	}
+}
+
+// TestTokenIndexEnforcesEntryCap covers the first of the two bounds.
+func TestTokenIndexEnforcesEntryCap(t *testing.T) {
+	const entryCap = 8
+	st := &tokenStoreStub{tokens: map[string][]string{}}
+	idx := newTestIndex(t, st, entryCap, 1<<20, time.Minute)
+	for i := range 64 {
+		txid := fmt.Sprintf("tx-%03d", i)
+		st.tokens[txid] = []string{tokA}
+		_ = idx.lookup(context.Background(), txid)
+	}
+	if got := idx.len(); got != entryCap {
+		t.Errorf("cache holds %d entries, want the cap %d", got, entryCap)
+	}
+}
+
+// TestTokenIndexEnforcesByteBudget covers the second bound. The entry cap
+// alone says nothing about bytes — token strings are caller-supplied — and
+// this pod has been OOM-killed by an unbounded resident set before
+// (#237/#238), so the byte budget must bind independently.
+func TestTokenIndexEnforcesByteBudget(t *testing.T) {
+	const budget = 4096
+	st := &tokenStoreStub{tokens: map[string][]string{}}
+	idx := newTestIndex(t, st, 1024, budget, time.Minute)
+
+	long := string(make([]byte, 512)) // a 512-byte callback token
+	for i := range 64 {
+		txid := fmt.Sprintf("tx-%03d", i)
+		st.tokens[txid] = []string{long}
+		_ = idx.lookup(context.Background(), txid)
+	}
+	if idx.len() >= 64 {
+		t.Errorf("cache holds %d entries, want the byte budget to have evicted", idx.len())
+	}
+	idx.mu.Lock()
+	resident := idx.bytes
+	idx.mu.Unlock()
+	if resident > budget {
+		t.Errorf("resident bytes = %d, over the %d budget", resident, budget)
+	}
+}
+
+// TestTokenIndexBatchBypassesCache pins the deliberate asymmetry: a bulk
+// event's txids are a block's terminal-state burst with no locality against
+// the live working set, so admitting them would evict the entries that
+// actually produce hits.
+func TestTokenIndexBatchBypassesCache(t *testing.T) {
+	st := &tokenStoreStub{tokens: map[string][]string{"tx-a": {tokA}, "tx-b": {tokA}}}
+	idx := newTestIndex(t, st, 16, 1<<20, time.Minute)
+
+	got := idx.resolveBatch(context.Background(), []string{"tx-a", "tx-b", "tx-c"})
+	if !got["tx-a"].has(tokA) || !got["tx-b"].has(tokA) {
+		t.Errorf("batch = %v, want tx-a and tx-b subscribed to %s", got, tokA)
+	}
+	if _, ok := got["tx-c"]; ok {
+		t.Errorf("unsubscribed txid present in batch result: %v", got["tx-c"])
+	}
+	if st.calls != 1 {
+		t.Errorf("store calls = %d, want 1 for the whole batch", st.calls)
+	}
+	if len(st.batches[0]) != 3 {
+		t.Errorf("batch carried %d txids, want 3", len(st.batches[0]))
+	}
+	if idx.len() != 0 {
+		t.Errorf("cache holds %d entries after a bulk resolve, want 0", idx.len())
+	}
+}
+
+// TestTokenIndexNilStore keeps the "no fan-out wired" construction safe.
+func TestTokenIndexNilStore(t *testing.T) {
+	idx := newTokenIndex(nil, zap.NewNop())
+	if got := idx.lookup(context.Background(), "tx"); got != nil {
+		t.Errorf("lookup with nil store = %v, want nil", got)
+	}
+	if got := idx.resolveBatch(context.Background(), []string{"tx"}); got != nil {
+		t.Errorf("resolveBatch with nil store = %v, want nil", got)
+	}
+}

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -195,8 +195,8 @@ func (s *fakeStore) IterateStatusesByToken(context.Context, string, time.Time, [
 	return nil
 }
 
-func (s *fakeStore) TokenHasSubmissionForTx(context.Context, string, string) (bool, error) {
-	return false, nil
+func (s *fakeStore) TokensForTxIDs(context.Context, []string) (map[string][]string, error) {
+	return map[string][]string{}, nil
 }
 func (s *fakeStore) InsertStump(context.Context, *models.Stump) error { return nil }
 func (s *fakeStore) GetStumpsByBlockHash(context.Context, string) ([]*models.Stump, error) {

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -1916,20 +1916,13 @@ loop:
 	return subs, nil
 }
 
-// TokenHasSubmissionForTx resolves via the txid secondary index (a txid
-// has a handful of submissions) — never the token side, which can hold
-// millions.
-func (s *Store) TokenHasSubmissionForTx(ctx context.Context, callbackToken, txid string) (bool, error) {
-	subs, err := s.GetSubmissionsByTxID(ctx, txid)
-	if err != nil {
-		return false, err
-	}
-	for _, sub := range subs {
-		if sub.CallbackToken == callbackToken {
-			return true, nil
-		}
-	}
-	return false, nil
+// TokensForTxIDs resolves via the txid secondary index (a txid has a handful
+// of submissions) — never the token side, which can hold millions. Aerospike
+// secondary-index queries take a single equality filter, so a batch is one
+// query per txid; the win over the probe this replaced is that fan-out asks
+// once per txid no matter how many clients are connected.
+func (s *Store) TokensForTxIDs(ctx context.Context, txids []string) (map[string][]string, error) {
+	return store.TokensForTxIDsViaPerTxID(ctx, txids, s.GetSubmissionsByTxID)
 }
 
 func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -1848,19 +1848,13 @@ func (s *Store) GetSubmissionsByToken(ctx context.Context, callbackToken string)
 	return s.submissionsByIndex(ctx, idxSubTokenPrefix(callbackToken))
 }
 
-// TokenHasSubmissionForTx resolves via the by-txid index (a txid has a
-// handful of submissions) — never the token index, which can hold millions.
-func (s *Store) TokenHasSubmissionForTx(ctx context.Context, callbackToken, txid string) (bool, error) {
-	subs, err := s.GetSubmissionsByTxID(ctx, txid)
-	if err != nil {
-		return false, err
-	}
-	for _, sub := range subs {
-		if sub.CallbackToken == callbackToken {
-			return true, nil
-		}
-	}
-	return false, nil
+// TokensForTxIDs resolves via the by-txid index (a txid has a handful of
+// submissions) — never the token index, which can hold millions. Pebble has
+// no set-returning read, so a batch is one local prefix scan per txid; the
+// win over the probe this replaced is that fan-out asks once per txid no
+// matter how many clients are connected.
+func (s *Store) TokensForTxIDs(ctx context.Context, txids []string) (map[string][]string, error) {
+	return store.TokensForTxIDsViaPerTxID(ctx, txids, s.GetSubmissionsByTxID)
 }
 
 func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {

--- a/store/pebble/pebble_test.go
+++ b/store/pebble/pebble_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -1237,16 +1239,21 @@ func TestIterateStatusesByToken(t *testing.T) {
 	}
 }
 
-// TestTokenHasSubmissionForTx covers the SSE fan-out membership probe:
-// match, wrong-token, and unknown-txid cases.
-func TestTokenHasSubmissionForTx(t *testing.T) {
+// TestTokensForTxIDs covers the SSE fan-out membership resolution: multiple
+// tokens on one txid, a txid with a single token, unknown txids, duplicate
+// inputs, submissions without a token, and the empty batch.
+func TestTokensForTxIDs(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 
 	subs := []*models.Submission{
 		{SubmissionID: "p1", TxID: "tx-probe", CallbackToken: "tok-1", CreatedAt: time.Now()},
 		{SubmissionID: "p2", TxID: "tx-probe", CallbackToken: "tok-2", CreatedAt: time.Now()},
+		// Same (txid, token) twice: the result must be de-duplicated.
+		{SubmissionID: "p2b", TxID: "tx-probe", CallbackToken: "tok-2", CreatedAt: time.Now()},
 		{SubmissionID: "p3", TxID: "tx-solo", CallbackToken: "tok-1", CreatedAt: time.Now()},
+		// SSE-less submission: no callback token, so it contributes nothing.
+		{SubmissionID: "p4", TxID: "tx-notoken", CreatedAt: time.Now()},
 	}
 	for _, sub := range subs {
 		if err := s.InsertSubmission(ctx, sub); err != nil {
@@ -1254,23 +1261,38 @@ func TestTokenHasSubmissionForTx(t *testing.T) {
 		}
 	}
 
-	cases := []struct {
-		token, txid string
-		want        bool
-	}{
-		{"tok-1", "tx-probe", true},
-		{"tok-2", "tx-probe", true},
-		{"tok-2", "tx-solo", false},  // txid exists, different token
-		{"tok-1", "tx-ghost", false}, // unknown txid
-		{"tok-none", "tx-probe", false},
+	// One batch resolves every txid, duplicates included.
+	got, err := s.TokensForTxIDs(ctx, []string{"tx-probe", "tx-probe", "tx-solo", "tx-notoken", "tx-ghost"})
+	if err != nil {
+		t.Fatalf("TokensForTxIDs: %v", err)
 	}
-	for _, tc := range cases {
-		got, err := s.TokenHasSubmissionForTx(ctx, tc.token, tc.txid)
-		if err != nil {
-			t.Fatalf("TokenHasSubmissionForTx(%s,%s): %v", tc.token, tc.txid, err)
+	want := map[string][]string{
+		"tx-probe": {"tok-1", "tok-2"},
+		"tx-solo":  {"tok-1"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("TokensForTxIDs returned %d txids (%v), want %d", len(got), got, len(want))
+	}
+	for txid, wantTokens := range want {
+		gotTokens := append([]string(nil), got[txid]...)
+		sort.Strings(gotTokens)
+		if !slices.Equal(gotTokens, wantTokens) {
+			t.Errorf("tokens for %s = %v, want %v", txid, gotTokens, wantTokens)
 		}
-		if got != tc.want {
-			t.Errorf("TokenHasSubmissionForTx(%s,%s) = %v, want %v", tc.token, tc.txid, got, tc.want)
+	}
+	// Absent, never present-but-empty: fan-out treats a missing key as
+	// "nobody subscribed".
+	for _, txid := range []string{"tx-ghost", "tx-notoken"} {
+		if _, ok := got[txid]; ok {
+			t.Errorf("%s must be absent from the result, got %v", txid, got[txid])
 		}
+	}
+
+	empty, err := s.TokensForTxIDs(ctx, nil)
+	if err != nil {
+		t.Fatalf("TokensForTxIDs(nil): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("TokensForTxIDs(nil) = %v, want empty", empty)
 	}
 }

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -1357,16 +1357,56 @@ func (s *Store) GetSubmissionsByToken(ctx context.Context, token string) ([]*mod
 	return s.submissions(ctx, "callback_token = $1", token)
 }
 
-// TokenHasSubmissionForTx is an indexed existence probe: keyed on txid
-// first (idx_sub_txid; a txid has a handful of submissions) rather than
-// the token side (idx_sub_token; a token can have millions).
-func (s *Store) TokenHasSubmissionForTx(ctx context.Context, callbackToken, txid string) (bool, error) {
-	const q = `SELECT EXISTS(SELECT 1 FROM submissions WHERE txid = $1 AND callback_token = $2)`
-	var exists bool
-	if err := s.pool.QueryRow(ctx, q, txid, callbackToken).Scan(&exists); err != nil {
-		return false, err
+// tokensForTxIDsChunk bounds how many txids ride in one TokensForTxIDs
+// query. A bulk MINED event carries up to the bump-builder's
+// maxTxIDsPerBulkEvent (5000) txids, so a whole batch resolves in a handful
+// of round-trips while each statement keeps a modest parameter array.
+const tokensForTxIDsChunk = 1000
+
+// TokensForTxIDs answers the SSE fan-out's membership question for a whole
+// batch of txids in one statement per chunk. It replaces a per-(event,
+// client) EXISTS probe that measured 0.583 ms under load against a 4.5M-row
+// submissions table and capped fan-out at ~1.6k events/s.
+//
+// The plan is an Index Only Scan of idx_sub_txid_token: (txid,
+// callback_token) covers both the predicate and the projection, so a match
+// costs no heap fetch. That is also why schema.sql DROPS the narrower
+// idx_sub_txid — verified by EXPLAIN, while it exists the planner costs it
+// lower, picks it, and pays the heap fetch anyway. Access is exclusively from
+// the txid side: a txid has a handful of submissions, a token can have
+// millions (interface contract).
+func (s *Store) TokensForTxIDs(ctx context.Context, txids []string) (map[string][]string, error) {
+	const q = `
+SELECT DISTINCT txid, callback_token
+FROM submissions
+WHERE txid = ANY($1) AND callback_token IS NOT NULL AND callback_token <> ''`
+	out := make(map[string][]string, len(txids))
+	for start := 0; start < len(txids); start += tokensForTxIDsChunk {
+		end := min(start+tokensForTxIDsChunk, len(txids))
+		if err := s.appendTokens(ctx, q, txids[start:end], out); err != nil {
+			return nil, err
+		}
 	}
-	return exists, nil
+	return out, nil
+}
+
+// appendTokens runs one TokensForTxIDs chunk and folds its rows into out.
+// Split out so the rows cursor is released per chunk instead of accumulating
+// across the whole batch.
+func (s *Store) appendTokens(ctx context.Context, q string, txids []string, out map[string][]string) error {
+	rows, err := s.pool.Query(ctx, q, txids)
+	if err != nil {
+		return fmt.Errorf("tokens for txids: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var txid, token string
+		if err := rows.Scan(&txid, &token); err != nil {
+			return fmt.Errorf("scan submission token row: %w", err)
+		}
+		out[txid] = append(out[txid], token)
+	}
+	return rows.Err()
 }
 
 func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -16,6 +16,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -1542,16 +1544,21 @@ func TestIterateStatusesByToken(t *testing.T) {
 	}
 }
 
-// TestTokenHasSubmissionForTx covers the SSE fan-out membership probe:
-// match, wrong-token, and unknown-txid cases.
-func TestTokenHasSubmissionForTx(t *testing.T) {
+// TestTokensForTxIDs covers the SSE fan-out membership resolution: multiple
+// tokens on one txid, a txid with a single token, unknown txids, duplicate
+// inputs, submissions without a token, and the empty batch.
+func TestTokensForTxIDs(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 
 	subs := []*models.Submission{
 		{SubmissionID: "p1", TxID: "tx-probe", CallbackToken: "tok-1", CreatedAt: time.Now()},
 		{SubmissionID: "p2", TxID: "tx-probe", CallbackToken: "tok-2", CreatedAt: time.Now()},
+		// Same (txid, token) twice: the result must be de-duplicated.
+		{SubmissionID: "p2b", TxID: "tx-probe", CallbackToken: "tok-2", CreatedAt: time.Now()},
 		{SubmissionID: "p3", TxID: "tx-solo", CallbackToken: "tok-1", CreatedAt: time.Now()},
+		// SSE-less submission: no callback token, so it contributes nothing.
+		{SubmissionID: "p4", TxID: "tx-notoken", CreatedAt: time.Now()},
 	}
 	for _, sub := range subs {
 		if err := s.InsertSubmission(ctx, sub); err != nil {
@@ -1559,23 +1566,38 @@ func TestTokenHasSubmissionForTx(t *testing.T) {
 		}
 	}
 
-	cases := []struct {
-		token, txid string
-		want        bool
-	}{
-		{"tok-1", "tx-probe", true},
-		{"tok-2", "tx-probe", true},
-		{"tok-2", "tx-solo", false},  // txid exists, different token
-		{"tok-1", "tx-ghost", false}, // unknown txid
-		{"tok-none", "tx-probe", false},
+	// One batch resolves every txid, duplicates included.
+	got, err := s.TokensForTxIDs(ctx, []string{"tx-probe", "tx-probe", "tx-solo", "tx-notoken", "tx-ghost"})
+	if err != nil {
+		t.Fatalf("TokensForTxIDs: %v", err)
 	}
-	for _, tc := range cases {
-		got, err := s.TokenHasSubmissionForTx(ctx, tc.token, tc.txid)
-		if err != nil {
-			t.Fatalf("TokenHasSubmissionForTx(%s,%s): %v", tc.token, tc.txid, err)
+	want := map[string][]string{
+		"tx-probe": {"tok-1", "tok-2"},
+		"tx-solo":  {"tok-1"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("TokensForTxIDs returned %d txids (%v), want %d", len(got), got, len(want))
+	}
+	for txid, wantTokens := range want {
+		gotTokens := append([]string(nil), got[txid]...)
+		sort.Strings(gotTokens)
+		if !slices.Equal(gotTokens, wantTokens) {
+			t.Errorf("tokens for %s = %v, want %v", txid, gotTokens, wantTokens)
 		}
-		if got != tc.want {
-			t.Errorf("TokenHasSubmissionForTx(%s,%s) = %v, want %v", tc.token, tc.txid, got, tc.want)
+	}
+	// Absent, never present-but-empty: fan-out treats a missing key as
+	// "nobody subscribed".
+	for _, txid := range []string{"tx-ghost", "tx-notoken"} {
+		if _, ok := got[txid]; ok {
+			t.Errorf("%s must be absent from the result, got %v", txid, got[txid])
 		}
+	}
+
+	empty, err := s.TokensForTxIDs(ctx, nil)
+	if err != nil {
+		t.Fatalf("TokensForTxIDs(nil): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("TokensForTxIDs(nil) = %v, want empty", empty)
 	}
 }

--- a/store/postgres/schema.sql
+++ b/store/postgres/schema.sql
@@ -131,8 +131,21 @@ ALTER TABLE submissions ADD COLUMN IF NOT EXISTS next_retry_at         TIMESTAMP
 ALTER TABLE submissions ADD COLUMN IF NOT EXISTS attempts              INT NOT NULL DEFAULT 0;
 ALTER TABLE submissions ADD COLUMN IF NOT EXISTS last_attempt_at       TIMESTAMPTZ;
 ALTER TABLE submissions ADD COLUMN IF NOT EXISTS last_result           TEXT;
-CREATE INDEX IF NOT EXISTS idx_sub_txid   ON submissions(txid);
 CREATE INDEX IF NOT EXISTS idx_sub_token  ON submissions(callback_token);
+-- Covering index for the txid-side access path: GetSubmissionsByTxID (webhook
+-- dispatch) and TokensForTxIDs (SSE fan-out membership). Carrying
+-- callback_token in the index turns the fan-out's batch resolution into an
+-- Index Only Scan — measured on 200k rows: Heap Fetches 0 and 97 shared
+-- buffers, against 217 with the heap fetch.
+CREATE INDEX IF NOT EXISTS idx_sub_txid_token ON submissions(txid, callback_token);
+-- idx_sub_txid is a strict prefix of idx_sub_txid_token, so it answers nothing
+-- the composite cannot. It must be DROPPED rather than merely left alone: while
+-- it exists the planner costs the narrower index lower, picks it, and pays the
+-- heap fetch anyway — verified by EXPLAIN, the composite is simply never
+-- chosen. Dropping it also removes one index write per submission INSERT on a
+-- 1000+/s ingest path. A downgrade to a release whose schema still creates it
+-- self-heals: that script's CREATE INDEX IF NOT EXISTS puts it back.
+DROP INDEX IF EXISTS idx_sub_txid;
 -- Partial index keyed off the webhook reaper's scan predicate; stays
 -- proportional to the in-retry backlog, not the full submissions table.
 CREATE INDEX IF NOT EXISTS idx_sub_retry_ready

--- a/store/store.go
+++ b/store/store.go
@@ -282,14 +282,22 @@ type Store interface {
 	// GetSubmissionsByToken retrieves all submissions for a callback token
 	GetSubmissionsByToken(ctx context.Context, callbackToken string) ([]*models.Submission, error)
 
-	// TokenHasSubmissionForTx reports whether txid has a submission registered
-	// under callbackToken. This is the SSE fan-out hot path — called once per
-	// event per token-filtered client — so implementations MUST resolve it via
-	// the by-txid index (a txid has a handful of submissions) and MUST NOT
-	// materialize the token's submission list: a single token can hold
-	// millions of submissions, and loading them per event is what OOM-killed
-	// the SSE service.
-	TokenHasSubmissionForTx(ctx context.Context, callbackToken, txid string) (bool, error)
+	// TokensForTxIDs returns the DISTINCT non-empty callback tokens registered
+	// against each of the supplied txids, keyed by txid. A txid with no
+	// submission — or none carrying a token — is ABSENT from the result map
+	// (never present with an empty slice), so an absent key means "nobody is
+	// subscribed". Duplicate txids in the input are collapsed.
+	//
+	// This is the SSE fan-out hot path. It replaced a per-(event, client)
+	// existence probe: fan-out now resolves a txid's token set ONCE and
+	// answers every connected client from that set in memory, and resolves a
+	// whole bulk event's txid list in one batch. Implementations MUST resolve
+	// from the txid side only (a txid has a handful of submissions) and MUST
+	// NOT materialize a token's submission list: a single token can hold
+	// millions of submissions, and loading one per event is what OOM-killed
+	// the SSE service (#237/#238). Implementations that cannot issue an
+	// unbounded batch must chunk internally rather than reject the call.
+	TokensForTxIDs(ctx context.Context, txids []string) (map[string][]string, error)
 
 	// IterateStatusesByToken streams the current status of every DISTINCT
 	// txid registered under callbackToken through fn, in ascending

--- a/store/submissions.go
+++ b/store/submissions.go
@@ -1,0 +1,73 @@
+package store
+
+import (
+	"context"
+
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// DistinctTokens collects the distinct non-empty callback tokens carried by a
+// txid's submissions, preserving first-seen order. Returns nil (not an empty
+// slice) when none of the submissions carry a token, which is what
+// TokensForTxIDs implementations use to decide whether a txid belongs in the
+// result map at all.
+//
+// The input is one txid's submission list — a handful of rows. It is never a
+// token's submission list; see the TokensForTxIDs contract.
+func DistinctTokens(subs []*models.Submission) []string {
+	var tokens []string
+	for _, sub := range subs {
+		if sub == nil || sub.CallbackToken == "" {
+			continue
+		}
+		dup := false
+		for _, seen := range tokens {
+			if seen == sub.CallbackToken {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			tokens = append(tokens, sub.CallbackToken)
+		}
+	}
+	return tokens
+}
+
+// TokensForTxIDsViaPerTxID is the TokensForTxIDs implementation for backends
+// whose only txid-side access path is a single-txid lookup (Pebble's by-txid
+// index prefix scan, Aerospike's txid secondary-index query). It is a plain
+// loop — the batching win for those backends is that fan-out asks once per
+// txid instead of once per (txid, client), not that the backend can round-trip
+// a batch. Postgres overrides this with a real set-returning query.
+//
+// getByTxID is the backend's GetSubmissionsByTxID. Duplicate txids are
+// resolved once.
+func TokensForTxIDsViaPerTxID(
+	ctx context.Context,
+	txids []string,
+	getByTxID func(context.Context, string) ([]*models.Submission, error),
+) (map[string][]string, error) {
+	out := make(map[string][]string, len(txids))
+	seen := make(map[string]struct{}, len(txids))
+	for _, txid := range txids {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if txid == "" {
+			continue
+		}
+		if _, dup := seen[txid]; dup {
+			continue
+		}
+		seen[txid] = struct{}{}
+		subs, err := getByTxID(ctx, txid)
+		if err != nil {
+			return nil, err
+		}
+		if tokens := DistinctTokens(subs); len(tokens) > 0 {
+			out[txid] = tokens
+		}
+	}
+	return out, nil
+}


### PR DESCRIPTION
## What Changed

The SSE fan-out no longer asks the store a question per (event, client).

**Store layer**
- `Store.TokenHasSubmissionForTx(token, txid) (bool, error)` → `Store.TokensForTxIDs(txids []string) (map[string][]string, error)`. Implemented in all three backends (Postgres batches in SQL; Pebble and Aerospike keep their per-txid index access behind a shared `store.TokensForTxIDsViaPerTxID` helper). Absent key means "nobody subscribed".
- `schema.sql`: adds `idx_sub_txid_token (txid, callback_token)` and **drops `idx_sub_txid`**.

**SSE layer**
- `fanOut` resolves a txid's subscriber token set **once**, then matches every client against it in memory.
- `fanOutBulk` (new) resolves a bulk event's **whole txid list in one batch** before the unfan loop, and snapshots the client registry once instead of per txid.
- `services/sse/tokenindex.go` (new): a bounded `txid → tokenSet` LRU that absorbs the repeat lookups a transaction's several live transitions produce.

**Also included** (same benchmark, same subsystem): mid-stream catchup rate-matching, the drop-warning re-scope plus new metrics, and nanosecond payload timestamps. Details under *Impact / Risk*.

## Why It Was Necessary

Measured on a 45-minute 1000 TPS run against a 4.5M-row `submissions` table.

`Manager.run` is **exactly one goroutine per pod**. For every event it called `txBelongsToToken` **inside the per-client loop**, running:

```sql
SELECT EXISTS(SELECT 1 FROM submissions WHERE txid = $1 AND callback_token = $2)
```

- **0.583 ms** under load (0.031 ms warm/idle — a ~19× contention penalty) ⇒ a **~1,600 events/s** ceiling on a serial goroutine.
- 1000 TPS emits ~4 transitions/tx ⇒ **~4,000 events/s** of demand.
- Result: **1,605,909 events dropped**, logged as `"dropped events for slow SSE client"` — while that client was idle at **6 of 32 cores** with a near-empty apply queue. The log line cost three runs' worth of misdirected investigation into the consumer.
- Worse for blocks: a bulk MINED event was unfanned into N synthetic per-tx statuses, **each running a full fan-out pass**. A 573,976-transaction block therefore cost 573,976 probes *per connected token client*, driving emit→applied p95 to **21.6 s**.

Two facts made the shape wrong rather than merely slow: the probe count scaled with *clients*, and the bulk path multiplied it by *block size*. Neither is fixable by parallelising — `store.postgres.max_conns` is 16 in the deployed config, so a worker pool would exhaust the pool.

### On the index

The composite index is not just an optimisation, and adding it alone would have been a no-op. `EXPLAIN (ANALYZE, BUFFERS)` on a 200k-row table, same query, three index configurations:

| indexes present | plan | buffers |
|---|---|---|
| `idx_sub_txid` only (pre-change) | `Index Scan using idx_sub_txid` + `Filter: callback_token …` | `shared hit=133 read=83` |
| both `idx_sub_txid` and the composite | **still** `Index Scan using idx_sub_txid` — composite never chosen | `shared hit=217` |
| composite only (**this PR**) | `Index Only Scan using idx_sub_txid_token`, `Heap Fetches: 0` | `shared hit=97` |

While the narrow index exists the planner costs it lower, picks it, and pays the heap fetch anyway. `idx_sub_txid` is a strict prefix of the composite, so `GetSubmissionsByTxID` is unaffected, and dropping it also removes one index write per submission INSERT on a 1000+/s ingest path. A downgrade to a release whose `schema.sql` still creates it self-heals via its own `CREATE INDEX IF NOT EXISTS`.

## Testing Performed

`go test ./...`, `go test -tags=postgres ./store/postgres/...`, `go test -race ./services/sse/`, `golangci-lint run ./...` — all clean.

Every new test was **verified to fail against the pre-change behaviour** (re-introduced temporarily as a per-(event, client) probe, the old 10,000-frame catchup budget, and RFC3339):

| test | pre-change | post-change |
|---|---|---|
| `TestFanOutResolvesTokensOncePerEvent` (8 clients × 50 events) | 400 round-trips | **50** |
| `TestFanOutBulkResolvesWholeBatchInOneQuery` (3 clients × 500 txids) | 1500 round-trips | **1** |
| `TestFanOutCachesTokenSetAcrossTransitions` (3 transitions, 1 txid) | 3 round-trips | **1** |
| `TestMidstreamCatchupRateMatchesLiveStream` | live frame never written (starvation) | written after one bounded round |
| `TestStatusFrameTimestampCarriesSubSecondPrecision` | `…T22:13:20Z` (1 s of error) | `…T22:13:20.123456789Z` |

`BenchmarkFanOut` reports the invariant directly — `queries/event` is now independent of client count, where it used to equal it:

```
BenchmarkFanOut/clients=1-32     20000    880.5 ns/op    1.000 queries/event
BenchmarkFanOut/clients=4-32     20000    898.9 ns/op    1.000 queries/event
BenchmarkFanOut/clients=16-32    20000   1728   ns/op    1.000 queries/event
```

Postgres-side timing on the same warm data (local socket, fully cached — the production ratio is far larger, since the measured probe was 0.583 ms plus network RTT): **1000 individual EXISTS probes = 23.7 ms** vs **one batched `TokensForTxIDs` = 6.1 ms**.

Compatibility guards that pass both before and after, on purpose: `TestFanOutSkipsStoreWhenNoClientFiltersByToken`, `TestStatusFrameTimestampWholeSecondsUnchanged`.

### How to verify in a deployment

1. `arcade_sse_token_lookup_duration_seconds{kind="batch"}` should show one observation per ≤1000-txid chunk during a block burst, where the old code produced one probe per transaction per client.
2. `rate(arcade_sse_token_cache_total{result="hit"}[5m]) / rate(arcade_sse_token_cache_total[5m])` should sit near 2/3 at steady state (the transitions after the first for each txid).
3. `arcade_api_sse_dropped_total{reason="slow_client"}` should stop climbing at 1000 TPS. If it does climb, `histogram_quantile(0.5, arcade_sse_fanout_duration_seconds)` now says whether fan-out or the consumer is the limit — that was previously unknowable from arcade's own signals.
4. `EXPLAIN` the fan-out query post-migration and confirm `Index Only Scan using idx_sub_txid_token` with `Heap Fetches: 0`.

## Impact / Risk

**Schema migration.** `schema.sql` is applied at boot as one transaction under an advisory lock (`EnsureIndexes`, #278), so the new `CREATE INDEX` runs inline — it takes `SHARE` on `submissions` and blocks INSERTs for the build (a few seconds at 4.5M rows), and `DROP INDEX` takes a brief `ACCESS EXCLUSIVE`. `lock_timeout` is 10 s per statement with retry to the 5-minute apply budget, so a contended database retries rather than wedging. This cannot use `CREATE INDEX CONCURRENTLY` — the apply is transactional by design. **Schedule the rollout accordingly.**

**Delivery correctness under caching.** A cached token set can only *suppress* a frame, so the cache is deliberately conservative: empty answers are never cached (the api-server records submissions asynchronously, so a status event can overtake its own submission row — caching that would mute the transaction for the whole TTL), store errors are never cached, entries carry a 2-minute TTL, and bulk batches neither read nor write the cache. The residual staleness window is a *second* submission registering the *same* txid under a *different* token within the TTL; that client's frames are covered by connect-time and mid-stream catchup.

**Memory.** The SSE pod has OOM'd before (#237/#238), so the cache is bounded two ways like `store/bumpcache`: 65,536 entries **and** a 16 MiB resident-cost budget with deliberately generous per-entry accounting. Worst case ≈16 MiB against the pod's 256Mi limit. Nothing on this path ever resolves from the token side.

**Behaviour changes to be aware of:**
- The `"dropped events for slow SSE client"` log message is **renamed**. Any log-based alert matching that string needs updating; the `arcade_api_sse_dropped_total{reason="slow_client"}` metric label is deliberately **unchanged** for dashboard compatibility (its `Help` text is corrected to stop asserting a diagnosis).
- Mid-stream catchup now runs **more, smaller rounds** (bounded by half the client's send buffer instead of a flat 10,000), so `arcade_sse_midstream_catchups_total` will read higher for the same amount of healing. That is the fix, not a regression: an unbounded round starved the buffer it was healing and re-armed its own drop flag.
- SSE payload `timestamp` gains fractional seconds. RFC3339Nano elides trailing zeros, so whole-second timestamps are byte-identical to before, and fractional seconds are optional in RFC 3339 — Go's `time.RFC3339`, JavaScript `Date`, and Python `datetime.fromisoformat` all accept both spellings. `docs/sse.md` and the OpenAPI spec are updated.

**Deliberately not changed:** replica counts and resource limits (every pod already consumes all 16 partitions because `Subscribe` mints a unique consumer group per pod, so scaling out does not divide this work); no parallelisation of store lookups (`max_conns` is 16); `events.subscriber_buffer` (4096) and the 8192-slot per-client buffer are both untouched so the two drop points stay comparable against the prior run.

## Notifications
-
