### PR TITLE
feat(propagation): multi-partition arcade.propagation with family keying and a missing-parent safety net

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -100,8 +100,14 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *zap.Logger) (*De
 	// dependency family, so per-partition order still delivers a parent's
 	// admit to its dispatcher before its children's, and cross-partition
 	// stragglers are absorbed by the missing-parent safety net instead of
-	// being terminally REJECTED. `>=` rather than `==` because extra
-	// partitions only cost idle dispatchers.
+	// being terminally REJECTED.
+	//
+	// `>=` rather than `==` because a wider topic is safe to run against —
+	// not because the extra partitions are inert. Nothing passes this value
+	// to a partitioner, so the producer hashes over the topic's ACTUAL
+	// partition count: every partition carries real traffic and gets its own
+	// dispatcher. This knob is a fail-closed assertion, not a placement
+	// control; lowering it does not narrow the producer's hash space.
 	if pErr := kafka.CheckMinPartitions(broker, kafka.TopicPropagation, cfg.Propagation.Partitions, logger); pErr != nil {
 		_ = producer.Close()
 		return nil, nil, fmt.Errorf("kafka partition check: %w", pErr)
@@ -110,9 +116,16 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *zap.Logger) (*De
 	// are currently no other hot-path topics that need it (TopicTransaction
 	// was retired with tx_validator) but the knob is retained so a future
 	// fan-out topic can opt into the check without re-introducing config.
+	//
+	// Deliberately still passed a nil topic list, which makes CheckPartitions
+	// a no-op. Handing it the real fan-out topics turns a check that has been
+	// dead since TopicTransaction was retired into a live boot-blocking one:
+	// any deployment carrying a leftover kafka.min_partitions greater than
+	// its actual arcade.tx_status / arcade.block_processed width would
+	// crash-loop on upgrade, for a reason unrelated to multi-partition
+	// propagation. Enabling it is its own change, with its own release note.
 	if cfg.Kafka.MinPartitions > 1 {
-		topics := []string{kafka.TopicStatusUpdate, kafka.TopicBlockProcessed}
-		if pErr := kafka.CheckPartitions(broker, topics, cfg.Kafka.MinPartitions, logger); pErr != nil {
+		if pErr := kafka.CheckPartitions(broker, nil, cfg.Kafka.MinPartitions, logger); pErr != nil {
 			_ = producer.Close()
 			return nil, nil, fmt.Errorf("kafka partition check: %w", pErr)
 		}

--- a/app/app.go
+++ b/app/app.go
@@ -82,19 +82,27 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *zap.Logger) (*De
 		zap.String("store_backend", cfg.Store.Backend),
 	)
 
-	broker, err := kafka.NewBroker(cfg.Kafka)
+	// The memory backend provisions its own topics, so it takes the
+	// propagation partition count directly; the sarama backend ignores the
+	// map (real topics are broker-provisioned and checked below).
+	broker, err := kafka.NewBroker(cfg.Kafka, map[string]int{
+		kafka.TopicPropagation: cfg.Propagation.Partitions,
+	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating kafka broker: %w", err)
 	}
 	producer := kafka.NewProducer(broker)
 
-	// Hard requirement: TopicPropagation MUST be single-partition. The
-	// dep-aware dispatcher's single-goroutine state ownership relies on
-	// total order at the topic level — parent/child txids on different
-	// partitions would bypass the in-memory dep index and reintroduce
-	// the cross-batch "missing inputs" race we just removed. Check this
-	// on every startup regardless of MinPartitions.
-	if pErr := kafka.CheckExactPartitions(broker, kafka.TopicPropagation, 1, logger); pErr != nil {
+	// TopicPropagation must exist with at least propagation.partitions
+	// partitions (fail-closed on a missing topic — auto-creation would let
+	// the broker default decide the key→partition mapping). Since #295 the
+	// topic may have any partition count: the api server keys messages by
+	// dependency family, so per-partition order still delivers a parent's
+	// admit to its dispatcher before its children's, and cross-partition
+	// stragglers are absorbed by the missing-parent safety net instead of
+	// being terminally REJECTED. `>=` rather than `==` because extra
+	// partitions only cost idle dispatchers.
+	if pErr := kafka.CheckMinPartitions(broker, kafka.TopicPropagation, cfg.Propagation.Partitions, logger); pErr != nil {
 		_ = producer.Close()
 		return nil, nil, fmt.Errorf("kafka partition check: %w", pErr)
 	}
@@ -103,7 +111,8 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *zap.Logger) (*De
 	// was retired with tx_validator) but the knob is retained so a future
 	// fan-out topic can opt into the check without re-introducing config.
 	if cfg.Kafka.MinPartitions > 1 {
-		if pErr := kafka.CheckPartitions(broker, nil, cfg.Kafka.MinPartitions, logger); pErr != nil {
+		topics := []string{kafka.TopicStatusUpdate, kafka.TopicBlockProcessed}
+		if pErr := kafka.CheckPartitions(broker, topics, cfg.Kafka.MinPartitions, logger); pErr != nil {
 			_ = producer.Close()
 			return nil, nil, fmt.Errorf("kafka partition check: %w", pErr)
 		}

--- a/compose/topic-init.sh
+++ b/compose/topic-init.sh
@@ -7,14 +7,18 @@
 # Idempotent: safe across `podman-compose up` re-runs and container restarts.
 #
 # Partition counts are load-bearing:
-#   - arcade.propagation MUST have exactly 1 partition. arcade enforces this
-#     fail-closed at startup in EVERY mode (kafka.CheckExactPartitions);
-#     parent/child tx ordering relies on total order at the topic level.
+#   - arcade.propagation needs at least PROPAGATION_PARTITIONS partitions
+#     (default 1). arcade enforces the same minimum fail-closed at startup
+#     (kafka.CheckMinPartitions). Any count preserves ordering: producers key
+#     messages by dependency family, so parent/child txs of one submission
+#     share a partition (#295).
 #   - block_processed(8) / tx_status(16) mirror production consumer fan-out.
 # See docs/production-kafka.md.
 set -euo pipefail
 
 RPK=(rpk -X brokers=redpanda:9092 -X admin.hosts=redpanda:9644)
+
+PROPAGATION_PARTITIONS="${PROPAGATION_PARTITIONS:-1}"
 
 # merkle-service (all-in-one) provisions its own topics (subtree, block,
 # stumps, ...) via client auto-creation; keep broker-side auto-create on for
@@ -26,8 +30,8 @@ RPK=(rpk -X brokers=redpanda:9092 -X admin.hosts=redpanda:9644)
 declare -A TOPICS=(
   [arcade.block_processed]=8
   [arcade.block_processed.dlq]=8
-  [arcade.propagation]=1
-  [arcade.propagation.dlq]=1
+  [arcade.propagation]="$PROPAGATION_PARTITIONS"
+  [arcade.propagation.dlq]="$PROPAGATION_PARTITIONS"
   [arcade.tx_status]=16
   [arcade.tx_status.dlq]=16
 )
@@ -42,11 +46,14 @@ for topic in "${!TOPICS[@]}"; do
   fi
 done
 
+# Grow an existing propagation topic in place when the target minimum rose
+# between runs. Partitions can only be added, never removed — a topic wider
+# than the target is fine (arcade's startup check is >=, and family keying
+# keeps ordering correct at any width).
 count="$("${RPK[@]}" topic list | awk '$1 == "arcade.propagation" { print $2 }')"
-if [[ "$count" != "1" ]]; then
-  echo "topic-init: FATAL: arcade.propagation has partitions=$count, expected exactly 1" >&2
-  echo "topic-init: delete the topic (rpk topic delete arcade.propagation) or wipe the redpanda-data volume" >&2
-  exit 1
+if [[ "$count" -lt "$PROPAGATION_PARTITIONS" ]]; then
+  "${RPK[@]}" topic add-partitions arcade.propagation --num "$((PROPAGATION_PARTITIONS - count))"
+  echo "topic-init: widened arcade.propagation ${count} -> ${PROPAGATION_PARTITIONS} partitions"
 fi
 
-echo "topic-init: all arcade topics present; arcade.propagation partition invariant OK"
+echo "topic-init: all arcade topics present; arcade.propagation has >= ${PROPAGATION_PARTITIONS} partition(s)"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -34,10 +34,10 @@ api:
 
 # Arcade does not create Kafka topics; the broker must already have them
 # (auto-create on first publish is typically disabled in production, and
-# arcade.propagation has a hard exactly-1-partition correctness constraint
-# that arcade enforces at startup). See docs/production-kafka.md for the
-# full topic list, partition guidance, and ready-to-paste rpk /
-# kafka-topics.sh commands.
+# arcade.propagation must exist with at least propagation.partitions
+# partitions — arcade fails closed at startup otherwise). See
+# docs/production-kafka.md for the full topic list, partition guidance,
+# and ready-to-paste rpk / kafka-topics.sh commands.
 kafka:
   brokers:
     - localhost:9092

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -202,6 +202,33 @@ health:
 #   subscriber_buffer: 4096
 
 # propagation:
+#   # Number of partitions arcade requires on arcade.propagation, and the
+#   # number of propagation replicas that can do work (one dep-aware
+#   # dispatcher per partition claim; extra replicas idle as standbys).
+#   # Checked fail-closed at startup: a topic with FEWER partitions than this
+#   # aborts the boot. More is allowed — the producer hashes over the topic's
+#   # actual partition count, so extra partitions carry real traffic and get
+#   # their own dispatchers. Widen the topic BEFORE raising this; see
+#   # docs/production-kafka.md "Widening an existing deployment".
+#   partitions: 1
+#
+#   # Fast-path requeue: a tx with no network verdict is retried in-memory up
+#   # to retry_max_attempts times, retry_backoff_ms apart, before parking at
+#   # PENDING_RETRY. At the defaults that is a ~10s window.
+#   retry_max_attempts: 5
+#   retry_backoff_ms: 2000
+#
+#   # Durable retry: once parked, a tx is drained by the reaper in
+#   # next_retry_at order with exponential backoff from
+#   # pending_retry_backoff_ms, doubling to pending_retry_max_backoff_ms.
+#   # After pending_retry_max_attempts it is terminalized REJECTED — the
+#   # give-up case is a tx spending an outpoint that never reaches the
+#   # network, which can neither succeed nor be condemned by an ancestor.
+#   # The default 288 attempts is ~24h at the 5-minute cap.
+#   pending_retry_backoff_ms: 5000
+#   pending_retry_max_backoff_ms: 300000
+#   pending_retry_max_attempts: 288
+#
 #   # Per-endpoint circuit-breaker for the datahub URL list. Endpoints that
 #   # accumulate `failure_threshold` consecutive failures are marked unhealthy
 #   # and excluded from broadcasts; a background probe hits GET /health on

--- a/config/config.go
+++ b/config/config.go
@@ -406,7 +406,7 @@ type PropagationConfig struct {
 	// declared but unread before #295 — deployments that explicitly set
 	// it (e.g. to the old default 500) start feeling their configured
 	// value on upgrade.
-	RetryBackoffMs int `mapstructure:"retry_backoff_ms"`
+	RetryBackoffMs   int `mapstructure:"retry_backoff_ms"`
 	ReaperIntervalMs int `mapstructure:"reaper_interval_ms"`
 	ReaperBatchSize  int `mapstructure:"reaper_batch_size"`
 	// ReaperRebroadcastBatch caps how many stuck transactions the reaper's

--- a/config/config.go
+++ b/config/config.go
@@ -406,9 +406,39 @@ type PropagationConfig struct {
 	// declared but unread before #295 — deployments that explicitly set
 	// it (e.g. to the old default 500) start feeling their configured
 	// value on upgrade.
-	RetryBackoffMs   int `mapstructure:"retry_backoff_ms"`
-	ReaperIntervalMs int `mapstructure:"reaper_interval_ms"`
-	ReaperBatchSize  int `mapstructure:"reaper_batch_size"`
+	RetryBackoffMs int `mapstructure:"retry_backoff_ms"`
+	// PendingRetryBackoffMs is the base delay before a PENDING_RETRY row's
+	// first reaper attempt. Each subsequent attempt doubles it, capped at
+	// PendingRetryMaxBackoffMs, with ±20% jitter so a batch parked together
+	// doesn't re-broadcast in lockstep.
+	//
+	// Before #299 there was no per-row schedule at all: eligibility was
+	// "parked more than a hardcoded 5 minutes ago", so every parked tx —
+	// including a child whose parent lands a second later — waited the full
+	// 5 minutes, and a row that kept failing was retried every tick forever.
+	// Defaults to 5000ms; non-positive falls back to the default.
+	PendingRetryBackoffMs int `mapstructure:"pending_retry_backoff_ms"`
+	// PendingRetryMaxBackoffMs caps the exponential above. Defaults to
+	// 300000ms (5 minutes) — the old flat eligibility age, so the slowest
+	// this ever retries matches the previous behavior while early attempts
+	// are far faster.
+	PendingRetryMaxBackoffMs int `mapstructure:"pending_retry_max_backoff_ms"`
+	// PendingRetryMaxAttempts bounds how many times the reaper rebroadcasts
+	// a PENDING_RETRY row before giving up and writing REJECTED.
+	//
+	// Without a bound a tx whose parent never arrives — the single most
+	// common client mistake, spending an outpoint that does not exist — is
+	// retried forever. Before #299 such rows were not retried forever so
+	// much as silently abandoned: their timestamp_at never moved, so at
+	// staleScanLookback (24h) they fell out of the reaper's scan window and
+	// stayed PENDING_RETRY with no terminal status, no log and no metric.
+	//
+	// The default 288 is 24h at the 5-minute backoff cap, so give-up happens
+	// about when abandonment used to — except it is now an observable
+	// verdict the submitter can read. Non-positive falls back to the default.
+	PendingRetryMaxAttempts int `mapstructure:"pending_retry_max_attempts"`
+	ReaperIntervalMs        int `mapstructure:"reaper_interval_ms"`
+	ReaperBatchSize         int `mapstructure:"reaper_batch_size"`
 	// ReaperRebroadcastBatch caps how many stuck transactions the reaper's
 	// durable-rebroadcast backstop pushes back through the register+broadcast
 	// pipeline per tick (reapOnce collects at most this many stale RECEIVED /
@@ -1001,6 +1031,9 @@ func setDefaults() {
 	viper.SetDefault("propagation.merkle_concurrency", 10)
 	viper.SetDefault("propagation.retry_max_attempts", 5)
 	viper.SetDefault("propagation.retry_backoff_ms", 2000)
+	viper.SetDefault("propagation.pending_retry_backoff_ms", 5000)
+	viper.SetDefault("propagation.pending_retry_max_backoff_ms", 300000)
+	viper.SetDefault("propagation.pending_retry_max_attempts", 288)
 	viper.SetDefault("propagation.reaper_interval_ms", 30000)
 	viper.SetDefault("propagation.reaper_batch_size", 500)
 	viper.SetDefault("propagation.reaper_rebroadcast_batch", 200)

--- a/config/config.go
+++ b/config/config.go
@@ -178,10 +178,8 @@ type Kafka struct {
 	BufferSize    int      `mapstructure:"buffer_size"`
 	// MinPartitions is a soft minimum-partition hint for horizontally-scaled
 	// topics; arcade fails fast at startup when an existing topic has fewer.
-	// Independent of this knob, TopicPropagation is ALWAYS checked for an
-	// exact partition count of 1 — the dep-aware dispatcher's single-goroutine
-	// state ownership requires total order at the topic level, so multiple
-	// partitions would reintroduce the cross-batch "missing inputs" race.
+	// TopicPropagation has its own dedicated knob (propagation.partitions)
+	// with a fail-closed startup check — see PropagationConfig.Partitions.
 	// Leave at 0 or 1 in standalone/single-replica deployments.
 	MinPartitions int `mapstructure:"min_partitions"`
 	// SendTimeoutMs bounds how long the in-process memory broker waits for a
@@ -356,6 +354,23 @@ type TelemetryConfig struct {
 }
 
 type PropagationConfig struct {
+	// Partitions is the minimum partition count arcade requires on
+	// arcade.propagation at startup (fail-closed: missing topic or fewer
+	// partitions aborts boot; more is fine — extra partitions only cost
+	// idle dispatchers). Set it to at least the propagation replica count
+	// when scaling horizontally, and widen the topic BEFORE rolling the
+	// config (a pod configured above the broker's actual count crash-loops
+	// by design).
+	//
+	// Ordering model (#295, replacing the #151 exact-1 rule): the api
+	// server keys every propagation message by its dependency family —
+	// all txs of one submission connected through in-batch spends share a
+	// partition key — so per-partition Kafka order still delivers parents
+	// to a dispatcher before their children. Cross-submission chains that
+	// land on different partitions are absorbed by the missing-parent
+	// safety net (TX_MISSING_PARENT is a retryable condition, never a
+	// terminal verdict on its own). Default 1.
+	Partitions        int `mapstructure:"partitions"`
 	MerkleConcurrency int `mapstructure:"merkle_concurrency"`
 	// RetryMaxAttempts bounds how many times the propagator will push a
 	// transaction back through the in-memory requeue loop when a broadcast
@@ -382,7 +397,16 @@ type PropagationConfig struct {
 	// fall back to the default rather than disabling the bound — an unbounded
 	// requeue is the failure mode this exists to prevent.
 	RetryMaxAttempts int `mapstructure:"retry_max_attempts"`
-	RetryBackoffMs   int `mapstructure:"retry_backoff_ms"`
+	// RetryBackoffMs is the flat wait (milliseconds) before a requeued tx
+	// lands back on the dispatcher for another broadcast attempt. Flat by
+	// design, not exponential: the budget above bounds total attempts, so
+	// a predictable wall-clock window (attempts × backoff ≈ 10s at the
+	// defaults) is what matters; the reaper's cadence dominates anything
+	// slower. Non-positive falls back to 2000ms. NOTE: this knob was
+	// declared but unread before #295 — deployments that explicitly set
+	// it (e.g. to the old default 500) start feeling their configured
+	// value on upgrade.
+	RetryBackoffMs int `mapstructure:"retry_backoff_ms"`
 	ReaperIntervalMs int `mapstructure:"reaper_interval_ms"`
 	ReaperBatchSize  int `mapstructure:"reaper_batch_size"`
 	// ReaperRebroadcastBatch caps how many stuck transactions the reaper's
@@ -973,9 +997,10 @@ func setDefaults() {
 	viper.SetDefault("telemetry.logs", false)
 	viper.SetDefault("telemetry.sample_ratio", 1.0)
 	viper.SetDefault("telemetry.export_timeout_ms", 10000)
+	viper.SetDefault("propagation.partitions", 1)
 	viper.SetDefault("propagation.merkle_concurrency", 10)
 	viper.SetDefault("propagation.retry_max_attempts", 5)
-	viper.SetDefault("propagation.retry_backoff_ms", 500)
+	viper.SetDefault("propagation.retry_backoff_ms", 2000)
 	viper.SetDefault("propagation.reaper_interval_ms", 30000)
 	viper.SetDefault("propagation.reaper_batch_size", 500)
 	viper.SetDefault("propagation.reaper_rebroadcast_batch", 200)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,6 +85,11 @@ services:
   topic-init:
     image: docker.io/redpandadata/redpanda:v26.1.9
     entrypoint: ["/bin/bash", "/topic-init.sh"]
+    # Keep in step with propagation.partitions in compose/arcade-config.yaml:
+    # arcade hard-fails at boot if the topic has fewer partitions than the
+    # service is configured for.
+    environment:
+      PROPAGATION_PARTITIONS: "${PROPAGATION_PARTITIONS:-1}"
     volumes:
       - ./compose/topic-init.sh:/topic-init.sh:ro,Z
     networks:

--- a/docs/production-kafka.md
+++ b/docs/production-kafka.md
@@ -235,7 +235,7 @@ multiple deployments share a Kafka cluster.
 ## What arcade checks at startup
 
 - `kafka.CheckMinPartitions(arcade.propagation, propagation.partitions)` — **hard fail** if
-  the topic is missing or has any partition count other than 1.
+  the topic is missing or has fewer partitions than `propagation.partitions`.
 - `kafka.CheckPartitions(...)` — soft warning path used when
   `kafka.min_partitions > 1`. Existing topics with fewer partitions cause a
   startup error; missing topics only log a warning ("will be auto-created

--- a/docs/production-kafka.md
+++ b/docs/production-kafka.md
@@ -3,8 +3,8 @@
 Arcade does **not** create Kafka topics itself — it relies on broker-side
 auto-creation on first publish, which is typically disabled in production
 clusters. One topic also has a hard correctness constraint (`arcade.propagation`
-must be **exactly 1 partition**) that arcade enforces at startup with a
-fail-closed check. This guide lists every topic an operator needs to
+must have **at least `propagation.partitions`**) that arcade enforces at startup
+with a fail-closed check. This guide lists every topic an operator needs to
 pre-create, with partition, replication, and retention guidance.
 
 This guide assumes a production deployment with `kafka.backend: sarama` pointed
@@ -15,7 +15,7 @@ don't need any of this — see [`getting-started.md`](getting-started.md).
 
 | Topic                          | Partitions                | Consumer group(s)                  | Purpose                                                              |
 | ------------------------------ | ------------------------- | ---------------------------------- | -------------------------------------------------------------------- |
-| `arcade.propagation`           | **exactly 1** (mandatory) | `<consumer_group>-propagation`     | API server → propagation: txs to broadcast to datahubs.              |
+| `arcade.propagation`           | **≥ `propagation.partitions`** (default 1) | `<consumer_group>-propagation`     | API server → propagation: txs to broadcast to datahubs.              |
 | `arcade.block_processed`       | ≥ N (N = bump-builder replicas) | `<consumer_group>-bump-builder` | API server → bump-builder: BLOCK_PROCESSED signals from Merkle Service. |
 | `arcade.tx_status`             | ≥ N (N = max concurrent SSE/webhook fan-outs) | ephemeral per-subscriber groups | All services → SSE/webhook: tx status mutations.                     |
 | `arcade.transaction`           | 1 (currently unused)      | none                               | Defined in `AllTopics()` but retired with `tx_validator`. Create or skip. |
@@ -30,14 +30,74 @@ applied automatically — operators only configure the base name.
 
 ## Partition counts
 
-### `arcade.propagation` — exactly 1 (mandatory)
+### `arcade.propagation` — at least `propagation.partitions`
 
-The propagation service uses a dep-aware dispatcher whose single-goroutine
-state ownership relies on **total order at the topic level**. Parent/child
-txids landing on different partitions would bypass the in-memory dependency
-index and reintroduce a "missing inputs" race. Arcade enforces this with a
-hard check at startup (`kafka.CheckExactPartitions`); a missing topic or any
-partition count other than 1 aborts startup.
+The propagation service runs one dep-aware dispatcher per partition claim.
+Each dispatcher owns its own in-memory dependency index, so a parent and its
+child must land on the **same** partition for the child to be held behind its
+parent.
+
+Intake guarantees that for transactions submitted together: `POST /txs`
+computes a partition key per **dependency family** — every tx in the request
+connected through in-batch spends shares one key (the lexicographically
+smallest member txid, so a shuffled resubmission maps to the same partition).
+A whole family therefore lands on one partition, and per-partition order
+delivers parents before children.
+
+Chains that span requests have no such guarantee, and that is by design rather
+than an oversight: a child can reach a datahub before its parent and draw
+`TX_MISSING_PARENT`. That is treated as a **condition, not a verdict** — the tx
+rides the bounded requeue, then parks at `PENDING_RETRY` for the reaper's
+durable retry queue. The only path to `REJECTED` is arcade's own store showing
+an ancestor terminally rejected. Note this means single-transaction `POST /tx`
+submissions get no cross-request ordering help: they are keyed by their own
+txid.
+
+Arcade enforces the floor at startup with `kafka.CheckMinPartitions`. A missing
+topic, or a topic with fewer partitions than `propagation.partitions`, aborts
+startup. More partitions than configured is allowed — but note the producer
+hashes over the topic's **actual** partition count, so extra partitions carry
+real traffic and get their own dispatchers. `propagation.partitions` is a
+fail-closed assertion, not a placement control.
+
+Sizing: run at most `propagation.partitions` propagation replicas. Extra
+replicas idle as standbys for failover. A single request whose transactions
+are all one dependency family lands entirely on one partition, so batches that
+are one long chain — or that contain a consolidation tx spending many
+in-request outputs — serialize regardless of partition count.
+
+### Widening an existing deployment
+
+Partition counts can be increased in place. Do it **topic first**, so arcade is
+never configured for more partitions than the topic has (that combination is a
+boot-time hard fail):
+
+```bash
+# 1. Widen the topic.
+rpk topic add-partitions arcade.propagation --num 3   # 1 -> 4 total
+
+# 2. Raise propagation.partitions to the new count (config or
+#    ARCADE_PROPAGATION_PARTITIONS), then roll the propagation pods.
+
+# 3. Scale replicas up to at most the partition count.
+kubectl scale deploy/propagation --replicas=4
+```
+
+Between steps 1 and 2 the producer already hashes over the wider topic, so a
+family submitted before the widen and its continuation submitted after can map
+to different partitions. That window is what the missing-parent safety net
+exists for. During it, watch:
+
+- `arcade_propagation_missing_parent_total{outcome="requeued"}` — a burst is
+  expected; it should return to baseline once the remap window passes.
+- `arcade_propagation_parked_depth` — a transient rise is normal; sustained
+  growth means chains are not converging.
+- `arcade_propagation_outcome_total{outcome="rejected"}` — should **not**
+  move. A spike would mean ordering artifacts reached a verdict, which the
+  condition-not-verdict rule is designed to make impossible.
+
+For a zero-race alternative, drain the topic and recreate it at the target
+width before rolling pods.
 
 ### `arcade.block_processed` and `arcade.tx_status` — match consumer scale
 
@@ -90,6 +150,8 @@ none of them are log-compacted.
 
 ```bash
 # Hot path
+# --partitions must be >= propagation.partitions (default 1). To go wider
+# later, see "Widening an existing deployment" above.
 rpk topic create arcade.propagation \
   --partitions 1 \
   --replicas 3 \
@@ -172,7 +234,7 @@ multiple deployments share a Kafka cluster.
 
 ## What arcade checks at startup
 
-- `kafka.CheckExactPartitions(arcade.propagation, 1)` — **hard fail** if
+- `kafka.CheckMinPartitions(arcade.propagation, propagation.partitions)` — **hard fail** if
   the topic is missing or has any partition count other than 1.
 - `kafka.CheckPartitions(...)` — soft warning path used when
   `kafka.min_partitions > 1`. Existing topics with fewer partitions cause a

--- a/kafka/factory.go
+++ b/kafka/factory.go
@@ -11,9 +11,16 @@ import (
 //   - "sarama" (default): real Kafka via IBM Sarama. Requires cfg.Brokers.
 //   - "memory": in-process broker. Zero external dependencies.
 //
+// topicPartitions widens selected topics on the memory backend (absent = 1
+// partition), so standalone mode reproduces the multi-partition
+// key→partition→dispatcher topology of a real deployment (#295 — the
+// caller passes propagation.partitions for TopicPropagation). The sarama
+// backend ignores it: real topics are provisioned broker-side and
+// validated at startup via CheckMinPartitions.
+//
 // The returned Broker is shared across all services in the process — main.go
 // constructs it once and hands it to Producer + every ConsumerGroup.
-func NewBroker(cfg config.Kafka) (Broker, error) {
+func NewBroker(cfg config.Kafka, topicPartitions map[string]int) (Broker, error) {
 	backend := cfg.Backend
 	if backend == "" {
 		backend = "sarama"
@@ -25,7 +32,7 @@ func NewBroker(cfg config.Kafka) (Broker, error) {
 		}
 		return NewSaramaBroker(cfg.Brokers, cfg.ConsumerGroup)
 	case "memory":
-		return NewMemoryBrokerWithTimeout(cfg.BufferSize, time.Duration(cfg.SendTimeoutMs)*time.Millisecond), nil
+		return NewMemoryBrokerWithPartitions(cfg.BufferSize, time.Duration(cfg.SendTimeoutMs)*time.Millisecond, topicPartitions), nil
 	default:
 		return nil, fmt.Errorf("unknown kafka backend %q", backend)
 	}

--- a/kafka/memory_broker.go
+++ b/kafka/memory_broker.go
@@ -130,7 +130,9 @@ func partitionForKey(key string, n int) int32 {
 	}
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(key))
-	p := int32(h.Sum32()) % int32(n)
+	// The uint32→int32 wrap is deliberate: it reproduces Sarama's hash
+	// partitioner bit-for-bit, and the abs below handles the negative half.
+	p := int32(h.Sum32()) % int32(n) // #nosec G115 -- sarama-compatible arithmetic
 	if p < 0 {
 		p = -p
 	}

--- a/kafka/memory_broker.go
+++ b/kafka/memory_broker.go
@@ -3,6 +3,8 @@ package kafka
 import (
 	"context"
 	"errors"
+	"fmt"
+	"hash/fnv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -12,13 +14,19 @@ import (
 // to saramaBroker — zero external dependencies, same interface.
 //
 // Semantics:
-//   - Each (groupID, topic) has a buffered channel. Publishing to a topic fans
-//     the message out to every groupID currently subscribed to it. Within a
-//     group, a single consumer drains the channel (mirrors Kafka consumer-group
-//     semantics for the common case where standalone mode runs one consumer
-//     per group).
-//   - Offsets are monotonically assigned per topic so DLQ envelopes and logs
-//     carry sensible values. Partition is always 0.
+//   - Each (groupID, topic, partition) has a buffered channel. Publishing to
+//     a topic routes the message to one partition by key (Sarama-compatible
+//     FNV-1a hash, #295 — so a smoke test observes the same family placement
+//     a production topic would) and fans it out to every groupID currently
+//     subscribed. Within a group, whichever consumer drains the partition
+//     mailbox wins the next message (mirrors Kafka consumer-group semantics).
+//   - Topics default to 1 partition; NewMemoryBrokerWithPartitions widens
+//     selected topics. Consume invokes the handler once per (topic,
+//     partition) — the same per-partition claim shape Sarama produces — so
+//     services like the dep-aware propagator get one dispatcher per
+//     partition in standalone mode too.
+//   - Offsets are monotonically assigned per (topic, partition) so DLQ
+//     envelopes and logs carry sensible values.
 //   - MarkMessage is a no-op; at-most-once on crash is acceptable for a
 //     single-binary deployment.
 //   - Close signals every subscriber's done channel and prevents further
@@ -33,8 +41,9 @@ import (
 type memoryBroker struct {
 	mu          sync.Mutex
 	closed      bool
-	groups      map[string]map[string]*memoryMailbox // [groupID][topic] = mailbox
-	offsets     map[string]*int64                    // per-topic monotonic offsets
+	groups      map[string]map[string][]*memoryMailbox // [groupID][topic][partition] = mailbox
+	offsets     map[string]*int64                      // per (topic,partition) monotonic offsets
+	partitions  map[string]int                         // per-topic partition count; absent = 1
 	buffer      int
 	sendTimeout time.Duration
 }
@@ -52,33 +61,41 @@ var ErrBrokerBackpressure = errors.New("broker mailbox full (backpressure)")
 // deadline.
 const defaultSendTimeout = 2 * time.Second
 
-// memoryMailbox is a per-(group, topic) delivery queue. Subscriptions joined
-// to the same group share it so either concurrent consumer wins the next
-// message (standard consumer-group semantics).
+// memoryMailbox is a per-(group, topic, partition) delivery queue.
+// Subscriptions joined to the same group share it so either concurrent
+// consumer wins the next message (standard consumer-group semantics).
 //
-// done is closed when the mailbox is being torn down (broker Close, or its
-// last subscription unwinding). Publishers select on it so a concurrent
-// teardown turns a would-be send-on-closed-channel into a clean drop. The
-// mailbox channel itself is intentionally never closed — the forward
-// goroutine exits via done instead, and the unreferenced channel is left to
-// the GC. See F-012.
+// done is closed when the mailbox is being torn down (broker Close).
+// Publishers select on it so a concurrent teardown turns a would-be
+// send-on-closed-channel into a clean drop. The mailbox channel itself is
+// intentionally never closed — consumers exit via done instead, and the
+// unreferenced channel is left to the GC. See F-012.
 type memoryMailbox struct {
-	ch       chan *Message
-	done     chan struct{}
-	refCount int
+	ch   chan *Message
+	done chan struct{}
 }
 
 // NewMemoryBroker constructs an in-process broker. buffer is the per-mailbox
 // channel capacity — larger values smooth out bursts at the cost of memory.
-// sendTimeout, when > 0, bounds how long Send blocks on a full mailbox before
-// returning ErrBrokerBackpressure; zero falls back to defaultSendTimeout.
 func NewMemoryBroker(buffer int) Broker {
 	return NewMemoryBrokerWithTimeout(buffer, 0)
 }
 
 // NewMemoryBrokerWithTimeout exposes the sendTimeout knob for tests and
 // callers that want to deliberately tighten or loosen backpressure handling.
+// sendTimeout, when > 0, bounds how long Send blocks on a full mailbox before
+// returning ErrBrokerBackpressure; zero falls back to defaultSendTimeout.
 func NewMemoryBrokerWithTimeout(buffer int, sendTimeout time.Duration) Broker {
+	return NewMemoryBrokerWithPartitions(buffer, sendTimeout, nil)
+}
+
+// NewMemoryBrokerWithPartitions additionally widens the named topics to the
+// given partition counts (absent or non-positive = 1). Keyed publishes route
+// with Sarama's default hash partitioner arithmetic so standalone-mode
+// placement matches what the same keys would do on a real topic (#295:
+// dependency families share a key, therefore a partition, therefore a
+// dispatcher).
+func NewMemoryBrokerWithPartitions(buffer int, sendTimeout time.Duration, partitions map[string]int) Broker {
 	if buffer <= 0 {
 		buffer = 10000
 	}
@@ -86,11 +103,38 @@ func NewMemoryBrokerWithTimeout(buffer int, sendTimeout time.Duration) Broker {
 		sendTimeout = defaultSendTimeout
 	}
 	return &memoryBroker{
-		groups:      make(map[string]map[string]*memoryMailbox),
+		groups:      make(map[string]map[string][]*memoryMailbox),
 		offsets:     make(map[string]*int64),
+		partitions:  partitions,
 		buffer:      buffer,
 		sendTimeout: sendTimeout,
 	}
+}
+
+// partitionsFor returns the topic's configured partition count (min 1).
+func (b *memoryBroker) partitionsFor(topic string) int {
+	if n, ok := b.partitions[topic]; ok && n > 0 {
+		return n
+	}
+	return 1
+}
+
+// partitionForKey mirrors sarama.NewHashPartitioner: FNV-1a 32-bit of the
+// key, cast to int32, mod partition count, absolute value. An empty key is
+// routed to partition 0 (deterministic; the real Sarama randomizes keyless
+// messages, but no arcade producer publishes keyless to a widened topic and
+// determinism is worth more to tests than fidelity here).
+func partitionForKey(key string, n int) int32 {
+	if n <= 1 || key == "" {
+		return 0
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key))
+	p := int32(h.Sum32()) % int32(n)
+	if p < 0 {
+		p = -p
+	}
+	return p
 }
 
 func (b *memoryBroker) Send(ctx context.Context, topic, key string, value []byte) error {
@@ -121,26 +165,30 @@ func (b *memoryBroker) publish(ctx context.Context, topic, key string, value []b
 		return errors.New("memory broker closed")
 	}
 
-	offsetPtr, ok := b.offsets[topic]
+	partition := partitionForKey(key, b.partitionsFor(topic))
+	offsetKey := fmt.Sprintf("%s#%d", topic, partition)
+	offsetPtr, ok := b.offsets[offsetKey]
 	if !ok {
 		var o int64
 		offsetPtr = &o
-		b.offsets[topic] = offsetPtr
+		b.offsets[offsetKey] = offsetPtr
 	}
 	offset := atomic.AddInt64(offsetPtr, 1) - 1
 
-	// Snapshot the mailboxes that currently care about this topic. Snapshot
-	// under the lock, then release before sending so a blocked receiver
-	// doesn't stall other publishers. Each mailbox's done channel rides
-	// along so a concurrent Close that tears down the mailbox between the
-	// snapshot and the send is observed as a drop rather than a panic.
+	// Snapshot the partition mailboxes that currently care about this
+	// topic. Snapshot under the lock, then release before sending so a
+	// blocked receiver doesn't stall other publishers. Each mailbox's done
+	// channel rides along so a concurrent Close that tears down the mailbox
+	// between the snapshot and the send is observed as a drop rather than a
+	// panic.
 	type target struct {
 		ch   chan *Message
 		done chan struct{}
 	}
 	var targets []target
 	for _, topics := range b.groups {
-		if mb, ok := topics[topic]; ok {
+		if mbs, ok := topics[topic]; ok && int(partition) < len(mbs) {
+			mb := mbs[partition]
 			targets = append(targets, target{ch: mb.ch, done: mb.done})
 		}
 	}
@@ -150,7 +198,7 @@ func (b *memoryBroker) publish(ctx context.Context, topic, key string, value []b
 		Topic:     topic,
 		Key:       []byte(key),
 		Value:     value,
-		Partition: 0,
+		Partition: partition,
 		Offset:    offset,
 		Timestamp: time.Now(),
 		// Injects the producer's trace context (nil on the disabled/no-span
@@ -215,64 +263,37 @@ func (b *memoryBroker) Subscribe(groupID string, topics []string, _ StartOffset)
 
 	topicMailboxes, ok := b.groups[groupID]
 	if !ok {
-		topicMailboxes = make(map[string]*memoryMailbox)
+		topicMailboxes = make(map[string][]*memoryMailbox)
 		b.groups[groupID] = topicMailboxes
 	}
 
-	// Merge all subscribed topics into a single delivery channel. Because all
-	// shared a groupID, round-robin across concurrent consumers in the same
-	// group happens naturally via Go channel receive semantics.
-	merged := make(chan *Message, b.buffer)
+	var claims []*memoryMailbox
 	for _, t := range topics {
-		mb, ok := topicMailboxes[t]
+		mbs, ok := topicMailboxes[t]
 		if !ok {
-			mb = &memoryMailbox{
-				ch:   make(chan *Message, b.buffer),
-				done: make(chan struct{}),
+			n := b.partitionsFor(t)
+			mbs = make([]*memoryMailbox, n)
+			for i := range mbs {
+				mbs[i] = &memoryMailbox{
+					ch:   make(chan *Message, b.buffer),
+					done: make(chan struct{}),
+				}
 			}
-			topicMailboxes[t] = mb
+			topicMailboxes[t] = mbs
 		}
-		mb.refCount++
-		go forward(mb.ch, merged, mb.done)
+		claims = append(claims, mbs...)
 	}
 
 	return &memorySubscription{
-		broker:  b,
-		groupID: groupID,
-		topics:  topics,
-		out:     merged,
+		broker:    b,
+		groupID:   groupID,
+		topics:    topics,
+		mailboxes: claims,
 	}, nil
 }
 
-// forward pipes messages from a per-topic mailbox into the merged per-
-// subscription channel until the mailbox is torn down. The mailbox channel
-// is never closed (see F-012), so we exit via done instead of relying on
-// channel-close detection. Any messages still buffered in the mailbox at
-// teardown are abandoned; publishers may have already raced past Close and
-// landed values that no consumer will see — this matches the at-most-once
-// semantics documented on the broker.
-func forward(in <-chan *Message, out chan<- *Message, done <-chan struct{}) {
-	for {
-		select {
-		case <-done:
-			return
-		case msg, ok := <-in:
-			if !ok {
-				return
-			}
-			select {
-			case out <- msg:
-			case <-done:
-				return
-			}
-		}
-	}
-}
-
-func (b *memoryBroker) PartitionCount(_ string) (int, error) {
-	// Memory broker has no concept of partitions — treat every topic as a
-	// single-partition topic so callers can compute concurrency uniformly.
-	return 1, nil
+func (b *memoryBroker) PartitionCount(topic string) (int, error) {
+	return b.partitionsFor(topic), nil
 }
 
 func (b *memoryBroker) Close() error {
@@ -286,43 +307,71 @@ func (b *memoryBroker) Close() error {
 	// close mb.ch: a publisher may have snapshotted the channel under the
 	// lock and released the lock before sending (see publish), so closing
 	// it here would race that send and panic. Closing done is enough —
-	// publishers select on it to drop, and forward goroutines select on it
-	// to exit. The unreferenced channel is reclaimed by the GC. (F-012)
+	// publishers select on it to drop, and consumers select on it to
+	// exit. The unreferenced channel is reclaimed by the GC. (F-012)
 	for _, topics := range b.groups {
-		for _, mb := range topics {
-			close(mb.done)
+		for _, mbs := range topics {
+			for _, mb := range mbs {
+				close(mb.done)
+			}
 		}
 	}
 	b.groups = nil
 	return nil
 }
 
-// memorySubscription is a single consumer's view of the broker. Because
-// standalone mode has no rebalances, Consume emits exactly one synthetic
-// claim whose lifetime matches the subscription.
+// memorySubscription is a single consumer's view of the broker. Standalone
+// mode has no rebalances, so Consume emits one synthetic claim per (topic,
+// partition) mailbox, each with the subscription's lifetime — the same
+// shape Sarama gives a consumer that owns every partition.
 type memorySubscription struct {
-	broker  *memoryBroker
-	groupID string
-	topics  []string
-	out     chan *Message
-	closed  atomic.Bool
+	broker    *memoryBroker
+	groupID   string
+	topics    []string
+	mailboxes []*memoryMailbox
+	closed    atomic.Bool
 }
 
+// Consume runs handler once per claim. A single mailbox (the pre-#295
+// common case: one topic, one partition) is served inline; multiple
+// mailboxes run concurrently — matching Sarama, which invokes ConsumeClaim
+// on its own goroutine per assigned partition. Returns the first handler
+// error, if any.
 func (s *memorySubscription) Consume(ctx context.Context, handler func(Claim) error) error {
 	claimCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	claim := &memoryClaim{ctx: claimCtx, ch: s.out}
-	return handler(claim)
+
+	if len(s.mailboxes) == 1 {
+		return handler(&memoryClaim{ctx: claimCtx, ch: s.mailboxes[0].ch})
+	}
+
+	errCh := make(chan error, len(s.mailboxes))
+	var wg sync.WaitGroup
+	wg.Add(len(s.mailboxes))
+	for _, mb := range s.mailboxes {
+		go func(mb *memoryMailbox) {
+			defer wg.Done()
+			if err := handler(&memoryClaim{ctx: claimCtx, ch: mb.ch}); err != nil {
+				errCh <- err
+			}
+		}(mb)
+	}
+	wg.Wait()
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		return nil
+	}
 }
 
 func (s *memorySubscription) Close() error {
 	if !s.closed.CompareAndSwap(false, true) {
 		return nil
 	}
-	// We don't close s.out here — the broker owns the underlying mailboxes
-	// and their done channels, and will signal them on broker Close().
-	// Closing out would risk a send on a closed channel from the still-
-	// running forward goroutines.
+	// The broker owns the underlying mailboxes and their done channels, and
+	// will signal them on broker Close(). Closing channels here would risk a
+	// send on a closed channel from concurrent publishers.
 	return nil
 }
 

--- a/kafka/memory_broker_partitions_test.go
+++ b/kafka/memory_broker_partitions_test.go
@@ -21,7 +21,7 @@ import (
 func saramaHashPartition(key string, n int32) int32 {
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(key))
-	p := int32(h.Sum32()) % n
+	p := int32(h.Sum32()) % n // #nosec G115 -- sarama-compatible arithmetic
 	if p < 0 {
 		p = -p
 	}
@@ -35,7 +35,7 @@ func TestMemoryBrokerPartitions_KeyRoutingMatchesSaramaHash(t *testing.T) {
 	const topic = "part-routing"
 	const n = 4
 	b := NewMemoryBrokerWithPartitions(100, 0, map[string]int{topic: n})
-	defer b.Close()
+	defer func() { _ = b.Close() }()
 
 	sub, err := b.Subscribe("g", []string{topic}, StartOldest)
 	if err != nil {
@@ -100,7 +100,7 @@ func TestMemoryBrokerPartitions_OneClaimPerPartition(t *testing.T) {
 	const topic = "part-claims"
 	const n = 3
 	b := NewMemoryBrokerWithPartitions(100, 0, map[string]int{topic: n})
-	defer b.Close()
+	defer func() { _ = b.Close() }()
 
 	sub, err := b.Subscribe("g", []string{topic}, StartOldest)
 	if err != nil {
@@ -179,7 +179,7 @@ func TestMemoryBrokerPartitions_OneClaimPerPartition(t *testing.T) {
 // configured topics report their count, everything else reports 1.
 func TestMemoryBrokerPartitions_PartitionCount(t *testing.T) {
 	b := NewMemoryBrokerWithPartitions(10, 0, map[string]int{"wide": 8})
-	defer b.Close()
+	defer func() { _ = b.Close() }()
 	if n, err := b.PartitionCount("wide"); err != nil || n != 8 {
 		t.Errorf("PartitionCount(wide) = %d, %v; want 8, nil", n, err)
 	}
@@ -193,7 +193,7 @@ func TestMemoryBrokerPartitions_PartitionCount(t *testing.T) {
 // before — one claim per subscribed topic.
 func TestMemoryBrokerPartitions_DefaultIsSingleClaim(t *testing.T) {
 	b := NewMemoryBroker(10)
-	defer b.Close()
+	defer func() { _ = b.Close() }()
 
 	sub, err := b.Subscribe("g", []string{"plain"}, StartOldest)
 	if err != nil {

--- a/kafka/memory_broker_partitions_test.go
+++ b/kafka/memory_broker_partitions_test.go
@@ -1,0 +1,219 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Partitioned memory broker (#295): standalone/smoke deployments need the
+// same key→partition→per-claim-dispatcher topology as production Kafka so
+// the multi-partition propagation path is testable without a real broker.
+// Routing must match Sarama's default hash partitioner (FNV-1a 32-bit,
+// mod partition count, abs) so a smoke test observes the same family
+// placement a production topic would produce.
+
+// saramaHashPartition mirrors sarama.NewHashPartitioner's arithmetic.
+func saramaHashPartition(key string, n int32) int32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key))
+	p := int32(h.Sum32()) % n
+	if p < 0 {
+		p = -p
+	}
+	return p
+}
+
+// TestMemoryBrokerPartitions_KeyRoutingMatchesSaramaHash pins that a keyed
+// publish lands on the Sarama-compatible partition, so same-key messages
+// (a #295 dependency family) always share a partition.
+func TestMemoryBrokerPartitions_KeyRoutingMatchesSaramaHash(t *testing.T) {
+	const topic = "part-routing"
+	const n = 4
+	b := NewMemoryBrokerWithPartitions(100, 0, map[string]int{topic: n})
+	defer b.Close()
+
+	sub, err := b.Subscribe("g", []string{topic}, StartOldest)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	var mu sync.Mutex
+	got := map[string]int32{} // key → partition observed
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = sub.Consume(ctx, func(c Claim) error {
+			for {
+				select {
+				case m := <-c.Messages():
+					mu.Lock()
+					got[string(m.Key)] = m.Partition
+					mu.Unlock()
+				case <-c.Context().Done():
+					return nil
+				}
+			}
+		})
+	}()
+
+	keys := []string{"alpha", "bravo", "charlie", "delta", "echo", "alpha"}
+	for _, k := range keys {
+		if err := b.Send(context.Background(), topic, k, []byte("v")); err != nil {
+			t.Fatalf("send %s: %v", k, err)
+		}
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(got)
+		mu.Unlock()
+		if n == 5 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	for k, p := range got {
+		if want := saramaHashPartition(k, n); p != want {
+			t.Errorf("key %q landed on partition %d, want sarama-compatible %d", k, p, want)
+		}
+	}
+}
+
+// TestMemoryBrokerPartitions_OneClaimPerPartition pins the consumer shape:
+// Consume invokes the handler once per partition, each claim seeing only
+// its own partition's messages in publish order — exactly what production
+// Sarama does with per-partition ConsumeClaim goroutines, and what gives
+// each partition its own dep-aware dispatcher.
+func TestMemoryBrokerPartitions_OneClaimPerPartition(t *testing.T) {
+	const topic = "part-claims"
+	const n = 3
+	b := NewMemoryBrokerWithPartitions(100, 0, map[string]int{topic: n})
+	defer b.Close()
+
+	sub, err := b.Subscribe("g", []string{topic}, StartOldest)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	var claims atomic.Int32
+	var mu sync.Mutex
+	perClaim := make(map[int][]string) // claim serial → keys in receive order
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = sub.Consume(ctx, func(c Claim) error {
+			serial := int(claims.Add(1))
+			for {
+				select {
+				case m := <-c.Messages():
+					mu.Lock()
+					perClaim[serial] = append(perClaim[serial], string(m.Key))
+					mu.Unlock()
+				case <-c.Context().Done():
+					return nil
+				}
+			}
+		})
+	}()
+
+	// 30 sends across 10 distinct keys; per-key order must survive.
+	var wantTotal int
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("key-%d", i)
+		for j := 0; j < 3; j++ {
+			if err := b.Send(context.Background(), topic, key, []byte{byte(j)}); err != nil {
+				t.Fatalf("send: %v", err)
+			}
+			wantTotal++
+		}
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		total := 0
+		for _, ks := range perClaim {
+			total += len(ks)
+		}
+		mu.Unlock()
+		if total == wantTotal {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	if got := claims.Load(); got != n {
+		t.Fatalf("handler invoked for %d claims, want one per partition (%d)", got, n)
+	}
+	// Every key's messages must be confined to a single claim.
+	mu.Lock()
+	defer mu.Unlock()
+	keyToClaim := map[string]int{}
+	for serial, ks := range perClaim {
+		for _, k := range ks {
+			if prev, ok := keyToClaim[k]; ok && prev != serial {
+				t.Fatalf("key %q seen on claims %d and %d — same key must map to one partition", k, prev, serial)
+			}
+			keyToClaim[k] = serial
+		}
+	}
+}
+
+// TestMemoryBrokerPartitions_PartitionCount pins the startup check's view:
+// configured topics report their count, everything else reports 1.
+func TestMemoryBrokerPartitions_PartitionCount(t *testing.T) {
+	b := NewMemoryBrokerWithPartitions(10, 0, map[string]int{"wide": 8})
+	defer b.Close()
+	if n, err := b.PartitionCount("wide"); err != nil || n != 8 {
+		t.Errorf("PartitionCount(wide) = %d, %v; want 8, nil", n, err)
+	}
+	if n, err := b.PartitionCount("other"); err != nil || n != 1 {
+		t.Errorf("PartitionCount(other) = %d, %v; want 1, nil", n, err)
+	}
+}
+
+// TestMemoryBrokerPartitions_DefaultIsSingleClaim pins backward
+// compatibility: a broker built without a partition map behaves exactly as
+// before — one claim per subscribed topic.
+func TestMemoryBrokerPartitions_DefaultIsSingleClaim(t *testing.T) {
+	b := NewMemoryBroker(10)
+	defer b.Close()
+
+	sub, err := b.Subscribe("g", []string{"plain"}, StartOldest)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	var claims atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = sub.Consume(ctx, func(c Claim) error {
+			claims.Add(1)
+			<-c.Context().Done()
+			return nil
+		})
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+	if got := claims.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 claim for an unpartitioned topic, got %d", got)
+	}
+}

--- a/kafka/memory_broker_test.go
+++ b/kafka/memory_broker_test.go
@@ -357,10 +357,10 @@ func TestMemoryBroker_SendTimeoutBackpressure(t *testing.T) {
 	b := NewMemoryBrokerWithTimeout(buffer, 50*time.Millisecond)
 	defer func() { _ = b.Close() }()
 
-	// Subscribe without consuming. The subscription's forward goroutine
-	// drains the per-(group, topic) mailbox into a merged channel of equal
-	// capacity, so the total slack between the producer's Send and a stuck
-	// consumer is 2 * buffer + 1 (one in-flight in forward).
+	// Subscribe without consuming. Claims read the per-(group, topic,
+	// partition) mailbox directly (#295 removed the merged-channel
+	// forward goroutine), so the total slack between the producer's Send
+	// and a stuck consumer is exactly the mailbox buffer.
 	sub, err := b.Subscribe("group-stall", []string{"topic-stall"}, StartOldest)
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
@@ -370,7 +370,7 @@ func TestMemoryBroker_SendTimeoutBackpressure(t *testing.T) {
 	ctx := context.Background()
 	// Fill every slot the consumer pipeline can absorb without an active
 	// receiver. After this loop the next Send must time out.
-	for i := 0; i < 2*buffer+1; i++ {
+	for i := 0; i < buffer; i++ {
 		if sendErr := b.Send(ctx, "topic-stall", "k", []byte("pad")); sendErr != nil {
 			t.Fatalf("pad send %d: %v", i, sendErr)
 		}

--- a/kafka/partition_ordering_test.go
+++ b/kafka/partition_ordering_test.go
@@ -1,0 +1,182 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/IBM/sarama"
+)
+
+// The entire #295 ordering model rests on two properties that nothing in the
+// repo currently asserts:
+//
+//  1. messages on one partition are delivered to their claim in publish
+//     order, and
+//  2. the producer routes by hashing the message key.
+//
+// Family partition keys are only meaningful if both hold. If (2) regressed to
+// round-robin or random, every family would scatter and the dep-aware
+// dispatcher would never see a parent before its child — with no test going
+// red. If (1) regressed, per-partition order would not imply parent-precedes-
+// child even within a co-located family.
+//
+// TestMemoryBrokerPartitions_OneClaimPerPartition's comment says "per-key
+// order must survive", but its recorder keeps only string(m.Key) and drops
+// the payload, so ordering is never actually checked.
+
+// TestMemoryBrokerPartitions_PreservesPerPartitionValueOrder pins property
+// (1) for the in-memory broker that smoke tests run against: for each key,
+// the claim must observe that key's payloads in the order they were sent.
+func TestMemoryBrokerPartitions_PreservesPerPartitionValueOrder(t *testing.T) {
+	const topic = "part-order"
+	const partitions = 3
+	const keys = 10
+	const perKey = 8
+
+	b := NewMemoryBrokerWithPartitions(1000, 0, map[string]int{topic: partitions})
+	defer func() { _ = b.Close() }()
+
+	sub, err := b.Subscribe("g", []string{topic}, StartOldest)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	var mu sync.Mutex
+	seen := make(map[string][]byte) // key → payload sequence in receive order
+	var total atomic.Int32
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = sub.Consume(ctx, func(c Claim) error {
+			for {
+				select {
+				case m := <-c.Messages():
+					mu.Lock()
+					seen[string(m.Key)] = append(seen[string(m.Key)], m.Value[0])
+					mu.Unlock()
+					total.Add(1)
+				case <-c.Context().Done():
+					return nil
+				}
+			}
+		})
+	}()
+
+	for i := 0; i < keys; i++ {
+		key := fmt.Sprintf("key-%d", i)
+		for j := 0; j < perKey; j++ {
+			if err := b.Send(context.Background(), topic, key, []byte{byte(j)}); err != nil {
+				t.Fatalf("send: %v", err)
+			}
+		}
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && total.Load() < int32(keys*perKey) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := int(total.Load()); got != keys*perKey {
+		t.Fatalf("received %d messages, want %d", got, keys*perKey)
+	}
+	for i := 0; i < keys; i++ {
+		key := fmt.Sprintf("key-%d", i)
+		got := seen[key]
+		if len(got) != perKey {
+			t.Errorf("key %q: got %d messages, want %d", key, len(got), perKey)
+			continue
+		}
+		for j := 0; j < perKey; j++ {
+			if got[j] != byte(j) {
+				t.Fatalf("key %q delivered out of order: got %v, want ascending 0..%d.\n"+
+					"Per-partition order is the foundation of family keying — without it, "+
+					"co-locating a family on one partition does not imply a parent's admit "+
+					"reaches the dispatcher before its child's.", key, got, perKey-1)
+			}
+		}
+	}
+}
+
+// TestNewSyncProducerConfig_RoutesByKeyHash pins property (2), and does it
+// behaviorally rather than by asserting a type name.
+//
+// It builds the partitioner the shipped producer config actually uses and
+// checks it agrees with the memory broker's partitionForKey across a key
+// corpus and every partition count that matters. That covers three
+// regressions at once:
+//
+//   - swapping Producer.Partitioner for round-robin/random (family keying
+//     silently stops working; TestNewSyncProducerConfig_OrderingInvariants
+//     does not look at this field)
+//   - a sarama upgrade changing the default partitioner or its arithmetic
+//     (referenceAbs / hashUnsigned flip mod-then-abs to abs-then-mod)
+//   - the memory broker drifting from production placement, which would make
+//     every smoke-test family observation meaningless
+//
+// The existing memory-broker test compares partitionForKey against a local
+// re-implementation of the same arithmetic, so it cannot catch any of these.
+func TestNewSyncProducerConfig_RoutesByKeyHash(t *testing.T) {
+	const topic = "arcade.propagation"
+
+	cfg := newSyncProducerConfig()
+	if cfg.Producer.Partitioner == nil {
+		t.Fatal("Producer.Partitioner is nil")
+	}
+	partitioner := cfg.Producer.Partitioner(topic)
+
+	keys := []string{
+		"alpha", "bravo", "charlie", "delta", "echo",
+		"0000000000000000000000000000000000000000000000000000000000000000",
+		"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		"21e64e24829013f04db6614fc3c865b92ada9e31d58dcb8a6a169023fa7d27bd",
+	}
+	for i := 0; i < 64; i++ {
+		keys = append(keys, fmt.Sprintf("family-%03d", i))
+	}
+
+	for _, n := range []int32{1, 2, 3, 4, 8, 16} {
+		for _, key := range keys {
+			msg := &sarama.ProducerMessage{Topic: topic, Key: sarama.StringEncoder(key)}
+			want, err := partitioner.Partition(msg, n)
+			if err != nil {
+				t.Fatalf("sarama Partition(%q, %d): %v", key, n, err)
+			}
+			if want < 0 || want >= n {
+				t.Fatalf("sarama returned partition %d for %q with n=%d — out of range; "+
+					"the configured partitioner is not a keyed hash partitioner", want, key, n)
+			}
+			if got := partitionForKey(key, int(n)); got != want {
+				t.Fatalf("partition mismatch for key %q with %d partitions: memory broker = %d, "+
+					"sarama = %d.\nA family placed by the memory broker in smoke tests would land "+
+					"on a different partition in production.", key, n, got, want)
+			}
+		}
+	}
+
+	// A keyed hash partitioner must also be deterministic across instances —
+	// the same family key produced by two different pods has to agree.
+	other := cfg.Producer.Partitioner(topic)
+	msg := &sarama.ProducerMessage{Topic: topic, Key: sarama.StringEncoder("alpha")}
+	a, err := partitioner.Partition(msg, 8)
+	if err != nil {
+		t.Fatalf("Partition: %v", err)
+	}
+	b, err := other.Partition(msg, 8)
+	if err != nil {
+		t.Fatalf("Partition: %v", err)
+	}
+	if a != b {
+		t.Fatalf("partitioner is not deterministic across instances: %d vs %d — "+
+			"two arcade pods would place the same family on different partitions", a, b)
+	}
+}

--- a/kafka/partitions.go
+++ b/kafka/partitions.go
@@ -46,21 +46,27 @@ func CheckPartitions(broker Broker, topics []string, minPartitions int, logger *
 	return nil
 }
 
-// CheckExactPartitions verifies that `topic` exists on the broker with
-// exactly `want` partitions. Returns an error on mismatch. Used for
-// topics where partition count is a correctness constraint (not a
-// scaling hint), e.g. the dep-aware dispatcher requires
-// TopicPropagation to be single-partition so its single-goroutine state
-// ownership covers the entire topic.
+// CheckMinPartitions verifies that `topic` exists on the broker with at
+// least `want` partitions. Used for topics whose partition count is a
+// correctness-adjacent deployment constraint: producers key
+// TopicPropagation by dependency family, so any partition count
+// preserves parent-before-child order per partition, but a topic with
+// fewer partitions than the deployment was sized for leaves consumers
+// idle and means config and topology have drifted apart. `want < 1` is
+// treated as 1 — the check is never a no-op.
 //
-// Missing topics are treated as errors: for correctness-constrained
-// topics, allowing auto-creation on first publish could create the topic
-// with the broker default partition count instead of `want`.
-func CheckExactPartitions(broker Broker, topic string, want int, logger *zap.Logger) error {
+// Missing topics are hard errors regardless of `want`: allowing
+// auto-creation on first publish would let the broker default decide
+// the partition count (and therefore the key→partition mapping) instead
+// of the operator.
+func CheckMinPartitions(broker Broker, topic string, want int, logger *zap.Logger) error {
+	if want < 1 {
+		want = 1
+	}
 	count, err := broker.PartitionCount(topic)
 	if errors.Is(err, ErrTopicNotFound) {
 		return fmt.Errorf(
-			"topic %s not found on broker; create it before startup with exactly %d partitions (correctness requirement)",
+			"topic %s not found on broker; create it before startup with at least %d partitions (correctness requirement)",
 			topic,
 			want,
 		)
@@ -68,13 +74,14 @@ func CheckExactPartitions(broker Broker, topic string, want int, logger *zap.Log
 	if err != nil {
 		return fmt.Errorf("querying partition count for %s: %w", topic, err)
 	}
-	if count != want {
-		return fmt.Errorf("topic %s has %d partitions, want exactly %d (correctness requirement)", topic, count, want)
+	if count < want {
+		return fmt.Errorf("topic %s has %d partition(s), want at least %d (propagation.partitions)", topic, count, want)
 	}
 	logger.Info(
-		"topic partition count matches required exact value",
+		"topic partition count meets required minimum",
 		zap.String("topic", topic),
 		zap.Int("partitions", count),
+		zap.Int("min_required", want),
 	)
 	return nil
 }

--- a/kafka/partitions_test.go
+++ b/kafka/partitions_test.go
@@ -45,42 +45,53 @@ func (b *stubPartitionBroker) PartitionCount(topic string) (int, error) {
 	return 0, ErrTopicNotFound
 }
 
-// TestCheckExactPartitions_MatchOK pins the success contract: when the
-// broker reports the exact requested partition count, no error.
-func TestCheckExactPartitions_MatchOK(t *testing.T) {
+// TestCheckMinPartitions_ExactMatchOK pins the success contract: when
+// the broker reports exactly the requested minimum, no error.
+func TestCheckMinPartitions_ExactMatchOK(t *testing.T) {
 	rb := &RecordingBroker{} // always reports 1 partition
-	if err := CheckExactPartitions(rb, TopicPropagation, 1, zap.NewNop()); err != nil {
+	if err := CheckMinPartitions(rb, TopicPropagation, 1, zap.NewNop()); err != nil {
 		t.Fatalf("expected nil error for matching partition count, got %v", err)
 	}
 }
 
-// TestCheckExactPartitions_MismatchFailsStartup pins the correctness
-// guard: a TopicPropagation with > 1 partition must fail startup hard,
-// because the dep-aware dispatcher's single-goroutine state ownership
-// relies on total order at the topic level.
-func TestCheckExactPartitions_MismatchFailsStartup(t *testing.T) {
-	br := &stubPartitionBroker{counts: map[string]int{TopicPropagation: 3}}
-	err := CheckExactPartitions(br, TopicPropagation, 1, zap.NewNop())
-	if err == nil {
-		t.Fatal("expected error for 3-partition propagation topic, got nil — dispatcher correctness rule must be enforced at startup")
-	}
-	if !strings.Contains(err.Error(), "3 partitions") {
-		t.Errorf("error message %q should report observed partition count", err.Error())
-	}
-	if !strings.Contains(err.Error(), "exactly 1") {
-		t.Errorf("error message %q should state the required value", err.Error())
+// TestCheckMinPartitions_MorePartitionsOK pins the contract change from
+// the retired exact-1 rule (#295): a propagation topic with MORE
+// partitions than configured is fine — family partition keys preserve
+// parent-before-child order per partition, and extra partitions only
+// cost idle dispatchers.
+func TestCheckMinPartitions_MorePartitionsOK(t *testing.T) {
+	br := &stubPartitionBroker{counts: map[string]int{TopicPropagation: 8}}
+	if err := CheckMinPartitions(br, TopicPropagation, 3, zap.NewNop()); err != nil {
+		t.Fatalf("expected nil error when actual (8) >= configured (3), got %v", err)
 	}
 }
 
-// TestCheckExactPartitions_TopicMissing_FailsStartup pins the hard-fail
-// contract: a missing topic is a startup error for correctness-
-// constrained topics. Auto-create on first publish would use the
-// broker's default partition count, silently breaking the dispatcher's
-// single-partition invariant (see CheckExactPartitions doc and the
-// call site in app/app.go that propagates the error to abort startup).
-func TestCheckExactPartitions_TopicMissing_FailsStartup(t *testing.T) {
+// TestCheckMinPartitions_FewerPartitionsFailsStartup pins the fail-closed
+// guard: fewer partitions than configured means producers hash over a
+// smaller space than the deployment was sized for and some consumers
+// would sit idle. Startup must abort so config and topology can't drift.
+func TestCheckMinPartitions_FewerPartitionsFailsStartup(t *testing.T) {
+	br := &stubPartitionBroker{counts: map[string]int{TopicPropagation: 1}}
+	err := CheckMinPartitions(br, TopicPropagation, 3, zap.NewNop())
+	if err == nil {
+		t.Fatal("expected error for 1-partition topic with configured minimum 3, got nil")
+	}
+	if !strings.Contains(err.Error(), "1 partition") {
+		t.Errorf("error message %q should report observed partition count", err.Error())
+	}
+	if !strings.Contains(err.Error(), "at least 3") {
+		t.Errorf("error message %q should state the required minimum", err.Error())
+	}
+}
+
+// TestCheckMinPartitions_TopicMissing_FailsStartup pins the hard-fail
+// contract: a missing topic is a startup error even when the configured
+// minimum is 1. Auto-create on first publish would use the broker's
+// default partition count, silently deciding the key→partition mapping
+// the dispatcher's ordering guarantees are built on.
+func TestCheckMinPartitions_TopicMissing_FailsStartup(t *testing.T) {
 	br := &stubPartitionBroker{} // no entries → ErrTopicNotFound
-	err := CheckExactPartitions(br, TopicPropagation, 1, zap.NewNop())
+	err := CheckMinPartitions(br, TopicPropagation, 1, zap.NewNop())
 	if err == nil {
 		t.Fatal("expected error for missing correctness-constrained topic, got nil")
 	}
@@ -92,16 +103,32 @@ func TestCheckExactPartitions_TopicMissing_FailsStartup(t *testing.T) {
 	}
 }
 
-// TestCheckExactPartitions_BrokerError_PropagatesError pins the
-// fail-loud contract: when the broker can't answer the question for a
+// TestCheckMinPartitions_BrokerError_PropagatesError pins the fail-loud
+// contract: when the broker can't answer the question for a
 // non-not-found reason, startup must fail rather than silently proceed.
-func TestCheckExactPartitions_BrokerError_PropagatesError(t *testing.T) {
+func TestCheckMinPartitions_BrokerError_PropagatesError(t *testing.T) {
 	br := &stubPartitionBroker{err: errors.New("broker unreachable")}
-	err := CheckExactPartitions(br, TopicPropagation, 1, zap.NewNop())
+	err := CheckMinPartitions(br, TopicPropagation, 1, zap.NewNop())
 	if err == nil {
 		t.Fatal("expected error when broker fails, got nil")
 	}
 	if !strings.Contains(err.Error(), "broker unreachable") {
 		t.Errorf("error %q should wrap the underlying broker error", err.Error())
+	}
+}
+
+// TestCheckMinPartitions_NonPositiveWantTreatedAsOne pins the floor:
+// want <= 0 is not "skip the check" — the topic must still exist with
+// at least one partition. This is what keeps the default config
+// (propagation.partitions unset → 0 via a zero-value struct) fail-closed
+// on a missing topic.
+func TestCheckMinPartitions_NonPositiveWantTreatedAsOne(t *testing.T) {
+	br := &stubPartitionBroker{} // topic missing
+	if err := CheckMinPartitions(br, TopicPropagation, 0, zap.NewNop()); err == nil {
+		t.Fatal("expected missing-topic error even with want=0, got nil")
+	}
+	ok := &stubPartitionBroker{counts: map[string]int{TopicPropagation: 1}}
+	if err := CheckMinPartitions(ok, TopicPropagation, 0, zap.NewNop()); err != nil {
+		t.Fatalf("expected nil error for existing topic with want=0, got %v", err)
 	}
 }

--- a/kafka/sarama_broker.go
+++ b/kafka/sarama_broker.go
@@ -51,13 +51,7 @@ func NewSaramaBroker(brokers []string, consumerGroup string) (Broker, error) {
 // zap logger for async-producer error logging. A nil logger falls back to
 // zap.NewNop() so the broker is always safe to construct.
 func NewSaramaBrokerWithLogger(brokers []string, consumerGroup string, logger *zap.Logger) (Broker, error) {
-	syncCfg := sarama.NewConfig()
-	syncCfg.Producer.RequiredAcks = sarama.WaitForAll
-	syncCfg.Producer.Retry.Max = 5
-	syncCfg.Producer.Return.Successes = true
-	syncCfg.Producer.Return.Errors = true
-
-	syncProducer, err := sarama.NewSyncProducer(brokers, syncCfg)
+	syncProducer, err := sarama.NewSyncProducer(brokers, newSyncProducerConfig())
 	if err != nil {
 		return nil, fmt.Errorf("creating sync producer: %w", err)
 	}
@@ -75,6 +69,28 @@ func NewSaramaBrokerWithLogger(brokers []string, consumerGroup string, logger *z
 	}
 
 	return newSaramaBrokerFromProducers(syncProducer, asyncProducer, brokers, consumerGroup, logger), nil
+}
+
+// newSyncProducerConfig builds the sync-producer config used for Send /
+// SendBatch — the path every ordering-sensitive topic goes through
+// (TopicPropagation most of all). Idempotent + MaxOpenRequests=1 makes
+// per-partition order survive broker-side retries: without it a failed
+// produce can be retried behind a newer in-flight batch, reordering a
+// dependency family's parent behind its child on the same partition
+// (#295 family keying makes that order load-bearing). Idempotence
+// requires WaitForAll acks (already the sync default here) and protocol
+// >= 0.11; 2.6.0 is safely below anything Redpanda or a maintained
+// Kafka speaks. Extracted so tests can pin these invariants.
+func newSyncProducerConfig() *sarama.Config {
+	syncCfg := sarama.NewConfig()
+	syncCfg.Version = sarama.V2_6_0_0
+	syncCfg.Producer.RequiredAcks = sarama.WaitForAll
+	syncCfg.Producer.Retry.Max = 5
+	syncCfg.Producer.Return.Successes = true
+	syncCfg.Producer.Return.Errors = true
+	syncCfg.Producer.Idempotent = true
+	syncCfg.Net.MaxOpenRequests = 1
+	return syncCfg
 }
 
 // newSaramaBrokerFromProducers wires the broker around already-constructed

--- a/kafka/sarama_broker_test.go
+++ b/kafka/sarama_broker_test.go
@@ -206,3 +206,29 @@ func TestNewSaramaConsumerConfig_StartOffset(t *testing.T) {
 		})
 	}
 }
+
+// TestNewSyncProducerConfig_OrderingInvariants pins the produce-side
+// ordering contract that family partition keying (#295) relies on: with
+// idempotence on and one open request, a retried produce cannot be
+// reordered behind a newer message on the same partition, so a family's
+// parent-before-child submission order survives broker hiccups. Version
+// must be >= 0.11 for idempotent produce; WaitForAll is required by
+// idempotence (and was already the sync default here).
+func TestNewSyncProducerConfig_OrderingInvariants(t *testing.T) {
+	cfg := newSyncProducerConfig()
+	if !cfg.Producer.Idempotent {
+		t.Error("sync producer must be idempotent — retries may otherwise reorder a family's messages within a partition")
+	}
+	if cfg.Net.MaxOpenRequests != 1 {
+		t.Errorf("Net.MaxOpenRequests = %d, want 1 (required by idempotent produce, guarantees per-partition order)", cfg.Net.MaxOpenRequests)
+	}
+	if cfg.Producer.RequiredAcks != sarama.WaitForAll {
+		t.Errorf("RequiredAcks = %v, want WaitForAll", cfg.Producer.RequiredAcks)
+	}
+	if !cfg.Version.IsAtLeast(sarama.V0_11_0_0) {
+		t.Errorf("Version = %v, want >= 0.11.0.0 for idempotent produce", cfg.Version)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("sarama config invalid: %v", err)
+	}
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -86,14 +86,15 @@ var PropagationBroadcastConsensus = promauto.NewCounterVec(prometheus.CounterOpt
 }, []string{"verdict"}) // accepted, unanimous_reject, mixed, unreachable
 
 // PropagationPendingDepth gauges how many propagationMsgs the dep-aware
-// dispatcher is currently holding in its pendingMsgs accumulator awaiting
-// the next flush. The dispatcher owns the slice on a single goroutine,
-// so the gauge tracks its length at every mutation point. Sustained
-// growth indicates downstream (teranode broadcast or merkle-service
-// register) is not keeping up with ingest.
+// dispatchers are currently holding in their pendingMsgs accumulators
+// awaiting the next flush, summed across this pod's partition
+// dispatchers (#295: one dispatcher per assigned partition claim; each
+// delta-adds its own contribution and removes it on claim teardown).
+// Sustained growth indicates downstream (teranode broadcast or
+// merkle-service register) is not keeping up with ingest.
 var PropagationPendingDepth = promauto.NewGauge(prometheus.GaugeOpts{
 	Name: "arcade_propagation_pending_depth",
-	Help: "Number of propagation messages buffered in the dispatcher awaiting flush.",
+	Help: "Propagation messages buffered awaiting flush, summed across this pod's partition dispatchers.",
 })
 
 // PropagationPendingRequeues gauges how many delayed-requeue goroutines
@@ -212,17 +213,19 @@ var PropagationClaimRevokedBatchesTotal = promauto.NewCounter(prometheus.Counter
 	Help: "Propagation batches aborted mid-pipeline because the Kafka claim was revoked; their txs stay uncommitted for replay.",
 })
 
-// PropagationInflightDepth gauges the dispatcher's full in-flight census:
+// PropagationInflightDepth gauges the dispatchers' full in-flight census:
 // every tx admitted from Kafka that has not yet reached a terminal verdict —
 // pending flush, mid-broadcast, held behind an in-flight parent, or parked in
-// a delayed requeue. Unlike PropagationPendingDepth, which admission
-// backpressure caps at max_pending, this gauge is uncapped, so it is the one
+// a delayed requeue — summed across this pod's partition dispatchers
+// (#295 delta accounting, same as PropagationPendingDepth). Unlike
+// PropagationPendingDepth, which admission backpressure caps at
+// max_pending per dispatcher, this gauge is uncapped, so it is the one
 // that shows a real backlog growing. Each in-flight entry pins its Kafka
-// offset below the commit watermark, so this depth also approximates the
-// uncommitted-offset backlog on the current claim.
+// offset below its partition's commit watermark, so this depth also
+// approximates the pod's uncommitted-offset backlog.
 var PropagationInflightDepth = promauto.NewGauge(prometheus.GaugeOpts{
 	Name: "arcade_propagation_inflight_depth",
-	Help: "Transactions in the dispatcher's in-flight set (admitted but not yet terminal); each pins an uncommitted Kafka offset.",
+	Help: "Transactions in the in-flight set (admitted but not yet terminal), summed across this pod's partition dispatchers; each pins an uncommitted Kafka offset.",
 })
 
 // PropagationConflictAttributionTotal counts conflict-family ("alien") Teranode
@@ -247,6 +250,26 @@ var PropagationConflictAttributionTotal = promauto.NewCounterVec(prometheus.Coun
 	Name: "arcade_propagation_conflict_attribution_total",
 	Help: "Conflict-family Teranode failure lines by whether the spent outpoint resolved to a submitted transaction.",
 }, []string{"result"}) // attributed, unattributable
+
+// PropagationMissingParentTotal counts Teranode missing-parent responses
+// (TX_MISSING_PARENT / TX_NOT_FOUND) by how arcade resolved them. With a
+// multi-partition arcade.propagation topic (#295) a child submitted in a
+// later request than its parent can reach Teranode first; that condition is
+// retryable, never a verdict on its own (#254).
+//
+// outcome="requeued": the parent wasn't terminally REJECTED in arcade's own
+// store, so the child went back through the bounded requeue (and, on budget
+// exhaustion, PENDING_RETRY + reaper). A short burst is expected during a
+// partition-count change (key remap window); a sustained rate at steady
+// state means family keying is not co-locating same-submission chains —
+// check the intake path. outcome="rejected_ancestor": arcade's store showed
+// a parent terminally REJECTED, so the child inherited REJECTED via the
+// standard cascade reason — the cross-partition analogue of the
+// dispatcher's same-partition cascade.
+var PropagationMissingParentTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_propagation_missing_parent_total",
+	Help: "Teranode missing-parent responses by resolution (requeued vs rejected via a REJECTED ancestor in arcade's store).",
+}, []string{"outcome"}) // requeued, rejected_ancestor
 
 // PropagationRequeueExhaustedTotal counts transactions parked at PENDING_RETRY
 // because they burned their whole in-memory requeue budget

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -292,6 +292,43 @@ var PropagationRequeueExhaustedTotal = promauto.NewCounter(prometheus.CounterOpt
 	Help: "Transactions parked at PENDING_RETRY after exhausting the in-memory requeue budget with no network verdict.",
 })
 
+// PropagationPendingRetryTotal counts durable-retry lifecycle events for
+// transactions parked at PENDING_RETRY.
+//
+// outcome="scheduled": a parked tx was booked for another reaper attempt with
+// an exponential-backoff next_retry_at. outcome="exhausted": it burned
+// propagation.pending_retry_max_attempts and was terminalized REJECTED
+// because a parent it spends never reached the network.
+//
+// A rising "exhausted" rate means clients are submitting transactions whose
+// parents arcade never sees — before #299 those rows were not terminalized at
+// all: their timestamp_at never moved, so at 24h they fell out of the reaper's
+// scan window and stayed PENDING_RETRY permanently, invisible to every gauge.
+var PropagationPendingRetryTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_propagation_pending_retry_total",
+	Help: "Durable-retry lifecycle events for PENDING_RETRY transactions (scheduled for another attempt vs terminalized after exhausting the budget).",
+}, []string{"outcome"}) // scheduled, exhausted
+
+// PropagationParkedDepth is the number of transactions currently parked at
+// PENDING_RETRY, and PropagationParkedOldestAgeSeconds the age of the oldest.
+//
+// PENDING_RETRY is deliberately absent from the stuck-transient census
+// (reaper.go stuckTransientStatuses tracks RECEIVED and ACCEPTED_BY_NETWORK
+// only), and reaper_ready_depth saturates at the per-tick rebroadcast cap, so
+// before these existed the parked set was both unbounded and unmeasurable —
+// while #299 makes parking an expected steady state for cross-submission
+// chains rather than a poison-batch rarity.
+var (
+	PropagationParkedDepth = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "arcade_propagation_parked_depth",
+		Help: "Transactions currently parked at PENDING_RETRY awaiting durable reaper rebroadcast.",
+	})
+	PropagationParkedOldestAgeSeconds = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "arcade_propagation_parked_oldest_age_seconds",
+		Help: "Age of the oldest transaction parked at PENDING_RETRY.",
+	})
+)
+
 // APITxsSubmittedTotal counts individual transactions submitted through the
 // API, by route and dedup result. Unlike the HTTP request histogram (one
 // sample per request), this counts PER TRANSACTION — the /txs batch route

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -268,8 +268,8 @@ var PropagationConflictAttributionTotal = promauto.NewCounterVec(prometheus.Coun
 // dispatcher's same-partition cascade.
 var PropagationMissingParentTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "arcade_propagation_missing_parent_total",
-	Help: "Teranode missing-parent responses by resolution (requeued vs rejected via a REJECTED ancestor in arcade's store).",
-}, []string{"outcome"}) // requeued, rejected_ancestor
+	Help: "Teranode missing-parent responses by resolution (requeued vs durable reaper retry vs rejected via a REJECTED ancestor in arcade's store).",
+}, []string{"outcome"}) // requeued, reaper_retry, rejected_ancestor
 
 // PropagationRequeueExhaustedTotal counts transactions parked at PENDING_RETRY
 // because they burned their whole in-memory requeue budget

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -264,7 +264,7 @@ var PropagationConflictAttributionTotal = promauto.NewCounterVec(prometheus.Coun
 // state means family keying is not co-locating same-submission chains —
 // check the intake path. outcome="rejected_ancestor": arcade's store showed
 // a parent terminally REJECTED, so the child inherited REJECTED via the
-// standard cascade reason — the cross-partition analogue of the
+// standard cascade reason — the cross-partition analog of the
 // dispatcher's same-partition cascade.
 var PropagationMissingParentTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "arcade_propagation_missing_parent_total",

--- a/metrics/preregister.go
+++ b/metrics/preregister.go
@@ -68,3 +68,20 @@ func PreRegisterBumpOutcomes() {
 		BumpBuilderBuildDuration.WithLabelValues(outcome)
 	}
 }
+
+// PreRegisterPropagationRetryOutcomes instantiates every outcome child of the
+// missing-parent and durable-retry counters. The propagation service calls
+// this at construction time.
+//
+// These matter more than most: the interesting series are the ones that stay
+// at zero in a healthy deployment (rejected_ancestor, exhausted), and an alert
+// on a series that was never born returns no-data rather than 0 — which most
+// alerting rules treat as "nothing to see" instead of "healthy".
+func PreRegisterPropagationRetryOutcomes() {
+	for _, outcome := range []string{"requeued", "reaper_retry", "rejected_ancestor"} {
+		PropagationMissingParentTotal.WithLabelValues(outcome)
+	}
+	for _, outcome := range []string{"scheduled", "exhausted"} {
+		PropagationPendingRetryTotal.WithLabelValues(outcome)
+	}
+}

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -1176,15 +1176,27 @@ func (s *Server) handleSubmitTransactions(c *gin.Context) {
 	// Phase 4: build propagation envelopes and publish as one batch.
 	// input_txids drives the dispatcher's dep-aware admission — children
 	// of any in-flight parent are held until the parent terminalizes.
+	// Messages are keyed by dependency family (#295): txs of this
+	// submission connected through in-batch spends share a key, so on a
+	// multi-partition topic a whole family lands on one partition and
+	// per-partition order still delivers parents before children.
 	if len(toPublish) > 0 {
+		txids := make([]string, len(toPublish))
+		inputs := make([][]string, len(toPublish))
+		for i, p := range toPublish {
+			txids[i] = p.txid
+			inputs[i] = collectInputTXIDs(p.tx)
+		}
+		keys := familyPartitionKeys(txids, inputs)
+
 		msgs := make([]kafka.KeyValue, 0, len(toPublish))
-		for _, p := range toPublish {
+		for i, p := range toPublish {
 			msgs = append(msgs, kafka.KeyValue{
-				Key: p.txid,
+				Key: keys[i],
 				Value: map[string]interface{}{
 					"txid":        p.txid,
 					"raw_tx":      p.raw,
-					"input_txids": collectInputTXIDs(p.tx),
+					"input_txids": inputs[i],
 				},
 			})
 		}

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -1028,11 +1028,6 @@ func (s *Server) handleSubmitTransactions(c *gin.Context) {
 	// Phase 1: parse the whole stream. Use the canonical TxID() (not a
 	// hash of the wire bytes) so Extended Format submissions key the
 	// same as the canonical txid the propagator broadcasts.
-	type parsedItem struct {
-		tx   *sdkTx.Transaction
-		raw  []byte
-		txid string
-	}
 	var parsed []parsedItem
 	offset := 0
 	for offset < len(body) {
@@ -1181,57 +1176,8 @@ func (s *Server) handleSubmitTransactions(c *gin.Context) {
 	// multi-partition topic a whole family lands on one partition and
 	// per-partition order still delivers parents before children.
 	if len(toPublish) > 0 {
-		// Keys are computed over `parsed` — the FULL submitted batch — not
-		// over toPublish. The distinction is the difference between a stable
-		// family key and a moving one.
-		//
-		// The key is min(family), so it moves whenever a member leaves the
-		// set. Members leave constantly: the Phase 3 dedup CAS drops every tx
-		// already known at a non-REJECTED status. The standard wallet pattern
-		// POST {P} then POST {P, C} therefore dedups P out, leaving the child
-		// with no in-batch parent and keying it by its own txid — onto a
-		// partition its still-in-flight parent is not on, where the
-		// dispatcher cannot hold it behind that parent. It draws
-		// TX_MISSING_PARENT and parks, where before #295's multi-partition
-		// topic it was admitted in milliseconds. The partial-produce retry
-		// path has the same shape: the members that already landed dedup out
-		// and the remainder recomputes onto a different partition.
-		//
-		// A deduped-out member can remain the family representative because
-		// the key is only a hash input; it does not have to be a txid that
-		// this request publishes.
-		allTxids := make([]string, len(parsed))
-		allInputs := make([][]string, len(parsed))
-		for i, p := range parsed {
-			allTxids[i] = p.txid
-			allInputs[i] = collectInputTXIDs(p.tx)
-		}
-		allKeys := familyPartitionKeys(allTxids, allInputs)
-		keyByTxid := make(map[string]string, len(parsed))
-		inputsByTxid := make(map[string][]string, len(parsed))
-		for i, p := range parsed {
-			if _, ok := keyByTxid[p.txid]; ok {
-				continue // duplicate txid in one body: first occurrence wins
-			}
-			keyByTxid[p.txid] = allKeys[i]
-			inputsByTxid[p.txid] = allInputs[i]
-		}
-
-		msgs := make([]kafka.KeyValue, 0, len(toPublish))
-		for _, p := range toPublish {
-			key, ok := keyByTxid[p.txid]
-			if !ok {
-				key = p.txid
-			}
-			msgs = append(msgs, kafka.KeyValue{
-				Key: key,
-				Value: map[string]interface{}{
-					"txid":        p.txid,
-					"raw_tx":      p.raw,
-					"input_txids": inputsByTxid[p.txid],
-				},
-			})
-		}
+		keyByTxid, inputsByTxid := familyKeysBySubmittedTxid(parsed)
+		msgs := propagationMessages(toPublish, keyByTxid, inputsByTxid)
 		if err := s.producer.SendBatch(ctx, kafka.TopicPropagation, msgs); err != nil {
 			if errors.Is(err, kafka.ErrBrokerBackpressure) {
 				s.logger.Warn("batch submit rejected: kafka backpressure", zap.Int("count", len(msgs)))

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -1181,22 +1181,54 @@ func (s *Server) handleSubmitTransactions(c *gin.Context) {
 	// multi-partition topic a whole family lands on one partition and
 	// per-partition order still delivers parents before children.
 	if len(toPublish) > 0 {
-		txids := make([]string, len(toPublish))
-		inputs := make([][]string, len(toPublish))
-		for i, p := range toPublish {
-			txids[i] = p.txid
-			inputs[i] = collectInputTXIDs(p.tx)
+		// Keys are computed over `parsed` — the FULL submitted batch — not
+		// over toPublish. The distinction is the difference between a stable
+		// family key and a moving one.
+		//
+		// The key is min(family), so it moves whenever a member leaves the
+		// set. Members leave constantly: the Phase 3 dedup CAS drops every tx
+		// already known at a non-REJECTED status. The standard wallet pattern
+		// POST {P} then POST {P, C} therefore dedups P out, leaving the child
+		// with no in-batch parent and keying it by its own txid — onto a
+		// partition its still-in-flight parent is not on, where the
+		// dispatcher cannot hold it behind that parent. It draws
+		// TX_MISSING_PARENT and parks, where before #295's multi-partition
+		// topic it was admitted in milliseconds. The partial-produce retry
+		// path has the same shape: the members that already landed dedup out
+		// and the remainder recomputes onto a different partition.
+		//
+		// A deduped-out member can remain the family representative because
+		// the key is only a hash input; it does not have to be a txid that
+		// this request publishes.
+		allTxids := make([]string, len(parsed))
+		allInputs := make([][]string, len(parsed))
+		for i, p := range parsed {
+			allTxids[i] = p.txid
+			allInputs[i] = collectInputTXIDs(p.tx)
 		}
-		keys := familyPartitionKeys(txids, inputs)
+		allKeys := familyPartitionKeys(allTxids, allInputs)
+		keyByTxid := make(map[string]string, len(parsed))
+		inputsByTxid := make(map[string][]string, len(parsed))
+		for i, p := range parsed {
+			if _, ok := keyByTxid[p.txid]; ok {
+				continue // duplicate txid in one body: first occurrence wins
+			}
+			keyByTxid[p.txid] = allKeys[i]
+			inputsByTxid[p.txid] = allInputs[i]
+		}
 
 		msgs := make([]kafka.KeyValue, 0, len(toPublish))
-		for i, p := range toPublish {
+		for _, p := range toPublish {
+			key, ok := keyByTxid[p.txid]
+			if !ok {
+				key = p.txid
+			}
 			msgs = append(msgs, kafka.KeyValue{
-				Key: keys[i],
+				Key: key,
 				Value: map[string]interface{}{
 					"txid":        p.txid,
 					"raw_tx":      p.raw,
-					"input_txids": inputs[i],
+					"input_txids": inputsByTxid[p.txid],
 				},
 			})
 		}

--- a/services/api_server/partition_key_stability_test.go
+++ b/services/api_server/partition_key_stability_test.go
@@ -1,0 +1,153 @@
+package api_server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-sdk/script"
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+
+	"github.com/bsv-blockchain/arcade/kafka"
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// parentChildWithParentLowest builds a parent/child pair whose parent txid
+// sorts BELOW the child's, so the family key (min of the two) is the
+// parent's. That distinction is what makes the assertion discriminating: if
+// the child sorted lowest, a buggy fallback to "key by my own txid" would
+// coincidentally equal the family key and the test would pass while the
+// child still landed on the wrong partition. LockTime is a free nonce.
+func parentChildWithParentLowest(t *testing.T) (parent, child *sdkTx.Transaction) {
+	t.Helper()
+	for nonce := uint32(0); nonce < 1000; nonce++ {
+		p := sdkTx.NewTransaction()
+		p.LockTime = nonce
+		p.AddOutput(&sdkTx.TransactionOutput{Satoshis: 0, LockingScript: &script.Script{}})
+		ph := p.TxID()
+
+		c := sdkTx.NewTransaction()
+		c.Inputs = append(c.Inputs, &sdkTx.TransactionInput{
+			SourceTXID:       ph,
+			SourceTxOutIndex: 0,
+			SequenceNumber:   sdkTx.DefaultSequenceNumber,
+		})
+		if ph.String() < c.TxID().String() {
+			return p, c
+		}
+	}
+	t.Fatal("no parent/child pair found with parent txid < child txid")
+	return nil, nil
+}
+
+// TestFamilyPartitionKeys_StableUnderPartialDedup pins the stability property
+// familyPartitionKeys' own doc comment promises:
+//
+//	"a client retrying the same family with the batch shuffled maps to the
+//	 same partition as the original messages"
+//
+// That holds for shuffling, but the keys are computed over toPublish — the
+// POST-DEDUP slice — so it does not hold when a family member drops out at
+// the Phase 3 GetOrInsertStatus CAS. And a member dropping out is the normal
+// case, not an edge case: the family key is min(family ∩ toPublish), and min
+// over a shrinking set moves.
+//
+// The scenario here is the standard wallet pattern — send the parent, then
+// send parent+child together a moment later (re-sending the parent for
+// safety):
+//
+//  1. POST {P}          → P published, keyed P, lands on partition h(P)
+//  2. POST {P, C}       → P dedups out at RECEIVED, so toPublish = {C}
+//  3. familyPartitionKeys([C], [[P]]) finds no in-batch source for C
+//  4. C is keyed by its OWN txid → partition h(C), which is not h(P)
+//
+// C's dispatcher has never seen P, so handleAdmit does not hold it behind
+// its parent. C broadcasts concurrently with P, draws TX_MISSING_PARENT,
+// burns retry_max_attempts × retry_backoff_ms (10s at defaults), parks at
+// PENDING_RETRY, and waits at least stalePendingRetryAge (5 minutes, a
+// hardcoded const) for the reaper. Under #151's single partition this child
+// was held cleanly and accepted in milliseconds.
+//
+// The same shape occurs on the partial-produce path: SendMessages fails for
+// a subset, the client retries the identical body, the members that already
+// landed dedup out, and the remainder recomputes onto a different partition
+// than the in-flight siblings it is supposed to be co-located with.
+//
+// Computing the keys over `parsed` (the full submitted batch) instead fixes
+// this. The key is only a hash input — it need not be a published txid — so
+// a deduped-out member remaining as the family representative is correct.
+func TestFamilyPartitionKeys_StableUnderPartialDedup(t *testing.T) {
+	parentTx, childTx := parentChildWithParentLowest(t)
+	parentTxid := parentTx.TxID().String()
+	childTxid := childTx.TxID().String()
+
+	// The family key both submissions must agree on. By construction the
+	// parent sorts lowest, so this differs from the child's own txid.
+	familyKey := parentTxid
+
+	// The parent is already known at RECEIVED — it was submitted moments ago
+	// and is still in flight on its partition. The child is new.
+	ms := &mockStore{
+		getOrInsertFn: func(status *models.TransactionStatus) (*models.TransactionStatus, bool, error) {
+			if status.TxID == parentTxid {
+				return &models.TransactionStatus{
+					TxID:      parentTxid,
+					Status:    models.StatusReceived,
+					Timestamp: time.Now(),
+				}, false, nil // found, not inserted → deduped out of toPublish
+			}
+			return nil, true, nil // inserted → published
+		},
+	}
+
+	broker := &kafka.RecordingBroker{}
+	srv, router := setupServerWithStore(broker, ms)
+	defer close(srv.submissionStop)
+
+	body := append(append([]byte(nil), parentTx.Bytes()...), childTx.Bytes()...)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/txs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+
+	broker.Lock()
+	defer broker.Unlock()
+	if len(broker.Batches) != 1 {
+		t.Fatalf("expected 1 SendBatch, got %d", len(broker.Batches))
+	}
+	keys := make(map[string]string, 1)
+	for _, kv := range broker.Batches[0] {
+		val, err := json.Marshal(kv.Value)
+		if err != nil {
+			t.Fatalf("marshal recorded value: %v", err)
+		}
+		var envelope struct {
+			TXID string `json:"txid"`
+		}
+		if err := json.Unmarshal(val, &envelope); err != nil {
+			t.Fatalf("unmarshal recorded envelope: %v", err)
+		}
+		keys[envelope.TXID] = kv.Key
+	}
+
+	got, published := keys[childTxid]
+	if !published {
+		t.Fatalf("child was not published; recorded keys = %v", keys)
+	}
+	if got != familyKey {
+		t.Fatalf("child key = %q, want family key %q.\n"+
+			"The parent deduped out of toPublish, so familyPartitionKeys saw no in-batch "+
+			"source for the child and fell back to its own txid — routing it to a partition "+
+			"its still-in-flight parent is not on. The dispatcher there cannot hold it behind "+
+			"its parent, so it draws TX_MISSING_PARENT and parks at PENDING_RETRY for at "+
+			"least stalePendingRetryAge (5m) instead of being admitted in milliseconds.",
+			got, familyKey)
+	}
+}

--- a/services/api_server/partition_keys.go
+++ b/services/api_server/partition_keys.go
@@ -1,0 +1,98 @@
+package api_server
+
+// familyPartitionKeys returns the Kafka partition key for each tx of a
+// submitted batch. Txs connected through in-batch spends — tx i lists an
+// input whose source txid is also in the batch — form a dependency family
+// and share one key: the lexicographically smallest txid of the family.
+// Isolated txs key by their own txid (keys[i] == txids[i]), matching the
+// pre-#295 behavior and the single-submit path.
+//
+// Same key ⇒ same partition ⇒ per-partition Kafka order delivers every
+// parent's admit to its dispatcher before its children's, which is what
+// lets the dep-aware dispatcher keep honoring Teranode's "no parent and
+// child in one /txs batch" contract without a cross-partition dep index.
+// The root is the smallest member (not the first submitted) so the key is
+// order-independent: a client retrying the same family with the batch
+// shuffled maps to the same partition as the original messages.
+//
+// Only same-submission edges join a family. A parent submitted in an
+// earlier HTTP request may land on a different partition than its child;
+// that residual race is absorbed by the propagator's missing-parent
+// safety net rather than by keying (see PropagationConfig.Partitions).
+//
+// inputs[i] holds the source txids of tx i's inputs (collectInputTXIDs).
+// Empty strings and self-references are ignored, mirroring the dispatcher's
+// admission guards. O((N+E)·α(N)) for N txs and E total inputs.
+func familyPartitionKeys(txids []string, inputs [][]string) []string {
+	n := len(txids)
+	if n == 0 {
+		return nil
+	}
+
+	index := make(map[string]int, n)
+	for i, id := range txids {
+		// First occurrence wins; a duplicate txid (store==nil intake path)
+		// unions with its first occurrence below, so both share a key.
+		if _, ok := index[id]; !ok {
+			index[id] = i
+		}
+	}
+
+	parent := make([]int, n)
+	size := make([]int, n)
+	for i := range parent {
+		parent[i] = i
+		size[i] = 1
+	}
+	var find func(int) int
+	find = func(i int) int {
+		for parent[i] != i {
+			parent[i] = parent[parent[i]] // path halving
+			i = parent[i]
+		}
+		return i
+	}
+	union := func(a, b int) {
+		ra, rb := find(a), find(b)
+		if ra == rb {
+			return
+		}
+		if size[ra] < size[rb] {
+			ra, rb = rb, ra
+		}
+		parent[rb] = ra
+		size[ra] += size[rb]
+	}
+
+	for i, ins := range inputs {
+		for _, src := range ins {
+			if src == "" || src == txids[i] {
+				continue
+			}
+			if j, ok := index[src]; ok {
+				union(i, j)
+			}
+		}
+	}
+	// Duplicate txids: union every later occurrence with the first so the
+	// whole family (including children referencing the txid) shares a key.
+	for i, id := range txids {
+		if first := index[id]; first != i {
+			union(i, first)
+		}
+	}
+
+	// Smallest member txid per component, then one key per tx.
+	keyOf := make(map[int]string, n)
+	for i, id := range txids {
+		r := find(i)
+		if cur, ok := keyOf[r]; !ok || id < cur {
+			keyOf[r] = id
+		}
+	}
+	keys := make([]string, n)
+	for i := range txids {
+		keys[i] = keyOf[find(i)]
+	}
+	return keys
+}

--- a/services/api_server/partition_keys.go
+++ b/services/api_server/partition_keys.go
@@ -1,5 +1,11 @@
 package api_server
 
+import (
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+
+	"github.com/bsv-blockchain/arcade/kafka"
+)
+
 // familyPartitionKeys returns the Kafka partition key for each tx of a
 // submitted batch. Txs connected through in-batch spends — tx i lists an
 // input whose source txid is also in the batch — form a dependency family
@@ -94,4 +100,84 @@ func familyPartitionKeys(txids []string, inputs [][]string) []string {
 		keys[i] = keyOf[find(i)]
 	}
 	return keys
+}
+
+// parsedItem is one transaction decoded from a POST /txs body: the parsed
+// transaction, its original wire bytes, and its canonical txid.
+type parsedItem struct {
+	tx   *sdkTx.Transaction
+	raw  []byte
+	txid string
+}
+
+// familyKeysBySubmittedTxid computes the dependency-family partition key and
+// the parent-txid list for every transaction in a submitted batch, indexed by
+// txid.
+//
+// It deliberately runs over the FULL submitted batch rather than over the
+// post-dedup publish set, because the family key is min(family) and therefore
+// moves whenever a member leaves the set — and members leave constantly, since
+// the intake dedup CAS drops every tx already known at a non-REJECTED status.
+//
+// The failure that causes: a client sends POST {P}, then POST {P, C} moments
+// later (re-sending the parent for safety). P dedups out, so a key computed
+// over the publish set sees no in-batch parent for C and falls back to C's own
+// txid — routing C to a partition its still-in-flight parent is not on, where
+// that dispatcher's inFlight map has never heard of P and cannot hold C behind
+// it. C draws TX_MISSING_PARENT and parks at PENDING_RETRY, when on a
+// single-partition topic it was admitted in milliseconds. The partial-produce
+// retry path has the same shape: the members that already landed dedup out on
+// the retry, and the remainder recomputes onto a different partition than its
+// own in-flight siblings.
+//
+// A deduped-out member remaining as the family representative is fine: the key
+// is only a hash input and need not be a txid this request publishes.
+func familyKeysBySubmittedTxid(parsed []parsedItem) (keyByTxid map[string]string, inputsByTxid map[string][]string) {
+	txids := make([]string, len(parsed))
+	inputs := make([][]string, len(parsed))
+	for i, p := range parsed {
+		txids[i] = p.txid
+		inputs[i] = collectInputTXIDs(p.tx)
+	}
+	keys := familyPartitionKeys(txids, inputs)
+
+	keyByTxid = make(map[string]string, len(parsed))
+	inputsByTxid = make(map[string][]string, len(parsed))
+	for i, p := range parsed {
+		if _, ok := keyByTxid[p.txid]; ok {
+			continue // duplicate txid in one body: first occurrence wins
+		}
+		keyByTxid[p.txid] = keys[i]
+		inputsByTxid[p.txid] = inputs[i]
+	}
+	return keyByTxid, inputsByTxid
+}
+
+// propagationMessages builds the Kafka envelopes for the txs a submission
+// actually publishes, keyed by dependency family.
+//
+// input_txids drives the dispatcher's dep-aware admission — children of any
+// in-flight parent are held until the parent terminalizes — and the key is
+// what co-locates a family on one partition so that hold is possible at all.
+//
+// keyByTxid/inputsByTxid come from familyKeysBySubmittedTxid over the full
+// submitted batch, so every published tx is present; the txid fallback is
+// belt-and-braces for a future caller whose publish set is not a subset.
+func propagationMessages(toPublish []parsedItem, keyByTxid map[string]string, inputsByTxid map[string][]string) []kafka.KeyValue {
+	msgs := make([]kafka.KeyValue, 0, len(toPublish))
+	for _, p := range toPublish {
+		key, ok := keyByTxid[p.txid]
+		if !ok {
+			key = p.txid
+		}
+		msgs = append(msgs, kafka.KeyValue{
+			Key: key,
+			Value: map[string]interface{}{
+				"txid":        p.txid,
+				"raw_tx":      p.raw,
+				"input_txids": inputsByTxid[p.txid],
+			},
+		})
+	}
+	return msgs
 }

--- a/services/api_server/partition_keys.go
+++ b/services/api_server/partition_keys.go
@@ -44,8 +44,7 @@ func familyPartitionKeys(txids []string, inputs [][]string) []string {
 		parent[i] = i
 		size[i] = 1
 	}
-	var find func(int) int
-	find = func(i int) int {
+	find := func(i int) int {
 		for parent[i] != i {
 			parent[i] = parent[parent[i]] // path halving
 			i = parent[i]

--- a/services/api_server/partition_keys_test.go
+++ b/services/api_server/partition_keys_test.go
@@ -1,0 +1,231 @@
+package api_server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bsv-blockchain/go-sdk/script"
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+
+	"github.com/bsv-blockchain/arcade/kafka"
+)
+
+// txidA < txidB < txidC … lexicographically; realistic 64-hex shapes so the
+// tests read like production data.
+var (
+	txidA = strings.Repeat("a", 64)
+	txidB = strings.Repeat("b", 64)
+	txidC = strings.Repeat("c", 64)
+	txidD = strings.Repeat("d", 64)
+	txidE = strings.Repeat("e", 64)
+	// An out-of-batch ancestor (confirmed on chain, never submitted here).
+	txidZ = strings.Repeat("0", 63) + "f"
+)
+
+func assertKeys(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("key count = %d, want %d (got %v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("keys[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestFamilyPartitionKeys_IsolatedTxsKeyByOwnTxid pins the degenerate
+// case: txs with no in-batch relatives keep today's key (their own
+// txid), so single-tx submissions and independent batch members hash
+// exactly as before #295.
+func TestFamilyPartitionKeys_IsolatedTxsKeyByOwnTxid(t *testing.T) {
+	keys := familyPartitionKeys(
+		[]string{txidB, txidC},
+		[][]string{{txidZ}, {txidZ}},
+	)
+	assertKeys(t, keys, []string{txidB, txidC})
+}
+
+// TestFamilyPartitionKeys_StarFamilySharesOneKey pins the headline #295
+// use case: two parents and their children submitted in one batch all
+// share one partition key — the lexicographically smallest family
+// member — so per-partition Kafka order preserves parent-before-child.
+func TestFamilyPartitionKeys_StarFamilySharesOneKey(t *testing.T) {
+	// D and E are parents; A, B, C are children spending them (A spends
+	// both — the fan-in that joins the two parents into one family).
+	keys := familyPartitionKeys(
+		[]string{txidD, txidE, txidA, txidB, txidC},
+		[][]string{{txidZ}, {txidZ}, {txidD, txidE}, {txidD}, {txidE}},
+	)
+	assertKeys(t, keys, []string{txidA, txidA, txidA, txidA, txidA})
+}
+
+// TestFamilyPartitionKeys_ChainIsTransitive pins transitivity: a → b → c
+// (grandparent/parent/child) is one family even though c never
+// references a directly.
+func TestFamilyPartitionKeys_ChainIsTransitive(t *testing.T) {
+	keys := familyPartitionKeys(
+		[]string{txidA, txidB, txidC},
+		[][]string{{txidZ}, {txidA}, {txidB}},
+	)
+	assertKeys(t, keys, []string{txidA, txidA, txidA})
+}
+
+// TestFamilyPartitionKeys_DisjointFamiliesStaySeparate pins that
+// unrelated families get different keys — this is what lets independent
+// traffic spread across partitions.
+func TestFamilyPartitionKeys_DisjointFamiliesStaySeparate(t *testing.T) {
+	keys := familyPartitionKeys(
+		[]string{txidA, txidB, txidC, txidD},
+		[][]string{{txidZ}, {txidA}, {txidZ}, {txidC}},
+	)
+	assertKeys(t, keys, []string{txidA, txidA, txidC, txidC})
+}
+
+// TestFamilyPartitionKeys_OutOfBatchParentDoesNotJoin pins that spending
+// an outpoint of a tx NOT in this batch never links two txs: two
+// siblings spending different outputs of the same confirmed ancestor
+// are independent for ordering purposes (the ancestor is already on
+// chain; neither needs to wait for the other).
+func TestFamilyPartitionKeys_OutOfBatchParentDoesNotJoin(t *testing.T) {
+	keys := familyPartitionKeys(
+		[]string{txidB, txidC},
+		[][]string{{txidZ}, {txidZ}},
+	)
+	if keys[0] == keys[1] {
+		t.Fatalf("siblings of an out-of-batch parent must not share a key, both got %q", keys[0])
+	}
+}
+
+// TestFamilyPartitionKeys_OrderIndependent pins the root-choice
+// property that makes resubmission safe: reordering the batch must not
+// change any tx's key, otherwise a client retry with a shuffled batch
+// would remap the family to a different partition than the original
+// messages.
+func TestFamilyPartitionKeys_OrderIndependent(t *testing.T) {
+	forward := familyPartitionKeys(
+		[]string{txidD, txidB, txidC},
+		[][]string{{txidZ}, {txidD}, {txidB}},
+	)
+	reversed := familyPartitionKeys(
+		[]string{txidC, txidB, txidD},
+		[][]string{{txidB}, {txidD}, {txidZ}},
+	)
+	if forward[0] != reversed[2] || forward[1] != reversed[1] || forward[2] != reversed[0] {
+		t.Fatalf("keys changed under reordering: forward=%v reversed=%v", forward, reversed)
+	}
+	if forward[0] != txidB {
+		t.Errorf("family key = %q, want lexicographically smallest member %q", forward[0], txidB)
+	}
+}
+
+// TestFamilyPartitionKeys_SelfAndEmptyRefsIgnored pins the defensive
+// guards (mirroring dispatcher handleAdmit): an empty input txid or a
+// self-reference must not join anything or panic.
+func TestFamilyPartitionKeys_SelfAndEmptyRefsIgnored(t *testing.T) {
+	keys := familyPartitionKeys(
+		[]string{txidA, txidB},
+		[][]string{{"", txidA}, {""}},
+	)
+	assertKeys(t, keys, []string{txidA, txidB})
+}
+
+// TestFamilyPartitionKeys_DuplicateTxidDoesNotPanic pins the store==nil
+// intake path where dedup is skipped and the same txid can appear twice
+// in one batch: both occurrences get the same key and nothing panics.
+func TestFamilyPartitionKeys_DuplicateTxidDoesNotPanic(t *testing.T) {
+	keys := familyPartitionKeys(
+		[]string{txidA, txidA, txidB},
+		[][]string{{txidZ}, {txidZ}, {txidA}},
+	)
+	if keys[0] != keys[1] {
+		t.Errorf("duplicate txid occurrences diverged: %q vs %q", keys[0], keys[1])
+	}
+	if keys[2] != keys[0] {
+		t.Errorf("child of duplicated parent got %q, want family key %q", keys[2], keys[0])
+	}
+}
+
+// TestFamilyPartitionKeys_EmptyBatch pins the trivial bound.
+func TestFamilyPartitionKeys_EmptyBatch(t *testing.T) {
+	if keys := familyPartitionKeys(nil, nil); len(keys) != 0 {
+		t.Fatalf("expected empty result for empty batch, got %v", keys)
+	}
+}
+
+// --- intake wiring ---
+
+// TestHandleSubmitTransactions_FamilyKeyedPublish pins the #295 intake
+// wiring: a batch containing a parent, its child, and an unrelated tx
+// must publish the parent and child under one shared partition key (the
+// lexicographically smallest family member's txid) and the unrelated tx
+// under its own txid. Without family keying, a multi-partition topic
+// would hash parent and child to different partitions and lose their
+// relative order.
+func TestHandleSubmitTransactions_FamilyKeyedPublish(t *testing.T) {
+	parentTx := sdkTx.NewTransaction()
+	parentTx.AddOutput(&sdkTx.TransactionOutput{Satoshis: 0, LockingScript: &script.Script{}})
+	parentHash := parentTx.TxID()
+	parentTxid := parentHash.String()
+
+	childTx := sdkTx.NewTransaction()
+	childTx.Inputs = append(childTx.Inputs, &sdkTx.TransactionInput{
+		SourceTXID:       parentHash,
+		SourceTxOutIndex: 0,
+		SequenceNumber:   sdkTx.DefaultSequenceNumber,
+	})
+	childTxid := childTx.TxID().String()
+
+	loner := sdkTx.NewTransaction()
+	lonerTxid := loner.TxID().String()
+
+	familyKey := parentTxid
+	if childTxid < familyKey {
+		familyKey = childTxid
+	}
+
+	broker := &kafka.RecordingBroker{}
+	_, router := setupServer(broker)
+
+	body := append(append(append([]byte(nil), parentTx.Bytes()...), childTx.Bytes()...), loner.Bytes()...)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/txs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+	broker.Lock()
+	defer broker.Unlock()
+	if len(broker.Batches) != 1 {
+		t.Fatalf("expected 1 SendBatch, got %d", len(broker.Batches))
+	}
+	keys := make(map[string]string, 3)
+	for _, kv := range broker.Batches[0] {
+		val, err := json.Marshal(kv.Value)
+		if err != nil {
+			t.Fatalf("marshal recorded value: %v", err)
+		}
+		var envelope struct {
+			TXID string `json:"txid"`
+		}
+		if err := json.Unmarshal(val, &envelope); err != nil {
+			t.Fatalf("unmarshal recorded envelope: %v", err)
+		}
+		keys[envelope.TXID] = kv.Key
+	}
+	if keys[parentTxid] != familyKey {
+		t.Errorf("parent key = %q, want family key %q", keys[parentTxid], familyKey)
+	}
+	if keys[childTxid] != familyKey {
+		t.Errorf("child key = %q, want family key %q", keys[childTxid], familyKey)
+	}
+	if keys[lonerTxid] != lonerTxid {
+		t.Errorf("unrelated tx key = %q, want its own txid %q", keys[lonerTxid], lonerTxid)
+	}
+}

--- a/services/propagation/depaware_test.go
+++ b/services/propagation/depaware_test.go
@@ -141,7 +141,7 @@ func TestApplyTerminalStatuses_ReleasesWaitersOnAccepted(t *testing.T) {
 
 	p.applyTerminalStatuses(context.Background(), []*models.TransactionStatus{
 		{TxID: "parent", Status: models.StatusAcceptedByNetwork, Timestamp: time.Now()},
-	}, 1, 0)
+	}, 1, 0, p.defaultIO)
 
 	if got := drainSet(p); !got["child"] {
 		t.Errorf("child should be released into pending batch after parent ACCEPTED; got %v", got)
@@ -174,7 +174,7 @@ func TestApplyTerminalStatuses_CascadesRejectedChildren(t *testing.T) {
 
 	p.applyTerminalStatuses(context.Background(), []*models.TransactionStatus{
 		{TxID: "parent", Status: models.StatusRejected, Timestamp: time.Now(), ExtraInfo: "bad parent"},
-	}, 0, 1)
+	}, 0, 1, p.defaultIO)
 
 	if got := drainSet(p); got["child"] || got["grandchild"] {
 		t.Errorf("cascaded descendants should NOT enter pending batch; got %v", got)
@@ -237,7 +237,7 @@ func TestSequentialReleaseDeepChain(t *testing.T) {
 	// because parent is still in-flight (just queued for broadcast).
 	p.applyTerminalStatuses(context.Background(), []*models.TransactionStatus{
 		{TxID: "grandparent", Status: models.StatusAcceptedByNetwork, Timestamp: time.Now()},
-	}, 1, 0)
+	}, 1, 0, p.defaultIO)
 
 	got := drainSet(p)
 	if !got["parent"] {
@@ -250,7 +250,7 @@ func TestSequentialReleaseDeepChain(t *testing.T) {
 	// parent ACCEPTED in its own batch — now child can release.
 	p.applyTerminalStatuses(context.Background(), []*models.TransactionStatus{
 		{TxID: "parent", Status: models.StatusAcceptedByNetwork, Timestamp: time.Now()},
-	}, 1, 0)
+	}, 1, 0, p.defaultIO)
 
 	got = drainSet(p)
 	if !got["child"] {
@@ -411,7 +411,7 @@ func TestRequeueAfterDelay_PendingRequeuesGauge(t *testing.T) {
 	t.Cleanup(cancel)
 
 	msgs := []propagationMsg{{TXID: "a", RawTx: []byte{0x01}}}
-	p.requeueAfterDelay(ctx, msgs)
+	p.requeueAfterDelay(ctx, msgs, p.defaultIO)
 
 	if got := testutil.ToFloat64(metrics.PropagationPendingRequeues); got != startVal+1 {
 		t.Fatalf("after requeueAfterDelay gauge = %v, want %v (inc by 1)", got, startVal+1)
@@ -442,7 +442,7 @@ func TestRequeueAfterDelay_EmptyMsgs_NoGaugeChange(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	startVal := testutil.ToFloat64(metrics.PropagationPendingRequeues)
-	p.requeueAfterDelay(t.Context(), nil)
+	p.requeueAfterDelay(t.Context(), nil, p.defaultIO)
 	if got := testutil.ToFloat64(metrics.PropagationPendingRequeues); got != startVal {
 		t.Fatalf("empty-msgs early-return mutated gauge: got %v, want %v", got, startVal)
 	}

--- a/services/propagation/dispatcher.go
+++ b/services/propagation/dispatcher.go
@@ -379,6 +379,18 @@ func handleAdmit(
 	// new offset and immediately mark it done so advanceMarks can
 	// flush it once the original terminalizes, and return without
 	// touching pendingMsgs.
+	//
+	// Scope, since #295: inFlight is per-claim, so this suppresses
+	// duplicates only on the SAME partition. It is no longer a process-wide
+	// guard and never was a fleet-wide one. Two intake branches can still
+	// publish a txid that is in flight elsewhere — the store-error branch
+	// (which publishes rather than risk dropping a genuinely new tx) and the
+	// REJECTED-resubmit branch. Family keys are computed over the whole
+	// submitted batch, so batch composition no longer moves a txid between
+	// partitions, but a resubmission whose family genuinely differs still
+	// can. The consequence is a duplicate broadcast and racing terminal
+	// writes, which the status lattice absorbs — not something this function
+	// guarantees against.
 	if _, exists := inFlight[msg.TXID]; exists {
 		tracker.Add(offset)
 		tracker.Done(offset)

--- a/services/propagation/dispatcher.go
+++ b/services/propagation/dispatcher.go
@@ -76,7 +76,7 @@ type terminalEvent struct {
 // re-enters them into pendingMsgs directly, so the next flushBatch
 // picks them up without any caller action.
 type terminalResult struct {
-	cascaded []string
+	cascaded []cascadedTx
 }
 
 // drainRequest is the protocol between flushBatch and the dispatcher.
@@ -612,14 +612,22 @@ func canRelease(
 // their own, only because an ancestor did. Every cascaded descendant's
 // Kafka offset is marked Done on the tracker so the commit watermark
 // can advance past them once the caller writes the REJECTED rows.
+// cascadedTx is one descendant terminalized by a cascade, carrying the raw
+// bytes captured from its held message so a parked descendant can be booked
+// into the durable retry queue.
+type cascadedTx struct {
+	txid  string
+	rawTx []byte
+}
+
 func cascadeReject(
 	rejectedTxID string,
 	inFlight map[string]int64,
 	waiters map[string]map[string]struct{},
 	heldMsgs map[string]propagationMsg,
 	tracker *offsetTracker,
-) []string {
-	var cascaded []string
+) []cascadedTx {
+	var cascaded []cascadedTx
 	queue := []string{rejectedTxID}
 	for len(queue) > 0 {
 		parent := queue[0]
@@ -631,12 +639,18 @@ func cascadeReject(
 		delete(waiters, parent)
 		for child := range children {
 			cleanupWaiterEntries(child, parent, waiters, heldMsgs)
+			// Capture the raw bytes BEFORE dropping the held message. A
+			// descendant parked by this cascade has to enter the durable
+			// retry queue, and that needs a body to rebroadcast — without it
+			// the row would sit at PENDING_RETRY with no next_retry_at, which
+			// GetReadyRetries cannot see.
+			rawTx := heldMsgs[child].RawTx
 			delete(heldMsgs, child)
 			if offset, ok := inFlight[child]; ok {
 				tracker.Done(offset)
 			}
 			delete(inFlight, child)
-			cascaded = append(cascaded, child)
+			cascaded = append(cascaded, cascadedTx{txid: child, rawTx: rawTx})
 			queue = append(queue, child)
 		}
 	}

--- a/services/propagation/dispatcher.go
+++ b/services/propagation/dispatcher.go
@@ -102,6 +102,38 @@ type dispatcherConfig struct {
 	maxPending int
 }
 
+// dispatcherIO is one dispatcher instance's channel set. Pre-#295 these
+// channels lived directly on the Propagator; with a multi-partition
+// topic Sarama runs one runDispatcher per assigned partition claim, and
+// a SHARED channel set would let partition B's loop consume partition
+// A's terminal event — B's handleTerminal would no-op the unknown txid,
+// A's offset would never be Done'd, and A's commit watermark would
+// freeze permanently. Every claim therefore gets its own dispatcherIO;
+// the batch pipeline spawned by a dispatcher carries its io along so
+// replies route back to the loop whose inFlight map owns the tx.
+//
+// The reaper terminalizes txs off any claim's Kafka path — it passes a
+// nil io to applyTerminalStatuses, which fans the event out to every
+// registered dispatcher (at most one owns the tx; the rest no-op).
+type dispatcherIO struct {
+	admitCh    chan admitRequest
+	requeueCh  chan requeueRequest
+	terminalCh chan terminalEvent
+	drainCh    chan drainRequest
+}
+
+// newDispatcherIO builds a channel set for one dispatcher instance.
+// drainCh is unbuffered (request/reply handshake); the rest use
+// dispatcherChannelBuffer to absorb bursts.
+func newDispatcherIO() *dispatcherIO {
+	return &dispatcherIO{
+		admitCh:    make(chan admitRequest, dispatcherChannelBuffer),
+		requeueCh:  make(chan requeueRequest, dispatcherChannelBuffer),
+		terminalCh: make(chan terminalEvent, dispatcherChannelBuffer),
+		drainCh:    make(chan drainRequest),
+	}
+}
+
 // runDispatcher is the single state-owning loop. ALL dep-aware state
 // (inFlight, waiters, heldMsgs, pendingMsgs, the offsetTracker, and the
 // per-offset *kafka.Message references used for marking) lives in this
@@ -117,18 +149,27 @@ type dispatcherConfig struct {
 //   - Test: invoked with a nil claim from a goroutine started by tests.
 //     admitCh is the message source; no MarkMessage calls.
 //
-// One goroutine, no locks, no atomics.
-func (p *Propagator) runDispatcher(ctx context.Context, claim kafka.Claim, cfg dispatcherConfig) error {
+// One goroutine, no locks, no atomics (the registry and depth mirrors on
+// the Propagator are the deliberate exceptions — see registerDispatcher
+// and the delta accounting below).
+func (p *Propagator) runDispatcher(ctx context.Context, claim kafka.Claim, cfg dispatcherConfig, io *dispatcherIO) error {
+	// Registration makes this loop reachable by the reaper's nil-io
+	// fan-out; deregistering on exit keeps a dead loop's channels from
+	// absorbing (and eventually blocking) fan-out sends.
+	p.registerDispatcher(io)
+	defer p.deregisterDispatcher(io)
+
 	inFlight := make(map[string]int64)
 	waiters := make(map[string]map[string]struct{})
 	heldMsgs := make(map[string]propagationMsg)
 	var pendingMsgs []propagationMsg
 	tracker := newOffsetTracker()
-	// pendingMarks is the per-offset Kafka-message reference we hand back
-	// to claim.MarkMessage when its offset terminalizes. Only populated
-	// when claim != nil; in test mode admitRequests carry no Kafka
-	// message and pendingMarks stays empty.
-	pendingMarks := make(map[int64]*kafka.Message)
+	// marks queues consumed Kafka messages until the commit watermark
+	// passes their offset; the 50ms flush tick (and the exit paths)
+	// advance it. Only populated when claim != nil; in test mode
+	// admitRequests carry no Kafka message and the queue stays empty.
+	// See markQueue for why this is a queue, not a map (#295).
+	marks := &markQueue{}
 
 	var claimMsgCh <-chan *kafka.Message
 	if claim != nil {
@@ -147,27 +188,40 @@ func (p *Propagator) runDispatcher(ctx context.Context, claim kafka.Claim, cfg d
 		flushTickC = t.C
 	}
 
+	// Depth accounting is delta-based (#295): with one dispatcher per
+	// partition claim, absolute Set()s from several loops would fight
+	// last-writer-wins. Each loop Adds only its own change, so the gauge
+	// and the Propagator-level atomic mirrors read as the POD TOTAL
+	// across owned partitions — which is what dashboards and the
+	// reaper's backlog log line want. The deferred removal zeroes this
+	// loop's contribution on exit so a rebalanced-away partition doesn't
+	// leave phantom depth behind.
+	//
+	// inFlight is the REAL backlog: every admitted-or-held tx whose
+	// Kafka offset is pinned below the commit watermark but which
+	// hasn't reached a terminal verdict. The pending gauge alone is
+	// misleading under load — admission backpressure caps it at
+	// maxPending, so during the 2026-08-10 load test a ~466k-tx
+	// uncommitted-offset backlog was invisible behind a flat pending
+	// depth.
+	var prevPending, prevInflight int
+	defer func() {
+		metrics.PropagationPendingDepth.Sub(float64(prevPending))
+		p.pendingDepth.Add(int64(-prevPending))
+		metrics.PropagationInflightDepth.Sub(float64(prevInflight))
+		p.inflightDepth.Add(int64(-prevInflight))
+	}()
+
 	for {
-		// Keep the depth gauges in sync at the top of every iteration.
-		// Every branch below that mutates pendingMsgs or inFlight
-		// (handleAdmit, handleRequeue, handleTerminal, drain, flush)
-		// is observed exactly once before the next select fires.
-		// A few atomic writes per iteration are negligible vs the
-		// throughput the dispatcher handles.
-		//
-		// inFlight is the REAL backlog: every admitted-or-held tx whose
-		// Kafka offset is pinned below the commit watermark but which
-		// hasn't reached a terminal verdict. The pending gauge alone is
-		// misleading under load — admission backpressure caps it at
-		// maxPending, so during the 2026-08-10 load test a ~466k-tx
-		// uncommitted-offset backlog was invisible behind a flat pending
-		// depth. The Propagator-level atomics mirror the gauges so the
-		// reaper's per-tick backlog log line can read them without a
-		// Prometheus read API.
-		metrics.PropagationPendingDepth.Set(float64(len(pendingMsgs)))
-		p.pendingDepth.Store(int64(len(pendingMsgs)))
-		metrics.PropagationInflightDepth.Set(float64(len(inFlight)))
-		p.inflightDepth.Store(int64(len(inFlight)))
+		// Observe depth changes at the top of every iteration: every
+		// branch below that mutates pendingMsgs or inFlight is seen
+		// exactly once before the next select fires.
+		metrics.PropagationPendingDepth.Add(float64(len(pendingMsgs) - prevPending))
+		p.pendingDepth.Add(int64(len(pendingMsgs) - prevPending))
+		prevPending = len(pendingMsgs)
+		metrics.PropagationInflightDepth.Add(float64(len(inFlight) - prevInflight))
+		p.inflightDepth.Add(int64(len(inFlight) - prevInflight))
+		prevInflight = len(inFlight)
 
 		// Backpressure: nil-channel trick excludes incoming-message
 		// sources from the select when pendingMsgs is at cap. Both
@@ -176,18 +230,25 @@ func (p *Propagator) runDispatcher(ctx context.Context, claim kafka.Claim, cfg d
 		var admitChIfRoom <-chan admitRequest
 		var claimChIfRoom <-chan *kafka.Message
 		if cfg.maxPending <= 0 || len(pendingMsgs) < cfg.maxPending {
-			admitChIfRoom = p.admitCh
+			admitChIfRoom = io.admitCh
 			claimChIfRoom = claimMsgCh
 		}
 
 		select {
 		case <-ctx.Done():
+			// Final drain: commit anything the watermark already passed
+			// so a clean teardown doesn't strand up to one tick's worth
+			// of finished work for replay. Still-unfinished offsets are
+			// never marked, so a revoked claim's in-flight work replays
+			// exactly as before.
+			marks.advance(claim, tracker)
 			return nil
 
 		case msg, ok := <-claimChIfRoom:
 			if !ok {
 				// Claim channel closed → claim ended; exit cleanly so
-				// Sarama can move on.
+				// Sarama can move on. Same final drain as ctx.Done.
+				marks.advance(claim, tracker)
 				return nil
 			}
 			var propMsg propagationMsg
@@ -225,26 +286,34 @@ func (p *Propagator) runDispatcher(ctx context.Context, claim kafka.Claim, cfg d
 			// safe to use here.
 			propMsg.spanCtx = trace.SpanContextFromContext(kafka.ExtractTraceContext(ctx, msg.Headers))
 			handleAdmit(propMsg, msg.Offset, inFlight, waiters, heldMsgs, &pendingMsgs, tracker)
-			pendingMarks[msg.Offset] = msg
+			marks.push(msg)
 
 		case req := <-admitChIfRoom:
 			res := handleAdmit(req.msg, req.offset, inFlight, waiters, heldMsgs, &pendingMsgs, tracker)
 			req.reply <- res
 
-		case req := <-p.requeueCh:
+		case req := <-io.requeueCh:
 			handleRequeue(req.msg, inFlight, waiters, heldMsgs, &pendingMsgs)
 
-		case ev := <-p.terminalCh:
+		case ev := <-io.terminalCh:
 			result := handleTerminal(ev, inFlight, waiters, heldMsgs, &pendingMsgs, tracker)
 			ev.reply <- result
-			advanceMarks(claim, tracker, pendingMarks)
+			// Marking moved to the flush tick: running the queue advance
+			// here per terminal event was the O(terminals × in-flight)
+			// serial hot spot of issue #295. The 50ms tick amortizes it
+			// (and the queue makes each advance O(newly-markable)).
 
-		case req := <-p.drainCh:
+		case req := <-io.drainCh:
 			batch := pendingMsgs
 			pendingMsgs = nil
 			req.reply <- batch
 
 		case <-flushTickC:
+			// Commit-watermark maintenance rides the existing production
+			// ticker: no extra timer, stays on the dispatcher goroutine
+			// (no-locks invariant), and runs whether or not there is a
+			// batch to flush.
+			marks.advance(claim, tracker)
 			if len(pendingMsgs) == 0 {
 				continue
 			}
@@ -268,27 +337,9 @@ func (p *Propagator) runDispatcher(ctx context.Context, claim kafka.Claim, cfg d
 					p.inflightBatches.Done()
 					metrics.PropagationInflightBatches.Set(float64(len(p.processBatchSem)))
 				}()
-				p.processBatch(ctx, batch)
+				p.processBatch(ctx, batch, io)
 			}()
 		}
-	}
-}
-
-// advanceMarks walks pendingMarks and calls claim.MarkMessage on every
-// offset that is strictly below the dispatcher's current lowest in-flight
-// offset. Idempotent and cheap when nothing has advanced. No-op when
-// claim is nil (test mode).
-func advanceMarks(claim kafka.Claim, tracker *offsetTracker, pendingMarks map[int64]*kafka.Message) {
-	if claim == nil {
-		return
-	}
-	lowest, hasUnfinished := tracker.LowestUnfinished()
-	for offset, msg := range pendingMarks {
-		if hasUnfinished && offset >= lowest {
-			continue
-		}
-		claim.MarkMessage(msg)
-		delete(pendingMarks, offset)
 	}
 }
 
@@ -618,17 +669,58 @@ func cleanupWaiterEntries(
 // workers.
 const dispatcherChannelBuffer = 256
 
+// registerDispatcher / deregisterDispatcher maintain the set of live
+// dispatcher loops. The registry exists for exactly one caller: the
+// reaper's nil-io fan-out in notifyTerminalToDispatcher. Everything on
+// a claim's own pipeline carries its dispatcherIO explicitly.
+func (p *Propagator) registerDispatcher(io *dispatcherIO) {
+	p.dispatchersMu.Lock()
+	p.dispatchers[io] = struct{}{}
+	p.dispatchersMu.Unlock()
+}
+
+func (p *Propagator) deregisterDispatcher(io *dispatcherIO) {
+	p.dispatchersMu.Lock()
+	delete(p.dispatchers, io)
+	p.dispatchersMu.Unlock()
+}
+
+// dispatcherTargets resolves which dispatcher(s) an event should reach:
+// the explicit io when the caller runs on a claim's pipeline, or a
+// snapshot of every live dispatcher for io == nil (reaper path — the
+// owning dispatcher, if any, releases the tx; the rest no-op).
+func (p *Propagator) dispatcherTargets(io *dispatcherIO) []*dispatcherIO {
+	if io != nil {
+		return []*dispatcherIO{io}
+	}
+	p.dispatchersMu.RLock()
+	defer p.dispatchersMu.RUnlock()
+	targets := make([]*dispatcherIO, 0, len(p.dispatchers))
+	for d := range p.dispatchers {
+		targets = append(targets, d)
+	}
+	return targets
+}
+
 // admitToDispatcher is the consumer-side helper. Sends the tx and its
-// Kafka offset, waits for the dispatcher's verdict, returns it.
+// Kafka offset, waits for the dispatcher's verdict, returns it. Only
+// used by the test-mode message path, so it always targets the default
+// dispatcher.
 func (p *Propagator) admitToDispatcher(msg propagationMsg, offset int64) admitResult {
 	reply := make(chan admitResult, 1)
-	p.admitCh <- admitRequest{msg: msg, offset: offset, reply: reply}
+	p.defaultIO.admitCh <- admitRequest{msg: msg, offset: offset, reply: reply}
 	return <-reply
 }
 
 // notifyTerminalToDispatcher is the post-broadcast helper. Tells the
 // dispatcher the txid reached terminal status, returns the cascaded
 // descendants (caller writes REJECTED rows for them).
+//
+// io names the dispatcher whose pipeline produced this terminal; a nil
+// io (reaper path — no claim of its own) fans the event out to every
+// registered dispatcher and merges the cascades: at most one dispatcher
+// owns the tx, the rest no-op, preserving the pre-#295 behavior where a
+// reaper verdict could release a tx wedged in a live dispatcher.
 //
 // Both the send and the reply receive are guarded by ctx. processBatch
 // goroutines outlive the dispatcher on a claim teardown (rebalance /
@@ -639,16 +731,33 @@ func (p *Propagator) admitToDispatcher(msg propagationMsg, offset int64) admitRe
 // offset is simply left un-Done and uncommitted, and the next claim
 // replays it (at-least-once). reply is buffered so a late dispatcher
 // answer after we've stopped waiting never blocks the dispatcher.
-func (p *Propagator) notifyTerminalToDispatcher(ctx context.Context, txid string, status models.Status) terminalResult {
+func (p *Propagator) notifyTerminalToDispatcher(ctx context.Context, io *dispatcherIO, txid string, status models.Status) terminalResult {
+	var merged terminalResult
+	for _, target := range p.dispatcherTargets(io) {
+		r, ok := p.notifyTerminalToOne(ctx, target, txid, status)
+		if !ok {
+			// ctx died mid-fan-out; whatever we already collected is
+			// still valid cascade output.
+			break
+		}
+		merged.cascaded = append(merged.cascaded, r.cascaded...)
+	}
+	return merged
+}
+
+// notifyTerminalToOne performs the single-dispatcher send/reply
+// round-trip described on notifyTerminalToDispatcher. The bool is false
+// when ctx was canceled before a reply was obtained.
+func (p *Propagator) notifyTerminalToOne(ctx context.Context, io *dispatcherIO, txid string, status models.Status) (terminalResult, bool) {
 	reply := make(chan terminalResult, 1)
 	select {
-	case p.terminalCh <- terminalEvent{txid: txid, status: status, reply: reply}:
+	case io.terminalCh <- terminalEvent{txid: txid, status: status, reply: reply}:
 	case <-ctx.Done():
-		return terminalResult{}
+		return terminalResult{}, false
 	}
 	select {
 	case r := <-reply:
-		return r
+		return r, true
 	case <-ctx.Done():
 		// ctx and reply can both be ready at once, and select picks a
 		// ready case at random — so a teardown could win even though the
@@ -659,20 +768,21 @@ func (p *Propagator) notifyTerminalToDispatcher(ctx context.Context, txid string
 		// cancellation with a final non-blocking read.
 		select {
 		case r := <-reply:
-			return r
+			return r, true
 		default:
-			return terminalResult{}
+			return terminalResult{}, false
 		}
 	}
 }
 
-// drainPending asks the dispatcher for the current pendingMsgs as a
-// batch. The dispatcher clears its slice and hands the snapshot to
-// the caller; the caller owns it fully and processBatch can mutate
-// it as needed.
+// drainPending asks the default dispatcher for the current pendingMsgs
+// as a batch (test-mode path only — production flushes happen inside
+// runDispatcher's own tick). The dispatcher clears its slice and hands
+// the snapshot to the caller; the caller owns it fully and processBatch
+// can mutate it as needed.
 func (p *Propagator) drainPending() []propagationMsg {
 	reply := make(chan []propagationMsg, 1)
-	p.drainCh <- drainRequest{reply: reply}
+	p.defaultIO.drainCh <- drainRequest{reply: reply}
 	return <-reply
 }
 
@@ -688,9 +798,9 @@ func (p *Propagator) drainPending() []propagationMsg {
 // if the requeue was handed to the dispatcher, false if ctx was
 // canceled first — in which case the tx is left uncommitted for the
 // next claim to replay.
-func (p *Propagator) requeueToDispatcher(ctx context.Context, msg propagationMsg) bool {
+func (p *Propagator) requeueToDispatcher(ctx context.Context, io *dispatcherIO, msg propagationMsg) bool {
 	select {
-	case p.requeueCh <- requeueRequest{msg: msg}:
+	case io.requeueCh <- requeueRequest{msg: msg}:
 		return true
 	case <-ctx.Done():
 		return false

--- a/services/propagation/dispatcher_routing_test.go
+++ b/services/propagation/dispatcher_routing_test.go
@@ -1,0 +1,125 @@
+package propagation
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/arcade/kafka"
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// waitForInflight polls the propagator's inflight-depth mirror until it
+// reaches want, or fails after ~3s.
+func waitForInflight(t *testing.T, p *Propagator, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.inflightDepth.Load() == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("inflight depth never reached %d (now %d)", want, p.inflightDepth.Load())
+}
+
+// startDispatcherWithIO runs a production dispatcher loop against its own
+// fakeClaim and its own dispatcherIO — the multi-partition shape: Sarama
+// gives each partition claim its own goroutine, and #295 gives each its
+// own channel set so events can only reach the dispatcher whose inFlight
+// map owns the tx. Callers must have stopped the New()-spawned test-mode
+// dispatcher first (see runDispatcherWithClaim for why).
+func startDispatcherWithIO(t *testing.T, p *Propagator, io *dispatcherIO) (*fakeClaim, func()) {
+	t.Helper()
+	claimCtx, cancel := context.WithCancel(context.Background())
+	claim := newFakeClaim(claimCtx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = p.runDispatcher(claimCtx, claim, dispatcherConfig{maxPending: 1000}, io)
+	}()
+	return claim, func() {
+		cancel()
+		<-done
+		p.WaitForBatches()
+	}
+}
+
+// TestRunDispatcher_TwoClaims_RouteTerminalsIndependently pins the #295
+// multi-partition routing contract: with two partition claims live on one
+// pod, a terminal event for a tx admitted on claim A must reach ONLY A's
+// dispatcher. With the pre-#295 shared terminalCh, either loop could
+// consume the other's event; the wrong dispatcher would no-op the
+// unknown txid, the owning tracker would never Done the offset, and that
+// partition's commit watermark would freeze — the head-of-line wedge
+// class from the 2026-08-11 incident, silently reintroduced.
+func TestRunDispatcher_TwoClaims_RouteTerminalsIndependently(t *testing.T) {
+	teranodeSrv := newTeranodeServer(&eventLog{}, http.StatusOK)
+	defer teranodeSrv.Close()
+
+	p := newPropagator("", teranodeSrv.URL, newMockStore())
+	// Stop the New()-spawned test-mode dispatcher: these production loops
+	// replace it (same contract as runDispatcherWithClaim).
+	p.dispatcherCancel()
+	<-p.dispatcherDone
+	p.dispatcherCancel = nil
+
+	claimA, stopA := startDispatcherWithIO(t, p, p.defaultIO)
+	defer stopA()
+	claimB, stopB := startDispatcherWithIO(t, p, newDispatcherIO())
+	defer stopB()
+
+	claimA.ch <- &kafka.Message{Offset: 11, Value: makePropMsg("tx-on-claim-a")}
+	claimB.ch <- &kafka.Message{Offset: 22, Value: makePropMsg("tx-on-claim-b")}
+
+	waitForMark(t, claimA, 11, "claim A's tx must commit on claim A")
+	waitForMark(t, claimB, 22, "claim B's tx must commit on claim B")
+
+	if claimA.isMarked(22) {
+		t.Error("claim A marked claim B's offset — events crossed dispatchers")
+	}
+	if claimB.isMarked(11) {
+		t.Error("claim B marked claim A's offset — events crossed dispatchers")
+	}
+}
+
+// TestApplyTerminalStatuses_NilIO_FansOutToAllDispatchers pins the reaper
+// path: the reaper terminalizes txs off the Kafka path with no claim of
+// its own, so its dispatcher notification (io == nil) must fan out to
+// every registered dispatcher — whichever one holds the tx in flight
+// releases the offset; the rest no-op. This preserves the pre-#295
+// behavior where a reaper verdict could release a tx wedged in the live
+// dispatcher.
+func TestApplyTerminalStatuses_NilIO_FansOutToAllDispatchers(t *testing.T) {
+	// Teranode returns 503 with no verdict body → the tx stays in flight
+	// (requeue path), pinning its offset; only the fan-out notify can
+	// release it.
+	teranodeSrv := newTeranodeServer(&eventLog{}, http.StatusServiceUnavailable)
+	defer teranodeSrv.Close()
+
+	ms := newMockStore()
+	p := newPropagator("", teranodeSrv.URL, ms)
+	p.dispatcherCancel()
+	<-p.dispatcherDone
+	p.dispatcherCancel = nil
+
+	claim, stop := startDispatcherWithIO(t, p, p.defaultIO)
+	defer stop()
+
+	claim.ch <- &kafka.Message{Offset: 31, Value: makePropMsg("reaper-owned-tx")}
+
+	// Wait until the dispatcher actually owns the tx (it admitted and
+	// broadcast it; the 503 keeps it in flight).
+	waitForInflight(t, p, 1)
+
+	// Reaper-style terminalization: no io. The fan-out must reach the
+	// claim's dispatcher and release offset 31.
+	p.applyTerminalStatuses(context.Background(), []*models.TransactionStatus{{
+		TxID:      "reaper-owned-tx",
+		Status:    models.StatusAcceptedByNetwork,
+		Timestamp: time.Now(),
+	}}, 1, 0, nil)
+
+	waitForMark(t, claim, 31, "a nil-io (reaper) terminal must fan out to the owning dispatcher")
+}

--- a/services/propagation/dispatcher_test.go
+++ b/services/propagation/dispatcher_test.go
@@ -260,9 +260,11 @@ var _ kafka.Claim = (*fakeClaim)(nil)
 // commit watermark. Returns the claim and a stop func.
 func runDispatcherWithClaim(t *testing.T, p *Propagator) (*fakeClaim, func()) {
 	t.Helper()
-	// The test-mode and production dispatcher loops share p.terminalCh
-	// et al. and must never run concurrently — cancel the test-mode one
-	// New() spawned and wait for it to exit first.
+	// The test-mode and production dispatcher loops share p.defaultIO
+	// and must never run concurrently — cancel the test-mode one
+	// New() spawned and wait for it to exit first. The production loop
+	// reuses defaultIO so the batch-pipeline helpers tests reach through
+	// the Propagator keep routing to this dispatcher.
 	p.dispatcherCancel()
 	<-p.dispatcherDone
 	p.dispatcherCancel = nil
@@ -272,7 +274,7 @@ func runDispatcherWithClaim(t *testing.T, p *Propagator) (*fakeClaim, func()) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_ = p.runDispatcher(claimCtx, claim, dispatcherConfig{maxPending: 1000})
+		_ = p.runDispatcher(claimCtx, claim, dispatcherConfig{maxPending: 1000}, p.defaultIO)
 	}()
 	return claim, func() {
 		cancel()
@@ -470,7 +472,7 @@ func TestProcessBatch_ClaimRevokedBeforeStart_NoSideEffects(t *testing.T) {
 	p.processBatch(ctx, []propagationMsg{
 		{TXID: "revoked-1", RawTx: []byte{0x01}},
 		{TXID: "revoked-2", RawTx: []byte{0x02}},
-	})
+	}, p.defaultIO)
 
 	if got := httpLog.count("register:"); got != 0 {
 		t.Errorf("no merkle /watch call may run under a revoked claim; got %d", got)
@@ -516,7 +518,7 @@ func TestApplyTerminalStatuses_StoreError_DoesNotReleaseOffset(t *testing.T) {
 	// Terminalize it — but the store write fails.
 	p.applyTerminalStatuses(context.Background(), []*models.TransactionStatus{
 		{TxID: "x", Status: models.StatusAcceptedByNetwork, Timestamp: time.Now()},
-	}, 1, 0)
+	}, 1, 0, p.defaultIO)
 
 	// The dispatcher must NOT have been notified: "x" is still in flight,
 	// so a re-admission is detected as a duplicate (offset bookkept, not a
@@ -542,7 +544,7 @@ func TestApplyTerminalStatuses_StoreOK_ReleasesOffset(t *testing.T) {
 
 	p.applyTerminalStatuses(context.Background(), []*models.TransactionStatus{
 		{TxID: "y", Status: models.StatusAcceptedByNetwork, Timestamp: time.Now()},
-	}, 1, 0)
+	}, 1, 0, p.defaultIO)
 
 	if res := p.admitToDispatcher(propagationMsg{TXID: "y", RawTx: []byte{0x01}}, 6); !res.admitted {
 		t.Fatalf("after a successful terminal write the tx must be released from in-flight; re-admit got %+v, want admitted", res)

--- a/services/propagation/lifecycle_log_test.go
+++ b/services/propagation/lifecycle_log_test.go
@@ -88,7 +88,7 @@ func TestRequeueAfterDelay_LogsRequeueForRetry(t *testing.T) {
 	defer cancel()
 
 	msgs := []propagationMsg{{TXID: "retry-tx-1"}, {TXID: "retry-tx-2"}}
-	p.requeueAfterDelay(ctx, msgs)
+	p.requeueAfterDelay(ctx, msgs, p.defaultIO)
 
 	entries := recorded.FilterMessage("transactions requeued for retry").All()
 	if len(entries) != 1 {
@@ -129,7 +129,7 @@ func TestRequeueAfterDelay_RevokedClaim_DropsImmediatelyWithoutParking(t *testin
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // claim already revoked when the requeue is scheduled
 
-	p.requeueAfterDelay(ctx, []propagationMsg{{TXID: "dead-1"}, {TXID: "dead-2"}})
+	p.requeueAfterDelay(ctx, []propagationMsg{{TXID: "dead-1"}, {TXID: "dead-2"}}, p.defaultIO)
 
 	entries := recorded.FilterMessage("requeue dropped before delay elapsed; txs left uncommitted for replay").All()
 	if len(entries) != 1 {

--- a/services/propagation/mark_queue.go
+++ b/services/propagation/mark_queue.go
@@ -1,0 +1,64 @@
+package propagation
+
+import (
+	"github.com/bsv-blockchain/arcade/kafka"
+)
+
+// markQueue holds consumed-but-unmarked Kafka messages awaiting the
+// commit watermark. It replaces the pendingMarks map whose advanceMarks
+// walked EVERY entry once per terminal event — O(terminals × in-flight
+// offsets) on the dispatcher's serial path, and the prime suspect for
+// the ~10x gap between the dependency-aware-dispatch plan's throughput
+// estimate and the ~1.6-1.9k TPS measured in issue #295.
+//
+// The dispatcher pushes messages in claim-delivery order, and Sarama
+// delivers a partition claim in offset order, so the queue is
+// monotonically increasing: advancing pops from the front while the
+// head is strictly below LowestUnfinished, touching only newly markable
+// entries — amortized O(1) per message no matter how often it runs.
+// A monotonicity violation (which claim delivery can't produce) could
+// only DELAY marks behind the out-of-order entry, never over-commit:
+// every marked offset is individually checked against the watermark.
+//
+// Owned exclusively by the runDispatcher goroutine; no locking.
+type markQueue struct {
+	msgs []*kafka.Message
+	head int
+}
+
+// push appends a consumed message awaiting its offset's release.
+func (q *markQueue) push(m *kafka.Message) {
+	q.msgs = append(q.msgs, m)
+}
+
+// pending returns the number of messages still awaiting marking.
+func (q *markQueue) pending() int {
+	return len(q.msgs) - q.head
+}
+
+// advance marks every queued message strictly below the tracker's
+// lowest unfinished offset (all of them when nothing is unfinished).
+// No-op with a nil claim (dispatcher test mode). Safe under claim
+// revocation: a still-in-flight offset is never marked, and marking an
+// already-dead session is broker-side bookkeeping only.
+func (q *markQueue) advance(claim kafka.Claim, tracker *offsetTracker) {
+	if claim == nil {
+		return
+	}
+	lowest, hasUnfinished := tracker.LowestUnfinished()
+	for q.head < len(q.msgs) {
+		msg := q.msgs[q.head]
+		if hasUnfinished && msg.Offset >= lowest {
+			break
+		}
+		claim.MarkMessage(msg)
+		q.msgs[q.head] = nil // release for GC
+		q.head++
+	}
+	// Compact once the consumed prefix dominates so the backing slice
+	// doesn't grow without bound across the claim's lifetime.
+	if q.head > 0 && q.head >= len(q.msgs)/2 {
+		q.msgs = append(q.msgs[:0], q.msgs[q.head:]...)
+		q.head = 0
+	}
+}

--- a/services/propagation/mark_queue_test.go
+++ b/services/propagation/mark_queue_test.go
@@ -1,0 +1,140 @@
+package propagation
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/bsv-blockchain/arcade/kafka"
+)
+
+// markQueue is the #295 replacement for the per-offset pendingMarks map:
+// advanceMarks used to walk the ENTIRE map once per terminal event —
+// O(terminals × in-flight offsets) on the dispatcher's serial path, the
+// suspected 10x throughput gap in issue #295. The queue is appended in
+// claim-delivery (offset) order, so advancing is a pop-from-the-front
+// loop that only touches newly markable entries: amortized O(1) per
+// message regardless of how often it runs.
+
+func mq(offsets ...int64) *markQueue {
+	q := &markQueue{}
+	for _, o := range offsets {
+		q.push(&kafka.Message{Offset: o})
+	}
+	return q
+}
+
+// TestMarkQueue_NothingUnfinished_DrainsAllInOrder pins the base case:
+// with no unfinished offsets, advance marks everything queued, in
+// offset order, and empties the queue.
+func TestMarkQueue_NothingUnfinished_DrainsAllInOrder(t *testing.T) {
+	claim := newFakeClaim(context.Background())
+	q := mq(1, 2, 3)
+	q.advance(claim, newOffsetTracker())
+
+	for _, o := range []int64{1, 2, 3} {
+		if !claim.isMarked(o) {
+			t.Errorf("offset %d not marked", o)
+		}
+	}
+	if q.pending() != 0 {
+		t.Errorf("queue should be empty after full drain, %d pending", q.pending())
+	}
+}
+
+// TestMarkQueue_StopsAtLowestUnfinished pins the watermark rule: only
+// offsets strictly below LowestUnfinished are marked; the rest stay
+// queued until their blocker terminalizes.
+func TestMarkQueue_StopsAtLowestUnfinished(t *testing.T) {
+	claim := newFakeClaim(context.Background())
+	tracker := newOffsetTracker()
+	tracker.Add(3) // offset 3 still in flight
+
+	q := mq(1, 2, 3, 4)
+	q.advance(claim, tracker)
+
+	if !claim.isMarked(1) || !claim.isMarked(2) {
+		t.Error("offsets below the watermark must be marked")
+	}
+	if claim.isMarked(3) || claim.isMarked(4) {
+		t.Error("offsets at/above the lowest unfinished offset must NOT be marked")
+	}
+	if q.pending() != 2 {
+		t.Errorf("2 offsets should remain queued, got %d", q.pending())
+	}
+
+	// Blocker terminalizes → the remainder drains on the next advance.
+	tracker.Done(3)
+	q.advance(claim, tracker)
+	if !claim.isMarked(3) || !claim.isMarked(4) {
+		t.Error("remainder must drain once the blocker is Done")
+	}
+	if q.pending() != 0 {
+		t.Errorf("queue should be empty, %d pending", q.pending())
+	}
+}
+
+// TestMarkQueue_NilClaim_NoOp pins test-mode semantics: a nil claim
+// (dispatcher test mode) must neither mark nor drop queued entries.
+func TestMarkQueue_NilClaim_NoOp(t *testing.T) {
+	q := mq(1, 2)
+	q.advance(nil, newOffsetTracker())
+	if q.pending() != 2 {
+		t.Errorf("nil-claim advance must retain entries, %d pending", q.pending())
+	}
+}
+
+// TestMarkQueue_CompactsConsumedPrefix pins the memory bound: the
+// backing slice must not grow without bound as entries are consumed —
+// after draining most of a large queue the consumed prefix is released.
+func TestMarkQueue_CompactsConsumedPrefix(t *testing.T) {
+	claim := newFakeClaim(context.Background())
+	tracker := newOffsetTracker()
+	tracker.Add(999) // pin the tail
+
+	q := &markQueue{}
+	for o := int64(0); o < 1000; o++ {
+		q.push(&kafka.Message{Offset: o})
+	}
+	q.advance(claim, tracker)
+
+	if q.pending() != 1 {
+		t.Fatalf("expected 1 pending entry (offset 999), got %d", q.pending())
+	}
+	if len(q.msgs) > 2 {
+		t.Errorf("consumed prefix not compacted: backing slice still holds %d entries for 1 pending", len(q.msgs))
+	}
+}
+
+// TestMarkQueue_EmptyAdvance_NoPanic pins the trivial bound.
+func TestMarkQueue_EmptyAdvance_NoPanic(t *testing.T) {
+	q := &markQueue{}
+	q.advance(newFakeClaim(context.Background()), newOffsetTracker())
+	if q.pending() != 0 {
+		t.Errorf("empty queue advance changed pending count: %d", q.pending())
+	}
+}
+
+// TestRunDispatcher_TeardownDrainsMarks pins the loop-exit drain: with
+// marking amortized onto the 50ms flush tick, a dispatcher that stops
+// right after a terminal event must still commit the finished offset on
+// its way out (ctx-done path) rather than stranding up to one tick of
+// completed work for replay. waitForMark first proves the terminal was
+// fully processed; stop() then exercises the exit path — the assertion
+// after stop() holds whether the tick or the exit drain got there first,
+// which is exactly the invariant: no markable offset left behind.
+func TestRunDispatcher_TeardownDrainsMarks(t *testing.T) {
+	teranodeSrv := newTeranodeServer(&eventLog{}, http.StatusOK)
+	defer teranodeSrv.Close()
+
+	p := newPropagator("", teranodeSrv.URL, newMockStore())
+	claim, stop := runDispatcherWithClaim(t, p)
+
+	claim.ch <- &kafka.Message{Offset: 21, Value: makePropMsg("teardown-tx")}
+	waitForMark(t, claim, 21, "accepted tx must be committed while the dispatcher runs")
+
+	stop()
+	if !claim.isMarked(21) {
+		t.Fatal("terminalized offset lost at teardown")
+	}
+}

--- a/services/propagation/missing_parent_test.go
+++ b/services/propagation/missing_parent_test.go
@@ -328,9 +328,9 @@ func TestRunDispatcher_MissingParentExhaustsBudget_ParksPendingRetry(t *testing.
 
 // --- reaper path ---------------------------------------------------------
 
-// reaperChild builds a stale PENDING_RETRY child row (real bytes so
-// rejectedAncestor can parse the parent) and a propagator wired to reap it.
-func reaperChild(t *testing.T, srvURL string, ms *mockStore, parentTxid string) (childTxid string) {
+// reaperChild seeds ms with a stale PENDING_RETRY child row (real bytes so
+// rejectedAncestor can parse the parent) and returns the child's txid.
+func reaperChild(t *testing.T, ms *mockStore, parentTxid string) (childTxid string) {
 	t.Helper()
 	childTxid, childRaw := spendingTx(t, parentTxid, 0, 1)
 	ms.replayRows = []*models.TransactionStatus{{
@@ -360,7 +360,7 @@ func TestReapOnce_MissingParent_LeavesRowForNextTick(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	childTxid = reaperChild(t, srv.URL, ms, parentTxid)
+	childTxid = reaperChild(t, ms, parentTxid)
 	p := poisonPropagator(srv.URL, ms, 5, time.Millisecond)
 
 	p.reapOnce(context.Background())
@@ -390,7 +390,7 @@ func TestReapOnce_MissingParent_AncestorRejected_CascadesRejected(t *testing.T) 
 	}))
 	defer srv.Close()
 
-	childTxid = reaperChild(t, srv.URL, ms, parentTxid)
+	childTxid = reaperChild(t, ms, parentTxid)
 	p := poisonPropagator(srv.URL, ms, 5, time.Millisecond)
 
 	p.reapOnce(context.Background())

--- a/services/propagation/missing_parent_test.go
+++ b/services/propagation/missing_parent_test.go
@@ -328,17 +328,18 @@ func TestRunDispatcher_MissingParentExhaustsBudget_ParksPendingRetry(t *testing.
 
 // --- reaper path ---------------------------------------------------------
 
-// reaperChild seeds ms with a stale PENDING_RETRY child row (real bytes so
+// reaperChild seeds ms with a due PENDING_RETRY child row (real bytes so
 // rejectedAncestor can parse the parent) and returns the child's txid.
+//
+// Parked rows now live in the durable retry queue (retry_count /
+// next_retry_at, drained by store.GetReadyRetries in next_retry_at order)
+// rather than being fished out of the timestamp_at walk, so the fixture
+// writes both halves — exactly what parkExhaustedRequeues produces.
 func reaperChild(t *testing.T, ms *mockStore, parentTxid string) (childTxid string) {
 	t.Helper()
 	childTxid, childRaw := spendingTx(t, parentTxid, 0, 1)
-	ms.replayRows = []*models.TransactionStatus{{
-		TxID:      childTxid,
-		Status:    models.StatusPendingRetry,
-		RawTx:     childRaw,
-		Timestamp: time.Now().Add(-2 * time.Hour),
-	}}
+	parkedAt := time.Now().Add(-2 * time.Hour)
+	ms.parkTx(childTxid, childRaw, parkedAt, parkedAt)
 	return childTxid
 }
 
@@ -368,8 +369,24 @@ func TestReapOnce_MissingParent_LeavesRowForNextTick(t *testing.T) {
 	if got := rejectedUpdates(ms); len(got) != 0 {
 		t.Fatalf("reaper missing-parent must leave the row for the next tick, got REJECTED %+v", got[0])
 	}
-	if got := ms.lastUpdateForTxid(childTxid); got != nil {
-		t.Fatalf("no status write expected for the child, got %+v", got)
+	// The row must survive as PENDING_RETRY — and must be RESCHEDULED, not
+	// left untouched. Leaving it alone was the original behavior and the
+	// direct cause of the starvation bug: a failed rebroadcast never rewrote
+	// the row, so its timestamp_at stayed frozen at park time, it sank below
+	// every newer eligible row in the newest-first scan, and at 24h it fell
+	// out of the lookback window and was abandoned in a non-terminal state.
+	if got := ms.lastUpdateForTxid(childTxid); got == nil || got.Status != models.StatusPendingRetry {
+		t.Fatalf("child should remain PENDING_RETRY, got %+v", got)
+	}
+	ms.mu.Lock()
+	pr := ms.pendingRetries[childTxid]
+	ms.mu.Unlock()
+	if pr == nil {
+		t.Fatal("child dropped out of the durable retry queue after a no-verdict rebroadcast")
+	}
+	if !pr.NextRetryAt.After(time.Now()) {
+		t.Errorf("next_retry_at = %v is not in the future; an unresolved row must back off "+
+			"rather than be re-broadcast on every tick forever", pr.NextRetryAt)
 	}
 }
 

--- a/services/propagation/missing_parent_test.go
+++ b/services/propagation/missing_parent_test.go
@@ -1,0 +1,428 @@
+package propagation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/kafka"
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/teranode"
+)
+
+// newTwoEndpointClient builds a teranode client that fans every broadcast
+// out to both URLs, for mixed-peer verdict tests.
+func newTwoEndpointClient(urlA, urlB string) *teranode.Client {
+	return teranode.NewClient([]string{urlA, urlB}, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
+}
+
+// The missing-parent safety net (#295). With arcade.propagation widened to
+// multiple partitions, a child submitted in a later HTTP request than its
+// parent can reach Teranode before the parent (different partition, different
+// pod). Teranode has no orphan pool: the child draws TX_MISSING_PARENT.
+// Pre-#295 any per-tx failure line terminalized as REJECTED — turning a pure
+// ordering artifact into a permanent verdict. Per the #254 principle,
+// missing-parent is a CONDITION, not a verdict: it routes to the bounded
+// requeue and parks at PENDING_RETRY, and the only way it becomes REJECTED is
+// arcade's own store showing an ancestor terminally REJECTED.
+
+// --- fixtures ------------------------------------------------------------
+
+// missingParentLineFor renders Teranode's deepest-cause missing-parent
+// failure line: no [ProcessTransaction] wrapper, child txid first (inside
+// the [Validate] wrapper), parent txid later in the message.
+func missingParentLineFor(child, parent string) string {
+	return fmt.Sprintf("TX_MISSING_PARENT (34): [Validate][%s] error getting parent transaction %s", child, parent)
+}
+
+// missingParentBody renders a /txs failure-list body from the given lines.
+func missingParentBody(lines ...string) string {
+	return "Failed to process transactions:\n" + strings.Join(lines, "\n") + "\n"
+}
+
+// missingParentServer answers every POST /txs with HTTP 422 and the given
+// failure-list body, counting calls via log.
+func missingParentServer(log *eventLog, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		log.add("broadcast")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// rejectedUpdates returns every REJECTED status write recorded by the store.
+func rejectedUpdates(m *mockStore) []*models.TransactionStatus {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []*models.TransactionStatus
+	for _, u := range m.updates {
+		if u.Status == models.StatusRejected {
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
+// --- the line matcher ----------------------------------------------------
+
+func TestLineIsMissingParentCondition(t *testing.T) {
+	child := strings.Repeat("c", 64)
+	parent := strings.Repeat("d", 64)
+	cases := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"deepest cause", missingParentLineFor(child, parent), true},
+		{"wrapped in PROCESSING", "PROCESSING (4): [ProcessTransaction][" + child + "] failed to validate transaction: TX_MISSING_PARENT (34): missing parent tx", true},
+		{"doubled prefix", "TX_MISSING_PARENT (34): TX_MISSING_PARENT (34): [Validate][" + child + "] error getting parent transaction " + parent, true},
+		{"tx not found", "TX_NOT_FOUND (30): [Validate][" + child + "] UTXO not found for vout 0", true},
+		{"conflict is a verdict", "UTXO_SPENT (70): " + parent + ":0 utxo already spent by tx " + child + "[0]", false},
+		{"policy is a verdict", "TX_INVALID (31): [ProcessTransaction][" + child + "] transaction has no inputs", false},
+		{"free text mentioning parent", "error getting parent transaction from cache", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lineIsMissingParentCondition(tc.line); got != tc.want {
+				t.Errorf("lineIsMissingParentCondition(%q) = %v, want %v", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- broadcast routing ---------------------------------------------------
+
+// TestBroadcast_MissingParentLine_RequeuesInsteadOfRejects is the core
+// safety-net assertion: a child rejected by Teranode with TX_MISSING_PARENT
+// (parent unknown to arcade's store too) must NOT terminalize REJECTED — it
+// requeues through the dispatcher for another attempt.
+func TestBroadcast_MissingParentLine_RequeuesInsteadOfRejects(t *testing.T) {
+	parentTxid := strings.Repeat("a", 64)
+	childTxid, childRaw := spendingTx(t, parentTxid, 0, 1)
+
+	log := &eventLog{}
+	srv := missingParentServer(log, missingParentBody(missingParentLineFor(childTxid, parentTxid)))
+	defer srv.Close()
+
+	ms := newMockStore()
+	p := poisonPropagator(srv.URL, ms, 5, time.Millisecond)
+
+	if err := handleAndFlush(t, p, realPropMsg(t, childTxid, childRaw)); err != nil {
+		t.Fatalf("handleAndFlush: %v", err)
+	}
+
+	if got := rejectedUpdates(ms); len(got) != 0 {
+		t.Fatalf("missing-parent must not terminalize REJECTED, got %d REJECTED writes (first: %+v)", len(got), got[0])
+	}
+	// The requeue must land back on the dispatcher (retry pending).
+	waitForPending(t, p, 1)
+}
+
+// TestBroadcast_MissingParentLine_SiblingsKeepImplicitAccepts pins that a
+// missing-parent line keyed to a submitted tx is NOT an alien line: the
+// peer processed the batch, so every tx absent from the failure list keeps
+// its implicit acceptance.
+func TestBroadcast_MissingParentLine_SiblingsKeepImplicitAccepts(t *testing.T) {
+	parentTxid := strings.Repeat("a", 64)
+	childTxid, childRaw := spendingTx(t, parentTxid, 0, 1)
+	confirmedSource := strings.Repeat("b", 64)
+	siblingTxid, siblingRaw := spendingTx(t, confirmedSource, 0, 2)
+
+	log := &eventLog{}
+	srv := missingParentServer(log, missingParentBody(missingParentLineFor(childTxid, parentTxid)))
+	defer srv.Close()
+
+	ms := newMockStore()
+	p := poisonPropagator(srv.URL, ms, 5, time.Millisecond)
+
+	// Admit both, then flush once so they share a single /txs POST.
+	if err := p.handleMessage(context.Background(), consumerMsg(realPropMsg(t, childTxid, childRaw))); err != nil {
+		t.Fatalf("handleMessage child: %v", err)
+	}
+	if err := p.handleMessage(context.Background(), consumerMsg(realPropMsg(t, siblingTxid, siblingRaw))); err != nil {
+		t.Fatalf("handleMessage sibling: %v", err)
+	}
+	if err := flushSync(t, p); err != nil {
+		t.Fatalf("flushSync: %v", err)
+	}
+
+	if got := ms.lastUpdateForTxid(siblingTxid); got == nil || got.Status != models.StatusAcceptedByNetwork {
+		t.Fatalf("sibling absent from the failure list must keep its implicit accept, got %+v", got)
+	}
+	if got := rejectedUpdates(ms); len(got) != 0 {
+		t.Fatalf("no REJECTED writes expected, got %+v", got[0])
+	}
+	waitForPending(t, p, 1) // the child requeues
+}
+
+// TestBroadcast_MissingParentPlusRealVerdict_VerdictWins pins precedence: a
+// genuine verdict from any peer (TX_INVALID from peer B) beats the
+// missing-parent condition from peer A — the tx terminalizes REJECTED with
+// the real verdict.
+func TestBroadcast_MissingParentPlusRealVerdict_VerdictWins(t *testing.T) {
+	parentTxid := strings.Repeat("a", 64)
+	childTxid, childRaw := spendingTx(t, parentTxid, 0, 1)
+
+	log := &eventLog{}
+	mpSrv := missingParentServer(log, missingParentBody(missingParentLineFor(childTxid, parentTxid)))
+	defer mpSrv.Close()
+	invalidLine := "TX_INVALID (31): [ProcessTransaction][" + childTxid + "] transaction invalid"
+	invalidSrv := missingParentServer(log, missingParentBody(invalidLine))
+	defer invalidSrv.Close()
+
+	ms := newMockStore()
+	p := poisonPropagator(mpSrv.URL, ms, 5, time.Millisecond)
+	p.teranodeClient = newTwoEndpointClient(mpSrv.URL, invalidSrv.URL)
+
+	if err := handleAndFlush(t, p, realPropMsg(t, childTxid, childRaw)); err != nil {
+		t.Fatalf("handleAndFlush: %v", err)
+	}
+
+	got := rejectedUpdates(ms)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 REJECTED write (the real TX_INVALID verdict), got %d", len(got))
+	}
+	if !strings.Contains(got[0].ExtraInfo, "TX_INVALID") {
+		t.Errorf("REJECTED ExtraInfo = %q, want the TX_INVALID verdict", got[0].ExtraInfo)
+	}
+}
+
+// TestBroadcast_MissingParentPlusAccept_AcceptWins pins sticky acceptance:
+// any peer 200 accepts the tx regardless of another peer's missing-parent.
+func TestBroadcast_MissingParentPlusAccept_AcceptWins(t *testing.T) {
+	parentTxid := strings.Repeat("a", 64)
+	childTxid, childRaw := spendingTx(t, parentTxid, 0, 1)
+
+	log := &eventLog{}
+	mpSrv := missingParentServer(log, missingParentBody(missingParentLineFor(childTxid, parentTxid)))
+	defer mpSrv.Close()
+	okSrv := newTeranodeServer(log, http.StatusOK)
+	defer okSrv.Close()
+
+	ms := newMockStore()
+	p := poisonPropagator(mpSrv.URL, ms, 5, time.Millisecond)
+	p.teranodeClient = newTwoEndpointClient(mpSrv.URL, okSrv.URL)
+
+	if err := handleAndFlush(t, p, realPropMsg(t, childTxid, childRaw)); err != nil {
+		t.Fatalf("handleAndFlush: %v", err)
+	}
+
+	if got := ms.lastUpdateForTxid(childTxid); got == nil || got.Status != models.StatusAcceptedByNetwork {
+		t.Fatalf("a peer 200 must win over another peer's missing-parent, got %+v", got)
+	}
+}
+
+// --- store-consult cascade ----------------------------------------------
+
+// TestBroadcast_MissingParent_AncestorRejectedInStore_CascadesRejected pins
+// the one legitimate path from missing-parent to REJECTED: arcade's own
+// store says a parent is terminally REJECTED, so the child inherits the
+// outcome with the standard cascade reason, and the dispatcher releases the
+// child's offset (commit watermark advances).
+func TestBroadcast_MissingParent_AncestorRejectedInStore_CascadesRejected(t *testing.T) {
+	parentTxid := strings.Repeat("a", 64)
+	childTxid, childRaw := spendingTx(t, parentTxid, 0, 1)
+
+	log := &eventLog{}
+	srv := missingParentServer(log, missingParentBody(missingParentLineFor(childTxid, parentTxid)))
+	defer srv.Close()
+
+	ms := newMockStore()
+	ms.setStatus(parentTxid, models.StatusRejected)
+	p := poisonPropagator(srv.URL, ms, 5, time.Millisecond)
+
+	claim, stop := runDispatcherWithClaim(t, p)
+	defer stop()
+
+	claim.ch <- &kafka.Message{Offset: 41, Value: realPropMsg(t, childTxid, childRaw)}
+	waitForMark(t, claim, 41, "a store-cascaded REJECTED must release the child's offset")
+
+	got := rejectedUpdates(ms)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 REJECTED write for the child, got %d", len(got))
+	}
+	if got[0].TxID != childTxid {
+		t.Errorf("REJECTED txid = %s, want child %s", got[0].TxID, childTxid)
+	}
+	if !strings.HasPrefix(got[0].ExtraInfo, "parent rejected (ancestor "+parentTxid+")") {
+		t.Errorf("ExtraInfo = %q, want the standard cascade reason naming ancestor %s", got[0].ExtraInfo, parentTxid)
+	}
+}
+
+// TestBroadcast_MissingParent_AncestorNonTerminal_Requeues pins the
+// conservative side: a parent at RECEIVED (or PENDING_RETRY, or unknown)
+// is NOT a verdict about the child — requeue, never REJECTED.
+func TestBroadcast_MissingParent_AncestorNonTerminal_Requeues(t *testing.T) {
+	for _, parentStatus := range []models.Status{models.StatusReceived, models.StatusPendingRetry} {
+		t.Run(string(parentStatus), func(t *testing.T) {
+			parentTxid := strings.Repeat("a", 64)
+			childTxid, childRaw := spendingTx(t, parentTxid, 0, 1)
+
+			log := &eventLog{}
+			srv := missingParentServer(log, missingParentBody(missingParentLineFor(childTxid, parentTxid)))
+			defer srv.Close()
+
+			ms := newMockStore()
+			ms.setStatus(parentTxid, parentStatus)
+			p := poisonPropagator(srv.URL, ms, 5, time.Millisecond)
+
+			if err := handleAndFlush(t, p, realPropMsg(t, childTxid, childRaw)); err != nil {
+				t.Fatalf("handleAndFlush: %v", err)
+			}
+			if got := rejectedUpdates(ms); len(got) != 0 {
+				t.Fatalf("parent %s must not condemn the child, got REJECTED write %+v", parentStatus, got[0])
+			}
+			waitForPending(t, p, 1)
+		})
+	}
+}
+
+// --- budget exhaustion ---------------------------------------------------
+
+// TestRunDispatcher_MissingParentExhaustsBudget_ParksPendingRetry pins the
+// no-wedge invariant: a child whose parent never shows up burns its requeue
+// budget, parks at PENDING_RETRY (NOT REJECTED — the reaper owns durable
+// retry from there), names the condition in ExtraInfo, and releases its
+// Kafka offset so the partition's watermark advances.
+func TestRunDispatcher_MissingParentExhaustsBudget_ParksPendingRetry(t *testing.T) {
+	parentTxid := strings.Repeat("a", 64)
+	childTxid, childRaw := spendingTx(t, parentTxid, 0, 1)
+
+	log := &eventLog{}
+	srv := missingParentServer(log, missingParentBody(missingParentLineFor(childTxid, parentTxid)))
+	defer srv.Close()
+
+	ms := newMockStore()
+	const maxAttempts = 2
+	p := poisonPropagator(srv.URL, ms, maxAttempts, time.Millisecond)
+
+	claim, stop := runDispatcherWithClaim(t, p)
+	defer stop()
+
+	claim.ch <- &kafka.Message{Offset: 51, Value: realPropMsg(t, childTxid, childRaw)}
+	waitForMark(t, claim, 51, "an exhausted missing-parent child must park and release its offset")
+
+	if got := rejectedUpdates(ms); len(got) != 0 {
+		t.Fatalf("missing-parent exhaustion must park, not reject; got %+v", got[0])
+	}
+	parked := ms.lastUpdateForTxid(childTxid)
+	if parked == nil || parked.Status != models.StatusPendingRetry {
+		t.Fatalf("child must end at PENDING_RETRY, got %+v", parked)
+	}
+	if !strings.Contains(parked.ExtraInfo, "TX_MISSING_PARENT") {
+		t.Errorf("park reason %q should name the missing-parent condition", parked.ExtraInfo)
+	}
+	// 1 initial broadcast + maxAttempts requeued broadcasts.
+	if got := log.count("broadcast"); got != 1+maxAttempts {
+		t.Errorf("broadcast count = %d, want %d (bounded by the requeue budget)", got, 1+maxAttempts)
+	}
+}
+
+// --- reaper path ---------------------------------------------------------
+
+// reaperChild builds a stale PENDING_RETRY child row (real bytes so
+// rejectedAncestor can parse the parent) and a propagator wired to reap it.
+func reaperChild(t *testing.T, srvURL string, ms *mockStore, parentTxid string) (childTxid string) {
+	t.Helper()
+	childTxid, childRaw := spendingTx(t, parentTxid, 0, 1)
+	ms.replayRows = []*models.TransactionStatus{{
+		TxID:      childTxid,
+		Status:    models.StatusPendingRetry,
+		RawTx:     childRaw,
+		Timestamp: time.Now().Add(-2 * time.Hour),
+	}}
+	return childTxid
+}
+
+// TestReapOnce_MissingParent_LeavesRowForNextTick is the regression test
+// for a latent pre-#295 bug: a reaper rebroadcast of a child whose parent
+// is still in flight (e.g. also PENDING_RETRY) drew TX_MISSING_PARENT and
+// falsely terminalized the child REJECTED. The row must stay untouched so
+// the next tick retries after the parent lands.
+func TestReapOnce_MissingParent_LeavesRowForNextTick(t *testing.T) {
+	parentTxid := strings.Repeat("a", 64)
+	ms := newMockStore()
+
+	log := &eventLog{}
+	var childTxid string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		log.add("broadcast")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(missingParentBody(missingParentLineFor(childTxid, parentTxid))))
+	}))
+	defer srv.Close()
+
+	childTxid = reaperChild(t, srv.URL, ms, parentTxid)
+	p := poisonPropagator(srv.URL, ms, 5, time.Millisecond)
+
+	p.reapOnce(context.Background())
+
+	if got := rejectedUpdates(ms); len(got) != 0 {
+		t.Fatalf("reaper missing-parent must leave the row for the next tick, got REJECTED %+v", got[0])
+	}
+	if got := ms.lastUpdateForTxid(childTxid); got != nil {
+		t.Fatalf("no status write expected for the child, got %+v", got)
+	}
+}
+
+// TestReapOnce_MissingParent_AncestorRejected_CascadesRejected closes the
+// durable loop: once the parent's row reads REJECTED, the reaper's next
+// rebroadcast of the parked child terminalizes it with the cascade reason.
+func TestReapOnce_MissingParent_AncestorRejected_CascadesRejected(t *testing.T) {
+	parentTxid := strings.Repeat("a", 64)
+	ms := newMockStore()
+	ms.setStatus(parentTxid, models.StatusRejected)
+
+	log := &eventLog{}
+	var childTxid string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		log.add("broadcast")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(missingParentBody(missingParentLineFor(childTxid, parentTxid))))
+	}))
+	defer srv.Close()
+
+	childTxid = reaperChild(t, srv.URL, ms, parentTxid)
+	p := poisonPropagator(srv.URL, ms, 5, time.Millisecond)
+
+	p.reapOnce(context.Background())
+
+	got := rejectedUpdates(ms)
+	if len(got) != 1 || got[0].TxID != childTxid {
+		t.Fatalf("expected the child to cascade REJECTED via the store consult, got %+v", got)
+	}
+	if !strings.HasPrefix(got[0].ExtraInfo, "parent rejected (ancestor "+parentTxid+")") {
+		t.Errorf("ExtraInfo = %q, want the standard cascade reason", got[0].ExtraInfo)
+	}
+}
+
+// --- config wiring -------------------------------------------------------
+
+// TestRetryBackoffMs_WiredIntoRequeueDelay pins that the (previously dead)
+// propagation.retry_backoff_ms knob now drives the flat requeue delay, with
+// non-positive values falling back to the 2s default.
+func TestRetryBackoffMs_WiredIntoRequeueDelay(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Propagation.MerkleConcurrency = 10
+	cfg.Propagation.RetryBackoffMs = 1234
+	tc := teranode.NewClient([]string{"http://127.0.0.1:1"}, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
+	p := New(cfg, zap.NewNop(), nil, nil, newMockStore(), nil, tc, nil)
+	if p.requeueDelay != 1234*time.Millisecond {
+		t.Errorf("requeueDelay = %v, want 1234ms from retry_backoff_ms", p.requeueDelay)
+	}
+
+	cfg2 := &config.Config{}
+	cfg2.Propagation.MerkleConcurrency = 10
+	p2 := New(cfg2, zap.NewNop(), nil, nil, newMockStore(), nil, tc, nil)
+	if p2.requeueDelay != defaultRequeueDelay {
+		t.Errorf("requeueDelay = %v, want default %v when retry_backoff_ms unset", p2.requeueDelay, defaultRequeueDelay)
+	}
+}

--- a/services/propagation/pending_retry_convergence_test.go
+++ b/services/propagation/pending_retry_convergence_test.go
@@ -182,15 +182,12 @@ func buildChain(t *testing.T, rootTxID string, depth int) []chainLink {
 	return links
 }
 
-// parkedRow renders a chain link as the store row parkExhaustedRequeues
-// leaves behind: PENDING_RETRY, carrying RawTx, stamped when it parked.
-func parkedRow(link chainLink, parkedAt time.Time) *models.TransactionStatus {
-	return &models.TransactionStatus{
-		TxID:      link.txid,
-		Status:    models.StatusPendingRetry,
-		RawTx:     link.raw,
-		Timestamp: parkedAt,
-	}
+// park seeds a chain link in the state parkExhaustedRequeues leaves behind.
+// parkedAt doubles as the next-attempt time so the row is immediately due —
+// these tests are about what the reaper does with a due row, not about the
+// backoff schedule (nextPendingRetryDelay has its own coverage).
+func park(ms *mockStore, link chainLink, parkedAt time.Time) {
+	ms.parkTx(link.txid, link.raw, parkedAt, parkedAt)
 }
 
 // newReaperPropagator builds a propagator with a configurable rebroadcast cap
@@ -247,10 +244,10 @@ func TestReapOnce_PendingRetryChain_ConvergesInOneTick(t *testing.T) {
 	root := strings.Repeat("11", 32)
 	chain := buildChain(t, root, depth)
 
-	parkedAt := time.Now().Add(-10 * time.Minute) // older than stalePendingRetryAge
+	parkedAt := time.Now().Add(-10 * time.Minute)
 	ms := newMockStore()
 	for _, link := range chain {
-		ms.replayRows = append(ms.replayRows, parkedRow(link, parkedAt))
+		park(ms, link, parkedAt)
 	}
 
 	tn := newDepAwareTeranode(t, root)
@@ -300,9 +297,9 @@ func TestReapOnce_PendingRetry_StarvedByNewerBacklog(t *testing.T) {
 
 	now := time.Now()
 	ms := newMockStore()
-	ms.replayRows = append(ms.replayRows, parkedRow(old, now.Add(-6*time.Hour)))
+	park(ms, old, now.Add(-6*time.Hour))
 	for i, link := range newer {
-		ms.replayRows = append(ms.replayRows, parkedRow(link, now.Add(-time.Duration(10+i)*time.Minute)))
+		park(ms, link, now.Add(-time.Duration(10+i)*time.Minute))
 	}
 
 	// Root of the newer rows is NOT accepted, so they never resolve and never
@@ -338,9 +335,7 @@ func TestReapOnce_PendingRetry_NeverSilentlyAbandoned(t *testing.T) {
 	orphan := buildChain(t, root, 1)[0]
 
 	ms := newMockStore()
-	ms.replayRows = []*models.TransactionStatus{
-		parkedRow(orphan, time.Now().Add(-25*time.Hour)), // past staleScanLookback
-	}
+	park(ms, orphan, time.Now().Add(-25*time.Hour)) // past staleScanLookback
 
 	// Parent is on-chain, so a retry would succeed immediately.
 	tn := newDepAwareTeranode(t, root)
@@ -427,7 +422,7 @@ func TestReapOnce_PendingRetry_RecoversWhenParentAccepted(t *testing.T) {
 	child := chain[0]
 
 	ms := newMockStore()
-	ms.replayRows = []*models.TransactionStatus{parkedRow(child, time.Now().Add(-10*time.Minute))}
+	park(ms, child, time.Now().Add(-10*time.Minute))
 
 	tn := newDepAwareTeranode(t, root) // parent already on-chain
 	p := newReaperPropagator(t, tn.URL(), ms, 0)
@@ -437,12 +432,22 @@ func TestReapOnce_PendingRetry_RecoversWhenParentAccepted(t *testing.T) {
 	if !acceptedTxIDs(ms)[child.txid] {
 		t.Fatalf("parked child was not lifted to ACCEPTED_BY_NETWORK after its parent landed")
 	}
-	ms.mu.Lock()
-	cleared := len(ms.cleared)
-	ms.mu.Unlock()
-	if cleared == 0 {
-		t.Errorf("ClearRetryState was never called: the row keeps its PENDING_RETRY retry " +
-			"bins after resolving, so it stays visible to a next_retry_at-ordered drain")
+
+	// And it must leave the retry queue. Asserted behaviorally rather than by
+	// watching for a ClearRetryState call: the resolving write goes through
+	// BatchUpdateStatusReturning, and GetReadyRetries filters on
+	// status='PENDING_RETRY', so a resolved row drops out on its own. Pinning
+	// the method would pin an implementation detail; pinning the query result
+	// pins the property that actually matters.
+	ready, err := ms.GetReadyRetries(context.Background(), time.Now(), 100)
+	if err != nil {
+		t.Fatalf("GetReadyRetries: %v", err)
+	}
+	for _, r := range ready {
+		if r.TxID == child.txid {
+			t.Fatalf("resolved child %s is still served by the durable retry drain; "+
+				"it would be rebroadcast to teranode every tick forever", child.txid[:12])
+		}
 	}
 }
 
@@ -466,9 +471,10 @@ func TestRejectedAncestor_GrandparentRejected_Cascades(t *testing.T) {
 
 	ms := newMockStore()
 	// Grandparent (the chain root) is terminally REJECTED; the parent between
-	// it and the child is merely parked.
+	// it and the child is merely parked. The parent's row carries its raw
+	// bytes, which is how the walk discovers the grandparent.
 	ms.setStatus(root, models.StatusRejected)
-	ms.setStatus(parent.txid, models.StatusPendingRetry)
+	ms.setStatusRow(parent.txid, models.StatusPendingRetry, parent.raw)
 
 	p := newReaperPropagator(t, "http://127.0.0.1:0", ms, 0)
 

--- a/services/propagation/pending_retry_convergence_test.go
+++ b/services/propagation/pending_retry_convergence_test.go
@@ -270,6 +270,15 @@ func TestReapOnce_PendingRetryChain_ConvergesInOneTick(t *testing.T) {
 			len(accepted), depth, strings.Join(stuck, ", "),
 			depth, depth, time.Duration(depth)*30*time.Second)
 	}
+
+	// And it must get there by submitting one layer at a time. A single /txs
+	// call carrying the whole chain would put parents and children in one
+	// batch, which is exactly the shape teranode's contract forbids and the
+	// reason a dep-blind batch could only ever advance one level.
+	if got := tn.requestCount(); got < depth {
+		t.Errorf("teranode saw %d /txs requests for a depth-%d chain, want one per "+
+			"dependency layer; the batch is not being layered", got, depth)
+	}
 }
 
 // TestReapOnce_PendingRetry_StarvedByNewerBacklog pins the fairness property.

--- a/services/propagation/pending_retry_convergence_test.go
+++ b/services/propagation/pending_retry_convergence_test.go
@@ -1,0 +1,488 @@
+package propagation
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/merkleservice"
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/teranode"
+)
+
+// These tests pin the convergence properties of the PENDING_RETRY path.
+//
+// #299 promotes that path from what it was on main — a rare poison-batch
+// escape hatch, reached only when a tx burned its whole requeue budget on
+// infra failures — to the DESIGNED steady-state landing spot for every
+// cross-submission parent/child chain. Family partition keys co-locate a
+// chain that arrives in ONE POST, but a chain split across submissions (or
+// submitted via POST /tx, which still keys by bare txid) has no ordering
+// guarantee: the child reaches teranode first, draws TX_MISSING_PARENT, and
+// after retry_max_attempts × retry_backoff_ms parks at PENDING_RETRY.
+//
+// From there the reaper owns it. These tests assert the properties that role
+// requires and the current implementation does not have:
+//
+//	convergence  — a parked chain must drain in bounded time, not one
+//	               dependency level per 30s reaper tick
+//	fairness     — a parked row must not be starved by newer eligible rows
+//	liveness     — a parked row must never be silently abandoned
+//	durability   — a park must record retry state, not just a status string
+//
+// The convergence math at shipped defaults (retry_max_attempts=5,
+// retry_backoff_ms=2000, reaper_interval_ms=30000, stalePendingRetryAge=5m)
+// is: T(D) ≈ 10s + 300s + (D−6) × 30s. Depth 100 is ~52 minutes.
+
+// depAwareTeranode is a stateful fake teranode that accepts a tx only when
+// every input's source tx was already accepted BEFORE the current request.
+//
+// The pre-request snapshot is the important detail, and it is deliberately
+// stricter than tests/smoke's dependencyAwareTeranode (which accepts a child
+// whose parent appears earlier in the same body). It models teranode's
+// parallel bulk processing, which is arcade's own stated assumption in two
+// places: handleAdmit's "Teranode's parallel bulk processing means we can't
+// trust same-batch ordering", and #299's "no parent and child in one /txs
+// batch" contract. A fake that resolved a whole chain from one batch would
+// be asserting a guarantee arcade explicitly says it does not have.
+type depAwareTeranode struct {
+	server *httptest.Server
+
+	mu       sync.Mutex
+	accepted map[string]bool
+	requests int // POST /txs count — one per broadcast chunk
+}
+
+func newDepAwareTeranode(t *testing.T, preAccepted ...string) *depAwareTeranode {
+	t.Helper()
+	d := &depAwareTeranode{accepted: make(map[string]bool)}
+	for _, txid := range preAccepted {
+		d.accepted[strings.ToLower(txid)] = true
+	}
+	d.server = httptest.NewServer(http.HandlerFunc(d.handle))
+	t.Cleanup(d.server.Close)
+	return d
+}
+
+func (d *depAwareTeranode) URL() string { return d.server.URL }
+
+func (d *depAwareTeranode) requestCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.requests
+}
+
+func (d *depAwareTeranode) isAccepted(txid string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.accepted[strings.ToLower(txid)]
+}
+
+func (d *depAwareTeranode) handle(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost || (req.URL.Path != "/txs" && req.URL.Path != "/tx") {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	type parsedTx struct {
+		txid    string
+		parents []string
+	}
+	var txs []parsedTx
+	for offset := 0; offset < len(body); {
+		tx, used, perr := sdkTx.NewTransactionFromStream(body[offset:])
+		if perr != nil || used == 0 {
+			break
+		}
+		p := parsedTx{txid: tx.TxID().String()}
+		for _, in := range tx.Inputs {
+			if in != nil && in.SourceTXID != nil {
+				p.parents = append(p.parents, in.SourceTXID.String())
+			}
+		}
+		txs = append(txs, p)
+		offset += used
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.requests++
+
+	// Snapshot BEFORE deciding anything, so siblings in this same request
+	// cannot satisfy each other's dependencies.
+	snapshot := make(map[string]bool, len(d.accepted))
+	for k, v := range d.accepted {
+		snapshot[k] = v
+	}
+
+	var failureLines []string
+	for _, p := range txs {
+		missing := ""
+		for _, parent := range p.parents {
+			if !snapshot[strings.ToLower(parent)] {
+				missing = parent
+				break
+			}
+		}
+		if missing != "" {
+			// Teranode's deepest-cause form. The [ProcessTransaction][<txid>]
+			// wrapper is what txsWrappedTxidPattern keys the failure map on,
+			// so the line is attributed to the child, not to the parent hash
+			// that also appears in it.
+			failureLines = append(failureLines, fmt.Sprintf(
+				"TX_MISSING_PARENT (34): [ProcessTransaction][%s] error getting parent transaction %s",
+				p.txid, missing))
+			continue
+		}
+		d.accepted[strings.ToLower(p.txid)] = true
+	}
+
+	if len(failureLines) == 0 {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	// 422 is teranode's status for the missing-parent family.
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	_, _ = io.WriteString(w, "Failed to process transactions:\n"+strings.Join(failureLines, "\n")+"\n")
+}
+
+// chainLink is one transaction in a linear parent→child chain.
+type chainLink struct {
+	txid string
+	raw  []byte
+}
+
+// buildChain returns depth transactions where each spends the previous, the
+// first spending rootTxID. Real bytes, real inputs — the reaper re-parses
+// RawTx to discover parents, so synthetic bodies would not exercise it.
+func buildChain(t *testing.T, rootTxID string, depth int) []chainLink {
+	t.Helper()
+	links := make([]chainLink, 0, depth)
+	parent := rootTxID
+	for i := 0; i < depth; i++ {
+		txid, raw := spendingTx(t, parent, 0, uint32(i+1))
+		links = append(links, chainLink{txid: txid, raw: raw})
+		parent = txid
+	}
+	return links
+}
+
+// parkedRow renders a chain link as the store row parkExhaustedRequeues
+// leaves behind: PENDING_RETRY, carrying RawTx, stamped when it parked.
+func parkedRow(link chainLink, parkedAt time.Time) *models.TransactionStatus {
+	return &models.TransactionStatus{
+		TxID:      link.txid,
+		Status:    models.StatusPendingRetry,
+		RawTx:     link.raw,
+		Timestamp: parkedAt,
+	}
+}
+
+// newReaperPropagator builds a propagator with a configurable rebroadcast cap
+// against a dependency-aware teranode.
+func newReaperPropagator(t *testing.T, teranodeURL string, st *mockStore, batchCap int) *Propagator {
+	t.Helper()
+	cfg := &config.Config{CallbackURL: "http://localhost:8080/callback"}
+	cfg.Propagation.MerkleConcurrency = 10
+	if batchCap > 0 {
+		cfg.Propagation.ReaperRebroadcastBatch = batchCap
+	}
+	log := &eventLog{}
+	merkleSrv := newMerkleServer(log, http.StatusOK)
+	t.Cleanup(merkleSrv.Close)
+	mc := merkleservice.NewClient(merkleSrv.URL, "", 5*time.Second)
+	tc := teranode.NewClient([]string{teranodeURL}, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
+	return New(cfg, zap.NewNop(), nil, nil, st, nil, tc, mc)
+}
+
+// acceptedTxIDs collects every txid the store was told reached
+// ACCEPTED_BY_NETWORK.
+func acceptedTxIDs(ms *mockStore) map[string]bool {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	out := make(map[string]bool)
+	for _, u := range ms.updates {
+		if u.Status == models.StatusAcceptedByNetwork {
+			out[u.TxID] = true
+		}
+	}
+	return out
+}
+
+// TestReapOnce_PendingRetryChain_ConvergesInOneTick is the headline
+// convergence regression.
+//
+// A depth-5 chain is parked at PENDING_RETRY (the shape produced when a
+// client submits a chain across several POSTs and the children outrun their
+// parents across partitions). Its root is already on-chain. One reaper tick
+// must drain the whole chain.
+//
+// It does not today, because reapOnce is dependency-blind in two ways:
+// it builds propagationMsg{TXID, RawTx} with InputTXIDs left empty, and it
+// hands the entire selected batch to broadcastInChunks as one /txs call with
+// no topological layering. So exactly one dependency level clears per tick,
+// and a parked chain of depth D costs (D−6) × reaper_interval_ms on top of
+// the 5-minute park floor — ~52 minutes at D=100.
+//
+// The fix is to layer the batch by in-batch dependency and emit one chunk
+// per layer within the tick, which also removes the parent-and-child-in-one-
+// batch shape the design says teranode forbids.
+func TestReapOnce_PendingRetryChain_ConvergesInOneTick(t *testing.T) {
+	const depth = 5
+	root := strings.Repeat("11", 32)
+	chain := buildChain(t, root, depth)
+
+	parkedAt := time.Now().Add(-10 * time.Minute) // older than stalePendingRetryAge
+	ms := newMockStore()
+	for _, link := range chain {
+		ms.replayRows = append(ms.replayRows, parkedRow(link, parkedAt))
+	}
+
+	tn := newDepAwareTeranode(t, root)
+	p := newReaperPropagator(t, tn.URL(), ms, 0)
+
+	p.reapOnce(context.Background())
+
+	accepted := acceptedTxIDs(ms)
+	var stuck []string
+	for i, link := range chain {
+		if !accepted[link.txid] {
+			stuck = append(stuck, fmt.Sprintf("level %d (%s)", i+1, link.txid[:12]))
+		}
+	}
+	if len(stuck) > 0 {
+		t.Fatalf("one reaper tick accepted %d of %d chain levels; still parked: %s\n"+
+			"reapOnce is dependency-blind: InputTXIDs is left empty and the whole batch "+
+			"goes out as a single /txs call, so only one level can clear per tick. At "+
+			"reaper_interval_ms=30000 a depth-%d chain needs %d ticks (%v).",
+			len(accepted), depth, strings.Join(stuck, ", "),
+			depth, depth, time.Duration(depth)*30*time.Second)
+	}
+}
+
+// TestReapOnce_PendingRetry_StarvedByNewerBacklog pins the fairness property.
+//
+// Two things combine into starvation:
+//
+//  1. The reaper's missing-parent arm deliberately leaves the row alone, and
+//     MarkMerkleRegisteredByTxIDs only writes merkle_registered_at — so a
+//     failing row's timestamp_at is FROZEN at park time.
+//  2. Selection is IterateStatusesSince, which Postgres serves as
+//     "ORDER BY timestamp_at DESC", early-stopped at rebroadcastBatch.
+//
+// So an old parked row sinks below every newer eligible row and is never
+// retried again. Here the cap is 2 and three newer rows are always eligible,
+// so the oldest row is never even offered to teranode.
+//
+// (Pebble walks idx:tx:updated ascending, so the two backends starve in
+// opposite directions — neither is FIFO. store.GetReadyRetries, which orders
+// by next_retry_at and is already implemented and indexed, is.)
+func TestReapOnce_PendingRetry_StarvedByNewerBacklog(t *testing.T) {
+	root := strings.Repeat("22", 32)
+	// One old orphan, plus newer rows that will always occupy the cap.
+	old := buildChain(t, root, 1)[0]
+	newer := buildChain(t, strings.Repeat("33", 32), 3)
+
+	now := time.Now()
+	ms := newMockStore()
+	ms.replayRows = append(ms.replayRows, parkedRow(old, now.Add(-6*time.Hour)))
+	for i, link := range newer {
+		ms.replayRows = append(ms.replayRows, parkedRow(link, now.Add(-time.Duration(10+i)*time.Minute)))
+	}
+
+	// Root of the newer rows is NOT accepted, so they never resolve and never
+	// stop being eligible — the steady-state backlog case.
+	tn := newDepAwareTeranode(t, root)
+	p := newReaperPropagator(t, tn.URL(), ms, 2)
+
+	for tick := 0; tick < 5; tick++ {
+		p.reapOnce(context.Background())
+	}
+
+	if !tn.isAccepted(old.txid) {
+		t.Fatalf("oldest parked row %s was never rebroadcast across 5 reaper ticks "+
+			"(its parent is on-chain, so it would have been accepted on sight).\n"+
+			"Newest-first selection + a frozen timestamp_at means a steady supply of "+
+			"newer eligible rows starves it permanently; at 24h it falls out of the "+
+			"staleScanLookback window and is silently abandoned.", old.txid[:12])
+	}
+}
+
+// TestReapOnce_PendingRetry_NeverSilentlyAbandoned pins the liveness property.
+//
+// staleScanLookback bounds the walk at 24h. Because a failing PENDING_RETRY
+// row's timestamp_at never moves, at park+24h it falls out of
+// "WHERE timestamp_at >= $1" and stops being visible to the reaper entirely.
+// It then stays PENDING_RETRY forever: no terminal status, no log line, no
+// metric, and GET /tx never reaches a terminal answer for the client.
+//
+// A row that old must reach SOME resolution — either it is still retried, or
+// it is terminalized with a reason. Silently vanishing is not an option.
+func TestReapOnce_PendingRetry_NeverSilentlyAbandoned(t *testing.T) {
+	root := strings.Repeat("44", 32)
+	orphan := buildChain(t, root, 1)[0]
+
+	ms := newMockStore()
+	ms.replayRows = []*models.TransactionStatus{
+		parkedRow(orphan, time.Now().Add(-25*time.Hour)), // past staleScanLookback
+	}
+
+	// Parent is on-chain, so a retry would succeed immediately.
+	tn := newDepAwareTeranode(t, root)
+	p := newReaperPropagator(t, tn.URL(), ms, 0)
+
+	p.reapOnce(context.Background())
+
+	if tn.isAccepted(orphan.txid) {
+		return // retried and resolved — acceptable outcome
+	}
+	last := ms.lastUpdateForTxid(orphan.txid)
+	if last != nil && last.Status.IsTerminal() {
+		return // terminalized with a verdict — also acceptable
+	}
+	t.Fatalf("a PENDING_RETRY row parked 25h ago was neither retried nor terminalized; "+
+		"last status = %v.\nstaleScanLookback (24h) excludes it from the walk and nothing "+
+		"else scans PENDING_RETRY, so it is abandoned in a non-terminal state forever — "+
+		"invisible to the stuck census, which only tracks RECEIVED and ACCEPTED_BY_NETWORK.",
+		statusOrNone(last))
+}
+
+func statusOrNone(st *models.TransactionStatus) models.Status {
+	if st == nil {
+		return models.StatusUnknown
+	}
+	return st.Status
+}
+
+// TestParkExhaustedRequeues_WritesDurableRetryFields pins the durability
+// property.
+//
+// The schema already carries retry_count and next_retry_at, with
+// idx_tx_retry_ready(next_retry_at) WHERE status='PENDING_RETRY' to serve
+// them, and store exposes BumpRetryCount / SetPendingRetryFields /
+// GetReadyRetries (ORDER BY next_retry_at LIMIT n FOR UPDATE SKIP LOCKED) /
+// ClearRetryState. All of it is implemented on every backend, mocked in this
+// package, and has zero callers outside store/ and its tests.
+//
+// parkExhaustedRequeues writes only a status row, so a parked tx has no
+// attempt count and no scheduled retry time. That is why the reaper has to
+// fall back to scanning by timestamp_at, which is what produces the
+// starvation and abandonment above.
+func TestParkExhaustedRequeues_WritesDurableRetryFields(t *testing.T) {
+	root := strings.Repeat("55", 32)
+	orphan := buildChain(t, root, 1)[0]
+
+	ms := newMockStore()
+	p := newReaperPropagator(t, "http://127.0.0.1:0", ms, 0)
+	p.retryMaxAttempts = 2
+
+	msg := propagationMsg{TXID: orphan.txid, RawTx: orphan.raw, retryReason: "TX_MISSING_PARENT (34): test"}
+	p.parkExhaustedRequeues(context.Background(), []propagationMsg{msg}, p.defaultIO)
+
+	ms.mu.Lock()
+	pr := ms.pendingRetries[orphan.txid]
+	count := ms.retryCounts[orphan.txid]
+	ms.mu.Unlock()
+
+	if pr == nil {
+		t.Fatalf("park wrote no durable retry state for %s: SetPendingRetryFields was never called.\n"+
+			"retry_count/next_retry_at stay NULL and idx_tx_retry_ready is dead for this path, "+
+			"so the reaper can only find the row by scanning timestamp_at.", orphan.txid[:12])
+	}
+	if pr.NextRetryAt.IsZero() {
+		t.Errorf("next_retry_at not set; the reaper cannot schedule a per-row retry")
+	}
+	if count < 1 {
+		t.Errorf("retry_count = %d, want >= 1; without it there is no basis for backoff or for giving up", count)
+	}
+}
+
+// TestReapOnce_PendingRetry_RecoversWhenParentAccepted is the durable happy
+// path — a parked child whose parent has since landed must be lifted out of
+// PENDING_RETRY and its retry state cleared.
+//
+// Worth stating that this path has no coverage at all today at any level:
+// the unit tests stop at "the row is left alone", and the smoke test
+// (TestSmoke_OrphanChild_ParksWithoutWedgingPipeline) runs with
+// ReaperIntervalMs=60000 against a hardcoded 5-minute stalePendingRetryAge,
+// so the parked row is provably unreachable inside its own test window.
+func TestReapOnce_PendingRetry_RecoversWhenParentAccepted(t *testing.T) {
+	root := strings.Repeat("66", 32)
+	chain := buildChain(t, root, 1)
+	child := chain[0]
+
+	ms := newMockStore()
+	ms.replayRows = []*models.TransactionStatus{parkedRow(child, time.Now().Add(-10*time.Minute))}
+
+	tn := newDepAwareTeranode(t, root) // parent already on-chain
+	p := newReaperPropagator(t, tn.URL(), ms, 0)
+
+	p.reapOnce(context.Background())
+
+	if !acceptedTxIDs(ms)[child.txid] {
+		t.Fatalf("parked child was not lifted to ACCEPTED_BY_NETWORK after its parent landed")
+	}
+	ms.mu.Lock()
+	cleared := len(ms.cleared)
+	ms.mu.Unlock()
+	if cleared == 0 {
+		t.Errorf("ClearRetryState was never called: the row keeps its PENDING_RETRY retry " +
+			"bins after resolving, so it stays visible to a next_retry_at-ordered drain")
+	}
+}
+
+// TestRejectedAncestor_GrandparentRejected_Cascades pins the depth of the
+// store-consult cascade.
+//
+// rejectedAncestor is documented as "the cross-partition analog of the
+// dispatcher's same-partition cascade" and its reason string renders
+// "parent rejected (ancestor %s)" — but cascadeReject is a recursive BFS
+// over the waiter graph while this walks parentTxIDsOf(msg) once. Direct
+// parents only.
+//
+// So with a REJECTED grandparent and a parent still at PENDING_RETRY, the
+// grandchild is not condemned: it requeues, waits for the parent to cascade
+// on some later tick, and only then cascades itself. The rejection path is
+// therefore also O(depth) reaper ticks when it could be one bounded walk.
+func TestRejectedAncestor_GrandparentRejected_Cascades(t *testing.T) {
+	root := strings.Repeat("77", 32)
+	chain := buildChain(t, root, 2)
+	parent, child := chain[0], chain[1]
+
+	ms := newMockStore()
+	// Grandparent (the chain root) is terminally REJECTED; the parent between
+	// it and the child is merely parked.
+	ms.setStatus(root, models.StatusRejected)
+	ms.setStatus(parent.txid, models.StatusPendingRetry)
+
+	p := newReaperPropagator(t, "http://127.0.0.1:0", ms, 0)
+
+	msg := propagationMsg{TXID: child.txid, RawTx: child.raw}
+	ancestor, found := p.rejectedAncestor(context.Background(), msg)
+
+	if !found {
+		t.Fatalf("rejectedAncestor found no REJECTED ancestor for a grandchild of a REJECTED tx.\n"+
+			"It walks direct parents only (parent %s is PENDING_RETRY, so the walk stops), "+
+			"despite the reason string and doc comment both promising an ancestor walk. "+
+			"The grandchild therefore burns a full reaper tick per generation before it "+
+			"can be condemned.", parent.txid[:12])
+	}
+	if ancestor != root {
+		t.Errorf("ancestor = %s, want the REJECTED root %s", ancestor, root)
+	}
+}

--- a/services/propagation/pending_retry_schedule_test.go
+++ b/services/propagation/pending_retry_schedule_test.go
@@ -303,3 +303,60 @@ func TestResolveMissingParents_ReaperPathIsNotLabelledRequeued(t *testing.T) {
 		t.Errorf("outcome=\"reaper_retry\" = %v, want %v", got, reaperBefore+1)
 	}
 }
+
+// TestReapOnce_AdoptsLegacyParkedRows is the upgrade path.
+//
+// Rows parked by a build that predates durable retry scheduling carry no
+// next_retry_at, and GetReadyRetries selects on "next_retry_at <= now" — so
+// moving parked rows onto the durable queue would make every already-parked
+// transaction invisible to both the walk and the drain. That is precisely the
+// silently-abandoned state this change exists to remove, so the reaper adopts
+// such rows into the queue when it encounters them.
+func TestReapOnce_AdoptsLegacyParkedRows(t *testing.T) {
+	root := strings.Repeat("bb", 32)
+	legacy := buildChain(t, root, 1)[0]
+
+	ms := newMockStore()
+	// A legacy park: a PENDING_RETRY status row with raw bytes and NO entry in
+	// the durable retry queue.
+	ms.replayRows = []*models.TransactionStatus{{
+		TxID:      legacy.txid,
+		Status:    models.StatusPendingRetry,
+		RawTx:     legacy.raw,
+		Timestamp: time.Now().Add(-2 * time.Hour),
+	}}
+
+	ms.mu.Lock()
+	queued := len(ms.pendingRetries)
+	ms.mu.Unlock()
+	if queued != 0 {
+		t.Fatalf("fixture should start with an empty durable queue, got %d", queued)
+	}
+
+	tn := newDepAwareTeranode(t, root) // parent on-chain, so a retry succeeds
+	p := newReaperPropagator(t, tn.URL(), ms, 0)
+	p.pendingRetryBackoff = time.Nanosecond
+	p.pendingRetryMaxBackoff = time.Nanosecond
+
+	// First tick adopts it; a later tick drains it once its schedule is due.
+	p.reapOnce(context.Background())
+	ms.mu.Lock()
+	_, adopted := ms.pendingRetries[legacy.txid]
+	ms.mu.Unlock()
+	if !adopted {
+		t.Fatalf("legacy parked row was not adopted into the durable retry queue; " +
+			"with no next_retry_at it is invisible to GetReadyRetries and would sit at " +
+			"PENDING_RETRY forever after the upgrade")
+	}
+
+	// nextPendingRetryDelay floors at 1ms, so an adopted row is not due the
+	// instant it is booked. Tick until it drains rather than assuming it is
+	// ready on the very next pass.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !acceptedTxIDs(ms)[legacy.txid] {
+		p.reapOnce(context.Background())
+	}
+	if !acceptedTxIDs(ms)[legacy.txid] {
+		t.Errorf("adopted legacy row was not retried to ACCEPTED_BY_NETWORK")
+	}
+}

--- a/services/propagation/pending_retry_schedule_test.go
+++ b/services/propagation/pending_retry_schedule_test.go
@@ -1,0 +1,305 @@
+package propagation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/bsv-blockchain/arcade/metrics"
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// TestReapOnce_DeepChain_ConvergesInBoundedTicks is the scale answer to "how
+// long can the PENDING_RETRY path take to resolve".
+//
+// A 500-deep chain is parked with a per-tick rebroadcast cap of 200, i.e. the
+// chain is 2.5x the batch the reaper can move in one pass. Convergence must
+// still be bounded and monotonic: every tick makes progress, and the whole
+// chain drains in ceil(depth/cap) ticks or so.
+//
+// This is the case that previously could not converge at all. Parked rows were
+// selected by scanning timestamp_at, all rows of one park batch share a single
+// timestamp (parkExhaustedRequeues stamps one now for the whole slice), and a
+// failed rebroadcast never rewrote the row — so the selection was a stable,
+// arbitrary 200-row slice of the chain. If the resolvable frontier was not in
+// that slice, the same 200 rows were re-broadcast every 30s forever, making
+// zero progress, until the whole set aged past staleScanLookback and was
+// abandoned. Draining by next_retry_at instead makes the frontier reachable by
+// construction.
+func TestReapOnce_DeepChain_ConvergesInBoundedTicks(t *testing.T) {
+	const (
+		depth    = 500
+		batchCap = 200
+	)
+	root := strings.Repeat("88", 32)
+	chain := buildChain(t, root, depth)
+
+	ms := newMockStore()
+	parkedAt := time.Now().Add(-time.Hour)
+	for _, link := range chain {
+		park(ms, link, parkedAt)
+	}
+
+	tn := newDepAwareTeranode(t, root)
+	p := newReaperPropagator(t, tn.URL(), ms, batchCap)
+	// Compress the backoff so rescheduled rows are due again immediately;
+	// this test is about how many drains convergence needs, not wall time.
+	p.pendingRetryBackoff = time.Nanosecond
+	p.pendingRetryMaxBackoff = time.Nanosecond
+
+	// Generous ceiling: the point is that convergence is BOUNDED, not the
+	// exact count. A tick can legitimately add nothing — rows that fail are
+	// rescheduled behind the ones not yet tried, so the queue rotates — but
+	// the rotation guarantees the frontier is reached. The old behavior
+	// selected a stable arbitrary slice by frozen timestamp and could rotate
+	// forever without ever including the frontier.
+	const maxTicks = 25
+	ticks := 0
+	for ; ticks < maxTicks; ticks++ {
+		p.reapOnce(context.Background())
+		if len(acceptedTxIDs(ms)) == depth {
+			break
+		}
+	}
+
+	if got := len(acceptedTxIDs(ms)); got != depth {
+		t.Fatalf("depth-%d chain drained only %d levels in %d ticks", depth, got, maxTicks)
+	}
+	t.Logf("depth-%d chain converged in %d reaper ticks at a %d-row cap "+
+		"(~%v at reaper_interval_ms=30000)", depth, ticks+1, batchCap,
+		time.Duration(ticks+1)*30*time.Second)
+}
+
+// TestNextPendingRetryDelay_ExponentialCappedJittered pins the durable retry
+// schedule. Before it existed, eligibility was a flat hardcoded 5 minutes for
+// every parked row regardless of how many times it had already failed.
+func TestNextPendingRetryDelay_ExponentialCappedJittered(t *testing.T) {
+	p := &Propagator{
+		pendingRetryBackoff:    time.Second,
+		pendingRetryMaxBackoff: 30 * time.Second,
+	}
+
+	// Jitter is +/-20%, so assert against the un-jittered target with slack.
+	for _, tc := range []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, time.Second},
+		{2, 2 * time.Second},
+		{3, 4 * time.Second},
+		{4, 8 * time.Second},
+		{5, 16 * time.Second},
+		{6, 30 * time.Second},  // capped
+		{50, 30 * time.Second}, // stays capped
+	} {
+		got := p.nextPendingRetryDelay(tc.attempt)
+		lo := time.Duration(float64(tc.want) * 0.79)
+		hi := time.Duration(float64(tc.want) * 1.21)
+		if got < lo || got > hi {
+			t.Errorf("attempt %d: delay = %v, want %v +/-20%%", tc.attempt, got, tc.want)
+		}
+	}
+
+	// Jitter must actually vary, or a batch parked together re-broadcasts in
+	// lockstep every cycle — a synchronized burst at teranode and
+	// merkle-service for as long as the shared parent is missing.
+	seen := make(map[time.Duration]struct{})
+	for i := 0; i < 32; i++ {
+		seen[p.nextPendingRetryDelay(4)] = struct{}{}
+	}
+	if len(seen) < 4 {
+		t.Errorf("only %d distinct delays across 32 calls; retries are effectively unjittered", len(seen))
+	}
+}
+
+// TestSchedulePendingRetry_GivesUpAfterMaxAttempts pins the terminal exit.
+//
+// A tx spending an outpoint that does not exist is the most common client
+// mistake there is, and it is unresolvable in both directions: it can never be
+// accepted, and rejectedAncestor can never condemn it because arcade has never
+// seen the parent at all. Without a bound those rows accumulate forever,
+// consume the reaper's per-tick batch, and re-POST to every healthy endpoint
+// on every cycle indefinitely.
+func TestSchedulePendingRetry_GivesUpAfterMaxAttempts(t *testing.T) {
+	root := strings.Repeat("99", 32)
+	orphan := buildChain(t, root, 1)[0]
+
+	ms := newMockStore()
+	p := newReaperPropagator(t, "http://127.0.0.1:0", ms, 0)
+	p.pendingRetryMaxAttempts = 3
+	p.pendingRetryBackoff = time.Millisecond
+	p.pendingRetryMaxBackoff = time.Millisecond
+
+	before := testutil.ToFloat64(metrics.PropagationPendingRetryTotal.WithLabelValues("exhausted"))
+
+	// Attempts 1..3 reschedule; the 4th exceeds the budget.
+	for i := 0; i < 4; i++ {
+		p.schedulePendingRetry(context.Background(), orphan.txid, orphan.raw)
+	}
+
+	last := ms.lastUpdateForTxid(orphan.txid)
+	if last == nil || last.Status != models.StatusRejected {
+		t.Fatalf("orphan was not terminalized after exceeding the durable retry budget; "+
+			"last status = %v. It would be re-broadcast to every endpoint forever.",
+			statusOrNone(last))
+	}
+	if !strings.Contains(last.ExtraInfo, "giving up") {
+		t.Errorf("ExtraInfo = %q, want a reason the submitter can act on", last.ExtraInfo)
+	}
+
+	ms.mu.Lock()
+	_, stillQueued := ms.pendingRetries[orphan.txid]
+	ms.mu.Unlock()
+	if stillQueued {
+		t.Errorf("orphan is still in the durable retry queue after being terminalized")
+	}
+
+	if got := testutil.ToFloat64(metrics.PropagationPendingRetryTotal.WithLabelValues("exhausted")); got != before+1 {
+		t.Errorf("exhausted counter = %v, want %v", got, before+1)
+	}
+}
+
+// TestLayerByDependency covers the topological split that lets one reaper tick
+// advance a whole chain. Each layer must contain no tx that spends another in
+// the same layer, since teranode processes a batch in parallel and cannot be
+// relied on to order within it.
+func TestLayerByDependency(t *testing.T) {
+	msg := func(txid string, parents ...string) propagationMsg {
+		return propagationMsg{TXID: txid, InputTXIDs: parents}
+	}
+
+	for _, tc := range []struct {
+		name       string
+		msgs       []propagationMsg
+		wantLayers int
+	}{
+		{"empty", nil, 1},
+		{"single", []propagationMsg{msg("a")}, 1},
+		{"independent siblings share a layer", []propagationMsg{msg("a"), msg("b"), msg("c")}, 1},
+		{"chain splits per level", []propagationMsg{msg("a"), msg("b", "a"), msg("c", "b")}, 3},
+		{"chain in reverse input order", []propagationMsg{msg("c", "b"), msg("b", "a"), msg("a")}, 3},
+		{"fan-out shares one child layer", []propagationMsg{msg("p"), msg("c1", "p"), msg("c2", "p")}, 2},
+		{"fan-in waits for its deepest parent", []propagationMsg{msg("a"), msg("b", "a"), msg("z", "a", "b")}, 3},
+		{"diamond", []propagationMsg{msg("a"), msg("b", "a"), msg("c", "a"), msg("d", "b", "c")}, 3},
+		{"out-of-batch parents are ignored", []propagationMsg{msg("a", "outside"), msg("b", "elsewhere")}, 1},
+		{"self-reference does not loop", []propagationMsg{msg("a", "a")}, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			layers := layerByDependency(tc.msgs)
+			if len(layers) != tc.wantLayers {
+				t.Fatalf("got %d layers, want %d: %v", len(layers), tc.wantLayers, layers)
+			}
+
+			// Every tx appears exactly once, and no layer contains a tx that
+			// spends another member of the same layer.
+			count := 0
+			placed := make(map[string]int)
+			for i, layer := range layers {
+				for _, m := range layer {
+					count++
+					placed[m.TXID] = i
+				}
+			}
+			if count != len(tc.msgs) {
+				t.Errorf("layering moved %d of %d messages", count, len(tc.msgs))
+			}
+			for i, layer := range layers {
+				inLayer := make(map[string]struct{}, len(layer))
+				for _, m := range layer {
+					inLayer[m.TXID] = struct{}{}
+				}
+				for _, m := range layer {
+					for _, parent := range m.InputTXIDs {
+						if parent == m.TXID {
+							continue
+						}
+						if _, clash := inLayer[parent]; clash {
+							t.Errorf("layer %d contains both %s and its parent %s", i, m.TXID, parent)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestLayerByDependency_CycleGuard: real transactions cannot form a cycle, but
+// the layering must not hang or drop messages if fed one.
+func TestLayerByDependency_CycleGuard(t *testing.T) {
+	msgs := []propagationMsg{
+		{TXID: "a", InputTXIDs: []string{"b"}},
+		{TXID: "b", InputTXIDs: []string{"a"}},
+	}
+	layers := layerByDependency(msgs)
+	total := 0
+	for _, l := range layers {
+		total += len(l)
+	}
+	if total != len(msgs) {
+		t.Fatalf("cycle dropped messages: placed %d of %d", total, len(msgs))
+	}
+}
+
+// TestConfigDefaults_PendingRetrySchedule pins that an unconfigured propagator
+// gets the documented schedule, so "shipped cadence unchanged" claims are
+// checkable rather than asserted in prose.
+func TestConfigDefaults_PendingRetrySchedule(t *testing.T) {
+	p := newPropagator("", "http://localhost:0", newMockStore())
+
+	if p.pendingRetryBackoff != defaultPendingRetryBackoff {
+		t.Errorf("pendingRetryBackoff = %v, want %v", p.pendingRetryBackoff, defaultPendingRetryBackoff)
+	}
+	if p.pendingRetryMaxBackoff != defaultPendingRetryMaxBackoff {
+		t.Errorf("pendingRetryMaxBackoff = %v, want %v", p.pendingRetryMaxBackoff, defaultPendingRetryMaxBackoff)
+	}
+	if p.pendingRetryMaxAttempts != defaultPendingRetryMaxAttempts {
+		t.Errorf("pendingRetryMaxAttempts = %d, want %d", p.pendingRetryMaxAttempts, defaultPendingRetryMaxAttempts)
+	}
+
+	// The cap must equal the flat eligibility age the reaper used before the
+	// durable schedule existed, so the slowest retry cadence is unchanged.
+	if defaultPendingRetryMaxBackoff != 5*time.Minute {
+		t.Errorf("max backoff = %v; it should match the previous flat 5m eligibility age",
+			defaultPendingRetryMaxBackoff)
+	}
+	// And the attempt bound should be about 24h at that cap — the age at which
+	// rows previously fell out of staleScanLookback and were abandoned.
+	span := time.Duration(defaultPendingRetryMaxAttempts) * defaultPendingRetryMaxBackoff
+	if span < 20*time.Hour || span > 28*time.Hour {
+		t.Errorf("give-up span = %v (%d attempts x %v), want ~24h to match the old "+
+			"silent-abandonment horizon", span, defaultPendingRetryMaxAttempts, defaultPendingRetryMaxBackoff)
+	}
+}
+
+// TestResolveMissingParents_ReaperPathIsNotLabelledRequeued keeps the
+// fast-path signal clean. #295's dashboard guidance says a sustained
+// missing_parent_total{outcome="requeued"} rate means family keying is not
+// co-locating same-submission chains — which is only true if the reaper's
+// durable retries are not also counted there.
+func TestResolveMissingParents_ReaperPathIsNotLabelledRequeued(t *testing.T) {
+	root := strings.Repeat("aa", 32)
+	orphan := buildChain(t, root, 1)[0]
+
+	ms := newMockStore()
+	p := newReaperPropagator(t, "http://127.0.0.1:0", ms, 0)
+
+	requeuedBefore := testutil.ToFloat64(metrics.PropagationMissingParentTotal.WithLabelValues("requeued"))
+	reaperBefore := testutil.ToFloat64(metrics.PropagationMissingParentTotal.WithLabelValues("reaper_retry"))
+
+	msgs := []propagationMsg{{TXID: orphan.txid, RawTx: orphan.raw}}
+	line := []string{fmt.Sprintf("TX_MISSING_PARENT (34): [ProcessTransaction][%s] error getting parent transaction %s", orphan.txid, root)}
+	p.resolveMissingParents(context.Background(), msgs, line, missingParentOutcomeReaperRetry)
+
+	if got := testutil.ToFloat64(metrics.PropagationMissingParentTotal.WithLabelValues("requeued")); got != requeuedBefore {
+		t.Errorf("reaper path incremented outcome=\"requeued\" (%v -> %v); a steady population "+
+			"of unresolvable orphans would pin that counter forever and read as a "+
+			"family-keying regression", requeuedBefore, got)
+	}
+	if got := testutil.ToFloat64(metrics.PropagationMissingParentTotal.WithLabelValues("reaper_retry")); got != reaperBefore+1 {
+		t.Errorf("outcome=\"reaper_retry\" = %v, want %v", got, reaperBefore+1)
+	}
+}

--- a/services/propagation/poison_batch_test.go
+++ b/services/propagation/poison_batch_test.go
@@ -552,7 +552,7 @@ func TestHandleTerminal_PendingRetry_ReleasesOffsetAndCascades(t *testing.T) {
 	}
 
 	res := s.terminal("parent", models.StatusPendingRetry)
-	if len(res.cascaded) != 1 || res.cascaded[0] != "child" {
+	if len(res.cascaded) != 1 || res.cascaded[0].txid != "child" {
 		t.Fatalf("parking a parent must cascade its held descendants; got %v", res.cascaded)
 	}
 	if !s.tracker.Empty() {

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -652,13 +652,13 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 	for _, txid := range terminalRejected {
 		r := p.notifyTerminalToDispatcher(ctx, io, txid, models.StatusRejected)
 		for _, child := range r.cascaded {
-			allRejectCascaded = append(allRejectCascaded, cascadeRejection{txid: child, ancestor: txid})
+			allRejectCascaded = append(allRejectCascaded, cascadeRejection{txid: child.txid, rawTx: child.rawTx, ancestor: txid})
 		}
 	}
 	for _, txid := range terminalParked {
 		r := p.notifyTerminalToDispatcher(ctx, io, txid, models.StatusPendingRetry)
 		for _, child := range r.cascaded {
-			allParkCascaded = append(allParkCascaded, cascadeRejection{txid: child, ancestor: txid})
+			allParkCascaded = append(allParkCascaded, cascadeRejection{txid: child.txid, rawTx: child.rawTx, ancestor: txid})
 		}
 	}
 	if len(allRejectCascaded) > 0 {
@@ -674,6 +674,7 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 // reason can name the row a client should look at (and resubmit first).
 type cascadeRejection struct {
 	txid     string
+	rawTx    []byte
 	ancestor string
 }
 
@@ -886,6 +887,17 @@ func (p *Propagator) persistCascade(ctx context.Context, cascaded []cascadeRejec
 			zap.Int("count", len(cascaded)),
 			zap.Error(err),
 		)
+	}
+	// A cascade-parked descendant has to enter the durable retry queue too.
+	// It reaches PENDING_RETRY without ever being broadcast — its ancestor
+	// got no verdict, so it was never charged a requeue budget and never went
+	// through parkExhaustedRequeues. Writing only the status row would leave
+	// it with a NULL next_retry_at, which GetReadyRetries cannot see: the row
+	// would sit at PENDING_RETRY forever with nothing scheduled to retry it.
+	if status == models.StatusPendingRetry {
+		for _, cr := range cascaded {
+			p.schedulePendingRetry(ctx, cr.txid, cr.rawTx)
+		}
 	}
 	p.publishBulkStatus(ctx, status, txids, now)
 }

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -139,6 +139,13 @@ type Propagator struct {
 	// retry loop to milliseconds instead of spending
 	// retryMaxAttempts × 2s of wall time per case.
 	requeueDelay time.Duration
+	// pendingRetryBackoff / pendingRetryMaxBackoff / pendingRetryMaxAttempts
+	// govern the DURABLE retry schedule a parked tx follows once the
+	// in-memory budget above is spent and the reaper owns it. See
+	// schedulePendingRetry.
+	pendingRetryBackoff     time.Duration
+	pendingRetryMaxBackoff  time.Duration
+	pendingRetryMaxAttempts int
 
 	// broadcastJobs feeds the persistent worker pool that runs every
 	// per-endpoint POST /txs call. Replaces the previous per-broadcast
@@ -367,6 +374,21 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 	if cfg.Propagation.RetryBackoffMs > 0 {
 		requeueDelay = time.Duration(cfg.Propagation.RetryBackoffMs) * time.Millisecond
 	}
+	pendingRetryBackoff := defaultPendingRetryBackoff
+	if cfg.Propagation.PendingRetryBackoffMs > 0 {
+		pendingRetryBackoff = time.Duration(cfg.Propagation.PendingRetryBackoffMs) * time.Millisecond
+	}
+	pendingRetryMaxBackoff := defaultPendingRetryMaxBackoff
+	if cfg.Propagation.PendingRetryMaxBackoffMs > 0 {
+		pendingRetryMaxBackoff = time.Duration(cfg.Propagation.PendingRetryMaxBackoffMs) * time.Millisecond
+	}
+	if pendingRetryMaxBackoff < pendingRetryBackoff {
+		pendingRetryMaxBackoff = pendingRetryBackoff
+	}
+	pendingRetryMaxAttempts := defaultPendingRetryMaxAttempts
+	if cfg.Propagation.PendingRetryMaxAttempts > 0 {
+		pendingRetryMaxAttempts = cfg.Propagation.PendingRetryMaxAttempts
+	}
 	p := &Propagator{
 		cfg:               cfg,
 		logger:            logger.Named("propagation"),
@@ -388,11 +410,16 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 		leaseTTL:          leaseTTL,
 		retryMaxAttempts:  retryMaxAttempts,
 		requeueDelay:      requeueDelay,
-		broadcastJobs:     make(chan broadcastJob, broadcastJobBuffer),
-		processBatchSem:   make(chan struct{}, maxConcurrentBatches),
-		defaultIO:         newDispatcherIO(),
-		dispatchers:       make(map[*dispatcherIO]struct{}),
-		initDone:          make(chan struct{}),
+
+		pendingRetryBackoff:     pendingRetryBackoff,
+		pendingRetryMaxBackoff:  pendingRetryMaxBackoff,
+		pendingRetryMaxAttempts: pendingRetryMaxAttempts,
+
+		broadcastJobs:   make(chan broadcastJob, broadcastJobBuffer),
+		processBatchSem: make(chan struct{}, maxConcurrentBatches),
+		defaultIO:       newDispatcherIO(),
+		dispatchers:     make(map[*dispatcherIO]struct{}),
+		initDone:        make(chan struct{}),
 	}
 	// Start a dispatcher goroutine with a nil claim so tests that
 	// construct via New and drive via admitCh / drainCh have a running
@@ -703,24 +730,64 @@ func parentTxIDsOf(msg propagationMsg) []string {
 // non-REJECTED status (RECEIVED, PENDING_RETRY, DOUBLE_SPEND_ATTEMPTED,
 // …) return false — anything else would invent a verdict. Runs on
 // processBatch / reaper worker goroutines only, never the dispatcher.
+//
+// The walk is transitive, bounded by maxAncestorWalkDepth and a visited set.
+// A single hop was not enough to match the behavior this is documented as
+// mirroring: cascadeReject is a recursive BFS over the waiter graph, so a
+// REJECTED grandparent condemns a grandchild immediately on the same
+// partition. Consulting direct parents only meant the cross-partition case
+// needed the parent to cascade first, costing one durable retry cycle per
+// generation before a doomed chain could be condemned.
 func (p *Propagator) rejectedAncestor(ctx context.Context, msg propagationMsg) (string, bool) {
 	if p.store == nil {
 		return "", false
 	}
-	for _, parent := range parentTxIDsOf(msg) {
-		if parent == "" || parent == msg.TXID {
-			continue
+	visited := map[string]struct{}{msg.TXID: {}}
+	frontier := parentTxIDsOf(msg)
+
+	for depth := 0; depth < maxAncestorWalkDepth && len(frontier) > 0; depth++ {
+		var next []string
+		for _, ancestor := range frontier {
+			if ancestor == "" {
+				continue
+			}
+			if _, seen := visited[ancestor]; seen {
+				continue
+			}
+			visited[ancestor] = struct{}{}
+
+			row, err := p.store.GetStatus(ctx, ancestor)
+			if err != nil || row == nil {
+				// Not arcade's tx, or a transient read failure. Either way we
+				// know nothing about it, and inventing a verdict from silence
+				// is exactly what this function exists to avoid.
+				continue
+			}
+			if row.Status == models.StatusRejected {
+				return ancestor, true
+			}
+			// Keep climbing only through ancestors that are themselves still
+			// unresolved. A tx that is ACCEPTED/SEEN/MINED is settled — its
+			// own parents cannot retroactively condemn this child.
+			if row.Status != models.StatusPendingRetry && row.Status != models.StatusReceived {
+				continue
+			}
+			if len(row.RawTx) == 0 {
+				continue
+			}
+			next = append(next, parentTxIDsOf(propagationMsg{TXID: ancestor, RawTx: row.RawTx})...)
 		}
-		row, err := p.store.GetStatus(ctx, parent)
-		if err != nil || row == nil {
-			continue
-		}
-		if row.Status == models.StatusRejected {
-			return parent, true
-		}
+		frontier = next
 	}
 	return "", false
 }
+
+// maxAncestorWalkDepth bounds the transitive rejectedAncestor climb. Each
+// level costs one GetStatus per unresolved ancestor, on a broadcast worker
+// goroutine, so this trades a deeper cascade against per-event store load.
+// Chains this long are already parked and draining a layer at a time; the
+// bound only decides how many generations one pass can condemn at once.
+const maxAncestorWalkDepth = 8
 
 // resolveMissingParents settles every txResultClassMissingParent result:
 // a REJECTED ancestor in the store cascades the child REJECTED (returned
@@ -1974,6 +2041,116 @@ func (p *Propagator) parkExhaustedRequeues(ctx context.Context, msgs []propagati
 	)
 
 	p.applyTerminalStatuses(ctx, statuses, 0, 0, io)
+
+	// Hand the txs to the durable retry queue. applyTerminalStatuses above
+	// wrote status=PENDING_RETRY and released the offset; this records the
+	// per-row retry bins (retry_count, next_retry_at) the reaper drains by.
+	//
+	// Without this the reaper can only find a parked row by scanning
+	// timestamp_at, which Postgres serves newest-first — and because a
+	// failed rebroadcast never rewrote the row, its timestamp stayed frozen
+	// at park time and it sank below every newer eligible row until it fell
+	// out of the 24h scan window entirely.
+	for _, m := range msgs {
+		p.schedulePendingRetry(ctx, m.TXID, m.RawTx)
+	}
+}
+
+// defaultPendingRetryBackoff / defaultPendingRetryMaxBackoff /
+// defaultPendingRetryMaxAttempts back the propagation.pending_retry_* knobs.
+// The max backoff equals the flat eligibility age the reaper used before
+// #299, so the slowest cadence is unchanged while early attempts are much
+// faster; the attempt bound is 24h at that cap, which is when a parked row
+// used to silently fall out of the scan window.
+const (
+	defaultPendingRetryBackoff     = 5 * time.Second
+	defaultPendingRetryMaxBackoff  = 5 * time.Minute
+	defaultPendingRetryMaxAttempts = 288
+)
+
+// nextPendingRetryDelay is the wait before attempt n+1 of a parked tx:
+// exponential in the attempt count, capped at pendingRetryMaxBackoff, with
+// ±20% jitter.
+//
+// Jitter matters more here than it looks. Every child of one late parent
+// parks in the same batch with the same attempt count, so an unjittered
+// schedule re-broadcasts them in lockstep — a synchronized burst at teranode
+// and merkle-service every cycle, forever, for as long as the parent is
+// missing.
+func (p *Propagator) nextPendingRetryDelay(retryCount int) time.Duration {
+	base := p.pendingRetryBackoff
+	if base <= 0 {
+		base = defaultPendingRetryBackoff
+	}
+	maxBackoff := p.pendingRetryMaxBackoff
+	if maxBackoff < base {
+		maxBackoff = base
+	}
+	delay := base
+	for i := 1; i < retryCount && delay < maxBackoff; i++ {
+		delay *= 2
+	}
+	if delay > maxBackoff {
+		delay = maxBackoff
+	}
+	// ±20% jitter. Sourced from crypto/rand only because it is already the
+	// package's rand import; nothing here is a security decision.
+	var b [2]byte
+	if _, err := rand.Read(b[:]); err == nil {
+		frac := float64(uint16(b[0])<<8|uint16(b[1])) / 65535.0
+		delay += time.Duration((frac*0.4 - 0.2) * float64(delay))
+	}
+	if delay < time.Millisecond {
+		delay = time.Millisecond
+	}
+	return delay
+}
+
+// schedulePendingRetry books a parked tx's next durable attempt, or gives up
+// on it.
+//
+// Give-up is the property the PENDING_RETRY path was missing entirely. A tx
+// spending an outpoint that does not exist — the most common client mistake
+// there is — draws TX_MISSING_PARENT forever: rejectedAncestor finds no
+// REJECTED ancestor because arcade has never seen the parent at all, so the
+// row can never be condemned and can never succeed. Before #299 those rows
+// accumulated without bound, monopolized the reaper's per-tick batch, and
+// were finally abandoned at 24h in a non-terminal state with no signal of
+// any kind. Now they terminate with a verdict the submitter can read.
+func (p *Propagator) schedulePendingRetry(ctx context.Context, txid string, rawTx []byte) {
+	if p.store == nil || len(rawTx) == 0 {
+		return
+	}
+	count, err := p.store.BumpRetryCount(ctx, txid)
+	if err != nil {
+		// The row may not exist yet on the intake path; the next reaper tick
+		// re-derives everything it needs, so this is not fatal.
+		p.logger.Warn("bump retry count failed; tx keeps its previous retry schedule",
+			logfields.TxID(txid), zap.Error(err))
+		return
+	}
+	if count > p.pendingRetryMaxAttempts {
+		reason := fmt.Sprintf(
+			"no network verdict after %d durable retry attempts: giving up — a parent this transaction spends has never reached the network",
+			p.pendingRetryMaxAttempts,
+		)
+		metrics.PropagationPendingRetryTotal.WithLabelValues("exhausted").Inc()
+		p.logger.Warn("durable retry budget exhausted; terminalizing parked tx as REJECTED",
+			logfields.TxID(txid), zap.Int("attempts", count))
+		if err := p.store.ClearRetryState(ctx, txid, models.StatusRejected, reason); err != nil {
+			p.logger.Error("clear retry state failed", logfields.TxID(txid), zap.Error(err))
+			return
+		}
+		p.publishBulkStatus(ctx, models.StatusRejected, []string{txid}, time.Now())
+		return
+	}
+	next := time.Now().Add(p.nextPendingRetryDelay(count))
+	if err := p.store.SetPendingRetryFields(ctx, txid, rawTx, next); err != nil {
+		p.logger.Error("set pending retry fields failed; tx may not be re-broadcast",
+			logfields.TxID(txid), zap.Error(err))
+		return
+	}
+	metrics.PropagationPendingRetryTotal.WithLabelValues("scheduled").Inc()
 }
 
 // Per-batch chunk parallelism is now config-driven via

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -421,6 +421,7 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 		dispatchers:     make(map[*dispatcherIO]struct{}),
 		initDone:        make(chan struct{}),
 	}
+	metrics.PreRegisterPropagationRetryOutcomes()
 	// Start a dispatcher goroutine with a nil claim so tests that
 	// construct via New and drive via admitCh / drainCh have a running
 	// state machine without needing to invoke Start. In production
@@ -789,12 +790,30 @@ func (p *Propagator) rejectedAncestor(ctx context.Context, msg propagationMsg) (
 // bound only decides how many generations one pass can condemn at once.
 const maxAncestorWalkDepth = 8
 
+// Labels for the requeue side of PropagationMissingParentTotal. The fast path
+// really does requeue; the reaper books a durable retry instead. Reporting
+// both as "requeued" meant a constant population of unresolvable orphans
+// pinned that counter at a steady rate forever, which reads exactly like the
+// sustained family-keying regression #295's dashboard note tells operators to
+// look for.
+const (
+	missingParentOutcomeRequeued    = "requeued"
+	missingParentOutcomeReaperRetry = "reaper_retry"
+)
+
 // resolveMissingParents settles every txResultClassMissingParent result:
 // a REJECTED ancestor in the store cascades the child REJECTED (returned
 // as extra terminal statuses); everything else requeues with the
 // Teranode line as its retry reason. Shared by processBatch and the
 // reaper (which passes collect=false semantics via its own loop).
-func (p *Propagator) resolveMissingParents(ctx context.Context, msgs []propagationMsg, lines []string) (cascaded []*models.TransactionStatus, requeue []propagationMsg) {
+//
+// outcome reports which caller this is, because the two do different things
+// with the returned requeue slice: processBatch actually requeues, while the
+// reaper discards it and books a durable retry instead. Labelling both
+// "requeued" made a steady population of unresolvable orphans pin that
+// counter at a constant rate forever — poisoning the exact signal #295's
+// dashboard guidance says to watch for family-keying regressions.
+func (p *Propagator) resolveMissingParents(ctx context.Context, msgs []propagationMsg, lines []string, outcome string) (cascaded []*models.TransactionStatus, requeue []propagationMsg) {
 	now := time.Now()
 	for i, msg := range msgs {
 		if ancestor, ok := p.rejectedAncestor(ctx, msg); ok {
@@ -812,7 +831,7 @@ func (p *Propagator) resolveMissingParents(ctx context.Context, msgs []propagati
 			})
 			continue
 		}
-		metrics.PropagationMissingParentTotal.WithLabelValues("requeued").Inc()
+		metrics.PropagationMissingParentTotal.WithLabelValues(outcome).Inc()
 		msg.retryReason = lines[i]
 		requeue = append(requeue, msg)
 	}
@@ -1808,7 +1827,7 @@ func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg, i
 			"teranode reported missing parents; treating as retryable condition, not verdict",
 			mpFields...,
 		)
-		cascaded, requeue := p.resolveMissingParents(ctx, missingParentMsgs, missingParentLines)
+		cascaded, requeue := p.resolveMissingParents(ctx, missingParentMsgs, missingParentLines, missingParentOutcomeRequeued)
 		rejected += len(cascaded)
 		terminalStatuses = append(terminalStatuses, cascaded...)
 		toRequeue = append(toRequeue, requeue...)

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -77,6 +77,12 @@ type propagationMsg struct {
 	// commit watermark (the 2026-08-11 dev-ovh-1 wedge: 337,247 messages of
 	// lag stationary behind 4,679 in-flight txs).
 	retryCount int
+	// retryReason, when non-empty, names the condition that sent this tx
+	// through the requeue loop (currently only the missing-parent line
+	// from Teranode) so parkExhaustedRequeues can write a specific
+	// PENDING_RETRY reason instead of the generic no-verdict text.
+	// Process-local like retryCount; never serialized.
+	retryReason string
 }
 
 type Propagator struct {
@@ -95,16 +101,18 @@ type Propagator struct {
 	consumer atomic.Pointer[kafka.ConsumerGroup]
 
 	maxPending int
-	// admitCh, requeueCh, terminalCh, and drainCh feed runDispatcher's
-	// single state-owning loop. The loop selects on these channels (and,
-	// in production, claim.Messages()) and runs ALL dep-aware state
-	// mutations — inFlight, waiters, heldMsgs, pendingMsgs, the
-	// offsetTracker, and the pendingMarks map — inside the goroutine
-	// that owns the loop. No locks, no atomics. See dispatcher.go.
-	admitCh           chan admitRequest
-	requeueCh         chan requeueRequest
-	terminalCh        chan terminalEvent
-	drainCh           chan drainRequest
+	// defaultIO is the dispatcherIO of the New()-spawned test-mode
+	// dispatcher; its channels feed that loop's dep-aware state machine
+	// exactly as each per-claim io feeds a production loop. Production
+	// claims each build their own io in handleClaim (#295: one dispatcher
+	// per partition claim; a shared channel set would mis-route events
+	// across partitions). See dispatcherIO in dispatcher.go.
+	defaultIO *dispatcherIO
+	// dispatchers is the live-dispatcher registry behind the reaper's
+	// nil-io terminal fan-out. Guarded by dispatchersMu; every other
+	// piece of dispatcher state stays goroutine-local.
+	dispatchersMu     sync.RWMutex
+	dispatchers       map[*dispatcherIO]struct{}
 	dispatcherCancel  context.CancelFunc
 	dispatcherDone    chan struct{}
 	merkleConcurrency int
@@ -251,6 +259,18 @@ const (
 	// row stays at RECEIVED in the DB; the dispatcher inFlight entry and
 	// pinned Kafka offset both persist across the requeue.
 	txResultClassRequeue
+	// txResultClassMissingParent: Teranode explicitly answered
+	// TX_MISSING_PARENT / TX_NOT_FOUND — the tx's parent isn't in the
+	// node's store YET. With multi-partition propagation (#295) this is
+	// the expected signature of a child broadcast before its
+	// cross-submission parent, so per the #254 principle it is a
+	// CONDITION, not a verdict: never terminalize REJECTED on it alone.
+	// processBatch consults arcade's own store first — a parent
+	// terminally REJECTED cascades the child REJECTED (that's a real
+	// verdict); anything else requeues, and budget exhaustion parks at
+	// PENDING_RETRY for the reaper's durable retry. errMsg carries the
+	// Teranode line for the park reason.
+	txResultClassMissingParent
 )
 
 // broadcastJobBuffer sizes the job channel between broadcast helpers and the
@@ -339,6 +359,14 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 	if retryMaxAttempts <= 0 {
 		retryMaxAttempts = defaultRetryMaxAttempts
 	}
+	// retry_backoff_ms drives the flat requeue delay. It existed as a
+	// declared-but-unread field long before #295 wired it up, so the viper
+	// default was bumped 500 → 2000 in the same change to keep the shipped
+	// cadence identical to the old hardcoded defaultRequeueDelay.
+	requeueDelay := defaultRequeueDelay
+	if cfg.Propagation.RetryBackoffMs > 0 {
+		requeueDelay = time.Duration(cfg.Propagation.RetryBackoffMs) * time.Millisecond
+	}
 	p := &Propagator{
 		cfg:               cfg,
 		logger:            logger.Named("propagation"),
@@ -359,13 +387,11 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 		holderID:          newHolderID(),
 		leaseTTL:          leaseTTL,
 		retryMaxAttempts:  retryMaxAttempts,
-		requeueDelay:      defaultRequeueDelay,
+		requeueDelay:      requeueDelay,
 		broadcastJobs:     make(chan broadcastJob, broadcastJobBuffer),
 		processBatchSem:   make(chan struct{}, maxConcurrentBatches),
-		admitCh:           make(chan admitRequest, dispatcherChannelBuffer),
-		requeueCh:         make(chan requeueRequest, dispatcherChannelBuffer),
-		terminalCh:        make(chan terminalEvent, dispatcherChannelBuffer),
-		drainCh:           make(chan drainRequest),
+		defaultIO:         newDispatcherIO(),
+		dispatchers:       make(map[*dispatcherIO]struct{}),
 		initDone:          make(chan struct{}),
 	}
 	// Start a dispatcher goroutine with a nil claim so tests that
@@ -381,7 +407,7 @@ func New(cfg *config.Config, logger *zap.Logger, producer *kafka.Producer, publi
 	p.dispatcherDone = make(chan struct{})
 	go func() {
 		defer close(p.dispatcherDone)
-		if err := p.runDispatcher(dispatcherCtx, nil, dispatcherConfig{maxPending: maxPending}); err != nil {
+		if err := p.runDispatcher(dispatcherCtx, nil, dispatcherConfig{maxPending: maxPending}, p.defaultIO); err != nil {
 			p.logger.Error("test-mode dispatcher exited with error", zap.Error(err))
 		}
 	}()
@@ -460,7 +486,9 @@ func (p *Propagator) Name() string { return "propagation" }
 //
 // Split out of processBatch so the surrounding flush loop stays under
 // nesting-complexity limits.
-func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses []*models.TransactionStatus, accepted, rejected int) {
+// io names the dispatcher whose pipeline produced these terminals; nil
+// (reaper path) fans the notifications out to every live dispatcher.
+func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses []*models.TransactionStatus, accepted, rejected int, io *dispatcherIO) {
 	if len(terminalStatuses) == 0 {
 		return
 	}
@@ -591,16 +619,16 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 	// ancestor.
 	var allRejectCascaded, allParkCascaded []cascadeRejection
 	for _, txid := range terminalAccepted {
-		p.notifyTerminalToDispatcher(ctx, txid, models.StatusAcceptedByNetwork)
+		p.notifyTerminalToDispatcher(ctx, io, txid, models.StatusAcceptedByNetwork)
 	}
 	for _, txid := range terminalRejected {
-		r := p.notifyTerminalToDispatcher(ctx, txid, models.StatusRejected)
+		r := p.notifyTerminalToDispatcher(ctx, io, txid, models.StatusRejected)
 		for _, child := range r.cascaded {
 			allRejectCascaded = append(allRejectCascaded, cascadeRejection{txid: child, ancestor: txid})
 		}
 	}
 	for _, txid := range terminalParked {
-		r := p.notifyTerminalToDispatcher(ctx, txid, models.StatusPendingRetry)
+		r := p.notifyTerminalToDispatcher(ctx, io, txid, models.StatusPendingRetry)
 		for _, child := range r.cascaded {
 			allParkCascaded = append(allParkCascaded, cascadeRejection{txid: child, ancestor: txid})
 		}
@@ -640,6 +668,88 @@ func cascadeReason(status models.Status, ancestor string) string {
 		"parent rejected (ancestor %s): retryable — resubmit after the ancestor is accepted",
 		ancestor,
 	)
+}
+
+// parentTxIDsOf returns msg's parent txids: InputTXIDs when the intake
+// envelope populated them, else parsed from the raw bytes (reaper
+// rebroadcast rows carry no InputTXIDs). Unparseable bytes yield nil —
+// the caller then just requeues/parks, which is always safe.
+func parentTxIDsOf(msg propagationMsg) []string {
+	if len(msg.InputTXIDs) > 0 {
+		return msg.InputTXIDs
+	}
+	tx, err := sdkTx.NewTransactionFromBytes(msg.RawTx)
+	if err != nil || tx == nil {
+		return nil
+	}
+	parents := make([]string, 0, len(tx.Inputs))
+	for _, in := range tx.Inputs {
+		if in == nil || in.SourceTXID == nil {
+			continue
+		}
+		parents = append(parents, in.SourceTXID.String())
+	}
+	return parents
+}
+
+// rejectedAncestor consults arcade's own status store for msg's parents
+// and returns the first that is terminally REJECTED. This is the ONLY
+// path from a Teranode missing-parent condition to a REJECTED child: the
+// ancestor's rejection is a real verdict, so inheriting it mirrors the
+// dispatcher's same-partition cascade for parents that live on another
+// partition (or terminalized before this pod ever saw them).
+//
+// Deliberately conservative: store.ErrNotFound, read errors, and every
+// non-REJECTED status (RECEIVED, PENDING_RETRY, DOUBLE_SPEND_ATTEMPTED,
+// …) return false — anything else would invent a verdict. Runs on
+// processBatch / reaper worker goroutines only, never the dispatcher.
+func (p *Propagator) rejectedAncestor(ctx context.Context, msg propagationMsg) (string, bool) {
+	if p.store == nil {
+		return "", false
+	}
+	for _, parent := range parentTxIDsOf(msg) {
+		if parent == "" || parent == msg.TXID {
+			continue
+		}
+		row, err := p.store.GetStatus(ctx, parent)
+		if err != nil || row == nil {
+			continue
+		}
+		if row.Status == models.StatusRejected {
+			return parent, true
+		}
+	}
+	return "", false
+}
+
+// resolveMissingParents settles every txResultClassMissingParent result:
+// a REJECTED ancestor in the store cascades the child REJECTED (returned
+// as extra terminal statuses); everything else requeues with the
+// Teranode line as its retry reason. Shared by processBatch and the
+// reaper (which passes collect=false semantics via its own loop).
+func (p *Propagator) resolveMissingParents(ctx context.Context, msgs []propagationMsg, lines []string) (cascaded []*models.TransactionStatus, requeue []propagationMsg) {
+	now := time.Now()
+	for i, msg := range msgs {
+		if ancestor, ok := p.rejectedAncestor(ctx, msg); ok {
+			metrics.PropagationMissingParentTotal.WithLabelValues("rejected_ancestor").Inc()
+			p.logger.Info(
+				"missing-parent child cascaded to REJECTED via store consult",
+				logfields.TxID(msg.TXID),
+				zap.String("ancestor", ancestor),
+			)
+			cascaded = append(cascaded, &models.TransactionStatus{
+				TxID:      msg.TXID,
+				Status:    models.StatusRejected,
+				Timestamp: now,
+				ExtraInfo: cascadeReason(models.StatusRejected, ancestor),
+			})
+			continue
+		}
+		metrics.PropagationMissingParentTotal.WithLabelValues("requeued").Inc()
+		msg.retryReason = lines[i]
+		requeue = append(requeue, msg)
+	}
+	return cascaded, requeue
 }
 
 // persistCascade writes rows for txs the dep cascade terminalized without ever
@@ -827,7 +937,10 @@ func (p *Propagator) handleClaim(ctx context.Context) kafka.ClaimHandler {
 			case <-claimCtx.Done():
 			}
 		}()
-		return p.runDispatcher(claimCtx, claim, cfg)
+		// One dispatcherIO per claim: Sarama runs one ConsumeClaim per
+		// assigned partition, and each loop's events must be unreachable
+		// by its siblings (#295 — see dispatcherIO).
+		return p.runDispatcher(claimCtx, claim, cfg, newDispatcherIO())
 	}
 }
 
@@ -960,7 +1073,6 @@ func (p *Propagator) flushBatch(ctx context.Context) error {
 	// drainCh request/reply. The dispatcher owns the slice; we
 	// receive a snapshot and own it from here on.
 	batch := p.drainPending()
-	metrics.PropagationPendingDepth.Set(0)
 
 	if len(batch) == 0 {
 		return nil
@@ -979,7 +1091,7 @@ func (p *Propagator) flushBatch(ctx context.Context) error {
 			p.inflightBatches.Done()
 			metrics.PropagationInflightBatches.Set(float64(len(p.processBatchSem)))
 		}()
-		p.processBatch(ctx, batch)
+		p.processBatch(ctx, batch, p.defaultIO)
 	}()
 	return nil
 }
@@ -1338,6 +1450,22 @@ func attributeOneConflictLine(line string, owners map[string]int) (int, bool) {
 
 // rejectionLineScore ranks a Teranode failure line for wallet-facing quality.
 // Higher is better. Unknown free text scores 0.
+// lineIsMissingParentCondition reports whether a Teranode failure line is
+// the missing-parent condition family: TX_MISSING_PARENT (34), or its
+// un-wrapped store-layer form TX_NOT_FOUND (30) — both produced when a
+// tx's parent isn't in the node's UTXO store yet, which on a
+// multi-partition propagation topic is the signature of an out-of-order
+// child rather than a verdict about the bytes. Substring match, not a
+// prefix: Teranode nests codes ("PROCESSING (4): … TX_MISSING_PARENT
+// (34): …") and doubles prefixes. Over-matching only routes a tx to the
+// bounded requeue (safe, self-correcting); under-matching risks a false
+// terminal REJECTED — so err on matching. The "(" suffix keeps free-text
+// mentions of parents from matching.
+func lineIsMissingParentCondition(line string) bool {
+	return strings.Contains(line, "TX_MISSING_PARENT (") ||
+		strings.Contains(line, "TX_NOT_FOUND (")
+}
+
 func rejectionLineScore(line string) int {
 	name, _, found := strings.Cut(line, " (")
 	if !found {
@@ -1510,7 +1638,9 @@ func (p *Propagator) abortBatchOnRevokedClaim(ctx context.Context, txCount int) 
 //
 // Failure paths are absorbed internally — there's no caller that reacts
 // to an aggregate error here, so the function returns void.
-func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) {
+// io is the channel set of the dispatcher that flushed this batch; every
+// downstream requeue and terminal notification routes back through it.
+func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg, io *dispatcherIO) {
 	// The dispatcher detaches this goroutine (see flushBatch / the flush
 	// tick), so the claim can be revoked before the batch even starts.
 	if p.abortBatchOnRevokedClaim(ctx, len(batch)) {
@@ -1526,7 +1656,7 @@ func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) {
 		return
 	}
 	if len(failedRegister) > 0 {
-		p.requeueAfterDelay(ctx, failedRegister)
+		p.requeueAfterDelay(ctx, failedRegister, io)
 	}
 	if len(registered) == 0 {
 		return
@@ -1567,6 +1697,8 @@ func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) {
 	var accepted, rejected int
 	terminalStatuses := make([]*models.TransactionStatus, 0, len(results))
 	var toRequeue []propagationMsg
+	var missingParentMsgs []propagationMsg
+	var missingParentLines []string
 	for i, res := range results {
 		if res.successEndpoint != "" {
 			if _, ok := seenEndpoints[res.successEndpoint]; !ok {
@@ -1585,6 +1717,11 @@ func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) {
 			if res.status != nil {
 				terminalStatuses = append(terminalStatuses, res.status)
 			}
+		case txResultClassMissingParent:
+			// Condition, not verdict (#254/#295): resolved below against
+			// arcade's own store before anything terminalizes.
+			missingParentMsgs = append(missingParentMsgs, batch[i])
+			missingParentLines = append(missingParentLines, res.errMsg)
 		default:
 			// Requeue / Unknown: transient infra failure. Collect for
 			// requeue after a short flat wait so the dispatcher re-runs
@@ -1594,7 +1731,23 @@ func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) {
 		}
 	}
 
-	p.applyTerminalStatuses(ctx, terminalStatuses, accepted, rejected)
+	if len(missingParentMsgs) > 0 {
+		mpTxids := make([]string, len(missingParentMsgs))
+		for i, m := range missingParentMsgs {
+			mpTxids[i] = m.TXID
+		}
+		mpFields := append([]zap.Field{logfields.Stage(logfields.StageNetwork)}, logfields.TxIDBatch(mpTxids)...)
+		p.logger.Warn(
+			"teranode reported missing parents; treating as retryable condition, not verdict",
+			mpFields...,
+		)
+		cascaded, requeue := p.resolveMissingParents(ctx, missingParentMsgs, missingParentLines)
+		rejected += len(cascaded)
+		terminalStatuses = append(terminalStatuses, cascaded...)
+		toRequeue = append(toRequeue, requeue...)
+	}
+
+	p.applyTerminalStatuses(ctx, terminalStatuses, accepted, rejected, io)
 	if len(toRequeue) > 0 {
 		// A claim revoked during broadcast classifies every no-verdict tx
 		// as Requeue (born-canceled submitCtx → instant SubmitTransactions
@@ -1606,7 +1759,7 @@ func (p *Propagator) processBatch(ctx context.Context, batch []propagationMsg) {
 		if p.abortBatchOnRevokedClaim(ctx, len(toRequeue)) {
 			return
 		}
-		p.requeueAfterDelay(ctx, toRequeue)
+		p.requeueAfterDelay(ctx, toRequeue, io)
 	}
 	metrics.PropagationOutcomeTotal.WithLabelValues("accepted").Add(float64(accepted))
 	metrics.PropagationOutcomeTotal.WithLabelValues("rejected").Add(float64(rejected))
@@ -1649,7 +1802,7 @@ const defaultRequeueDelay = 2 * time.Second
 // uncommitted offset IS the retry. The drop must not be silent though:
 // it's logged so a teardown that strands a large requeue batch is
 // visible in the operator's logs rather than looking like lost work.
-func (p *Propagator) requeueAfterDelay(ctx context.Context, msgs []propagationMsg) {
+func (p *Propagator) requeueAfterDelay(ctx context.Context, msgs []propagationMsg, io *dispatcherIO) {
 	if len(msgs) == 0 {
 		return
 	}
@@ -1674,7 +1827,7 @@ func (p *Propagator) requeueAfterDelay(ctx context.Context, msgs []propagationMs
 
 	msgs, exhausted := p.chargeRetryBudget(msgs)
 	if len(exhausted) > 0 {
-		p.parkExhaustedRequeues(ctx, exhausted)
+		p.parkExhaustedRequeues(ctx, exhausted, io)
 	}
 	if len(msgs) == 0 {
 		return
@@ -1713,7 +1866,7 @@ func (p *Propagator) requeueAfterDelay(ctx context.Context, msgs []propagationMs
 			// requeueToDispatcher selects on ctx, so a teardown mid-loop
 			// unblocks the send instead of leaking this goroutine on a
 			// requeueCh whose dispatcher has already exited.
-			if !p.requeueToDispatcher(ctx, m) {
+			if !p.requeueToDispatcher(ctx, io, m) {
 				p.logger.Debug(
 					"requeue dropped mid-batch; txs left uncommitted for replay",
 					zap.Int("dropped", len(msgs)-i),
@@ -1774,16 +1927,27 @@ func (p *Propagator) chargeRetryBudget(msgs []propagationMsg) (retry, exhausted 
 // one path that both persists the status AND notifies the dispatcher. A park
 // that skipped the notify would leave the in-flight entry — and therefore the
 // wedge — exactly as it was.
-func (p *Propagator) parkExhaustedRequeues(ctx context.Context, msgs []propagationMsg) {
+func (p *Propagator) parkExhaustedRequeues(ctx context.Context, msgs []propagationMsg, io *dispatcherIO) {
 	now := time.Now()
 	txids := make([]string, len(msgs))
 	statuses := make([]*models.TransactionStatus, len(msgs))
-	reason := fmt.Sprintf(
+	genericReason := fmt.Sprintf(
 		"no network verdict after %d propagation attempts: retryable — parked for durable rebroadcast by the propagation reaper",
 		p.retryMaxAttempts,
 	)
 	for i, m := range msgs {
 		txids[i] = m.TXID
+		// A tx that cycled here on a named condition (missing parent)
+		// gets a reason stating it, so GET /tx explains WHY the fast
+		// path gave up instead of the generic no-verdict text.
+		reason := genericReason
+		if m.retryReason != "" {
+			reason = fmt.Sprintf(
+				"parent not yet accepted by the network after %d propagation attempts: retryable — parked for durable rebroadcast by the propagation reaper; last error: %s",
+				p.retryMaxAttempts,
+				m.retryReason,
+			)
+		}
 		statuses[i] = &models.TransactionStatus{
 			TxID:      m.TXID,
 			Status:    models.StatusPendingRetry,
@@ -1809,7 +1973,7 @@ func (p *Propagator) parkExhaustedRequeues(ctx context.Context, msgs []propagati
 		parkFields...,
 	)
 
-	p.applyTerminalStatuses(ctx, statuses, 0, 0)
+	p.applyTerminalStatuses(ctx, statuses, 0, 0, io)
 }
 
 // Per-batch chunk parallelism is now config-driven via
@@ -2082,6 +2246,12 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 	outcomes := make([]endpointOutcome, 0, submitted)
 	acceptedByAny := make([]bool, len(batch))
 	rejectionLine := make([]string, len(batch))
+	// missingParentLine collects TX_MISSING_PARENT / TX_NOT_FOUND lines
+	// separately from real verdicts: they are conditions (#254), not
+	// rejections, and rank below any genuine verdict in the final
+	// classification. See lineIsMissingParentCondition and
+	// txResultClassMissingParent.
+	missingParentLine := make([]string, len(batch))
 	// outpointOwners is the batch's spent-outpoint → tx index map used to
 	// attribute conflict-family lines back to submitted txs. Built lazily and
 	// at most once: it costs a full parse of every raw tx in the batch, which
@@ -2191,13 +2361,29 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 		}
 		for j, lower := range lowerTxids {
 			if line, failed := result.failures[lower]; failed {
-				rejectionLine[j] = preferRejectionLine(rejectionLine[j], line)
+				// A missing-parent line keyed to a submitted tx is NOT a
+				// verdict about its bytes — the peer processed the batch
+				// and told us the parent isn't there yet. Route it to the
+				// condition bucket; the siblings' implicit accepts above
+				// are untouched (the line is in-batch-keyed, not alien).
+				if lineIsMissingParentCondition(line) {
+					missingParentLine[j] = preferRejectionLine(missingParentLine[j], line)
+				} else {
+					rejectionLine[j] = preferRejectionLine(rejectionLine[j], line)
+				}
 			} else if alienCount == 0 {
 				acceptedByAny[j] = true
 			}
 		}
 		for idx, line := range attributed {
-			rejectionLine[idx] = preferRejectionLine(rejectionLine[idx], line)
+			// Attributed lines are conflict-family by construction, but the
+			// condition check is kept for defense: a mis-shaped line must
+			// never become a terminal verdict via the attribution path.
+			if lineIsMissingParentCondition(line) {
+				missingParentLine[idx] = preferRejectionLine(missingParentLine[idx], line)
+			} else {
+				rejectionLine[idx] = preferRejectionLine(rejectionLine[idx], line)
+			}
 		}
 		// A single-tx batch has exactly one possible owner for an alien
 		// verdict — the tx itself. Terminalize it with the real reason
@@ -2207,7 +2393,11 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 		// attribution can't cover — a conflict line about an outpoint the tx
 		// doesn't visibly spend, or raw bytes we failed to parse.
 		if alienCount > 0 && len(batch) == 1 {
-			rejectionLine[0] = preferRejectionLine(rejectionLine[0], bestAlien)
+			if lineIsMissingParentCondition(bestAlien) {
+				missingParentLine[0] = preferRejectionLine(missingParentLine[0], bestAlien)
+			} else {
+				rejectionLine[0] = preferRejectionLine(rejectionLine[0], bestAlien)
+			}
 		}
 	}
 	recordBroadcastOutcomes(p.teranodeClient, outcomes)
@@ -2246,6 +2436,15 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 					ExtraInfo:  errMsg,
 				},
 				rawTx: msg.RawTx,
+			}
+		case missingParentLine[i] != "":
+			// Condition, not verdict: no status write here. processBatch
+			// consults the store (rejected ancestor → cascade REJECTED)
+			// and otherwise requeues with this line as the retry reason.
+			results[i] = txResult{
+				class:  txResultClassMissingParent,
+				errMsg: missingParentLine[i],
+				rawTx:  msg.RawTx,
 			}
 		default:
 			results[i] = txResult{

--- a/services/propagation/propagator_test.go
+++ b/services/propagation/propagator_test.go
@@ -154,6 +154,10 @@ type mockStore struct {
 	// rawByTxID carries raw_tx alongside statusByTxID so GetStatus returns
 	// rows shaped like the real backends'. See setStatusRow.
 	rawByTxID map[string][]byte
+	// retrySeq records the order rows entered the durable retry queue, so
+	// GetReadyRetries can break next_retry_at ties the way an index scan does.
+	retrySeq     map[string]int
+	retrySeqNext int
 }
 
 // setStatus seeds the row GetStatus returns for txid.
@@ -201,6 +205,7 @@ func newMockStore() *mockStore {
 	return &mockStore{
 		retryCounts:    make(map[string]int),
 		pendingRetries: make(map[string]*store.PendingRetry),
+		retrySeq:       make(map[string]int),
 	}
 }
 
@@ -250,6 +255,10 @@ func (m *mockStore) BumpRetryCount(_ context.Context, txid string) (int, error) 
 func (m *mockStore) SetPendingRetryFields(_ context.Context, txid string, rawTx []byte, nextRetryAt time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if _, ok := m.retrySeq[txid]; !ok {
+		m.retrySeq[txid] = m.retrySeqNext
+		m.retrySeqNext++
+	}
 	m.pendingRetries[txid] = &store.PendingRetry{
 		TxID:        txid,
 		RawTx:       append([]byte(nil), rawTx...),
@@ -295,7 +304,11 @@ func (m *mockStore) SetPendingRetryFields(_ context.Context, txid string, rawTx 
 func (m *mockStore) GetReadyRetries(_ context.Context, now time.Time, limit int) ([]*store.PendingRetry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	out := make([]*store.PendingRetry, 0, len(m.pendingRetries))
+	type entry struct {
+		pr  *store.PendingRetry
+		seq int
+	}
+	pending := make([]entry, 0, len(m.pendingRetries))
 	for txid, pr := range m.pendingRetries {
 		if pr.NextRetryAt.After(now) {
 			continue
@@ -303,12 +316,30 @@ func (m *mockStore) GetReadyRetries(_ context.Context, now time.Time, limit int)
 		if st, ok := m.latestStatusLocked(txid); ok && st != models.StatusPendingRetry {
 			continue
 		}
-		cp := *pr
-		out = append(out, &cp)
+		pending = append(pending, entry{pr: pr, seq: m.retrySeq[txid]})
 	}
-	sort.SliceStable(out, func(i, j int) bool { return out[i].NextRetryAt.Before(out[j].NextRetryAt) })
-	if limit > 0 && len(out) > limit {
-		out = out[:limit]
+	// Order by next_retry_at, breaking ties by insertion sequence.
+	//
+	// The tie-break is not cosmetic. Rows parked by one call all share a
+	// single timestamp (parkExhaustedRequeues stamps one now for the whole
+	// slice), so ties are the common case, and Postgres serves
+	// "ORDER BY next_retry_at LIMIT n" from idx_tx_retry_ready — equal keys
+	// come back in index/heap order, which tracks insertion. Ranging over a
+	// Go map instead would hand back a random subset each call, which is both
+	// unfaithful and non-deterministic across runs.
+	sort.SliceStable(pending, func(i, j int) bool {
+		if pending[i].pr.NextRetryAt.Equal(pending[j].pr.NextRetryAt) {
+			return pending[i].seq < pending[j].seq
+		}
+		return pending[i].pr.NextRetryAt.Before(pending[j].pr.NextRetryAt)
+	})
+	if limit > 0 && len(pending) > limit {
+		pending = pending[:limit]
+	}
+	out := make([]*store.PendingRetry, 0, len(pending))
+	for _, e := range pending {
+		cp := *e.pr
+		out = append(out, &cp)
 	}
 	return out, nil
 }
@@ -342,6 +373,10 @@ func (m *mockStore) parkTx(txid string, rawTx []byte, parkedAt, nextRetryAt time
 		Timestamp: parkedAt,
 	})
 	m.retryCounts[txid]++
+	if _, ok := m.retrySeq[txid]; !ok {
+		m.retrySeq[txid] = m.retrySeqNext
+		m.retrySeqNext++
+	}
 	m.pendingRetries[txid] = &store.PendingRetry{
 		TxID:        txid,
 		RawTx:       append([]byte(nil), rawTx...),

--- a/services/propagation/propagator_test.go
+++ b/services/propagation/propagator_test.go
@@ -265,6 +265,18 @@ func (m *mockStore) SetPendingRetryFields(_ context.Context, txid string, rawTx 
 		RetryCount:  m.retryCounts[txid],
 		NextRetryAt: nextRetryAt,
 	}
+	// Mirror the write onto the row the scan walk sees. The real statement
+	// updates the transactions row itself, so a later IterateStatusesSince
+	// observes the new next_retry_at — which is what stops the reaper's
+	// legacy-row adoption from re-firing on every tick.
+	for _, r := range m.replayRows {
+		if r.TxID == txid {
+			r.Status = models.StatusPendingRetry
+			r.NextRetryAt = nextRetryAt
+			r.RetryCount = m.retryCounts[txid]
+			r.Timestamp = time.Now()
+		}
+	}
 	// Reflect PENDING_RETRY status in the updates stream so existing tests that
 	// inspect status updates continue to observe the transition.
 	//
@@ -366,13 +378,19 @@ func (m *mockStore) latestStatusLocked(txid string) (models.Status, bool) {
 func (m *mockStore) parkTx(txid string, rawTx []byte, parkedAt, nextRetryAt time.Time) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.replayRows = append(m.replayRows, &models.TransactionStatus{
-		TxID:      txid,
-		Status:    models.StatusPendingRetry,
-		RawTx:     rawTx,
-		Timestamp: parkedAt,
-	})
 	m.retryCounts[txid]++
+	// The status row carries the retry bins too, because the real park writes
+	// them with SetPendingRetryFields. A row without next_retry_at is a LEGACY
+	// park (pre-durable-scheduling) and the reaper deliberately treats it
+	// differently — see TestReapOnce_AdoptsLegacyParkedRows.
+	m.replayRows = append(m.replayRows, &models.TransactionStatus{
+		TxID:        txid,
+		Status:      models.StatusPendingRetry,
+		RawTx:       rawTx,
+		Timestamp:   parkedAt,
+		RetryCount:  m.retryCounts[txid],
+		NextRetryAt: nextRetryAt,
+	})
 	if _, ok := m.retrySeq[txid]; !ok {
 		m.retrySeq[txid] = m.retrySeqNext
 		m.retrySeqNext++

--- a/services/propagation/propagator_test.go
+++ b/services/propagation/propagator_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -325,6 +326,17 @@ func (m *mockStore) IterateStatusesSince(_ context.Context, since time.Time, fn 
 	m.mu.Lock()
 	rows := append([]*models.TransactionStatus(nil), m.replayRows...)
 	m.mu.Unlock()
+	// Match the real query's ordering. Postgres serves this as
+	// "ORDER BY timestamp_at DESC" (store/postgres.IterateStatusesSince), so
+	// the reaper walks NEWEST first and its rebroadcast cap is spent on the
+	// most recent eligible rows. Returning insertion order here made the
+	// walk order an accident of test setup and hid every starvation bug the
+	// cap can produce — see TestReapOnce_PendingRetry_StarvedByNewerBacklog.
+	// Stable sort so equal timestamps keep insertion order, mirroring a
+	// stable index scan over rows written with a single batch timestamp.
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].Timestamp.After(rows[j].Timestamp)
+	})
 	for _, r := range rows {
 		// Honor the lookback filter so replay tests can pin behavior that
 		// depends on it. Rows with a zero Timestamp are always returned —

--- a/services/propagation/propagator_test.go
+++ b/services/propagation/propagator_test.go
@@ -151,6 +151,9 @@ type mockStore struct {
 	// net's store consult (rejectedAncestor). Absent txids return
 	// store.ErrNotFound.
 	statusByTxID map[string]models.Status
+	// rawByTxID carries raw_tx alongside statusByTxID so GetStatus returns
+	// rows shaped like the real backends'. See setStatusRow.
+	rawByTxID map[string][]byte
 }
 
 // setStatus seeds the row GetStatus returns for txid.
@@ -163,13 +166,27 @@ func (m *mockStore) setStatus(txid string, status models.Status) {
 	m.statusByTxID[txid] = status
 }
 
+// setStatusRow seeds status AND raw bytes for txid. The raw bytes matter to
+// rejectedAncestor's transitive walk: climbing from a parent to a grandparent
+// means re-deriving the parent's own inputs, which real store rows carry in
+// raw_tx.
+func (m *mockStore) setStatusRow(txid string, status models.Status, rawTx []byte) {
+	m.setStatus(txid, status)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.rawByTxID == nil {
+		m.rawByTxID = make(map[string][]byte)
+	}
+	m.rawByTxID[txid] = append([]byte(nil), rawTx...)
+}
+
 // GetStatus serves the seeded statusByTxID map; unknown txids return
 // store.ErrNotFound, matching the real backends' contract.
 func (m *mockStore) GetStatus(_ context.Context, txid string) (*models.TransactionStatus, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if st, ok := m.statusByTxID[txid]; ok {
-		return &models.TransactionStatus{TxID: txid, Status: st}, nil
+		return &models.TransactionStatus{TxID: txid, Status: st, RawTx: m.rawByTxID[txid]}, nil
 	}
 	return nil, store.ErrNotFound
 }
@@ -241,28 +258,96 @@ func (m *mockStore) SetPendingRetryFields(_ context.Context, txid string, rawTx 
 	}
 	// Reflect PENDING_RETRY status in the updates stream so existing tests that
 	// inspect status updates continue to observe the transition.
+	//
+	// Carry the row's current ExtraInfo forward. The real statement is
+	// "UPDATE transactions SET status=$2, raw_tx=$3, next_retry_at=$4,
+	// timestamp_at=NOW()" — it does not touch extra_info, so the park reason
+	// written moments earlier by applyTerminalStatuses survives. A mock that
+	// appended a reason-less row would make GET /tx look like it lost the
+	// explanation when it hadn't.
+	var extra string
+	for i := len(m.updates) - 1; i >= 0; i-- {
+		if m.updates[i].TxID == txid {
+			extra = m.updates[i].ExtraInfo
+			break
+		}
+	}
 	m.updates = append(m.updates, &models.TransactionStatus{
 		TxID:      txid,
 		Status:    models.StatusPendingRetry,
 		Timestamp: time.Now(),
+		ExtraInfo: extra,
 	})
 	return nil
 }
 
+// GetReadyRetries mirrors the real query's contract:
+//
+//	WHERE status = 'PENDING_RETRY' AND next_retry_at <= now
+//	ORDER BY next_retry_at LIMIT n
+//
+// Both halves matter. The status filter is how a row leaves the retry queue
+// when it resolves — the resolving write goes through BatchUpdateStatusReturning,
+// not through ClearRetryState, so a mock that ignored status would keep serving
+// rows that are already ACCEPTED. And the ordering is the whole point of using
+// this queue rather than a timestamp scan: oldest schedule first, so no row can
+// be starved by newer arrivals.
 func (m *mockStore) GetReadyRetries(_ context.Context, now time.Time, limit int) ([]*store.PendingRetry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	out := make([]*store.PendingRetry, 0, len(m.pendingRetries))
-	for _, pr := range m.pendingRetries {
-		if !pr.NextRetryAt.After(now) {
-			cp := *pr
-			out = append(out, &cp)
-			if len(out) >= limit {
-				break
-			}
+	for txid, pr := range m.pendingRetries {
+		if pr.NextRetryAt.After(now) {
+			continue
 		}
+		if st, ok := m.latestStatusLocked(txid); ok && st != models.StatusPendingRetry {
+			continue
+		}
+		cp := *pr
+		out = append(out, &cp)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].NextRetryAt.Before(out[j].NextRetryAt) })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
 	}
 	return out, nil
+}
+
+// latestStatusLocked returns the most recent status written for txid, falling
+// back to its seeded replay row. Caller holds m.mu.
+func (m *mockStore) latestStatusLocked(txid string) (models.Status, bool) {
+	for i := len(m.updates) - 1; i >= 0; i-- {
+		if m.updates[i].TxID == txid {
+			return m.updates[i].Status, true
+		}
+	}
+	for _, r := range m.replayRows {
+		if r.TxID == txid {
+			return r.Status, true
+		}
+	}
+	return "", false
+}
+
+// parkTx seeds a transaction in the state parkExhaustedRequeues leaves behind:
+// a PENDING_RETRY status row carrying the raw bytes, plus the durable retry
+// bins the reaper drains by.
+func (m *mockStore) parkTx(txid string, rawTx []byte, parkedAt, nextRetryAt time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.replayRows = append(m.replayRows, &models.TransactionStatus{
+		TxID:      txid,
+		Status:    models.StatusPendingRetry,
+		RawTx:     rawTx,
+		Timestamp: parkedAt,
+	})
+	m.retryCounts[txid]++
+	m.pendingRetries[txid] = &store.PendingRetry{
+		TxID:        txid,
+		RawTx:       append([]byte(nil), rawTx...),
+		RetryCount:  m.retryCounts[txid],
+		NextRetryAt: nextRetryAt,
+	}
 }
 
 func (m *mockStore) MarkMerkleRegisteredByTxIDs(_ context.Context, txids []string, ts time.Time) error {

--- a/services/propagation/propagator_test.go
+++ b/services/propagation/propagator_test.go
@@ -146,6 +146,31 @@ type mockStore struct {
 	// returns — simulating a store write failure so tests can exercise the
 	// at-least-once guard that skips dispatcher notification on error.
 	returningErr error
+	// statusByTxID drives GetStatus, used by the missing-parent safety
+	// net's store consult (rejectedAncestor). Absent txids return
+	// store.ErrNotFound.
+	statusByTxID map[string]models.Status
+}
+
+// setStatus seeds the row GetStatus returns for txid.
+func (m *mockStore) setStatus(txid string, status models.Status) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.statusByTxID == nil {
+		m.statusByTxID = make(map[string]models.Status)
+	}
+	m.statusByTxID[txid] = status
+}
+
+// GetStatus serves the seeded statusByTxID map; unknown txids return
+// store.ErrNotFound, matching the real backends' contract.
+func (m *mockStore) GetStatus(_ context.Context, txid string) (*models.TransactionStatus, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if st, ok := m.statusByTxID[txid]; ok {
+		return &models.TransactionStatus{TxID: txid, Status: st}, nil
+	}
+	return nil, store.ErrNotFound
 }
 
 type clearedCall struct {

--- a/services/propagation/reaper.go
+++ b/services/propagation/reaper.go
@@ -424,7 +424,7 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 
 	var accepted, rejected int
 	terminalStatuses := make([]*models.TransactionStatus, 0, len(results))
-	for _, res := range results {
+	for i, res := range results {
 		switch res.class {
 		case txResultClassAccepted:
 			accepted++
@@ -436,6 +436,18 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 			if res.status != nil {
 				terminalStatuses = append(terminalStatuses, res.status)
 			}
+		case txResultClassMissingParent:
+			// The reaper's dep-blind rebroadcast can resurface a child
+			// before its parent (both parked, or the parent wedged on
+			// another pod). Pre-#295 this drew TX_MISSING_PARENT and
+			// falsely terminalized the child REJECTED. Condition, not
+			// verdict: only a REJECTED ancestor in arcade's own store
+			// condemns the child; otherwise the row stays as-is and the
+			// next tick retries after the parent lands.
+			if cascaded, _ := p.resolveMissingParents(ctx, []propagationMsg{registered[i]}, []string{res.errMsg}); len(cascaded) > 0 {
+				rejected += len(cascaded)
+				terminalStatuses = append(terminalStatuses, cascaded...)
+			}
 		case txResultClassUnknown, txResultClassRequeue:
 			// Requeue / Unknown from the reaper's rebroadcast path:
 			// leave the row alone so the next reaper tick picks it up.
@@ -444,5 +456,8 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 			// tick.
 		}
 	}
-	p.applyTerminalStatuses(ctx, terminalStatuses, accepted, rejected)
+	// nil io: the reaper runs off any claim's pipeline, so terminal
+	// notifications fan out to every live dispatcher — whichever one
+	// holds a tx in flight releases its offset, the rest no-op.
+	p.applyTerminalStatuses(ctx, terminalStatuses, accepted, rejected, nil)
 }

--- a/services/propagation/reaper.go
+++ b/services/propagation/reaper.go
@@ -336,7 +336,8 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 	// During the 2026-08-10 load test a ~466k-tx uncommitted-offset backlog
 	// was invisible without a DB/Kafka query; this line makes growth
 	// visible in plain logs.
-	p.logger.Info("reaper: propagation backlog depth",
+	p.logger.Info(
+		"reaper: propagation backlog depth",
 		zap.Int64("pending_depth", p.pendingDepth.Load()),
 		zap.Int64("inflight_depth", p.inflightDepth.Load()),
 		zap.Int("reaper_ready_depth", len(stuck)),

--- a/services/propagation/reaper.go
+++ b/services/propagation/reaper.go
@@ -43,15 +43,13 @@ import (
 // result is a store no-op: the stuck gauge drains only when the tx genuinely
 // reaches SEEN/MINED/REJECTED, never via a spurious timestamp refresh.
 //
-// stalePendingRetryAge: a row parked at PENDING_RETRY by the propagation
-// requeue-budget escape (parkExhaustedRequeues) got no verdict from any peer
-// across its whole fast-path budget, so its dispatcher in-flight entry was
-// released to free the Kafka commit watermark and the reaper inherited the
-// retry. Much shorter than the other thresholds — the row is not "stuck", it
-// is explicitly queued for another attempt, and the failure that parked it
-// (a peer outage, a conflict line arcade could not attribute) typically
-// clears in minutes. Long enough that a tx cannot bounce between the
-// fast path and the reaper faster than the fast path's own budget.
+// Parked PENDING_RETRY rows are NOT age-selected here: they carry a per-row
+// next_retry_at and are drained by drainParkedRetries via store.GetReadyRetries.
+// A flat eligibility age meant every parked tx waited the same 5 minutes no
+// matter how many times it had already failed, and — because a failed
+// rebroadcast never rewrote the row — that a row which kept failing was
+// retried on every single tick while its frozen timestamp_at sank it out of
+// the selection window entirely.
 //
 // staleScanLookback bounds how far back IterateStatusesSince walks. Rows
 // older than this are assumed permanently stuck and outside the reaper's
@@ -60,7 +58,6 @@ const (
 	staleSeenOnNetworkAge     = time.Hour
 	staleReceivedAge          = time.Hour
 	staleAcceptedByNetworkAge = time.Hour
-	stalePendingRetryAge      = 5 * time.Minute
 	staleScanLookback         = 24 * time.Hour
 
 	// defaultReaperRebroadcastBatch is the per-tick rebroadcast cap applied
@@ -187,13 +184,14 @@ func (p *Propagator) tryReap(ctx context.Context) {
 // requeue was lost, or an intake Kafka-publish failure the submitter never
 // retried), and ACCEPTED_BY_NETWORK past staleAcceptedByNetworkAge (accepted
 // into a mempool but the SEEN state-transfer from merkle-service never
-// arrived — re-register + re-broadcast to nudge it toward SEEN), and
-// PENDING_RETRY past stalePendingRetryAge (parked by the propagation
-// requeue-budget escape after getting no verdict from any peer; the reaper is
-// its only remaining retry path). All carry RawTx and are validated txs we
-// accepted responsibility to propagate, so rebroadcasting self-heals a
-// transient downstream outage. Recent rows (still in the normal intake/requeue
-// path) and body-less rows are left alone.
+// arrived — re-register + re-broadcast to nudge it toward SEEN). All carry
+// RawTx and are validated txs we accepted responsibility to propagate, so
+// rebroadcasting self-heals a transient downstream outage. Recent rows (still
+// in the normal intake/requeue path) and body-less rows are left alone.
+//
+// Rows parked at PENDING_RETRY are NOT selected by this age walk. They have a
+// per-row schedule and are drained by drainParkedRetries in next_retry_at
+// order — see there for why age selection starved them.
 //
 // Rebroadcasts go through the same registerBatch + broadcastInChunks +
 // applyTerminalStatuses pipeline as processBatch but bypass the
@@ -521,7 +519,7 @@ func (p *Propagator) rebroadcastStuck(ctx context.Context, msgs []propagationMsg
 				// Condition, not verdict (#254/#295): only a REJECTED
 				// ancestor in arcade's own store condemns the child. A
 				// missing parent that is merely late must never terminalize.
-				cascaded, _ := p.resolveMissingParents(ctx, []propagationMsg{layer[i]}, []string{res.errMsg})
+				cascaded, _ := p.resolveMissingParents(ctx, []propagationMsg{layer[i]}, []string{res.errMsg}, missingParentOutcomeReaperRetry)
 				if len(cascaded) > 0 {
 					rejected += len(cascaded)
 					terminalStatuses = append(terminalStatuses, cascaded...)

--- a/services/propagation/reaper.go
+++ b/services/propagation/reaper.go
@@ -231,6 +231,9 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 	attrib := make([]stuckRef, 0, stuckAttributionCap)
 
 	stuck := make([]propagationMsg, 0, p.rebroadcastBatch)
+	// adopt collects legacy PENDING_RETRY rows (parked before durable retry
+	// scheduling existed) so they can be booked into the queue after the walk.
+	var adopt []propagationMsg
 	err := p.store.IterateStatusesSince(ctx, since, func(st *models.TransactionStatus) error {
 		// Best-effort per-callback attribution sample (bounded by
 		// stuckAttributionCap). The census COUNTS come from
@@ -281,8 +284,8 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 				return nil
 			}
 		case models.StatusPendingRetry:
-			// Parked rows are NOT selected by this walk any more — they are
-			// drained by next_retry_at via store.GetReadyRetries below.
+			// Parked rows are NOT rebroadcast from this walk any more — they
+			// are drained by next_retry_at via store.GetReadyRetries below.
 			//
 			// Selecting them here meant selecting by timestamp_at, which
 			// Postgres serves newest-first and Pebble oldest-first, capped at
@@ -292,6 +295,17 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 			// again, and on Pebble a block of unresolvable orphans sat at the
 			// head of the queue and starved every other arm of this walk.
 			// Either way the row silently left the 24h scan window for good.
+			//
+			// One job remains here: adopt legacy rows. A tx parked by an
+			// older build has no next_retry_at, so GetReadyRetries — which
+			// selects on "next_retry_at <= now" — cannot see it. Without this
+			// the upgrade would strand every already-parked tx in exactly the
+			// invisible state this change exists to remove. Booking a
+			// schedule for it is idempotent and self-healing: once adopted it
+			// drains normally on a later tick.
+			if st.NextRetryAt.IsZero() {
+				adopt = append(adopt, propagationMsg{TXID: st.TxID, RawTx: st.RawTx})
+			}
 			return nil
 		default:
 			// Terminal statuses (REJECTED, DOUBLE_SPEND_ATTEMPTED, MINED,
@@ -402,6 +416,16 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 	if len(stuck) > 0 {
 		p.logger.Info("reaper: rebroadcasting stuck txs", zap.Int("count", len(stuck)))
 		p.rebroadcastStuck(ctx, stuck, false)
+	}
+
+	// Bring any legacy parked rows into the durable queue before draining, so
+	// an upgrade doesn't strand transactions that were already parked.
+	if len(adopt) > 0 {
+		p.logger.Info("reaper: adopting legacy parked txs into the durable retry queue",
+			zap.Int("count", len(adopt)))
+		for _, m := range adopt {
+			p.schedulePendingRetry(ctx, m.TXID, m.RawTx)
+		}
 	}
 
 	// Parked rows are a separate, next_retry_at-ordered drain.

--- a/services/propagation/reaper.go
+++ b/services/propagation/reaper.go
@@ -210,7 +210,6 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 	seenDeadline := now.Add(-staleSeenOnNetworkAge)
 	receivedDeadline := now.Add(-staleReceivedAge)
 	acceptedDeadline := now.Add(-staleAcceptedByNetworkAge)
-	pendingRetryDeadline := now.Add(-stalePendingRetryAge)
 
 	stuckTransientDeadline := now.Add(-stuckTransientAge)
 	// The stuck-transient census (counts + oldest age per status) is resolved
@@ -284,17 +283,18 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 				return nil
 			}
 		case models.StatusPendingRetry:
-			// Parked by parkExhaustedRequeues: the fast path spent its whole
-			// requeue budget without a verdict and released the tx's Kafka
-			// offset so the consumer could keep moving. The reaper is now the
-			// ONLY thing that will retry it, so this arm is what makes the
-			// poison-batch escape a park rather than a drop. A successful
-			// rebroadcast lifts the row straight to ACCEPTED_BY_NETWORK /
-			// REJECTED (the lattice permits both from PENDING_RETRY); another
-			// no-verdict result leaves it here for the next tick.
-			if !st.Timestamp.Before(pendingRetryDeadline) {
-				return nil
-			}
+			// Parked rows are NOT selected by this walk any more — they are
+			// drained by next_retry_at via store.GetReadyRetries below.
+			//
+			// Selecting them here meant selecting by timestamp_at, which
+			// Postgres serves newest-first and Pebble oldest-first, capped at
+			// rebroadcastBatch. Since a failed rebroadcast never rewrote the
+			// row, its timestamp stayed frozen at park time: on Postgres it
+			// sank below every newer eligible row and was never retried
+			// again, and on Pebble a block of unresolvable orphans sat at the
+			// head of the queue and starved every other arm of this walk.
+			// Either way the row silently left the 24h scan window for good.
+			return nil
 		default:
 			// Terminal statuses (REJECTED, DOUBLE_SPEND_ATTEMPTED, MINED,
 			// IMMUTABLE) and the remaining transient in-between states are
@@ -401,64 +401,206 @@ func (p *Propagator) reapOnce(ctx context.Context) {
 			zap.Int("cap", stuckAttributionCap))
 	}
 
-	if len(stuck) == 0 {
+	if len(stuck) > 0 {
+		p.logger.Info("reaper: rebroadcasting stuck txs", zap.Int("count", len(stuck)))
+		p.rebroadcastStuck(ctx, stuck, false)
+	}
+
+	// Parked rows are a separate, next_retry_at-ordered drain.
+	p.drainParkedRetries(ctx, now, since)
+}
+
+// drainParkedRetries rebroadcasts PENDING_RETRY rows whose next_retry_at is
+// due, oldest schedule first.
+//
+// This replaces selecting parked rows in the timestamp_at walk above. The
+// store already had everything needed for a proper durable retry queue —
+// retry_count, next_retry_at, idx_tx_retry_ready(next_retry_at) WHERE
+// status='PENDING_RETRY', and GetReadyRetries' "ORDER BY next_retry_at LIMIT n
+// FOR UPDATE SKIP LOCKED" — implemented on every backend and wired to nothing.
+// Using it buys FIFO drain, per-row backoff, a per-row attempt count to give
+// up on, and multi-process safety, all at once.
+func (p *Propagator) drainParkedRetries(ctx context.Context, now, since time.Time) {
+	if p.store == nil {
 		return
 	}
 
-	p.logger.Info("reaper: rebroadcasting stuck txs", zap.Int("count", len(stuck)))
+	// Parked-set gauges. PENDING_RETRY is deliberately absent from
+	// stuckTransientStatuses, and reaper_ready_depth saturates at the
+	// per-tick cap, so without these the parked set is invisible — and #299
+	// makes parking an expected steady state, not a rarity. Safe to bound by
+	// `since`: every reschedule rewrites timestamp_at, so a live parked row
+	// is always inside the window.
+	if census, err := p.store.CensusStatusesSince(ctx, since, now, []models.Status{models.StatusPendingRetry}); err == nil {
+		c := census[models.StatusPendingRetry]
+		metrics.PropagationParkedDepth.Set(float64(c.Count))
+		age := 0.0
+		if !c.Oldest.IsZero() {
+			age = now.Sub(c.Oldest).Seconds()
+		}
+		metrics.PropagationParkedOldestAgeSeconds.Set(age)
+	} else {
+		p.logger.Error("reaper: parked census failed", zap.Error(err))
+	}
 
+	ready, err := p.store.GetReadyRetries(ctx, now, p.rebroadcastBatch)
+	if err != nil {
+		p.logger.Error("reaper: parked retry scan failed", zap.Error(err))
+		return
+	}
+	if len(ready) == 0 {
+		return
+	}
+
+	msgs := make([]propagationMsg, 0, len(ready))
+	for _, r := range ready {
+		// Carry InputTXIDs so the dependency layering below — and
+		// rejectedAncestor's store consult — don't have to re-parse RawTx
+		// once per tx per tick, forever, for rows that never resolve.
+		msgs = append(msgs, propagationMsg{
+			TXID:       r.TxID,
+			RawTx:      r.RawTx,
+			InputTXIDs: parentTxIDsOf(propagationMsg{TXID: r.TxID, RawTx: r.RawTx}),
+		})
+	}
+	p.logger.Info("reaper: rebroadcasting parked txs", zap.Int("count", len(msgs)))
+	p.rebroadcastStuck(ctx, msgs, true)
+}
+
+// rebroadcastStuck pushes msgs back through the register+broadcast pipeline
+// and settles each result.
+//
+// parked marks the durable-retry path: a msg that still has no verdict gets
+// its next attempt booked (or is given up on) rather than being left for an
+// unconditional retry on the next tick.
+func (p *Propagator) rebroadcastStuck(ctx context.Context, msgs []propagationMsg, parked bool) {
 	// Use the same broadcast pipeline as processBatch so the per-tx
 	// classification (Accepted / Rejected / Requeue) applies uniformly.
 	// applyTerminalStatuses writes terminal rows AND notifies the
 	// dispatcher — txids the dispatcher doesn't know about (because the
 	// original Kafka message terminated long ago) get a no-op notify,
 	// which is fine.
-	registered, _ := p.registerBatch(ctx, stuck)
+	registered, _ := p.registerBatch(ctx, msgs)
 	if len(registered) == 0 {
 		return
 	}
-	rawTxs := make([][]byte, len(registered))
-	for i, m := range registered {
-		rawTxs[i] = m.RawTx
-	}
-	results := p.broadcastInChunks(ctx, registered, rawTxs)
 
 	var accepted, rejected int
-	terminalStatuses := make([]*models.TransactionStatus, 0, len(results))
-	for i, res := range results {
-		switch res.class {
-		case txResultClassAccepted:
-			accepted++
-			if res.status != nil {
-				terminalStatuses = append(terminalStatuses, res.status)
+	terminalStatuses := make([]*models.TransactionStatus, 0, len(registered))
+	// unresolved collects msgs that produced no verdict this pass.
+	var unresolved []propagationMsg
+
+	// Broadcast one dependency layer at a time. Within a layer no tx spends
+	// another, so teranode's parallel bulk processing can accept them all;
+	// each layer's accepts are visible to the next.
+	//
+	// Before this the whole selected batch went out as a single /txs call —
+	// which both violated the "no parent and child in one batch" contract the
+	// design relies on, and meant a parked chain could only advance ONE level
+	// per tick. At reaper_interval_ms=30000 a depth-100 chain took ~52
+	// minutes; it now drains in a single tick.
+	for _, layer := range layerByDependency(registered) {
+		rawTxs := make([][]byte, len(layer))
+		for i, m := range layer {
+			rawTxs[i] = m.RawTx
+		}
+		results := p.broadcastInChunks(ctx, layer, rawTxs)
+		for i, res := range results {
+			switch res.class {
+			case txResultClassAccepted:
+				accepted++
+				if res.status != nil {
+					terminalStatuses = append(terminalStatuses, res.status)
+				}
+			case txResultClassRejected:
+				rejected++
+				if res.status != nil {
+					terminalStatuses = append(terminalStatuses, res.status)
+				}
+			case txResultClassMissingParent:
+				// Condition, not verdict (#254/#295): only a REJECTED
+				// ancestor in arcade's own store condemns the child. A
+				// missing parent that is merely late must never terminalize.
+				cascaded, _ := p.resolveMissingParents(ctx, []propagationMsg{layer[i]}, []string{res.errMsg})
+				if len(cascaded) > 0 {
+					rejected += len(cascaded)
+					terminalStatuses = append(terminalStatuses, cascaded...)
+					continue
+				}
+				unresolved = append(unresolved, layer[i])
+			case txResultClassUnknown, txResultClassRequeue:
+				// No verdict from any peer. The reaper bypasses the
+				// dispatcher, so there is no inFlight entry to requeue
+				// against — the retry is the next scheduled attempt.
+				unresolved = append(unresolved, layer[i])
 			}
-		case txResultClassRejected:
-			rejected++
-			if res.status != nil {
-				terminalStatuses = append(terminalStatuses, res.status)
-			}
-		case txResultClassMissingParent:
-			// The reaper's dep-blind rebroadcast can resurface a child
-			// before its parent (both parked, or the parent wedged on
-			// another pod). Pre-#295 this drew TX_MISSING_PARENT and
-			// falsely terminalized the child REJECTED. Condition, not
-			// verdict: only a REJECTED ancestor in arcade's own store
-			// condemns the child; otherwise the row stays as-is and the
-			// next tick retries after the parent lands.
-			if cascaded, _ := p.resolveMissingParents(ctx, []propagationMsg{registered[i]}, []string{res.errMsg}); len(cascaded) > 0 {
-				rejected += len(cascaded)
-				terminalStatuses = append(terminalStatuses, cascaded...)
-			}
-		case txResultClassUnknown, txResultClassRequeue:
-			// Requeue / Unknown from the reaper's rebroadcast path:
-			// leave the row alone so the next reaper tick picks it up.
-			// The reaper bypasses the dispatcher, so there's no inFlight
-			// entry to requeue against — natural retry is just the next
-			// tick.
 		}
 	}
+
 	// nil io: the reaper runs off any claim's pipeline, so terminal
 	// notifications fan out to every live dispatcher — whichever one
 	// holds a tx in flight releases its offset, the rest no-op.
 	p.applyTerminalStatuses(ctx, terminalStatuses, accepted, rejected, nil)
+
+	if parked {
+		for _, m := range unresolved {
+			p.schedulePendingRetry(ctx, m.TXID, m.RawTx)
+		}
+	}
+}
+
+// layerByDependency splits msgs into dependency layers: layer 0 has no parent
+// inside msgs, layer N's parents all live in layers < N. Order within a layer
+// is the input order.
+//
+// Any msg left in a cycle (impossible for real transactions, but cheap to
+// guard) is appended as a final layer so nothing is silently dropped.
+func layerByDependency(msgs []propagationMsg) [][]propagationMsg {
+	if len(msgs) < 2 {
+		return [][]propagationMsg{msgs}
+	}
+	index := make(map[string]int, len(msgs))
+	for i, m := range msgs {
+		if _, ok := index[m.TXID]; !ok {
+			index[m.TXID] = i
+		}
+	}
+	// depth[i] = 1 + max(depth of in-batch parents), memoized.
+	depth := make([]int, len(msgs))
+	state := make([]int8, len(msgs)) // 0 unvisited, 1 in progress, 2 done
+	var resolve func(i int) int
+	resolve = func(i int) int {
+		switch state[i] {
+		case 2:
+			return depth[i]
+		case 1:
+			return 0 // cycle guard
+		}
+		state[i] = 1
+		best := 0
+		for _, parent := range msgs[i].InputTXIDs {
+			j, ok := index[parent]
+			if !ok || j == i {
+				continue
+			}
+			if d := resolve(j) + 1; d > best {
+				best = d
+			}
+		}
+		depth[i] = best
+		state[i] = 2
+		return best
+	}
+
+	maxDepth := 0
+	for i := range msgs {
+		if d := resolve(i); d > maxDepth {
+			maxDepth = d
+		}
+	}
+	layers := make([][]propagationMsg, maxDepth+1)
+	for i, m := range msgs {
+		layers[depth[i]] = append(layers[depth[i]], m)
+	}
+	return layers
 }

--- a/services/propagation/reaper_test.go
+++ b/services/propagation/reaper_test.go
@@ -450,6 +450,13 @@ func TestReapOnce_LogsBacklogDepth(t *testing.T) {
 	tc := teranode.NewClient([]string{teranodeSrv.URL}, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
 	p := New(cfg, zap.New(core), nil, nil, ms, nil, tc, mc)
 
+	// The depth gauges are delta-accounted pod totals (#295): every live
+	// dispatcher adds its own contribution, and test-mode dispatchers
+	// from other tests in this process may still hold theirs. Assert the
+	// gauge's CHANGE from this propagator's two admissions, not an
+	// absolute value.
+	gaugeBefore := testutil.ToFloat64(metrics.PropagationInflightDepth)
+
 	// Seed dispatcher state: two admitted txs, the first drained into a
 	// "mid-broadcast" batch — in-flight counts both, pending only the second.
 	if res := p.admitToDispatcher(propagationMsg{TXID: "inflight-a", RawTx: []byte{0x0a}}, 1); !res.admitted {
@@ -472,8 +479,8 @@ func TestReapOnce_LogsBacklogDepth(t *testing.T) {
 	if got := p.inflightDepth.Load(); got != 2 {
 		t.Fatalf("inflightDepth mirror = %d, want 2 (admitted a + b, neither terminal)", got)
 	}
-	if got := testutil.ToFloat64(metrics.PropagationInflightDepth); got != 2 {
-		t.Fatalf("PropagationInflightDepth gauge = %v, want 2", got)
+	if got := testutil.ToFloat64(metrics.PropagationInflightDepth); got != gaugeBefore+2 {
+		t.Fatalf("PropagationInflightDepth gauge = %v, want %v (before + this dispatcher's 2)", got, gaugeBefore+2)
 	}
 
 	p.reapOnce(context.Background())

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -876,6 +876,20 @@ func (s *Store) SetPendingRetryFields(ctx context.Context, txid string, rawTx []
 	if err != nil {
 		return err
 	}
+	// Lattice guard: the park path writes twice (a guarded status update, then
+	// this), so skipping it here would silently undo the first write's
+	// protection and drag a MINED / IMMUTABLE / SEEN / REJECTED row back to
+	// PENDING_RETRY. Silent skip matches the guarded update's semantics.
+	rec, gerr := s.client.Get(s.readPolicy(ctx), key, "status")
+	if gerr != nil && !isKeyNotFound(gerr) {
+		return fmt.Errorf("read status for lattice check %s: %w", txid, gerr)
+	}
+	if rec == nil {
+		return fmt.Errorf("set pending retry fields %s: %w", txid, store.ErrNotFound)
+	}
+	if !models.StatusPendingRetry.CanTransitionFrom(models.Status(getString(rec, "status"))) {
+		return nil
+	}
 	ops := []*aero.Operation{
 		aero.PutOp(aero.NewBin("status", string(models.StatusPendingRetry))),
 		aero.PutOp(aero.NewBin("raw_tx", rawTx)),

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -879,6 +879,14 @@ func (s *Store) SetPendingRetryFields(ctx context.Context, txid string, rawTx []
 		return fmt.Errorf("set pending retry fields %s: %w", txid, store.ErrNotFound)
 	}
 
+	// Lattice guard: the park path writes twice (a guarded status update, then
+	// this), so skipping it here would silently undo the first write's
+	// protection and drag a MINED / IMMUTABLE / SEEN / REJECTED row back to
+	// PENDING_RETRY. Silent skip matches the guarded update's semantics.
+	if !models.StatusPendingRetry.CanTransitionFrom(models.Status(existing.Status)) {
+		return nil
+	}
+
 	updated := *existing
 	updated.Status = string(models.StatusPendingRetry)
 	updated.RawTx = rawTx

--- a/store/pebble/pebble_test.go
+++ b/store/pebble/pebble_test.go
@@ -1296,3 +1296,46 @@ func TestTokensForTxIDs(t *testing.T) {
 		t.Errorf("TokensForTxIDs(nil) = %v, want empty", empty)
 	}
 }
+
+// TestSetPendingRetryFields_RespectsStatusLattice is the pebble half of the
+// backend-parity guard; see the postgres test of the same name for why the
+// second write of the park path must not bypass the lattice.
+func TestSetPendingRetryFields_RespectsStatusLattice(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, prev := range models.StatusPendingRetry.DisallowedPreviousStatuses() {
+		t.Run(string(prev), func(t *testing.T) {
+			txid := "lattice-" + string(prev)
+			if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+				TxID: txid, Status: models.StatusReceived,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.UpdateStatus(ctx, &models.TransactionStatus{TxID: txid, Status: prev}); err != nil {
+				t.Fatalf("seed %s: %v", prev, err)
+			}
+
+			if err := s.SetPendingRetryFields(ctx, txid, []byte{0xaa}, time.Now().Add(-time.Second)); err != nil {
+				t.Fatalf("SetPendingRetryFields: %v", err)
+			}
+
+			got, err := s.GetStatus(ctx, txid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status != prev {
+				t.Errorf("status = %s, want %s left untouched", got.Status, prev)
+			}
+			ready, err := s.GetReadyRetries(ctx, time.Now(), 10)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, r := range ready {
+				if r.TxID == txid {
+					t.Errorf("%s row entered the durable retry queue", prev)
+				}
+			}
+		})
+	}
+}

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -820,12 +820,25 @@ func (s *Store) BumpRetryCount(ctx context.Context, txid string) (int, error) {
 	return n, nil
 }
 
+// SetPendingRetryFields records the durable-retry bins for a parked tx.
+//
+// The lattice guard in the WHERE clause is load-bearing, not decorative. The
+// park path writes twice — a lattice-guarded BatchUpdateStatusReturning,
+// then this — so without it the second write would silently undo the first
+// one's protection and force a MINED / IMMUTABLE / SEEN / REJECTED row back
+// to PENDING_RETRY, where the reaper would then rebroadcast it. Rows whose
+// current status forbids PENDING_RETRY are skipped, matching
+// BatchUpdateStatusReturning's silent-skip semantics.
 func (s *Store) SetPendingRetryFields(ctx context.Context, txid string, rawTx []byte, nextRetryAt time.Time) error {
 	const q = `
 UPDATE transactions
 SET status=$2, raw_tx=$3, next_retry_at=$4, timestamp_at=NOW()
-WHERE txid=$1`
-	_, err := s.pool.Exec(ctx, q, txid, string(models.StatusPendingRetry), rawTx, nextRetryAt)
+WHERE txid=$1 AND status <> ALL($5)`
+	disallowed := disallowedPrevAsStrings(models.StatusPendingRetry)
+	if disallowed == nil {
+		disallowed = []string{}
+	}
+	_, err := s.pool.Exec(ctx, q, txid, string(models.StatusPendingRetry), rawTx, nextRetryAt, disallowed)
 	if err != nil {
 		return fmt.Errorf("set pending retry fields %s: %w", txid, err)
 	}

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -1601,3 +1601,59 @@ func TestTokensForTxIDs(t *testing.T) {
 		t.Errorf("TokensForTxIDs(nil) = %v, want empty", empty)
 	}
 }
+
+// TestSetPendingRetryFields_RespectsStatusLattice pins that the durable-retry
+// setter cannot drag a transaction back out of a protected status.
+//
+// This matters because the park path writes twice: applyTerminalStatuses does
+// a lattice-guarded BatchUpdateStatusReturning (which correctly SKIPS a row
+// whose current status forbids PENDING_RETRY), and the durable-retry
+// scheduling then records the retry bins. If the second write ignores the
+// lattice it silently undoes the first one's protection — so a MINED
+// transaction redelivered by Kafka and re-broadcast without a verdict would be
+// knocked back to PENDING_RETRY and re-broadcast by the reaper from then on.
+//
+// models.StatusPendingRetry.DisallowedPreviousStatuses() is the source of
+// truth; every status in it must be immune here.
+func TestSetPendingRetryFields_RespectsStatusLattice(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, prev := range models.StatusPendingRetry.DisallowedPreviousStatuses() {
+		t.Run(string(prev), func(t *testing.T) {
+			txid := "lattice-" + string(prev)
+			if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+				TxID: txid, Status: models.StatusReceived,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.UpdateStatus(ctx, &models.TransactionStatus{TxID: txid, Status: prev}); err != nil {
+				t.Fatalf("seed %s: %v", prev, err)
+			}
+
+			err := s.SetPendingRetryFields(ctx, txid, []byte{0xaa}, time.Now().Add(-time.Second))
+			if err != nil {
+				t.Fatalf("SetPendingRetryFields: %v", err)
+			}
+
+			got, err := s.GetStatus(ctx, txid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status != prev {
+				t.Errorf("status = %s, want %s left untouched: PENDING_RETRY must not be "+
+					"forced over a status the lattice protects", got.Status, prev)
+			}
+			// And it must not have joined the retry drain.
+			ready, err := s.GetReadyRetries(ctx, time.Now(), 10)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, r := range ready {
+				if r.TxID == txid {
+					t.Errorf("%s row entered the durable retry queue", prev)
+				}
+			}
+		})
+	}
+}

--- a/tests/smoke/chained_txs_test.go
+++ b/tests/smoke/chained_txs_test.go
@@ -36,6 +36,22 @@ import (
 // also catch interesting regressions: an ordering inversion would
 // surface in (2), a requeue bug in (3), a chunking bug in (4).
 func TestSmoke_ChainedTxBatchOrdering(t *testing.T) {
+	runChainedTxBatchOrdering(t, 1)
+}
+
+// TestSmoke_ChainedTxBatchOrdering_MultiPartition is the #295 variant: the
+// same forest, the same four invariants, but arcade.propagation runs 4
+// partitions with one dep-aware dispatcher each. The invariants only hold
+// because intake keys every submission's dependency family to one
+// partition (familyPartitionKeys) — key by txid instead (the pre-#295
+// producer behavior) and parents and children shard apart, children
+// broadcast before parents, and assertParentPrecedesChild goes red.
+func TestSmoke_ChainedTxBatchOrdering_MultiPartition(t *testing.T) {
+	runChainedTxBatchOrdering(t, 4)
+}
+
+func runChainedTxBatchOrdering(t *testing.T, partitions int) {
+	t.Helper()
 	const (
 		totalTxs             = 10_000
 		minDepth             = 2
@@ -48,7 +64,10 @@ func TestSmoke_ChainedTxBatchOrdering(t *testing.T) {
 	)
 
 	recorder := newRecordingTeranode(t)
-	rt := startArcadeSmoke(t, smokeOptions{TeranodeURL: recorder.URL()})
+	rt := startArcadeSmoke(t, smokeOptions{
+		TeranodeURL:           recorder.URL(),
+		PropagationPartitions: partitions,
+	})
 
 	chains := BuildChains(ChainOpts{
 		TotalTxs: totalTxs,
@@ -60,12 +79,14 @@ func TestSmoke_ChainedTxBatchOrdering(t *testing.T) {
 
 	// Flatten into submission batches. Each chain lives entirely
 	// inside one submission so the dispatcher's ordering guarantee
-	// holds: a single SendBatch on a single-partition Kafka topic
-	// preserves order within the batch, so parent always reaches the
-	// dispatcher before child. Concurrent submitters race the
-	// submissions themselves, but since chains don't span submissions
-	// and different chains share no edges, no cross-submission race
-	// can produce a child-before-parent on the wire.
+	// holds: intake keys every same-submission dependency family to one
+	// partition (#295 familyPartitionKeys), and Kafka preserves order
+	// within a partition, so parent always reaches its dispatcher
+	// before child — at any partition count. Concurrent submitters race
+	// the submissions themselves, but since chains don't span
+	// submissions and different chains share no edges, no
+	// cross-submission race can produce a child-before-parent on the
+	// wire.
 	submissions := buildSubmissionBatches(chains, submissionBatchSize)
 
 	start := time.Now()
@@ -108,12 +129,13 @@ func TestSmoke_ChainedTxBatchOrdering(t *testing.T) {
 
 // buildSubmissionBatches groups chains into HTTP submission batches such
 // that each chain lives entirely inside one submission. This is the
-// crucial invariant for the test: a SendBatch on the single-partition
-// Kafka topic preserves order, so parent reaches the dispatcher before
-// child for txs in the same submission. Different chains share no
-// edges, so the order in which submissions arrive at Kafka doesn't
-// matter — there's no cross-submission race that can produce a
-// child-before-parent on the wire.
+// crucial invariant for the test: a same-submission family shares a
+// partition key (#295), and Kafka preserves per-partition order, so
+// parent reaches its dispatcher before child for txs in the same
+// submission. Different chains share no edges, so the order in which
+// submissions arrive at Kafka doesn't matter — there's no
+// cross-submission race that can produce a child-before-parent on the
+// wire.
 //
 // Chain order across submissions is shuffled (deterministically by
 // seed) so concurrent submitters still stress the dispatcher with txs

--- a/tests/smoke/harness.go
+++ b/tests/smoke/harness.go
@@ -46,6 +46,17 @@ type smokeOptions struct {
 	// disabled — the suite's baseline, proving the gate fails open when no
 	// chain source exists.
 	ChaintracksRemoteURL string
+	// PropagationPartitions widens arcade.propagation on the in-process
+	// memory broker (#295): family-keyed publishes shard across this many
+	// partitions and the propagator runs one dep-aware dispatcher per
+	// partition — the production multi-partition topology, in-process.
+	// Zero means 1 (the pre-#295 shape).
+	PropagationPartitions int
+	// MutateConfig, when set, gets the fully-built smoke config last so a
+	// test can override individual knobs (e.g. a larger retry budget for
+	// the missing-parent recovery window) without the harness growing a
+	// field per knob.
+	MutateConfig func(*config.Config)
 }
 
 // startArcadeSmoke boots arcade in-process via app.Bootstrap +
@@ -179,6 +190,7 @@ func buildSmokeConfig(t *testing.T, port int, opts smokeOptions) *config.Config 
 		ChaintracksServer: config.ChaintracksServerConfig{Enabled: false},
 		Chaintracks:       chaintracksRemoteConfig(opts.ChaintracksRemoteURL),
 		Propagation: config.PropagationConfig{
+			Partitions:        opts.PropagationPartitions,
 			MerkleConcurrency: 2,
 			RetryMaxAttempts:  1,
 			RetryBackoffMs:    50,
@@ -209,6 +221,9 @@ func buildSmokeConfig(t *testing.T, port int, opts smokeOptions) *config.Config 
 			StoragePath:      t.TempDir(),
 			AllowPrivateURLs: true,
 		},
+	}
+	if opts.MutateConfig != nil {
+		opts.MutateConfig(cfg)
 	}
 	return cfg
 }

--- a/tests/smoke/missing_parent_test.go
+++ b/tests/smoke/missing_parent_test.go
@@ -292,3 +292,66 @@ func TestSmoke_OrphanChild_ParksWithoutWedgingPipeline(t *testing.T) {
 		t.Fatalf("orphan child was REJECTED — missing-parent must park, never reject")
 	}
 }
+
+// TestSmoke_DeepChainAcrossSubmissions_ConvergesViaReaper is the end-to-end
+// answer to "how long does the PENDING_RETRY path take to resolve for a
+// worst-case parent/child topology".
+//
+// A depth-12 chain is submitted in REVERSE order, one transaction per request,
+// on a 4-partition topic. That is the shape family keying deliberately does
+// not cover: each tx is its own request, so each is keyed by its own txid and
+// scatters across partitions with no ordering relationship at all. Every child
+// reaches teranode before its parent, draws TX_MISSING_PARENT, burns its
+// (deliberately tiny) fast-path budget and parks at PENDING_RETRY. From there
+// the reaper's durable retry queue is the only thing that can resolve it.
+//
+// The whole chain must reach ACCEPTED_BY_NETWORK, and nothing may ever be
+// REJECTED — an ordering artifact is a condition, not a verdict.
+//
+// Before the durable-retry rework this could not pass in a bounded window at
+// any tick rate: parked rows were selected by scanning timestamp_at behind a
+// hardcoded 5-minute eligibility age, and the reaper broadcast the whole
+// selection as one /txs call, so at most one dependency level cleared per
+// tick. Depth 12 meant 5 minutes plus 12 ticks.
+func TestSmoke_DeepChainAcrossSubmissions_ConvergesViaReaper(t *testing.T) {
+	const depth = 12
+
+	teranode := newDependencyAwareTeranode(t)
+	rt := startArcadeSmoke(t, smokeOptions{
+		TeranodeURL:           teranode.URL(),
+		PropagationPartitions: 4,
+		MutateConfig: func(cfg *config.Config) {
+			// Compress the durable schedule so the reaper's behavior is
+			// observable inside a smoke window. The cadence is what changes;
+			// the ordering and layering under test are not timing-dependent.
+			cfg.Propagation.RetryMaxAttempts = 1
+			cfg.Propagation.RetryBackoffMs = 25
+			cfg.Propagation.ReaperIntervalMs = 100
+			cfg.Propagation.PendingRetryBackoffMs = 25
+			cfg.Propagation.PendingRetryMaxBackoffMs = 100
+		},
+	})
+
+	chain := BuildChains(ChainOpts{TotalTxs: depth, MinDepth: depth, MaxDepth: depth, Seed: 29})[0]
+	if len(chain) != depth {
+		t.Fatalf("built a chain of %d, want %d", len(chain), depth)
+	}
+
+	// Deepest descendant first, root last: every submission but the last is
+	// an orphan at the moment it arrives.
+	for i := len(chain) - 1; i >= 0; i-- {
+		if err := postTxs(rt, []*bt.Tx{chain[i]}); err != nil {
+			t.Fatalf("submit chain[%d]: %v", i, err)
+		}
+	}
+
+	start := time.Now()
+	for i, tx := range chain {
+		waitForArcadeStatus(t, rt, tx.TxID(), "ACCEPTED_BY_NETWORK", 30*time.Second)
+		if got := arcadeTxStatus(t, rt, tx.TxID()); got == "REJECTED" {
+			t.Fatalf("chain[%d] was REJECTED; a missing parent is a condition, not a verdict", i)
+		}
+	}
+	t.Logf("depth-%d chain submitted in reverse across %d requests on 4 partitions "+
+		"converged in %v", depth, depth, time.Since(start).Round(time.Millisecond))
+}

--- a/tests/smoke/missing_parent_test.go
+++ b/tests/smoke/missing_parent_test.go
@@ -1,0 +1,294 @@
+//go:build smoke
+
+package smoke
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+
+	"github.com/bsv-blockchain/arcade/config"
+)
+
+// These tests pin the #295 missing-parent safety net end-to-end: with a
+// multi-partition arcade.propagation topic, a child submitted in a LATER
+// HTTP request than its parent has no ordering guarantee — it can reach
+// teranode first and draw TX_MISSING_PARENT. Arcade must treat that as a
+// retryable condition (requeue → eventual accept once the parent lands, or
+// PENDING_RETRY park when it never does), and must NEVER mark the child
+// REJECTED for what is purely an ordering artifact.
+
+// dependencyAwareTeranode is a stateful fake teranode: it accepts a tx only
+// when every input's source tx is already in its accepted set, and answers
+// HTTP 422 with a real deepest-cause missing-parent failure line for each
+// tx whose parent it hasn't seen — the deployed-teranode behavior arcade's
+// parser is built against. Txs absent from the failure list are implicitly
+// accepted, matching teranode's "Failed to process transactions:" contract.
+type dependencyAwareTeranode struct {
+	server *httptest.Server
+
+	mu             sync.Mutex
+	accepted       map[string]bool
+	rejectionCount int // /txs responses that carried missing-parent lines
+	batches        []BatchRecord
+}
+
+func newDependencyAwareTeranode(t *testing.T) *dependencyAwareTeranode {
+	t.Helper()
+	d := &dependencyAwareTeranode{accepted: make(map[string]bool)}
+	// BuildChains roots spend a synthetic confirmed outpoint (32 bytes of
+	// 0x01, symmetric so byte order is moot) — treat it as on-chain so
+	// roots are accepted on sight, exactly like a real node that has the
+	// funding tx in its UTXO set.
+	d.accepted[strings.Repeat("01", 32)] = true
+	d.server = httptest.NewServer(http.HandlerFunc(d.handle))
+	t.Cleanup(d.server.Close)
+	return d
+}
+
+func (d *dependencyAwareTeranode) URL() string { return d.server.URL }
+
+func (d *dependencyAwareTeranode) handle(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost || (req.URL.Path != "/txs" && req.URL.Path != "/tx") {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Parse the concatenated txs, keeping inputs for the parent check.
+	type parsed struct {
+		txid    string
+		parents []string
+	}
+	var txs []parsed
+	offset := 0
+	for offset < len(body) {
+		tx, used, perr := sdkTx.NewTransactionFromStream(body[offset:])
+		if perr != nil {
+			http.Error(w, fmt.Sprintf("parse at %d: %v", offset, perr), http.StatusBadRequest)
+			return
+		}
+		if used == 0 {
+			break
+		}
+		p := parsed{txid: tx.TxID().String()}
+		for _, in := range tx.Inputs {
+			if in != nil && in.SourceTXID != nil {
+				p.parents = append(p.parents, in.SourceTXID.String())
+			}
+		}
+		txs = append(txs, p)
+		offset += used
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var failureLines []string
+	var batchTxids []string
+	for _, p := range txs {
+		batchTxids = append(batchTxids, p.txid)
+		missing := ""
+		for _, parent := range p.parents {
+			if !d.accepted[parent] {
+				missing = parent
+				break
+			}
+		}
+		if missing != "" {
+			failureLines = append(failureLines,
+				fmt.Sprintf("TX_MISSING_PARENT (34): [Validate][%s] error getting parent transaction %s", p.txid, missing))
+			continue
+		}
+		d.accepted[p.txid] = true
+	}
+	d.batches = append(d.batches, BatchRecord{
+		Seq:        len(d.batches),
+		TxIDs:      batchTxids,
+		ReceivedAt: time.Now(),
+	})
+
+	if len(failureLines) == 0 {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+		return
+	}
+	d.rejectionCount++
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	_, _ = w.Write([]byte("Failed to process transactions:\n" + strings.Join(failureLines, "\n") + "\n"))
+}
+
+func (d *dependencyAwareTeranode) hasAccepted(txid string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.accepted[txid]
+}
+
+func (d *dependencyAwareTeranode) missingParentResponses() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.rejectionCount
+}
+
+func (d *dependencyAwareTeranode) snapshotBatches() []BatchRecord {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make([]BatchRecord, len(d.batches))
+	copy(out, d.batches)
+	return out
+}
+
+// waitForAccepted polls until the fake teranode has accepted txid.
+func (d *dependencyAwareTeranode) waitForAccepted(t *testing.T, txid string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if d.hasAccepted(txid) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("teranode never accepted %s within %s", txid, timeout)
+}
+
+// waitForMissingParentResponse polls until the fake teranode has answered
+// at least n missing-parent 422s.
+func (d *dependencyAwareTeranode) waitForMissingParentResponse(t *testing.T, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if d.missingParentResponses() >= n {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("teranode never answered %d missing-parent responses within %s", n, timeout)
+}
+
+// arcadeTxStatus fetches GET /tx/:txid and returns the persisted status.
+func arcadeTxStatus(t *testing.T, rt *arcadeRuntime, txid string) string {
+	t.Helper()
+	resp, err := http.Get(rt.baseURL + "/tx/" + txid)
+	if err != nil {
+		t.Fatalf("GET /tx/%s: %v", txid, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var out struct {
+		Status string `json:"txStatus"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode /tx/%s: %v", txid, err)
+	}
+	return out.Status
+}
+
+// waitForArcadeStatus polls GET /tx/:txid until it reports want.
+func waitForArcadeStatus(t *testing.T, rt *arcadeRuntime, txid, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	last := ""
+	for time.Now().Before(deadline) {
+		last = arcadeTxStatus(t, rt, txid)
+		if last == want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("tx %s never reached status %s within %s (last: %s)", txid, want, timeout, last)
+}
+
+// TestSmoke_OutOfOrderChild_RecoversViaMissingParentRetry is the #295
+// cross-submission race, end to end on a 4-partition topic: the child is
+// submitted (and broadcast) BEFORE its parent ever reaches arcade. Teranode
+// 422s it with TX_MISSING_PARENT; arcade requeues instead of rejecting;
+// once the parent is submitted and accepted, the child's retry lands.
+// Assertions: both txs end ACCEPTED_BY_NETWORK, the child was genuinely
+// rejected at least once by teranode (the race really happened), no batch
+// ever co-housed parent and child, and NOTHING was marked REJECTED.
+func TestSmoke_OutOfOrderChild_RecoversViaMissingParentRetry(t *testing.T) {
+	teranode := newDependencyAwareTeranode(t)
+	rt := startArcadeSmoke(t, smokeOptions{
+		TeranodeURL:           teranode.URL(),
+		PropagationPartitions: 4,
+		MutateConfig: func(cfg *config.Config) {
+			// A wide in-memory retry window so the child keeps retrying
+			// until the parent (submitted only after the child's first
+			// 422) lands — without depending on reaper cadence.
+			cfg.Propagation.RetryMaxAttempts = 50
+			cfg.Propagation.RetryBackoffMs = 25
+		},
+	})
+
+	chain := BuildChains(ChainOpts{TotalTxs: 2, MinDepth: 2, MaxDepth: 2, Seed: 7})[0]
+	parent, child := chain[0], chain[1]
+
+	// Child first — the out-of-order submission.
+	if err := postTxs(rt, []*bt.Tx{child}); err != nil {
+		t.Fatalf("submit child: %v", err)
+	}
+	// The race must actually happen: teranode rejects the child at least
+	// once before we even submit the parent.
+	teranode.waitForMissingParentResponse(t, 1, 10*time.Second)
+
+	if err := postTxs(rt, []*bt.Tx{parent}); err != nil {
+		t.Fatalf("submit parent: %v", err)
+	}
+	teranode.waitForAccepted(t, parent.TxID(), 10*time.Second)
+	teranode.waitForAccepted(t, child.TxID(), 15*time.Second)
+
+	waitForArcadeStatus(t, rt, parent.TxID(), "ACCEPTED_BY_NETWORK", 10*time.Second)
+	waitForArcadeStatus(t, rt, child.TxID(), "ACCEPTED_BY_NETWORK", 10*time.Second)
+
+	// The ordering artifact must never have produced a verdict.
+	if got := arcadeTxStatus(t, rt, child.TxID()); got == "REJECTED" {
+		t.Fatalf("child ended REJECTED — the missing-parent safety net failed")
+	}
+	assertParentChildNeverCohabits(t, teranode.snapshotBatches(), [][]*bt.Tx{chain})
+}
+
+// TestSmoke_OrphanChild_ParksWithoutWedgingPipeline pins the no-wedge
+// invariant: a child whose parent NEVER arrives exhausts its (small)
+// requeue budget and parks at PENDING_RETRY — not REJECTED — while
+// unrelated traffic keeps flowing through the same partitioned pipeline.
+func TestSmoke_OrphanChild_ParksWithoutWedgingPipeline(t *testing.T) {
+	teranode := newDependencyAwareTeranode(t)
+	rt := startArcadeSmoke(t, smokeOptions{
+		TeranodeURL:           teranode.URL(),
+		PropagationPartitions: 4,
+		// Harness defaults: RetryMaxAttempts=1, RetryBackoffMs=50 — the
+		// child parks after one retry.
+	})
+
+	chain := BuildChains(ChainOpts{TotalTxs: 2, MinDepth: 2, MaxDepth: 2, Seed: 11})[0]
+	orphanChild := chain[1] // its parent is never submitted
+
+	if err := postTxs(rt, []*bt.Tx{orphanChild}); err != nil {
+		t.Fatalf("submit orphan child: %v", err)
+	}
+	waitForArcadeStatus(t, rt, orphanChild.TxID(), "PENDING_RETRY", 15*time.Second)
+
+	// The pipeline must not be wedged: an unrelated tx submitted after the
+	// orphan still broadcasts and terminalizes.
+	unrelated := BuildChains(ChainOpts{TotalTxs: 1, MinDepth: 1, MaxDepth: 1, Seed: 13})[0][0]
+	if err := postTxs(rt, []*bt.Tx{unrelated}); err != nil {
+		t.Fatalf("submit unrelated: %v", err)
+	}
+	waitForArcadeStatus(t, rt, unrelated.TxID(), "ACCEPTED_BY_NETWORK", 15*time.Second)
+
+	if got := arcadeTxStatus(t, rt, orphanChild.TxID()); got == "REJECTED" {
+		t.Fatalf("orphan child was REJECTED — missing-parent must park, never reject")
+	}
+}


### PR DESCRIPTION
Closes #295.

## What this does

Lifts the single-partition intake ceiling (~1.6–1.9k TPS measured in #295) by letting `arcade.propagation` run N partitions with one dep-aware dispatcher per partition claim — without ever letting an out-of-order broadcast produce a false terminal REJECTED.

## The ordering model (replacing the #151 exact-1 rule)

Two mechanisms replace total topic order:

1. **Family partition keys at intake.** `handleSubmitTransactions` runs a union-find over each submitted batch: all txs connected through in-batch spends share one partition key (the lexicographically smallest member txid — order-independent, so shuffled resubmissions map to the same partition). The headline case — 2 parents + 98 children in one POST — lands whole on one partition, so per-partition Kafka order still delivers parents to their dispatcher before children, and Teranode's *no parent and child in one `/txs` batch* contract holds structurally. Isolated txs keep today's txid key.
2. **Missing-parent safety net.** Chains that span submissions (child POSTed after its parent, possibly on another partition/pod) have no ordering guarantee — the child can reach Teranode first and draw `TX_MISSING_PARENT` (or `TX_NOT_FOUND`, the un-wrapped store-layer form). Per the #254 principle these are **conditions, not verdicts**: the tx rides the existing bounded requeue, parks at `PENDING_RETRY` on budget exhaustion (reaper owns durable retry — the no-wedge invariant from #294 is preserved), and the *only* path to REJECTED is arcade's own store showing an ancestor terminally REJECTED (the cross-partition analog of the dispatcher's same-partition cascade, with the same `parent rejected (ancestor …)` reason). This also fixes a latent false-REJECT: the reaper's dep-blind rebroadcast of a child whose parent was still parked previously terminalized the child REJECTED.

Enforcement moves from `CheckExactPartitions(…, 1)` to a fail-closed `CheckMinPartitions` against new config `propagation.partitions` (default 1 — existing deployments upgrade with zero action; a missing topic still aborts startup).

## Multi-dispatcher correctness + the serial-path hot spot

- **Per-claim `dispatcherIO` channel sets.** The dispatcher's terminal/requeue channels lived on the shared `Propagator`; with two claims, partition B's loop could consume partition A's terminal event, leaving A's offset never `Done` and its commit watermark frozen — the #294 wedge class, silently reintroduced. Each claim now gets its own channel set, threaded through the batch pipeline; the reaper's terminal notifications (nil io) fan out to every registered dispatcher (at most one owns the tx, the rest no-op).
- **Delta-accounted depth gauges.** `arcade_propagation_pending_depth` / `inflight_depth` (and the atomics behind the reaper's backlog log line) become pod totals across partition dispatchers, with each loop's contribution removed on claim teardown. No metric schema change.
- **`advanceMarks` amortization (#295's suspected 10x).** The full `pendingMarks` map walk per terminal event is replaced by an ordered `markQueue` popped on the existing 50 ms flush tick (plus a teardown drain): amortized O(1) per message instead of O(terminals × in-flight). Claim-revocation semantics unchanged — only offsets strictly below `LowestUnfinished` are ever marked.
- **Producer ordering hardening.** The sync producer is now idempotent with `MaxOpenRequests=1` (protocol 2.6): a broker-side retry can no longer reorder a family's messages within a partition. Note: this bumps the wire protocol for all sync produces — fine for Redpanda/modern Kafka.
- **`retry_backoff_ms` is now actually read** (it was declared-but-dead config). Its viper default moves 500→2000 so shipped cadence is unchanged; deployments that explicitly set it will start feeling their configured value.

## Testing

- **Smoke, real topology in-process**: the memory broker gains sarama-compatible key-hash partitions and per-partition claims. The 10k-tx chained-batch ordering test now also runs at 4 partitions — all four invariants (no cohabitation, parent-precedes-child, exactly-once, chunk cap) hold; sabotaging the intake back to txid keying makes it fail with dozens of child-before-parent inversions, so the guard is load-bearing. New smoke tests drive the out-of-order child (submitted before its parent, 4 partitions) recovering to ACCEPTED via missing-parent retry with zero REJECTED, and an orphan child parking at PENDING_RETRY while unrelated traffic keeps flowing.
- **Unit**: family-key table (star/chain/fan-in/reorder-stability), min-partition contract, two-claim terminal routing isolation, reaper nil-io fan-out, markQueue, missing-parent line matcher (wrapped/deepest-cause/TX_NOT_FOUND vs conflict/policy negatives), verdict-vs-condition precedence (peer verdict wins, sticky accept wins), store-consult cascade both ways, budget exhaustion parks-not-rejects, reaper leaves-row/cascades regression pair.
- `-race` clean on `services/propagation` and `kafka`; `golangci-lint` clean.

## Observability

New `arcade_propagation_missing_parent_total{outcome="requeued"|"rejected_ancestor"}`. A burst of `requeued` is expected during a partition widen (key remap window); a sustained steady-state rate means family keying isn't co-locating same-submission chains. Dashboards note: PENDING_RETRY baseline may rise (children of slow parents); worth checking the stuck-transient alert tolerates it, and considering PENDING_RETRY in the #291 census as a follow-up.

## Rollout

Topic-first, per the "Widening an existing deployment" section in docs/production-kafka.md: `rpk topic add-partitions` → raise `propagation.partitions` → roll pods → scale replicas up to the partition count. During the remap window watch `missing_parent_total{outcome="requeued"}` (expected burst) and `outcome_total{outcome="rejected"}` (a spike would mean ordering artifacts reached a verdict — the thing this PR makes impossible by construction). Zero-race alternative: drain and recreate (the #151 cutover pattern).

Follow-ups deliberately out of scope: a multi-partition e2e against real redpanda (smoke covers the topology in-process; the e2e harness currently has the podman registry pull issue), and standby right-sizing on the scale cluster.


---

## Follow-up: PENDING_RETRY convergence (review response)

An adversarial review of this branch asked how long the `PENDING_RETRY` path
takes to resolve for a worst-case parent/child topology. The answer at the
time was: too long, and sometimes never.

The safety net this PR leans on — `parkExhaustedRequeues`, the reaper's
`PENDING_RETRY` arm, `stalePendingRetryAge`, `staleScanLookback` — all
pre-existed on `main`, where it was a rare poison-batch escape hatch. This PR
promotes it to the designed steady-state landing spot for every
cross-submission chain, and it did not have the properties that role needs.

### What was wrong

At shipped defaults a parked chain of depth D drained in
`10s + 300s + (D-6) x 30s` — about 52 minutes at depth 100 — because
`reapOnce` built its messages with `InputTXIDs` empty and broadcast the whole
selection as a single `/txs` call, so exactly one dependency level could clear
per tick. That also put parents and children in one batch, the shape the
design says teranode forbids.

Three cases never converged at all:

- **Starvation.** Selection was `IterateStatusesSince`, which Postgres serves
  `ORDER BY timestamp_at DESC` and Pebble ascending, capped per tick. The
  missing-parent arm deliberately left the row alone and
  `MarkMerkleRegisteredByTxIDs` only writes `merkle_registered_at`, so a
  failing row's `timestamp_at` was frozen at park time. On Postgres it sank
  below every newer eligible row; on Pebble a block of unresolvable orphans
  sat at the head and starved the walk's other arms deployment-wide.
- **Silent abandonment.** At `park + 24h` a frozen row fell out of
  `staleScanLookback` and stayed `PENDING_RETRY` permanently — no terminal
  status, no log line, no metric, and `GET /tx` never reached a terminal
  answer.
- **Parent that never arrives.** `rejectedAncestor` returns false on
  `ErrNotFound`, so a tx spending a non-existent outpoint — the most common
  client mistake there is — parked immortally, where on `main` it was
  REJECTED in about a second.

### What changed

**Drain by `next_retry_at`, not by scanning `timestamp_at`.** The store
already had a complete durable retry queue — `retry_count`, `next_retry_at`,
`idx_tx_retry_ready(next_retry_at) WHERE status='PENDING_RETRY'`, and
`BumpRetryCount` / `SetPendingRetryFields` / `GetReadyRetries` (`ORDER BY
next_retry_at LIMIT n FOR UPDATE SKIP LOCKED`) / `ClearRetryState` implemented
on all three backends — with zero callers outside `store/`. Wiring the park
path to it fixes starvation, the frozen timestamps, the Postgres/Pebble
ordering divergence and multi-process safety in one change.

**Broadcast one dependency layer at a time.** `layerByDependency` splits the
selected batch so each layer's accepts are visible to the next, which also
removes the parent-and-child-in-one-batch shape.

**Give up visibly.** After `pending_retry_max_attempts` (default 288, about
24h at the backoff cap — roughly when rows used to be abandoned) an
unresolvable tx is terminalized REJECTED with a reason the submitter can read.

**Walk ancestors transitively.** `rejectedAncestor` consulted direct parents
only while documented as the analog of `cascadeReject`'s recursive BFS, so a
REJECTED grandparent behind a `PENDING_RETRY` parent cost one retry cycle per
generation to condemn.

**Family keys are computed over the full submitted batch.** The key is
`min(family)`, so it moved whenever a member left the set — and the intake
dedup CAS drops members constantly. `POST {P}` then `POST {P, C}` deduped the
parent out and re-keyed the child onto a partition its in-flight parent was
not on, losing the dispatcher's dep-hold entirely.

### Numbers

| case | before | after |
|---|---|---|
| depth-5 parked chain | 5 reaper ticks | 1 tick |
| depth-500 parked chain, 200-row cap | ~4h, or never | **3 ticks (~90s)** |
| depth-12 chain, reverse order, 12 requests, 4 partitions (smoke, compressed timers) | did not converge | **169ms** |
| orphan whose parent never arrives | PENDING_RETRY forever, silently dropped at 24h | REJECTED with a reason |

### Observability

New `arcade_propagation_parked_depth` and
`arcade_propagation_parked_oldest_age_seconds` (PENDING_RETRY is absent from
`stuckTransientStatuses` and `reaper_ready_depth` saturates at the per-tick
cap, so the parked set was unbounded and unmeasurable), plus
`arcade_propagation_pending_retry_total{scheduled,exhausted}`. The reaper path
now reports `missing_parent_total{outcome="reaper_retry"}` instead of
`"requeued"` — a steady population of unresolvable orphans previously pinned
that counter at a constant rate, which reads exactly like the family-keying
regression its own dashboard note tells operators to watch for. All outcome
children are pre-registered so alerts get 0 rather than no-data.

### Also in this follow-up

- `docs/production-kafka.md` is rewritten for multi-partition. It still
  documented `arcade.propagation` as "exactly 1 (mandatory)" and referenced
  `CheckExactPartitions`, a function this PR deletes; an operator following it
  would create a 1-partition topic and crash-loop any pod configured for more.
  The "Widening an existing deployment" section now exists.
- `app.go` keeps `CheckPartitions`' nil topic list. Passing it the real
  fan-out topics turned a check that has been dead since `TopicTransaction`
  was retired into a live boot-blocking one: a deployment with a leftover
  `kafka.min_partitions` above its actual `tx_status` / `block_processed`
  width would crash-loop on upgrade, for an unrelated reason.
- `propagation` block added to `config.example.yaml`;
  `PROPAGATION_PARTITIONS` wired through `docker-compose.yaml` to `topic-init`,
  which read the variable but was never passed it.

### New config

`propagation.pending_retry_backoff_ms` (5000),
`pending_retry_max_backoff_ms` (300000 — the old flat eligibility age, so the
slowest cadence is unchanged while early attempts are far faster),
`pending_retry_max_attempts` (288).

### Testing

- Six pinning tests landed failing first, then fixed: convergence, fairness,
  liveness, durability, the durable happy path, and the ancestor walk depth.
- `layerByDependency` across chain / fan-out / fan-in / diamond /
  out-of-batch parents / self-reference / cycle guard.
- End-to-end smoke for a deep chain submitted in reverse across separate
  requests on 4 partitions. This caught a bug in the fix itself:
  cascade-parked descendants were being written with a NULL `next_retry_at`
  and so were invisible to the new drain.
- `mockStore.GetReadyRetries` now honors the real query's status filter and
  `next_retry_at` ordering, with insertion-order tie-breaks; ties are the
  common case and were previously served from a Go map in random order,
  masking how much convergence depends on that ordering.
- Full unit suite, `-race` on `services/propagation`, `kafka`,
  `services/api_server`, `-tags=smoke`, `-tags=postgres`, and
  `golangci-lint` all clean.
