### PR TITLE
fix(propagation): publish REJECTED with the reason arcade already persisted

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -34,6 +34,12 @@ type Publisher interface {
 	// to coalesce per-block MINED bursts (N=14k+) into one event so the
 	// webhook service's bounded work queue can't saturate on BUMP fan-out.
 	// template.TxID is ignored; template.TxIDs must be non-empty.
+	//
+	// The template's WHOLE payload applies to every txid it carries — the
+	// unfan copies the struct per txid. A caller holding a per-transaction
+	// payload (a rejection reason, say) must therefore split its txids into
+	// one call per distinct payload rather than send one event whose fields
+	// fit only some of them; see propagation.publishRejections.
 	PublishBulk(ctx context.Context, template *models.TransactionStatus) error
 	Subscribe(ctx context.Context, caller string) (<-chan *models.TransactionStatus, error)
 	Close() error

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -44,14 +44,18 @@ type TransactionStatus struct {
 	StatusCode int       `json:"status,omitempty"`
 	Timestamp  time.Time `json:"timestamp"`
 	// TxIDs, when populated, marks this as a bulk-transition event: every
-	// txid in the slice carries the same Status/BlockHash/BlockHeight. Used
+	// txid in the slice carries the same payload — Status, BlockHash,
+	// BlockHeight, ExtraInfo and StatusCode all apply to all of them. Used
 	// by bump-builder's MINED fan-out to publish ONE Kafka event per block
 	// instead of N events per block, which previously saturated the webhook
 	// service's bounded work queue (~185k drops/block on testnet bursts).
 	// Subscribers detect bulk via len(TxIDs) > 0 and unfan in their own
-	// handler. omitempty so the HTTP API surface (single-tx status reads)
-	// is unaffected — TxIDs is never set on rows read from the store, only
-	// on transient events on the publisher channel.
+	// handler, copying the whole struct per txid — so a publisher holding a
+	// per-transaction payload must split the event by payload rather than
+	// send one whose fields fit only some of its txids (issue #301; see
+	// propagation.publishRejections). omitempty so the HTTP API surface
+	// (single-tx status reads) is unaffected — TxIDs is never set on rows
+	// read from the store, only on transient events on the publisher channel.
 	TxIDs        []string  `json:"txids,omitempty"`
 	BlockHash    string    `json:"blockHash,omitempty"`
 	BlockHeight  uint64    `json:"blockHeight,omitempty"`

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -539,9 +539,11 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 	terminalRejected := make([]string, 0, rejected)
 	var terminalParked []string
 	// published* drive the bulk publish: only rows whose store status
-	// actually transitioned.
+	// actually transitioned. publishedRejected carries whole rows, not just
+	// txids, because a rejection's payload (the reason arcade just persisted)
+	// has to ride the event out — see publishRejections.
 	publishedAccepted := make([]string, 0, accepted)
-	publishedRejected := make([]string, 0, rejected)
+	publishedRejected := make([]*models.TransactionStatus, 0, rejected)
 	var publishedParked []string
 	now := time.Now()
 	for i, st := range terminalStatuses {
@@ -582,7 +584,7 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 		case models.StatusAcceptedByNetwork:
 			publishedAccepted = append(publishedAccepted, st.TxID)
 		case models.StatusRejected:
-			publishedRejected = append(publishedRejected, st.TxID)
+			publishedRejected = append(publishedRejected, st)
 			p.logger.Info(
 				"transaction rejected",
 				logfields.TxID(st.TxID),
@@ -614,7 +616,7 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 	})
 
 	p.publishBulkStatus(ctx, models.StatusAcceptedByNetwork, publishedAccepted, now)
-	p.publishBulkStatus(ctx, models.StatusRejected, publishedRejected, now)
+	p.publishRejections(ctx, publishedRejected, now)
 	p.publishBulkStatus(ctx, models.StatusPendingRetry, publishedParked, now)
 
 	// Notify the dispatcher ONLY when the batch status write fully
@@ -899,6 +901,13 @@ func (p *Propagator) persistCascade(ctx context.Context, cascaded []cascadeRejec
 			p.schedulePendingRetry(ctx, cr.txid, cr.rawTx)
 		}
 	}
+	if status == models.StatusRejected {
+		// statuses (not txids): every cascaded child's reason names ITS OWN
+		// ancestor, so the publish has to group by reason rather than fan one
+		// payload-free event across the whole cascade — see publishRejections.
+		p.publishRejections(ctx, statuses, now)
+		return
+	}
 	p.publishBulkStatus(ctx, status, txids, now)
 }
 
@@ -911,16 +920,88 @@ func (p *Propagator) publishBulkStatus(ctx context.Context, status models.Status
 	if p.publisher == nil || len(txids) == 0 {
 		return
 	}
-	template := &models.TransactionStatus{
+	p.publishBulk(ctx, &models.TransactionStatus{
 		Status:    status,
 		Timestamp: ts,
 		TxIDs:     txids,
+	})
+}
+
+// publishRejections fans REJECTED transitions onto the events Publisher with
+// the reason attached, grouped so that every txid on an event shares one
+// reason.
+//
+// A bulk event carries no per-transaction payload by construction: one event,
+// N txids, so any field it set would be right for at most one of them. That
+// is correct for the uniform statuses it was built for (ACCEPTED_BY_NETWORK,
+// MINED) and wrong for REJECTED, the one status whose payload decides what
+// the client does next — UTXO_SPENT means "your view of the chain is stale,
+// resync", TX_INVALID means "these bytes will never be accepted, don't
+// retry". Until this, arcade parsed the Teranode reason, persisted it on the
+// row, logged it, and then published REJECTED with an empty extraInfo.
+//
+// Nothing was lost — the row keeps the reason and GET /tx/<txid> serves it —
+// but the push event did not describe itself, so learning why cost a round
+// trip. REJECTED is terminal, which makes that trap worse than it sounds: a
+// client that correctly stops polling on a terminal status stops exactly when
+// polling is the only way to find out (issue #301, found on a 128-chain
+// covenant workload where one rejection condemns a whole chain).
+//
+// Grouping — rather than one event per transaction — is deliberate, and it is
+// the cascade that makes the difference. A dep-cascade condemns every
+// descendant of one rejected ancestor with the SAME cascadeReason string, and
+// that is the burst that gets large (one rejection at the head of a chain
+// condemns the whole chain). Those still ride a single event, so the SSE
+// fan-out keeps its one batched token resolution instead of paying a store
+// round-trip per descendant on its single fan-out goroutine. A Teranode
+// verdict, by contrast, names the offending txid inside its own failure line,
+// so those reasons are distinct per transaction and the grouping degenerates
+// to one event each — which is exactly what carrying a per-transaction reason
+// requires.
+//
+// Only TxID, ExtraInfo and StatusCode are read from each status; the event's
+// Status and Timestamp come from the caller, matching publishBulkStatus.
+func (p *Propagator) publishRejections(ctx context.Context, rejected []*models.TransactionStatus, ts time.Time) {
+	if p.publisher == nil || len(rejected) == 0 {
+		return
 	}
+	// Grouped in first-seen order, not map order, so a batch's events come
+	// out in the order the batch produced them and stay comparable with the
+	// "transaction rejected" log lines emitted alongside them.
+	type reason struct {
+		extraInfo  string
+		statusCode int
+	}
+	index := make(map[reason]int, len(rejected))
+	groups := make([]*models.TransactionStatus, 0, len(rejected))
+	for _, st := range rejected {
+		key := reason{extraInfo: st.ExtraInfo, statusCode: st.StatusCode}
+		i, seen := index[key]
+		if !seen {
+			i = len(groups)
+			index[key] = i
+			groups = append(groups, &models.TransactionStatus{
+				Status:     models.StatusRejected,
+				StatusCode: st.StatusCode,
+				Timestamp:  ts,
+				ExtraInfo:  st.ExtraInfo,
+			})
+		}
+		groups[i].TxIDs = append(groups[i].TxIDs, st.TxID)
+	}
+	for _, g := range groups {
+		p.publishBulk(ctx, g)
+	}
+}
+
+// publishBulk sends one prepared bulk event. Non-fatal: the durable store
+// rows are already written, and SSE catchup recovers any dropped events.
+func (p *Propagator) publishBulk(ctx context.Context, template *models.TransactionStatus) {
 	if err := p.publisher.PublishBulk(ctx, template); err != nil {
 		p.logger.Warn(
 			"failed to publish bulk propagation status",
-			logfields.Status(string(status)),
-			zap.Int("count", len(txids)),
+			logfields.Status(string(template.Status)),
+			zap.Int("count", len(template.TxIDs)),
 			zap.Error(err),
 		)
 	}
@@ -2172,7 +2253,16 @@ func (p *Propagator) schedulePendingRetry(ctx context.Context, txid string, rawT
 			p.logger.Error("clear retry state failed", logfields.TxID(txid), zap.Error(err))
 			return
 		}
-		p.publishBulkStatus(ctx, models.StatusRejected, []string{txid}, time.Now())
+		// Same reason string that just went onto the row. A give-up is the
+		// least self-evident rejection arcade issues — no peer ever answered
+		// for this tx, so there is no verdict to quote and nothing about the
+		// bytes explains it — which makes it the one most worth carrying on
+		// the event rather than leaving to a GET /tx.
+		p.publishRejections(ctx, []*models.TransactionStatus{{
+			TxID:      txid,
+			Status:    models.StatusRejected,
+			ExtraInfo: reason,
+		}}, time.Now())
 		return
 	}
 	next := time.Now().Add(p.nextPendingRetryDelay(count))

--- a/services/propagation/reject_reason_test.go
+++ b/services/propagation/reject_reason_test.go
@@ -1,0 +1,301 @@
+package propagation
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/events"
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
+	"github.com/bsv-blockchain/arcade/teranode"
+)
+
+// Issue #301. arcade parses Teranode's reject reason, persists it on the row
+// and logs it — and then publishes REJECTED through the payload-free bulk
+// fan-out, so every SSE and webhook subscriber sees a terminal REJECTED with an
+// empty extraInfo. The row keeps the reason and GET /tx/<txid> serves it, so
+// nothing is lost; what is missing is that the push event does not describe
+// itself. That costs a round trip on the one status whose payload decides what
+// the client does next (UTXO_SPENT means "your view of the chain is stale,
+// resync"; TX_INVALID means "these bytes will never be accepted, stop
+// retrying") — and REJECTED is terminal, so a client that correctly stops
+// polling on a terminal status stops exactly when polling becomes the only way
+// to learn why.
+//
+// These tests pin the property end to end: every REJECTED event a subscriber
+// can receive carries the SAME reason string arcade wrote to the row.
+
+// rejectionPropagator wires a propagator with a recording publisher and no
+// merkle client (registerBatch is then a pass-through), so a flush's published
+// events can be inspected directly. The requeue delay is parked at an hour:
+// these tests assert on the terminal publish, never on a retry landing.
+func rejectionPropagator(teranodeURL string, st store.Store, pub events.Publisher) *Propagator {
+	cfg := &config.Config{}
+	cfg.Propagation.MerkleConcurrency = 10
+	cfg.Propagation.RetryMaxAttempts = 5
+	tc := teranode.NewClient([]string{teranodeURL}, "", teranode.HealthConfig{FailureThreshold: 1 << 20})
+	p := New(cfg, zap.NewNop(), nil, pub, st, nil, tc, nil)
+	p.requeueDelay = time.Hour
+	return p
+}
+
+// publishedReasons flattens every bulk event the publisher recorded into a
+// txid → extraInfo map, mirroring the unfan both real subscribers perform
+// (services/sse.Manager.fanOutBulk and services/webhook.Service.handleUpdate
+// both copy the whole struct per txid).
+func publishedReasons(pub *recordingPublisher, status models.Status) map[string]string {
+	out := make(map[string]string)
+	for _, ev := range pub.bulkSnapshot() {
+		if ev.Status != status {
+			continue
+		}
+		for _, txid := range ev.TxIDs {
+			out[txid] = ev.ExtraInfo
+		}
+	}
+	return out
+}
+
+// persistedReasons collects the reason arcade wrote to each REJECTED row, so a
+// test can assert the published string is that exact string rather than a
+// second rendering of the same idea.
+func persistedReasons(ms *mockStore) map[string]string {
+	out := make(map[string]string)
+	for _, u := range rejectedUpdates(ms) {
+		out[u.TxID] = u.ExtraInfo
+	}
+	return out
+}
+
+// TestApplyTerminalStatuses_RejectionCarriesTeranodeReason is the reported bug
+// at batch scale: two txs double-spend two different outpoints, Teranode 409s
+// the batch with one UTXO_SPENT line each, and both terminalize REJECTED. Each
+// tx's event must carry that tx's own line and its ARC code — pre-fix the whole
+// batch shared ONE event whose extraInfo was "" and whose status code was 0.
+func TestApplyTerminalStatuses_RejectionCarriesTeranodeReason(t *testing.T) {
+	const (
+		outA    = "256fc7143c6ef5436cd5258ade24b68c43d0f8268c086bd9fa90055dd5a7ae43"
+		outB    = "9d2c1f0e7b5a48361c0e7f2d6b48a91c33e0f8261c086bd9fa90055dd5a7bb11"
+		spender = "7dfbe0fcacf630066b23036bc007e73d58a61ab9bcb8e66f6b214f8ef5f28489"
+	)
+	txidA, rawA := spendingTx(t, outA, 2, 1)
+	txidB, rawB := spendingTx(t, outB, 0, 2)
+
+	body := conflictBody([]string{outpointRef(outA, 2), outpointRef(outB, 0)}, spender)
+	srv := conflictServer(&eventLog{}, body)
+	defer srv.Close()
+
+	ms := newMockStore()
+	pub := &recordingPublisher{}
+	p := rejectionPropagator(srv.URL, ms, pub)
+
+	for _, tx := range []struct {
+		txid string
+		raw  []byte
+	}{{txidA, rawA}, {txidB, rawB}} {
+		if err := p.handleMessage(context.Background(), consumerMsg(realPropMsg(t, tx.txid, tx.raw))); err != nil {
+			t.Fatalf("handleMessage %s: %v", tx.txid, err)
+		}
+	}
+	if err := flushSync(t, p); err != nil {
+		t.Fatalf("flushBatch: %v", err)
+	}
+
+	persisted := persistedReasons(ms)
+	if len(persisted) != 2 {
+		t.Fatalf("expected 2 REJECTED rows, got %d — the fixture stopped producing verdicts", len(persisted))
+	}
+	published := publishedReasons(pub, models.StatusRejected)
+	for _, txid := range []string{txidA, txidB} {
+		reason, ok := published[txid]
+		if !ok {
+			t.Fatalf("no REJECTED event published for %s", txid)
+		}
+		if reason == "" {
+			t.Errorf("REJECTED event for %s carries no reason, so a subscriber cannot tell a "+
+				"double-spend from a policy failure without a GET /tx round trip (#301)", txid)
+		}
+		if reason != persisted[txid] {
+			t.Errorf("published reason for %s = %q, persisted = %q; the event and the row must "+
+				"agree on one string", txid, reason, persisted[txid])
+		}
+		if !strings.Contains(reason, "UTXO_SPENT (70)") {
+			t.Errorf("published reason for %s = %q, want Teranode's UTXO_SPENT verdict", txid, reason)
+		}
+	}
+
+	// The ARC code rides along for the same reason the intake rejection path
+	// (api_server.rejectAtIntake) publishes it: 466 is the machine-readable
+	// form of "conflict", and a client that switches on prose is a client that
+	// breaks when the prose changes.
+	for _, ev := range pub.bulkSnapshot() {
+		if ev.Status == models.StatusRejected && ev.StatusCode != 466 {
+			t.Errorf("REJECTED event %v carries status code %d, want 466 (ARC conflict)", ev.TxIDs, ev.StatusCode)
+		}
+	}
+}
+
+// TestPersistCascade_RejectionGroupsByAncestorReason covers the cascade path
+// and the batching property in one shot.
+//
+// A cascade is where rejection volume actually comes from: one rejected tx at
+// the head of a chain condemns every descendant behind it, and the report came
+// from a 128-chain covenant workload where exactly that happened. Every
+// descendant of ONE ancestor shares one cascadeReason string, so they must
+// still ride ONE event — publishing per transaction would cost the SSE fan-out
+// a store round-trip per descendant on its single goroutine, which is too much
+// to pay for a convenience improvement. Two ancestors mean two reasons, and
+// therefore two events: pre-fix all four txs shared one event with no reason.
+func TestPersistCascade_RejectionGroupsByAncestorReason(t *testing.T) {
+	const (
+		ancestorA = "aaaa1f0e7b5a48361c0e7f2d6b48a91c33e0f8261c086bd9fa90055dd5a7bb11"
+		ancestorB = "bbbb1f0e7b5a48361c0e7f2d6b48a91c33e0f8261c086bd9fa90055dd5a7bb11"
+	)
+	ms := newMockStore()
+	pub := &recordingPublisher{}
+	p := rejectionPropagator("http://127.0.0.1:0", ms, pub)
+
+	cascaded := []cascadeRejection{
+		{txid: "child-a1", ancestor: ancestorA},
+		{txid: "child-a2", ancestor: ancestorA},
+		{txid: "child-a3", ancestor: ancestorA},
+		{txid: "child-b1", ancestor: ancestorB},
+	}
+	p.persistCascade(context.Background(), cascaded, models.StatusRejected, time.Now())
+
+	emitted := pub.bulkSnapshot()
+	if len(emitted) != 2 {
+		t.Fatalf("expected 1 event per distinct cascade reason (2), got %d: %+v", len(emitted), emitted)
+	}
+	byReason := make(map[string][]string, 2)
+	for _, ev := range emitted {
+		if ev.TxID != "" {
+			t.Errorf("bulk event carries TxID %q; the contract is TxIDs populated, TxID empty", ev.TxID)
+		}
+		byReason[ev.ExtraInfo] = ev.TxIDs
+	}
+
+	wantA := cascadeReason(models.StatusRejected, ancestorA)
+	if got := byReason[wantA]; len(got) != 3 {
+		t.Errorf("ancestor %s condemned 3 descendants; its event carries %v — descendants of one "+
+			"ancestor share a reason and must stay batched", ancestorA, got)
+	}
+	wantB := cascadeReason(models.StatusRejected, ancestorB)
+	if got := byReason[wantB]; len(got) != 1 || got[0] != "child-b1" {
+		t.Errorf("event for ancestor %s carries %v, want [child-b1]", ancestorB, got)
+	}
+
+	// Same invariant as the direct path: what was published is what was
+	// persisted, character for character.
+	published := publishedReasons(pub, models.StatusRejected)
+	persisted := persistedReasons(ms)
+	for _, cr := range cascaded {
+		if published[cr.txid] != persisted[cr.txid] {
+			t.Errorf("%s: published reason %q != persisted reason %q",
+				cr.txid, published[cr.txid], persisted[cr.txid])
+		}
+	}
+}
+
+// TestSchedulePendingRetry_GiveUpCarriesReason covers the third and least
+// self-evident way a tx reaches REJECTED: the durable retry budget runs out
+// because a parent it spends never reached the network, so there is no peer
+// verdict to quote and nothing about the transaction itself explains the
+// outcome.
+func TestSchedulePendingRetry_GiveUpCarriesReason(t *testing.T) {
+	root := strings.Repeat("99", 32)
+	orphan := buildChain(t, root, 1)[0]
+
+	ms := newMockStore()
+	pub := &recordingPublisher{}
+	p := rejectionPropagator("http://127.0.0.1:0", ms, pub)
+	p.pendingRetryMaxAttempts = 3
+	p.pendingRetryBackoff = time.Millisecond
+	p.pendingRetryMaxBackoff = time.Millisecond
+
+	// Attempts 1..3 reschedule; the 4th exceeds the budget and terminalizes.
+	for i := 0; i < 4; i++ {
+		p.schedulePendingRetry(context.Background(), orphan.txid, orphan.raw)
+	}
+
+	emitted := pub.bulkSnapshot()
+	if len(emitted) != 1 {
+		t.Fatalf("expected exactly 1 REJECTED event for the give-up, got %d: %+v", len(emitted), emitted)
+	}
+	ev := emitted[0]
+	if ev.Status != models.StatusRejected || len(ev.TxIDs) != 1 || ev.TxIDs[0] != orphan.txid {
+		t.Fatalf("give-up event = %+v, want REJECTED for %s", ev, orphan.txid)
+	}
+	if !strings.Contains(ev.ExtraInfo, "giving up") {
+		t.Errorf("give-up event reason = %q, want the same budget-exhausted reason written to the "+
+			"row", ev.ExtraInfo)
+	}
+
+	ms.mu.Lock()
+	cleared := append([]clearedCall(nil), ms.cleared...)
+	ms.mu.Unlock()
+	if len(cleared) != 1 {
+		t.Fatalf("expected exactly 1 ClearRetryState call, got %d", len(cleared))
+	}
+	if ev.ExtraInfo != cleared[0].extraInfo {
+		t.Errorf("published reason %q != the reason written to the row %q", ev.ExtraInfo, cleared[0].extraInfo)
+	}
+}
+
+// TestPublishBulkStatus_NonRejectionPayloadUnchanged guards the blast radius.
+// The reason plumbing is scoped to REJECTED: ACCEPTED_BY_NETWORK and
+// PENDING_RETRY keep the payload-free bulk event they have always emitted, so
+// no existing subscriber sees a byte it did not see before. PENDING_RETRY does
+// carry a reason on its row, but it is transient — the reaper resolves it — and
+// widening the wire for it belongs in its own change.
+func TestPublishBulkStatus_NonRejectionPayloadUnchanged(t *testing.T) {
+	pub := &recordingPublisher{}
+	p := rejectionPropagator("http://127.0.0.1:0", newMockStore(), pub)
+
+	now := time.Now()
+	p.publishBulkStatus(context.Background(), models.StatusAcceptedByNetwork, []string{"tx1", "tx2"}, now)
+	p.publishBulkStatus(context.Background(), models.StatusPendingRetry, []string{"tx3"}, now)
+
+	emitted := pub.bulkSnapshot()
+	if len(emitted) != 2 {
+		t.Fatalf("expected 2 bulk events, got %d", len(emitted))
+	}
+	for _, ev := range emitted {
+		if ev.ExtraInfo != "" || ev.StatusCode != 0 {
+			t.Errorf("non-rejection bulk event %s gained a payload (extraInfo=%q, status=%d)",
+				ev.Status, ev.ExtraInfo, ev.StatusCode)
+		}
+	}
+	if got := len(emitted[0].TxIDs); got != 2 {
+		t.Errorf("ACCEPTED_BY_NETWORK event carries %d txids, want 2 — accepts must stay batched", got)
+	}
+}
+
+// TestBulkUnfanCarriesRejectionReason proves the consumer side of the fix
+// without reaching into services/sse or services/webhook: both unfan a bulk
+// event by copying the whole struct and overwriting TxID/TxIDs, so a reason on
+// the event is a reason on every per-tx frame. This is why the fix needs no
+// wire format change and no subscriber change — the field was always
+// serialized, the publisher just never set it.
+func TestBulkUnfanCarriesRejectionReason(t *testing.T) {
+	bulk := &models.TransactionStatus{
+		Status:     models.StatusRejected,
+		StatusCode: 466,
+		ExtraInfo:  "UTXO_SPENT (70): outpoint already spent",
+		TxIDs:      []string{"tx1", "tx2"},
+		Timestamp:  time.Now(),
+	}
+	for _, txid := range bulk.TxIDs {
+		perTx := *bulk
+		perTx.TxID = txid
+		perTx.TxIDs = nil
+		if perTx.ExtraInfo != bulk.ExtraInfo || perTx.StatusCode != bulk.StatusCode {
+			t.Fatalf("unfanned frame for %s lost its payload: %+v", txid, perTx)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #301.

## Diagnosis

A `REJECTED` status delivered over SSE or webhook carried no reason. arcade parsed Teranode's verdict, persisted it on the row and logged it — and then published the event through `publishBulkStatus`, which builds its template from `Status`/`Timestamp`/`TxIDs` only:

```go
template := &models.TransactionStatus{
	Status:    status,
	Timestamp: ts,
	TxIDs:     txids,
}
```

`ExtraInfo` and `StatusCode` were dropped there. Teranode is not at fault and neither is the parse — #292 is present and correct on the deployed build. The reason was lost at the publish seam, and it is structural: a bulk event is ONE event carrying N txids, so it cannot carry a per-transaction payload even if the field were set.

### Severity, accurately

The reporter's original write-up said the reason became unrecoverable because the propagation reaper deletes terminal rows. **That part was a testing error and has been retracted on the issue** — the query used `/api/v1/tx/<txid>`, which is not an arcade route and falls through to gin's no-route handler. The real route is `/tx/<txid>` and it returns the record intact with `extraInfo` present. No data is lost, and this PR does nothing about retention.

What is actually wrong is narrower: **the push event does not describe itself**. Learning why a transaction was rejected costs a round trip on the one status whose payload decides what the client does next — `UTXO_SPENT` means "your view of the chain is stale, resync", `TX_INVALID` means "these bytes will never be accepted, stop retrying", and the correct response is completely different. `REJECTED` is also terminal, which makes it a trap: a client that correctly stops polling on a terminal status stops exactly when polling becomes the way to find out.

## The fix

`publishRejections` groups a batch's rejections by reason and emits one bulk event per distinct reason, with `ExtraInfo` and `StatusCode` set from the rows that were just written.

**Why grouping rather than one event per transaction** (the shape the issue proposed):

- **No wire format change and no subscriber change is needed.** Both subscribers already unfan a bulk event by copying the whole struct and overwriting `TxID`/`TxIDs` — `services/sse.Manager.fanOutBulk` and `services/webhook.Service.handleUpdate` — so a reason on the event is already a reason on every per-tx frame. The field was always serialized; the publisher simply never set it. Confirmed on the consumer side as the brief asked: a per-tx event is also handled correctly (it is the primary path), and `go-arcade-toolbox`'s SSE client never sees bulk events at all because arcade's SSE manager unfans before the frame reaches the wire.
- **It keeps the case that actually produces rejection volume batched.** A dep-cascade condemns every descendant of one rejected ancestor with the *same* `cascadeReason` string. That is the burst that gets large — the report came from a 128-chain covenant workload where one rejection condemns a whole chain. Grouped, that chain still rides one event. Published per transaction it would cost the SSE fan-out one `tokenIndex.lookup` store round-trip per descendant on its single fan-out goroutine (bulk events deliberately bypass the LRU, so these would be misses), plus N Kafka messages, plus LRU pollution with terminal txids that evict the live working set. That is the "unbounded per-event round trip in a hot loop" the design should avoid, and it is too much to pay for what is a convenience improvement.
- **It degenerates to per-transaction exactly where that is required.** A Teranode verdict names the offending txid inside its own failure line, so those reasons are distinct per transaction and each gets its own event.

Every path that terminalizes a transaction as `REJECTED` now carries its reason:

| path | site | before |
|---|---|---|
| direct Teranode verdict + store-consult cascade | `applyTerminalStatuses` (`publishedRejected` now carries whole rows, not txids) | reason on the row, empty on the event |
| dispatcher dep-cascade | `persistCascade` | `cascadeReason` computed per child, written to the row, then discarded at the publish |
| durable-retry give-up | `schedulePendingRetry` | reason on the row, empty on the event |

The reaper is covered too — it publishes through `applyTerminalStatuses`.

The published string is the same string that was persisted, not a second rendering; two of the tests assert that equality directly rather than matching on shape.

## Blast radius

Non-rejection statuses are untouched. `ACCEPTED_BY_NETWORK` and `PENDING_RETRY` keep the payload-free bulk event they have always emitted, so no existing subscriber sees a byte it did not see before. `PENDING_RETRY` does carry a reason on its row and the same treatment would apply, but it is transient — the reaper resolves it — so widening the wire for it belongs in its own change.

## Test evidence

`services/propagation/reject_reason_test.go`. Verified both directions.

Against the pre-fix code (production files reverted, tests kept):

```
--- FAIL: TestApplyTerminalStatuses_RejectionCarriesTeranodeReason
    published reason for 0a9f02e6… = "", persisted = "UTXO_SPENT (70): … utxo already spent by tx …"
    REJECTED event […] carries status code 0, want 466 (ARC conflict)
--- FAIL: TestPersistCascade_RejectionGroupsByAncestorReason
    expected 1 event per distinct cascade reason (2), got 1
--- FAIL: TestSchedulePendingRetry_GiveUpCarriesReason
    published reason "" != the reason written to the row "no network verdict after 3 durable retry attempts: giving up — …"
--- PASS: TestPublishBulkStatus_NonRejectionPayloadUnchanged
--- PASS: TestBulkUnfanCarriesRejectionReason
```

The two that pass in both directions are the guards: one pins that non-rejection events gained no payload, the other pins the unfan behaviour the fix relies on. The three that fail are the bug.

Against this branch: all five pass.

`go build ./...`, `go vet ./...`, `go test ./...` and `golangci-lint run` (0 issues) all pass on a clean checkout of this branch.

## Deliberately not in this PR

Retention of rejected rows. The issue listed it as independently worth doing; it is not needed, because the row is retained and `GET /tx/<txid>` serves the reason. Worth noting for anyone who goes looking: arcade's propagation reaper only rebroadcasts stale rows, it never deletes them, and no Go code in this repo deletes transaction rows — expiry, where it happens, is a store-level concern outside this path.

https://claude.ai/code/session_01DJRc7gb3XLjkqcknGzGznp
