### PR TITLE
fix(sse): stop silent data loss on resume, declare gaps in-band, drain gracefully

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -768,6 +768,25 @@ type SSEConfig struct {
 	// behavior. Tokenless (firehose) clients always keep drop-only behavior —
 	// the store catchup source is token-scoped.
 	CatchupOnDrop bool `mapstructure:"catchup_on_drop"`
+	// DrainQuiesceMS is how long shutdown waits, after /ready starts failing,
+	// before it begins closing client connections. It covers endpoint-removal
+	// propagation: kube-proxy and the ingress learn the pod is unready
+	// asynchronously, so cutting connections immediately means clients
+	// reconnect straight back into a terminating pod. Default
+	// DefaultSSEDrainQuiesceMS.
+	DrainQuiesceMS int `mapstructure:"drain_quiesce_ms"`
+	// DrainRetryMaxMS bounds the reconnect delay handed to clients on
+	// shutdown. Each connection gets its own value drawn uniformly below this
+	// and emitted as an SSE `retry:` directive on its shutdown frame, so a
+	// rolling restart releases clients as a ramp rather than a synchronized
+	// herd hitting a pod that is still cold. Default
+	// DefaultSSEDrainRetryMaxMS; zero omits the hint and clients fall back to
+	// their own backoff.
+	DrainRetryMaxMS int `mapstructure:"drain_retry_max_ms"`
+	// ShutdownTimeoutMS bounds the final http.Server.Shutdown. Connections are
+	// already closing by then, so this only covers stragglers. Default
+	// DefaultSSEShutdownTimeoutMS.
+	ShutdownTimeoutMS int `mapstructure:"shutdown_timeout_ms"`
 }
 
 // WebhookConfig tunes the HTTP webhook delivery service. The service
@@ -872,6 +891,29 @@ const DefaultEventsSubscriberBuffer = 4096
 // headroom over a single ~50-event bulk-unfan while staying a modest
 // per-connection memory cost (channel of *TransactionStatus pointers).
 const DefaultSSEClientBuffer = 8192
+
+// SSE graceful-drain defaults.
+//
+// A long-lived streaming connection is never "idle", so http.Server.Shutdown
+// can never complete on its own: it burns its whole timeout, the process then
+// exits, and every stream is severed with a TCP RST — sending every client back
+// simultaneously. These bound an explicit drain instead: fail readiness, wait
+// for the endpoint to be withdrawn, then release clients with staggered
+// reconnect hints.
+//
+// Their sum must fit inside the pod's terminationGracePeriodSeconds, or the
+// kubelet SIGKILLs mid-drain and the RST is back.
+const (
+	// DefaultSSEDrainQuiesceMS covers endpoint-removal propagation through
+	// kube-proxy and the ingress.
+	DefaultSSEDrainQuiesceMS = 10_000
+	// DefaultSSEDrainRetryMaxMS is the widest reconnect delay handed out during
+	// a drain; each client draws its own beneath it.
+	DefaultSSEDrainRetryMaxMS = 30_000
+	// DefaultSSEShutdownTimeoutMS bounds the final server shutdown once clients
+	// have been released.
+	DefaultSSEShutdownTimeoutMS = 15_000
+)
 
 // ValidatorConfig controls intake-time transaction validation. It carries the
 // operator-facing fee floor enforced against EF/BEEF submissions; the consensus
@@ -1147,6 +1189,9 @@ func setDefaults() {
 	viper.SetDefault("sse.enabled", true)
 	viper.SetDefault("sse.host", "0.0.0.0")
 	viper.SetDefault("sse.port", 8082)
+	viper.SetDefault("sse.drain_quiesce_ms", DefaultSSEDrainQuiesceMS)
+	viper.SetDefault("sse.drain_retry_max_ms", DefaultSSEDrainRetryMaxMS)
+	viper.SetDefault("sse.shutdown_timeout_ms", DefaultSSEShutdownTimeoutMS)
 	viper.SetDefault("sse.client_buffer_size", DefaultSSEClientBuffer)
 	viper.SetDefault("sse.catchup_on_drop", true)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // baseValidConfig returns a Config populated with the minimum fields other
@@ -348,5 +350,42 @@ func TestValidate_AllowsZeroSchemaApplyTimeout(t *testing.T) {
 	cfg.Store.Postgres.SchemaApplyTimeoutMs = 0
 	if err := validate(cfg); err != nil {
 		t.Fatalf("zero schema_apply_timeout_ms (= use default) should be accepted, got: %v", err)
+	}
+}
+
+// TestSSEDrainKnobsBind pins the viper wiring for the SSE drain windows.
+//
+// The failure mode this guards is silent: a typo in a mapstructure tag or a
+// SetDefault key leaves the field at its zero value, the service falls back to
+// its compiled-in default, and nothing anywhere reports that the operator's
+// setting was ignored. These particular knobs have to stay coordinated with
+// the pod's terminationGracePeriodSeconds, so an ignored override is a drain
+// that gets SIGKILLed halfway through.
+func TestSSEDrainKnobsBind(t *testing.T) {
+	cfg, err := Load(&cobra.Command{})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"drain_quiesce_ms", cfg.SSE.DrainQuiesceMS, DefaultSSEDrainQuiesceMS},
+		{"drain_retry_max_ms", cfg.SSE.DrainRetryMaxMS, DefaultSSEDrainRetryMaxMS},
+		{"shutdown_timeout_ms", cfg.SSE.ShutdownTimeoutMS, DefaultSSEShutdownTimeoutMS},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("sse.%s = %d, want %d", tc.name, tc.got, tc.want)
+		}
+	}
+
+	t.Setenv("ARCADE_SSE_DRAIN_QUIESCE_MS", "2500")
+	overridden, err := Load(&cobra.Command{})
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if overridden.SSE.DrainQuiesceMS != 2500 {
+		t.Errorf("ARCADE_SSE_DRAIN_QUIESCE_MS override = %d, want 2500", overridden.SSE.DrainQuiesceMS)
 	}
 }

--- a/docs/sse.md
+++ b/docs/sse.md
@@ -149,7 +149,30 @@ The server only replays missed events when **both** of these are present on the 
 
 Replay walks the submissions registered under the token and emits the current status for each txid whose `timestamp` is later than `Last-Event-ID`. There is no replay for unfiltered (no-token) consumers — that mode is for live monitoring only.
 
+Note that replay emits each txid's **current** status, not the sequence of transitions you missed. If a transaction went `ACCEPTED → SEEN_ON_NETWORK → MINED` while you were disconnected, you get one `MINED` frame, not three.
+
 Slow consumers will drop frames: the fan-out is non-blocking, so if your client doesn't drain the connection fast enough, the server skips that update for that client rather than stalling. Reconnecting with `Last-Event-ID` is the recovery path.
+
+### `event: gap` — the stream is discontiguous
+
+Whenever the server knows it handed you an incomplete stream, it says so in-band rather than leaving you to assume you are whole:
+
+```
+event: gap
+data: {"reason":"catchup_truncated","from":"1786493743374103486","count":10000,"action":"reconcile"}
+```
+
+| `reason` | Meaning |
+|---|---|
+| `catchup_truncated` | A reconnect replay hit the server's frame budget. Matching history after `from` was not sent. |
+| `firehose_drop` | A no-token stream dropped a frame. No token-scoped replay can recover it, so this is the only recovery signal available to unfiltered consumers. |
+| `replay_unavailable` | The store could not serve the replay. The connection continues with live frames only. |
+
+`from` is the last nanosecond cursor you can trust; everything between it and the live stream may be missing. `action` is always `reconcile`: re-fetch the affected transactions with `GET /tx/{txid}`.
+
+Treat a gap as an event to act on, not a warning to log. It is the difference between bounded, self-healing loss and silent loss — a stream that never emits `gap` is complete, and one that does tells you exactly where to look.
+
+Unknown `event:` types must be ignored by conformant clients, so this frame is safe for existing consumers: it costs them nothing and they behave exactly as before.
 
 ## Failure modes
 

--- a/events/kafka_publisher.go
+++ b/events/kafka_publisher.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -30,7 +32,7 @@ const dropLogInterval = 5 * time.Second
 // change. Publish JSON-encodes the TransactionStatus and sends it under
 // kafka.TopicStatusUpdate keyed by txid (so updates for the same tx land on
 // the same partition in real Kafka). Subscribe spins up a dedicated
-// consumer group with a random ID — every caller gets every message
+// consumer group per (process, caller) — every caller gets every message
 // published after it subscribed, regardless of how many other subscribers
 // are running. History is never served from Kafka: subscribers are
 // live-only by contract, and missed events recover through store-backed
@@ -47,6 +49,11 @@ type KafkaPublisher struct {
 	mu     sync.Mutex
 	closed bool
 	subs   []*kafkaSubscription
+	// groupSeq counts Subscribe calls per caller so each gets its own consumer
+	// group even when one process subscribes twice under the same caller. See
+	// subscriberGroupID: sharing a group would split the topic's partitions
+	// between the two subscribers instead of giving each the whole stream.
+	groupSeq map[string]int
 }
 
 // NewKafkaPublisher wraps a kafka.Producer. The producer's underlying broker
@@ -116,11 +123,14 @@ func (p *KafkaPublisher) PublishBulk(ctx context.Context, template *models.Trans
 	return err
 }
 
-// Subscribe joins a fresh consumer group on TopicStatusUpdate and returns a
-// channel that yields decoded TransactionStatus values until ctx is canceled.
-// The unique groupID guarantees this subscriber sees every message published
-// from subscription time onward — useful when multiple subscribers (SSE
-// manager + webhook service) coexist in the same process or across pods.
+// Subscribe joins a consumer group on TopicStatusUpdate and returns a channel
+// that yields decoded TransactionStatus values until ctx is canceled.
+//
+// The group id is unique per (process, caller) — see subscriberGroupID — which
+// is what guarantees this subscriber sees EVERY message published from
+// subscription time onward rather than a partition subset. That property is
+// load-bearing: it is why any SSE replica can serve any client and why no
+// sticky routing is needed.
 //
 // The group starts at the LATEST offset. A fresh random group with
 // StartOldest silently replays the topic's entire retained backlog on every
@@ -145,10 +155,16 @@ func (p *KafkaPublisher) Subscribe(ctx context.Context, caller string) (<-chan *
 		caller = "unknown"
 	}
 
-	groupID, err := uniqueGroupID()
+	groupID, err := p.subscriberGroupID(caller)
 	if err != nil {
 		return nil, fmt.Errorf("generating group id: %w", err)
 	}
+	// Logged because a duplicate group id across pods is otherwise invisible:
+	// the partitions would be split between them and each pod's clients would
+	// quietly receive a fraction of the stream.
+	p.logger.Info("events subscriber joining consumer group",
+		zap.String("caller", caller),
+		zap.String("group_id", groupID))
 
 	out := make(chan *models.TransactionStatus, p.subscriberBuffer)
 
@@ -245,14 +261,72 @@ type kafkaSubscription struct {
 	out chan *models.TransactionStatus
 }
 
-// uniqueGroupID returns a per-call group identifier. Used so each Subscribe
-// gets its own consumer group, which in turn guarantees every subscriber
-// sees every message published after it joined (the broker fans out across
-// distinct groups; each group starts at the topic head — see Subscribe).
-func uniqueGroupID() (string, error) {
+// subscriberGroupID returns this subscriber's consumer-group identifier.
+//
+// EVERY Subscribe call must get its own group. That is the Publisher's core
+// fan-out contract: distinct groups each receive the whole topic, whereas two
+// subscribers sharing a group have the partitions split between them and each
+// sees only a fraction of the stream. For SSE that fraction would be silently
+// missing events, and the "every replica sees everything" property — the
+// reason any replica can serve any client without sticky routing — would be
+// gone. Hence the per-caller sequence number: it is what keeps the contract
+// intact for two same-caller subscribers in one process.
+//
+// Within that constraint the id is built from caller + hostname (the pod name
+// under Kubernetes) rather than random bytes. A purely random id made
+// redpanda_kafka_consumer_group_lag effectively unusable: the group label was
+// unrecognizable and changed on every restart, so the most useful broker-side
+// signal could not be matched, aggregated, or alerted on. The id now sorts and
+// regex-matches by caller (`arcade-events-sse-.*`) and names the pod it
+// belongs to, so lag joins back to something an operator can go and look at.
+//
+// This is safe with respect to #239 (the StartOldest backlog-replay OOM):
+// this consumer never marks messages, so the group never commits an offset and
+// Offsets.Initial (StartLatest) applies on every join. A rejoining pod still
+// starts at the head, even if it reuses a name.
+//
+// Falls back to random bytes when the hostname is missing or non-identifying,
+// where uniqueness matters more than legibility.
+func (p *KafkaPublisher) subscriberGroupID(caller string) (string, error) {
+	p.mu.Lock()
+	if p.groupSeq == nil {
+		p.groupSeq = make(map[string]int)
+	}
+	seq := p.groupSeq[caller]
+	p.groupSeq[caller]++
+	p.mu.Unlock()
+
+	host, err := os.Hostname()
+	if err != nil {
+		return uniqueGroupID(caller)
+	}
+	sanitized := sanitizeGroupComponent(host)
+	if sanitized == "" || sanitized == "localhost" {
+		return uniqueGroupID(caller)
+	}
+	return fmt.Sprintf("arcade-events-%s-%s-%d", caller, sanitized, seq), nil
+}
+
+// uniqueGroupID returns a random per-call group identifier, used when no
+// stable identity is available.
+func uniqueGroupID(caller string) (string, error) {
 	var b [12]byte
 	if _, err := rand.Read(b[:]); err != nil {
 		return "", err
 	}
-	return "arcade-events-" + hex.EncodeToString(b[:]), nil
+	return "arcade-events-" + caller + "-" + hex.EncodeToString(b[:]), nil
+}
+
+// sanitizeGroupComponent reduces a string to characters that are safe in a
+// Kafka group id, dropping anything else.
+func sanitizeGroupComponent(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }

--- a/events/kafka_publisher_test.go
+++ b/events/kafka_publisher_test.go
@@ -2,6 +2,8 @@ package events
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -55,6 +57,51 @@ func TestKafkaPublisherRoundtrip(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not receive status update")
+	}
+}
+
+// TestSubscriberGroupIDIsUniqueAndAttributable pins both halves of the group-id
+// contract.
+//
+// Uniqueness is a correctness property with a SILENT failure mode: two
+// subscribers sharing a group have the topic's partitions split between them,
+// so each sees only a fraction of the stream. For SSE that is missed events
+// with no error anywhere.
+//
+// Attributability is the observability property: the id must carry the caller
+// and the host so redpanda_kafka_consumer_group_lag can be matched and
+// aggregated. A purely random id — the previous behavior — could not be.
+func TestSubscriberGroupIDIsUniqueAndAttributable(t *testing.T) {
+	broker := kafka.NewMemoryBroker(1)
+	defer func() { _ = broker.Close() }()
+	pub := NewKafkaPublisher(kafka.NewProducer(broker), zap.NewNop(), 0)
+
+	seen := map[string]bool{}
+	for _, caller := range []string{"sse", "sse", "webhook", "sse"} {
+		id, err := pub.subscriberGroupID(caller)
+		if err != nil {
+			t.Fatalf("subscriberGroupID(%q): %v", caller, err)
+		}
+		if seen[id] {
+			t.Fatalf("duplicate group id %q: two subscribers would split partitions and each silently miss events", id)
+		}
+		seen[id] = true
+		if !strings.HasPrefix(id, "arcade-events-"+caller+"-") {
+			t.Errorf("group id %q is not matchable by caller (want prefix arcade-events-%s-)", id, caller)
+		}
+	}
+
+	host, err := os.Hostname()
+	if err == nil && sanitizeGroupComponent(host) != "" && sanitizeGroupComponent(host) != "localhost" {
+		var found bool
+		for id := range seen {
+			if strings.Contains(id, sanitizeGroupComponent(host)) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("no group id names the host; lag cannot be traced back to a pod. got %v", seen)
+		}
 	}
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -747,6 +747,28 @@ var SSEMidstreamCatchupFramesTotal = promauto.NewCounter(prometheus.CounterOpts{
 	Help: "Frames replayed from the store by mid-stream SSE catchup rounds.",
 })
 
+// SSEGapEventsTotal counts `event: gap` frames written to /events clients —
+// every occasion on which the server KNOWS it handed a client a discontiguous
+// stream and said so. Reasons:
+//   - "catchup_truncated": a connect-time replay stopped at the frame cap with
+//     matching history still beyond the cursor.
+//   - "firehose_drop": a tokenless client's frame was dropped on channel
+//     overflow. There is no bounded store query that reconstructs an
+//     unfiltered stream, so a gap notice is the only recovery signal these
+//     clients can be given.
+//   - "replay_unavailable": the store could not serve the replay (iteration
+//     error, or a backend that refused an unbounded scan).
+//
+// This is the counterpart to APISSEDroppedTotal: drops say the server lost
+// something, gaps say the CLIENT was told. A drop rate without a matching gap
+// rate is silent loss, which is the failure mode this metric exists to make
+// impossible to miss. The client's contract on receiving one is to reconcile
+// the window over REST.
+var SSEGapEventsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_sse_gap_events_total",
+	Help: "SSE `event: gap` frames written, by reason.",
+}, []string{"reason"}) // catchup_truncated, firehose_drop, replay_unavailable
+
 // EventsSubscriberDroppedTotal counts events.Publisher.Subscribe channel
 // drops, labeled by which caller's channel filled. The publisher emits a
 // drop when the per-subscriber buffer is at capacity and the kafka handler

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -747,6 +747,38 @@ var SSEMidstreamCatchupFramesTotal = promauto.NewCounter(prometheus.CounterOpts{
 	Help: "Frames replayed from the store by mid-stream SSE catchup rounds.",
 })
 
+// SSEClientLagSeconds measures, per client per keepalive tick, how far behind
+// the present that client's last delivered frame is.
+//
+// This is the single most useful health signal for the push path and the one
+// whose absence let 1.6M dropped events go unnoticed for a whole 45-minute
+// run: drops and fan-out duration each describe one component, while lag
+// describes what a consumer actually EXPERIENCES. It is nearly free — the
+// writer goroutine already maintains the lastDelivered watermark, and this
+// samples it once per client per keepalive rather than per frame.
+//
+// A client with nothing to receive reads as lag, so interpret it against
+// SSEConnectedClients and the publish rate: it is a "is the stream keeping
+// up" signal, not a liveness check.
+var SSEClientLagSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+	Name:    "arcade_sse_client_lag_seconds",
+	Help:    "Age of the last frame delivered to an SSE client, sampled per keepalive tick.",
+	Buckets: []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 300},
+})
+
+// SSEConnectionsTotal counts finished /events connections by how they ended:
+//   - "client_closed": the request context was canceled (normal disconnect).
+//   - "drain":         released by a graceful shutdown.
+//   - "write_error":   the connection died mid-write.
+//
+// The rate is the reconnect rate, and the label says why. A reconnect storm
+// with outcome="write_error" is a very different problem from one with
+// outcome="drain", and before this the two were indistinguishable.
+var SSEConnectionsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "arcade_sse_connections_total",
+	Help: "Finished SSE /events connections, by how they ended.",
+}, []string{"outcome"}) // client_closed, drain, write_error
+
 // SSEGapEventsTotal counts `event: gap` frames written to /events clients —
 // every occasion on which the server KNOWS it handed a client a discontiguous
 // stream and said so. Reasons:

--- a/services/sse/manager.go
+++ b/services/sse/manager.go
@@ -467,18 +467,8 @@ func (s *Service) handleEvents(c *gin.Context) {
 	s.manager.Register(client)
 	defer s.manager.Unregister(client.ID)
 
-	if token != "" {
-		var since time.Time
-		if lastEventID := c.GetHeader("Last-Event-ID"); lastEventID != "" {
-			if ns, err := strconv.ParseInt(lastEventID, 10, 64); err == nil {
-				since = time.Unix(0, ns)
-			}
-		}
-		// The pre-stream catchup threads the client through so lastDelivered
-		// is initialized from the replayed history — a later mid-stream
-		// catchup then resumes from a fresh watermark instead of replaying
-		// from zero.
-		s.sendCatchup(ctx, writer, token, since, client, false, catchupMaxFrames)
+	if token != "" && !s.connectCatchup(ctx, writer, token, c.GetHeader("Last-Event-ID"), client) {
+		return // connection is gone; nothing left to serve
 	}
 
 	keepalive := time.NewTicker(15 * time.Second)
@@ -520,6 +510,39 @@ func (s *Service) handleEvents(c *gin.Context) {
 			}
 		}
 	}
+}
+
+// connectCatchup runs the pre-stream replay for a token-scoped connection and
+// reports whether the connection is still writable.
+//
+// The client is threaded through so lastDelivered is initialized from the
+// replayed history — a later mid-stream catchup then resumes from a fresh
+// watermark instead of replaying from zero. A malformed Last-Event-ID is
+// treated as absent, which yields fresh-connect semantics (non-terminal
+// statuses only) rather than an error.
+//
+// A store failure here leaves a writable connection that owes history it will
+// never send, so it raises a gap rather than sliding silently into live
+// frames. Truncation raises its own gap inside sendCatchup.
+func (s *Service) connectCatchup(ctx context.Context, w *sseWriter, token, lastEventID string, client *Client) bool {
+	var since time.Time
+	if lastEventID != "" {
+		if ns, err := strconv.ParseInt(lastEventID, 10, 64); err == nil {
+			since = time.Unix(0, ns)
+		}
+	}
+	res := s.sendCatchup(ctx, w, token, since, client, false, catchupMaxFrames)
+	if res.writeFailed {
+		return false
+	}
+	if res.err == nil {
+		return true
+	}
+	s.logger.Warn("sse connect catchup failed; client notified of gap",
+		zap.Int64("client_id", client.ID),
+		zap.Int("frames", res.frames),
+		zap.Error(res.err))
+	return writeGap(w, gapReasonReplayUnavailable, since.UnixNano(), 0) == nil
 }
 
 // catchupMaxFrames bounds a single catchup replay. A well-behaved token
@@ -595,6 +618,10 @@ type catchupResult struct {
 	// err is any non-cap error: a write error (connection dead) or a store
 	// iteration error.
 	err error
+	// writeFailed distinguishes the two err sources. A store failure leaves a
+	// writable connection that has silently missed history and must be told so
+	// with a gap frame; a write failure means there is nobody left to tell.
+	writeFailed bool
 }
 
 // sendCatchup replays persisted statuses for txids registered under the
@@ -618,15 +645,23 @@ type catchupResult struct {
 // client, when non-nil, has its lastDelivered watermark advanced per written
 // frame so mid-stream catchup can resume from where any earlier pass ended.
 //
-// midstream=true adapts the pass for the live-loop caller: the frame cap
-// becomes "soft" at a timestamp boundary — once the cap is reached the pass
-// keeps writing while the timestamp stays EQUAL to the last written frame's.
-// The store's since-filter is strictly-after, so a timestamp-cursor cannot
-// resume mid-way through an equal-timestamp run (SetMinedByTxIDs stamps a
-// whole block's rows with one timestamp_at); stopping inside one would
-// strand the remainder forever. Draining the tie bounds the overshoot by the
-// largest same-timestamp batch, and guarantees `capped` passes always end on
-// a boundary the next round can resume from strictly-after.
+// The frame cap is ALWAYS soft at a timestamp boundary, on both the
+// connect-time and the mid-stream path: once the cap is reached the pass keeps
+// writing while the timestamp stays EQUAL to the last written frame's. The
+// store's since-filter is strictly-after and timestamp_at is only
+// microsecond-resolution, so a timestamp cursor cannot resume mid-way through
+// an equal-timestamp run (SetMinedByTxIDs stamps a whole block's rows with one
+// timestamp_at) — stopping inside one strands the remainder FOREVER. That was
+// a silent, permanent loss on the Last-Event-ID reconnect path: the pass
+// stopped mid-tie, reported lastTS as the tied timestamp, and the client
+// resumed strictly after it. Draining the tie bounds the overshoot by the
+// largest same-timestamp batch (frames are streamed, never accumulated, so the
+// cost is time and not memory) and guarantees a `capped` pass always ends on a
+// boundary the next round can resume from.
+//
+// midstream=true only changes how a capped pass is REPORTED: the live loop
+// paginates by design, so it is not logged as a truncation and does not raise
+// a gap.
 //
 // maxFrames is the pass's frame budget: catchupMaxFrames for connect-time
 // replay, and the smaller midstreamRoundFrames(client) for live rounds, which
@@ -641,14 +676,12 @@ func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, s
 	enrichedBlocks := make(map[string]struct{})
 	err := s.store.IterateStatusesByToken(ctx, token, since, only, func(status *models.TransactionStatus) error {
 		ts := status.Timestamp.UnixNano()
-		if res.frames >= maxFrames {
-			if !midstream || ts != res.lastTS {
-				res.capped = true
-				return errCatchupCapped
-			}
-			// midstream: same-timestamp tie with the frame that hit the cap —
-			// finish the tie (see the function comment).
+		if res.frames >= maxFrames && ts != res.lastTS {
+			res.capped = true
+			return errCatchupCapped
 		}
+		// Reaching here past the cap means a same-timestamp tie with the frame
+		// that hit it — finish the tie (see the function comment).
 		if status.Status == models.StatusMined || status.Status == models.StatusImmutable {
 			_, seen := enrichedBlocks[status.BlockHash]
 			if status.BlockHash != "" && (seen || len(enrichedBlocks) < catchupBlockBudget) {
@@ -660,6 +693,7 @@ func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, s
 			}
 		}
 		if err := writeStatus(w, status); err != nil {
+			res.writeFailed = true
 			return err
 		}
 		res.frames++
@@ -680,10 +714,36 @@ func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, s
 		s.logger.Warn("sse catchup truncated at frame cap",
 			zap.Int("cap", maxFrames),
 			zap.Bool("fresh_connect", since.IsZero()))
+		// Tell the CLIENT, not just the log. Everything after res.lastTS that
+		// matched this token is history it will never be pushed; without this
+		// frame it has no way to know that and would carry on as if whole.
+		if gapErr := writeGap(w, gapReasonCatchupTruncated, res.lastTS, int64(res.frames)); gapErr != nil {
+			res.err = gapErr
+			res.writeFailed = true
+		}
 	default:
 		res.err = err
 	}
 	return res
+}
+
+// declareFirehoseGap handles a drop on a tokenless (firehose) connection.
+//
+// No bounded store query can reconstruct an unfiltered stream, so there is
+// nothing to replay — but the drop can still be declared. Consumes the drop
+// flag (so the gap is raised once per episode rather than on every keepalive
+// tick) and writes one gap frame carrying the earliest dropped timestamp as
+// the cursor the client can still trust. Returns false when the connection is
+// no longer writable.
+func declareFirehoseGap(w *sseWriter, client *Client) bool {
+	if !client.dropped.Swap(false) {
+		return true
+	}
+	from := int64(0)
+	if floor := client.droppedFloor.Swap(math.MaxInt64); floor != math.MaxInt64 {
+		from = floor
+	}
+	return writeGap(w, gapReasonFirehoseDrop, from, 0) == nil
 }
 
 // midstreamCatchup heals a live token-scoped connection after fanOut dropped
@@ -714,7 +774,10 @@ func (s *Service) sendCatchup(ctx context.Context, w *sseWriter, token string, s
 // it was healing overflowed again mid-replay — the drop→catchup→drop loop
 // that kept a stream in permanent recovery.
 func (s *Service) midstreamCatchup(ctx context.Context, w *sseWriter, client *Client) bool {
-	if client.Token == "" || !s.manager.catchupOnDrop {
+	if client.Token == "" {
+		return declareFirehoseGap(w, client)
+	}
+	if !s.manager.catchupOnDrop {
 		return true
 	}
 	roundFrames := midstreamRoundFrames(client)
@@ -847,6 +910,63 @@ func buildStatusFrame(status *models.TransactionStatus) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("id: %d\nevent: status\ndata: %s\n\n", status.Timestamp.UnixNano(), data), nil
+}
+
+// Gap reasons. These are the `reason` field on a gap frame and the label on
+// metrics.SSEGapEventsTotal — keep the two in step.
+const (
+	// gapReasonCatchupTruncated: a connect-time replay stopped at the frame cap
+	// with matching history still beyond the cursor.
+	gapReasonCatchupTruncated = "catchup_truncated"
+	// gapReasonFirehoseDrop: a tokenless client's frame was dropped on channel
+	// overflow and no token-scoped replay can recover it.
+	gapReasonFirehoseDrop = "firehose_drop"
+	// gapReasonReplayUnavailable: the store could not serve the replay, so the
+	// connection proceeded to live frames without the history it owed.
+	gapReasonReplayUnavailable = "replay_unavailable"
+)
+
+// gapPayload is the JSON shape inside a `data:` field on an `event: gap`
+// frame. It is the server admitting, in-band, that the stream it just handed
+// this client is discontiguous.
+//
+// Before this existed, the two ways a client silently lost history — a
+// connect-time replay stopped at the frame cap, and a tokenless client's
+// dropped frame — produced only a server-side Warn and a counter. The client
+// streamed on believing it was whole. `from` is the last cursor the client can
+// trust; everything after it, up to the live stream, may be missing.
+//
+// Unknown event types are ignored by every conformant SSE client (including
+// go-arcade-toolbox, which skips any `event:` other than "status"), so this
+// frame is purely additive and safe to emit at any protocol version.
+type gapPayload struct {
+	// Reason is machine-readable and matches the SSEGapEventsTotal label.
+	Reason string `json:"reason"`
+	// From is the nanosecond cursor the gap starts after — the last id the
+	// client was handed. Empty when no cursor is known (a firehose client with
+	// no delivered frame yet).
+	From string `json:"from,omitempty"`
+	// Count is a best-effort magnitude of what was skipped, when known.
+	Count int64 `json:"count,omitempty"`
+	// Action tells the client what to do. Always "reconcile": re-fetch the
+	// affected transactions over REST.
+	Action string `json:"action"`
+}
+
+// writeGap emits an `event: gap` frame and flushes it. Errors are returned so
+// callers on the writer goroutine can treat a failed write as a dead
+// connection, matching writeStatus.
+func writeGap(w *sseWriter, reason string, from int64, count int64) error {
+	p := gapPayload{Reason: reason, Count: count, Action: "reconcile"}
+	if from > 0 {
+		p.From = strconv.FormatInt(from, 10)
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+	metrics.SSEGapEventsTotal.WithLabelValues(reason).Inc()
+	return w.write(fmt.Sprintf("event: gap\ndata: %s\n\n", data))
 }
 
 // writeStatus emits one status frame and flushes it. Used for single frames

--- a/services/sse/manager.go
+++ b/services/sse/manager.go
@@ -9,6 +9,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -113,14 +114,15 @@ type Manager struct {
 	// parentCtx roots every per-client context, so canceling it cancels every
 	// registered client's fan-out path at once.
 	//
-	// It is deliberately rooted at context.Background(), NOT at the service
-	// context, and is cancelled only by Drain. If it inherited the service
-	// context then a shutdown would cancel every client the instant SIGTERM
-	// landed — before the drain had failed readiness, waited for the endpoint
-	// to be withdrawn, or handed out reconnect hints. The drain would be a
-	// no-op and every stream would still be severed simultaneously. The
-	// manager's own run goroutine keeps using the service context, because it
-	// SHOULD stop immediately.
+	// It is derived from the service context via context.WithoutCancel, so it
+	// inherits that context's VALUES (trace and logging context stay attached
+	// to per-client work) while dropping its cancellation, and is cancelled
+	// only by Drain. If it inherited cancellation too, a shutdown would cancel
+	// every client the instant SIGTERM landed — before the drain had failed
+	// readiness, waited for the endpoint to be withdrawn, or handed out
+	// reconnect hints. The drain would be a no-op and every stream would still
+	// be severed simultaneously. The manager's own run goroutine keeps using
+	// the service context directly, because it SHOULD stop immediately.
 	parentCtx    context.Context //nolint:containedctx // long-lived registry root
 	parentCancel context.CancelFunc
 
@@ -1071,22 +1073,32 @@ func writeGap(w *sseWriter, reason string, from int64, count int64) error {
 }
 
 // writeShutdown emits the farewell frame for a client released by
-// Manager.Drain: an SSE `retry:` directive carrying this connection's own
-// reconnect delay, plus a shutdown event naming the reason.
+// Manager.Drain: a shutdown event naming the reason, preceded by an SSE
+// `retry:` directive carrying this connection's own reconnect delay when one
+// was assigned.
 //
-// `retry:` is the only in-band channel a server has for telling clients when to
-// come back. Without it a rolling restart releases every client at once and
-// they all re-dial on their own identical backoff schedule, landing together on
-// a pod that is still cold. Errors are ignored: the connection is closing
-// either way, and a client that misses the hint just falls back to its own
-// backoff.
+// The shutdown event is emitted UNCONDITIONALLY. It is what distinguishes a
+// deliberate release from a connection that broke, and a client that can tell
+// those apart does not have to treat a rolling restart as an error — so
+// withholding it when reconnect hints happen to be disabled would remove the
+// more important of the two signals to save a line of output.
+//
+// The `retry:` directive is the only in-band channel a server has for saying
+// WHEN to come back. Without it a rolling restart releases every client at
+// once and they all re-dial on their own identical backoff schedule, landing
+// together on a pod that is still cold; a client that receives no hint simply
+// falls back to its own backoff, which is correct but less well spread.
+//
+// Errors are ignored: the connection is closing either way.
 func writeShutdown(w *sseWriter, client *Client) {
-	retryMS := client.drainRetryMS.Load()
-	if retryMS <= 0 {
-		return
+	var frame strings.Builder
+	if retryMS := client.drainRetryMS.Load(); retryMS > 0 {
+		fmt.Fprintf(&frame, "retry: %d\n", retryMS)
+		fmt.Fprintf(&frame, "event: shutdown\ndata: {\"reason\":\"draining\",\"reconnectAfterMs\":%d}\n\n", retryMS)
+	} else {
+		frame.WriteString("event: shutdown\ndata: {\"reason\":\"draining\"}\n\n")
 	}
-	_ = w.write(fmt.Sprintf("retry: %d\nevent: shutdown\ndata: {\"reason\":\"draining\",\"reconnectAfterMs\":%d}\n\n",
-		retryMS, retryMS))
+	_ = w.write(frame.String())
 }
 
 // writeStatus emits one status frame and flushes it. Used for single frames

--- a/services/sse/manager.go
+++ b/services/sse/manager.go
@@ -896,6 +896,16 @@ func (s *Service) midstreamCatchup(ctx context.Context, w *sseWriter, client *Cl
 		metrics.SSEMidstreamCatchupsTotal.Inc()
 		res := s.sendCatchup(ctx, w, client.Token, time.Unix(0, sinceNS), client, true, roundFrames)
 		metrics.SSEMidstreamCatchupFramesTotal.Add(float64(res.frames))
+		if errors.Is(res.err, store.ErrReplayUnavailable) {
+			// The backend refused this replay (a token too large to serve
+			// without an index over it). That is a bounded, declared
+			// degradation, not a dead connection: tell the client to reconcile
+			// and keep the LIVE stream running, which is still useful.
+			s.logger.Warn("sse mid-stream catchup unavailable; client notified of gap",
+				zap.Int64("client_id", client.ID),
+				zap.Error(res.err))
+			return writeGap(w, gapReasonReplayUnavailable, sinceNS, 0) == nil
+		}
 		if res.err != nil {
 			// Either the connection is dead (write error) or the store
 			// iteration failed mid-window. Both ways the safe move is to end

--- a/services/sse/manager.go
+++ b/services/sse/manager.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand/v2"
 	"net/http"
 	"strconv"
 	"sync"
@@ -68,6 +69,13 @@ type Client struct {
 	// block's burst used to emit one Warn PER dropped event.
 	dropsSinceLog atomic.Int64
 	lastDropLog   atomic.Int64
+
+	// drainRetryMS is this connection's personal reconnect delay, set by
+	// Manager.Drain just before it cancels Ctx and read once by the writer
+	// goroutine on its way out. Zero means "no hint" (either not a drain, or
+	// hints are disabled). Per-client rather than shared because a single
+	// shared delay relocates a reconnect herd instead of dispersing it.
+	drainRetryMS atomic.Int64
 }
 
 // Manager owns the per-pod registry of SSE clients listening on
@@ -102,10 +110,19 @@ type Manager struct {
 	fanoutEWMA   float64
 	fanoutEvents int64
 
-	// parentCtx is the long-lived context that owns the manager
-	// goroutine. Per-client contexts are derived from it so canceling
-	// the manager also cancels every registered client's fan-out path.
-	parentCtx context.Context //nolint:containedctx // long-lived registry root
+	// parentCtx roots every per-client context, so canceling it cancels every
+	// registered client's fan-out path at once.
+	//
+	// It is deliberately rooted at context.Background(), NOT at the service
+	// context, and is cancelled only by Drain. If it inherited the service
+	// context then a shutdown would cancel every client the instant SIGTERM
+	// landed — before the drain had failed readiness, waited for the endpoint
+	// to be withdrawn, or handed out reconnect hints. The drain would be a
+	// no-op and every stream would still be severed simultaneously. The
+	// manager's own run goroutine keeps using the service context, because it
+	// SHOULD stop immediately.
+	parentCtx    context.Context //nolint:containedctx // long-lived registry root
+	parentCancel context.CancelFunc
 
 	nextClientID atomic.Int64
 
@@ -143,12 +160,15 @@ func newManager(ctx context.Context, publisher events.Publisher, st store.Store,
 		return nil, nil //nolint:nilnil // intentional: nil manager means "no fan-out wired"
 	}
 	named := logger.Named("sse")
+	// clientRoot outlives ctx on purpose — see Manager.parentCtx.
+	clientRoot, cancelClients := context.WithCancel(context.WithoutCancel(ctx))
 	m := &Manager{
 		publisher:     publisher,
 		store:         st,
 		logger:        named,
 		tokens:        newTokenIndex(st, named),
-		parentCtx:     ctx,
+		parentCtx:     clientRoot,
+		parentCancel:  cancelClients,
 		catchupOnDrop: true,
 		clients:       make(map[int64]*Client),
 	}
@@ -411,6 +431,35 @@ func (m *Manager) Unregister(id int64) {
 	}
 }
 
+// Drain releases every registered client for a graceful shutdown and reports
+// how many it released.
+//
+// Each client is given its OWN reconnect delay, drawn uniformly below
+// retryMax, before its context is canceled. The per-client draw is the whole
+// point: releasing N clients with one shared delay just moves the herd, it
+// does not disperse it. The writer goroutine observes the cancellation, emits
+// a shutdown frame carrying that delay as an SSE `retry:` directive, and
+// returns — so the stream ends with a clean FIN instead of the RST that a
+// process exit produces.
+//
+// retryMax <= 0 skips the hint entirely and clients fall back to their own
+// backoff, which is still correct, just less well spread.
+func (m *Manager) Drain(retryMax time.Duration) int {
+	clients := m.snapshot()
+	for _, c := range clients {
+		if retryMax > 0 {
+			//nolint:gosec // reconnect spreading is a load-shaping device, not a security primitive
+			c.drainRetryMS.Store(1 + rand.Int64N(retryMax.Milliseconds()))
+		}
+		c.Cancel()
+	}
+	// Catch anything that connected between the snapshot and here. Those get
+	// no reconnect hint, which is the right trade: they arrived after readiness
+	// had already failed, so there should be none.
+	m.parentCancel()
+	return len(clients)
+}
+
 // NewClient assembles a client with a fresh id, buffered channel, and
 // per-client cancel handle. The client context is derived from the
 // manager's parent ctx so a manager shutdown propagates to every client.
@@ -477,6 +526,12 @@ func (s *Service) handleEvents(c *gin.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			return
+		case <-client.Ctx.Done():
+			// Manager-initiated release (Drain). Unlike the request-ctx arm
+			// above, the connection is still writable here, so say goodbye
+			// with a staggered reconnect hint rather than dropping the socket.
+			writeShutdown(writer, client)
 			return
 		case status := <-client.Ch:
 			if status != nil {
@@ -967,6 +1022,25 @@ func writeGap(w *sseWriter, reason string, from int64, count int64) error {
 	}
 	metrics.SSEGapEventsTotal.WithLabelValues(reason).Inc()
 	return w.write(fmt.Sprintf("event: gap\ndata: %s\n\n", data))
+}
+
+// writeShutdown emits the farewell frame for a client released by
+// Manager.Drain: an SSE `retry:` directive carrying this connection's own
+// reconnect delay, plus a shutdown event naming the reason.
+//
+// `retry:` is the only in-band channel a server has for telling clients when to
+// come back. Without it a rolling restart releases every client at once and
+// they all re-dial on their own identical backoff schedule, landing together on
+// a pod that is still cold. Errors are ignored: the connection is closing
+// either way, and a client that misses the hint just falls back to its own
+// backoff.
+func writeShutdown(w *sseWriter, client *Client) {
+	retryMS := client.drainRetryMS.Load()
+	if retryMS <= 0 {
+		return
+	}
+	_ = w.write(fmt.Sprintf("retry: %d\nevent: shutdown\ndata: {\"reason\":\"draining\",\"reconnectAfterMs\":%d}\n\n",
+		retryMS, retryMS))
 }
 
 // writeStatus emits one status frame and flushes it. Used for single frames

--- a/services/sse/manager.go
+++ b/services/sse/manager.go
@@ -516,7 +516,15 @@ func (s *Service) handleEvents(c *gin.Context) {
 	s.manager.Register(client)
 	defer s.manager.Unregister(client.ID)
 
+	// outcome records why this connection ended. The rate of this counter is
+	// the reconnect rate and the label is the reason — a storm of write_error
+	// is a completely different problem from a storm of drain, and the two
+	// used to be indistinguishable.
+	outcome := "client_closed"
+	defer func() { metrics.SSEConnectionsTotal.WithLabelValues(outcome).Inc() }()
+
 	if token != "" && !s.connectCatchup(ctx, writer, token, c.GetHeader("Last-Event-ID"), client) {
+		outcome = "write_error"
 		return // connection is gone; nothing left to serve
 	}
 
@@ -531,11 +539,13 @@ func (s *Service) handleEvents(c *gin.Context) {
 			// Manager-initiated release (Drain). Unlike the request-ctx arm
 			// above, the connection is still writable here, so say goodbye
 			// with a staggered reconnect hint rather than dropping the socket.
+			outcome = "drain"
 			writeShutdown(writer, client)
 			return
 		case status := <-client.Ch:
 			if status != nil {
 				if err := writeStatusBuffered(writer, status); err != nil {
+					outcome = "write_error"
 					return
 				}
 				client.lastDelivered.Store(status.Timestamp.UnixNano())
@@ -544,27 +554,53 @@ func (s *Service) handleEvents(c *gin.Context) {
 			// one Kafka message lands ~50 frames here; without coalescing we'd
 			// flush per frame.
 			if _, err := drainLive(writer, client); err != nil {
+				outcome = "write_error"
 				return
 			}
 			if err := writer.flush(); err != nil {
+				outcome = "write_error"
 				return
 			}
 			if !s.midstreamCatchup(ctx, writer, client) {
+				outcome = "write_error"
 				return
 			}
 		case <-keepalive.C:
 			if err := writer.write(": keepalive\n\n"); err != nil {
+				outcome = "write_error"
 				return
 			}
+			observeClientLag(client)
 			// Also heal on the keepalive tick: a drop can land just after the
 			// writer's post-drain check (the flag is set by the concurrent
 			// fan-out goroutine), and if the stream then goes quiet no further
 			// drain cycle would notice it.
 			if !s.midstreamCatchup(ctx, writer, client) {
+				outcome = "write_error"
 				return
 			}
 		}
 	}
+}
+
+// observeClientLag samples how far behind the present this connection's last
+// delivered frame is.
+//
+// Sampled on the keepalive tick rather than per frame: the watermark is
+// already maintained by the writer goroutine, so this costs one atomic load
+// and one histogram observation per client per 15s. It is the signal that
+// describes what a consumer actually experiences — drops and fan-out duration
+// each describe one component in isolation, which is how 1.6M dropped events
+// went unnoticed for a whole benchmark run.
+//
+// Skipped before the first delivery: a connection that has legitimately had
+// nothing to receive would otherwise report its entire uptime as lag.
+func observeClientLag(client *Client) {
+	last := client.lastDelivered.Load()
+	if last <= 0 {
+		return
+	}
+	metrics.SSEClientLagSeconds.Observe(time.Since(time.Unix(0, last)).Seconds())
 }
 
 // connectCatchup runs the pre-stream replay for a token-scoped connection and

--- a/services/sse/service.go
+++ b/services/sse/service.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -39,6 +40,10 @@ type Service struct {
 
 	manager *Manager
 	server  *http.Server
+	// draining flips on shutdown and is read by /ready. Liveness deliberately
+	// does NOT consult it: failing liveness mid-drain gets the pod killed
+	// instead of drained.
+	draining atomic.Bool
 }
 
 // New constructs the Service. Returns nil when sse.enabled is false or
@@ -80,7 +85,7 @@ func (s *Service) Start(ctx context.Context) error {
 	router := gin.New()
 	router.GET("/events", s.handleEvents)
 	router.GET("/health", s.handleHealth)
-	router.GET("/ready", s.handleHealth)
+	router.GET("/ready", s.handleReady)
 
 	addr := fmt.Sprintf("%s:%d", s.cfg.SSE.Host, s.cfg.SSE.Port)
 	s.server = &http.Server{
@@ -101,21 +106,82 @@ func (s *Service) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop gracefully shuts the HTTP server.
+// Stop drains connected clients and then shuts the HTTP server.
+//
+// http.Server.Shutdown alone is the wrong tool here: it waits for connections
+// to become IDLE, and an SSE connection never is. Left to it, shutdown burned
+// its whole timeout, the process exited, and every stream was severed with a
+// TCP RST — putting every client back on the door of the next pod at the same
+// instant. So the drain is explicit and ordered:
+//
+//  1. Fail /ready, so kube-proxy and the ingress stop sending new connections.
+//  2. Wait DrainQuiesce for that withdrawal to propagate. Cutting connections
+//     before it lands just bounces clients back into this terminating pod.
+//  3. Release every client with its own reconnect hint, so they come back as a
+//     ramp rather than a herd, and close each stream cleanly.
+//  4. Shutdown, which now completes promptly because nothing is still open.
+//
+// The three windows must fit inside the pod's terminationGracePeriodSeconds;
+// if the kubelet SIGKILLs mid-drain the RST is back.
 func (s *Service) Stop() error {
-	if s.server != nil {
-		s.logger.Info("shutting down SSE service")
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-		return s.server.Shutdown(ctx)
+	if s.server == nil {
+		return nil
 	}
-	return nil
+	s.draining.Store(true)
+
+	quiesce := msOrDefault(s.cfg.SSE.DrainQuiesceMS, config.DefaultSSEDrainQuiesceMS)
+	retryMax := time.Duration(max(s.cfg.SSE.DrainRetryMaxMS, 0)) * time.Millisecond
+	s.logger.Info("draining SSE service",
+		zap.Duration("quiesce", quiesce),
+		zap.Duration("retry_max", retryMax),
+		zap.Int("clients", s.clientCount()))
+
+	time.Sleep(quiesce)
+
+	if s.manager != nil {
+		released := s.manager.Drain(retryMax)
+		s.logger.Info("released SSE clients", zap.Int("clients", released))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(),
+		msOrDefault(s.cfg.SSE.ShutdownTimeoutMS, config.DefaultSSEShutdownTimeoutMS))
+	defer cancel()
+	return s.server.Shutdown(ctx)
 }
 
-// handleHealth is a minimal liveness probe for SSE pods. The real
-// readiness signal is whether the Kafka subscriber is healthy; that's
-// checked at startup (Subscribe returns an error if the broker is
-// unreachable) and reflected by the process exit code if it fails.
+// clientCount reports registered clients, tolerating a nil manager.
+func (s *Service) clientCount() int {
+	if s.manager == nil {
+		return 0
+	}
+	return s.manager.clientCount()
+}
+
+// msOrDefault converts a millisecond config value to a Duration, falling back
+// to def when the value is non-positive.
+func msOrDefault(ms, def int) time.Duration {
+	if ms <= 0 {
+		ms = def
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// handleHealth is the liveness probe. It reports the process is alive and
+// deliberately keeps reporting that during a drain — a liveness failure gets
+// the pod killed, which is the opposite of draining it.
 func (s *Service) handleHealth(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// handleReady is the readiness probe. It fails as soon as shutdown begins so
+// the pod is withdrawn from Service endpoints before any connection is cut.
+// Splitting it from liveness is what makes the drain in Stop possible: the two
+// used to be the same handler, so there was no way to say "stop sending me
+// traffic" without also saying "kill me".
+func (s *Service) handleReady(c *gin.Context) {
+	if s.draining.Load() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "draining"})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }

--- a/services/sse/sse_test.go
+++ b/services/sse/sse_test.go
@@ -741,10 +741,12 @@ func TestSSEMidstreamCatchupDeliversDroppedEvents(t *testing.T) {
 	}
 }
 
-// TestSSEMidstreamCatchupTokenlessKeepsDropOnly verifies the firehose
-// (tokenless) client keeps the historical behavior: drops are counted, but no
-// store-backed catchup runs — the catchup source is token-scoped.
-func TestSSEMidstreamCatchupTokenlessKeepsDropOnly(t *testing.T) {
+// TestSSEMidstreamCatchupTokenlessRaisesGapNotCatchup verifies what a firehose
+// (tokenless) client gets on a drop: NO store-backed catchup round, because the
+// catchup source is token-scoped and no bounded query reconstructs an
+// unfiltered stream — but a gap frame, so the loss is declared rather than
+// silent. Historically this path produced only a counter and a log line.
+func TestSSEMidstreamCatchupTokenlessRaisesGapNotCatchup(t *testing.T) {
 	st := &sseStoreStub{
 		subsByToken: map[string][]*models.Submission{},
 		statusByTx:  map[string]*models.TransactionStatus{},
@@ -775,8 +777,11 @@ func TestSSEMidstreamCatchupTokenlessKeepsDropOnly(t *testing.T) {
 	if ok := svc.midstreamCatchup(t.Context(), w, client); !ok {
 		t.Fatal("midstreamCatchup reported a dead connection")
 	}
-	if rec.Body.Len() != 0 {
-		t.Errorf("tokenless client received catchup frames: %q", rec.Body.String())
+	if strings.Contains(rec.Body.String(), "event: status") {
+		t.Errorf("tokenless client received catchup status frames: %q", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"reason":"`+gapReasonFirehoseDrop+`"`) {
+		t.Errorf("tokenless drop was not declared to the client: %q", rec.Body.String())
 	}
 	if got := testutil.ToFloat64(metrics.SSEMidstreamCatchupsTotal) - catchupsBefore; got != 0 {
 		t.Errorf("catchup rounds ran for tokenless client: %v", got)
@@ -916,6 +921,196 @@ func TestSSEMidstreamCatchupSameTimestampGlut(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(metrics.SSEMidstreamCatchupsTotal) - catchupsBefore; got != 1 {
 		t.Errorf("catchup rounds = %v, want 1 (single round drains the tie)", got)
+	}
+}
+
+// txidsFromFrames extracts the txid of every `event: status` frame in an SSE
+// body, in wire order.
+func txidsFromFrames(t *testing.T, body string) []string {
+	t.Helper()
+	var out []string
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var payload struct {
+			TxID string `json:"txid"`
+		}
+		raw := strings.TrimPrefix(line, "data: ")
+		if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+			continue // gap/lag frames carry a different shape
+		}
+		if payload.TxID != "" {
+			out = append(out, payload.TxID)
+		}
+	}
+	return out
+}
+
+// TestSSEConnectCatchupSameTimestampGlutIsResumable is the regression for the
+// silent-loss bug on the CONNECT-TIME catchup path.
+//
+// transactions.timestamp_at is TIMESTAMPTZ (microsecond) and the store filter
+// is strictly-after, while SetMinedByTxIDs stamps a whole block's rows with one
+// timestamp_at. The mid-stream path already drains an equal-timestamp run that
+// straddles the frame cap; the connect-time path did not, so it stopped
+// mid-tie, reported lastTS as the tied timestamp, and every remaining row
+// sharing that microsecond became unreachable forever — the client resumed
+// strictly after it and was told nothing.
+//
+// The assertion is an identity, not a frame count: replay, resume from the id
+// the client would have kept, replay again, and require that the union covers
+// every row.
+func TestSSEConnectCatchupSameTimestampGlutIsResumable(t *testing.T) {
+	n := catchupMaxFrames + 500
+	subs := make([]*models.Submission, 0, n)
+	statusByTx := make(map[string]*models.TransactionStatus, n)
+	ts := time.Now().UTC().Add(-time.Hour).Truncate(time.Microsecond)
+	for i := 0; i < n; i++ {
+		txid := fmt.Sprintf("tie-%06d", i)
+		subs = append(subs, &models.Submission{TxID: txid, CallbackToken: "tok-tie"})
+		statusByTx[txid] = &models.TransactionStatus{
+			TxID:      txid,
+			Status:    models.StatusMined,
+			Timestamp: ts, // one SetMinedByTxIDs batch: the whole block shares ONE timestamp
+		}
+	}
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{"tok-tie": subs},
+		statusByTx:  statusByTx,
+	}
+	svc, _, _, cancel := setupSSEService(t, st)
+	defer cancel()
+
+	client := svc.manager.NewClient("tok-tie")
+	// A Last-Event-ID reconnect: `since` is non-zero, so terminal statuses
+	// replay and the strictly-after filter admits the whole tie.
+	since := ts.Add(-time.Second)
+
+	seen := make(map[string]bool, n)
+	rec := httptest.NewRecorder()
+	res := svc.sendCatchup(t.Context(), &sseWriter{w: rec, f: nopFlusher{rec}}, "tok-tie", since, client, false, catchupMaxFrames)
+	if res.err != nil {
+		t.Fatalf("connect catchup: %v", res.err)
+	}
+	for _, txid := range txidsFromFrames(t, rec.Body.String()) {
+		seen[txid] = true
+	}
+
+	// Resume exactly as the client would: Last-Event-ID is the last id it was
+	// handed, and the store filter is strictly-after it.
+	rec2 := httptest.NewRecorder()
+	res2 := svc.sendCatchup(t.Context(), &sseWriter{w: rec2, f: nopFlusher{rec2}}, "tok-tie", time.Unix(0, res.lastTS), client, false, catchupMaxFrames)
+	if res2.err != nil {
+		t.Fatalf("resumed catchup: %v", res2.err)
+	}
+	for _, txid := range txidsFromFrames(t, rec2.Body.String()) {
+		seen[txid] = true
+	}
+
+	var missing []string
+	for txid := range statusByTx {
+		if !seen[txid] {
+			missing = append(missing, txid)
+		}
+	}
+	if len(missing) != 0 {
+		sort.Strings(missing)
+		show := missing
+		if len(show) > 5 {
+			show = show[:5]
+		}
+		t.Errorf("%d of %d rows are unreachable after resuming from the delivered cursor (e.g. %v); "+
+			"a same-timestamp run straddling the frame cap must be drained, not stranded", len(missing), n, show)
+	}
+}
+
+// TestSSEConnectCatchupTruncationEmitsGap asserts that a connect-time replay
+// which genuinely runs out of frame budget tells the client so. Truncation is
+// not the bug — SILENT truncation is; before the gap frame this path logged a
+// server-side Warn and the client streamed on believing it was whole.
+func TestSSEConnectCatchupTruncationEmitsGap(t *testing.T) {
+	n := catchupMaxFrames + 500
+	subs := make([]*models.Submission, 0, n)
+	statusByTx := make(map[string]*models.TransactionStatus, n)
+	base := time.Now().UTC().Add(-time.Hour)
+	for i := 0; i < n; i++ {
+		txid := fmt.Sprintf("trunc-%06d", i)
+		subs = append(subs, &models.Submission{TxID: txid, CallbackToken: "tok-trunc"})
+		statusByTx[txid] = &models.TransactionStatus{
+			TxID:   txid,
+			Status: models.StatusMined,
+			// DISTINCT timestamps, so the cap bites at a real boundary rather
+			// than being drained as a tie.
+			Timestamp: base.Add(time.Duration(i) * time.Millisecond),
+		}
+	}
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{"tok-trunc": subs},
+		statusByTx:  statusByTx,
+	}
+	svc, _, _, cancel := setupSSEService(t, st)
+	defer cancel()
+
+	client := svc.manager.NewClient("tok-trunc")
+	gapsBefore := testutil.ToFloat64(metrics.SSEGapEventsTotal.WithLabelValues(gapReasonCatchupTruncated))
+
+	rec := httptest.NewRecorder()
+	res := svc.sendCatchup(t.Context(), &sseWriter{w: rec, f: nopFlusher{rec}}, "tok-trunc", base.Add(-time.Second), client, false, catchupMaxFrames)
+	if !res.capped {
+		t.Fatalf("catchup did not cap: frames=%d", res.frames)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "\nevent: gap\n") && !strings.HasPrefix(body, "event: gap\n") {
+		t.Error("truncated catchup wrote no gap frame; the client cannot know it lost history")
+	}
+	if !strings.Contains(body, `"reason":"`+gapReasonCatchupTruncated+`"`) {
+		t.Errorf("gap frame missing reason %q", gapReasonCatchupTruncated)
+	}
+	if !strings.Contains(body, `"action":"reconcile"`) {
+		t.Error("gap frame missing the reconcile action the client contract depends on")
+	}
+	if got := testutil.ToFloat64(metrics.SSEGapEventsTotal.WithLabelValues(gapReasonCatchupTruncated)) - gapsBefore; got != 1 {
+		t.Errorf("gap metric delta = %v, want 1", got)
+	}
+}
+
+// TestSSEFirehoseDropEmitsGap covers the tokenless client, which has no
+// token-scoped replay available and previously got a counter and a log line and
+// nothing else — its stream degraded silently and permanently.
+func TestSSEFirehoseDropEmitsGap(t *testing.T) {
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{},
+		statusByTx:  map[string]*models.TransactionStatus{},
+	}
+	svc, _, _, cancel := setupSSEService(t, st)
+	defer cancel()
+
+	client := svc.manager.NewClient("") // firehose
+	dropTS := time.Now().UTC().Add(-time.Minute).UnixNano()
+	client.droppedFloor.Store(dropTS)
+	client.dropped.Store(true)
+
+	gapsBefore := testutil.ToFloat64(metrics.SSEGapEventsTotal.WithLabelValues(gapReasonFirehoseDrop))
+	rec := httptest.NewRecorder()
+	w := &sseWriter{w: rec, f: nopFlusher{rec}}
+	if ok := svc.midstreamCatchup(t.Context(), w, client); !ok {
+		t.Fatal("midstreamCatchup reported a dead connection")
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"reason":"`+gapReasonFirehoseDrop+`"`) {
+		t.Errorf("firehose drop wrote no gap frame; body = %q", body)
+	}
+	if !strings.Contains(body, fmt.Sprintf(`"from":"%d"`, dropTS)) {
+		t.Errorf("gap frame missing the drop floor as its cursor; body = %q", body)
+	}
+	if got := testutil.ToFloat64(metrics.SSEGapEventsTotal.WithLabelValues(gapReasonFirehoseDrop)) - gapsBefore; got != 1 {
+		t.Errorf("gap metric delta = %v, want 1", got)
+	}
+	if client.dropped.Load() {
+		t.Error("drop flag not consumed: the gap would be re-emitted on every keepalive tick")
 	}
 }
 

--- a/services/sse/sse_test.go
+++ b/services/sse/sse_test.go
@@ -77,6 +77,10 @@ type sseStoreStub struct {
 	subsByToken map[string][]*models.Submission
 	statusByTx  map[string]*models.TransactionStatus
 
+	// iterErr, when set, is returned by IterateStatusesByToken instead of
+	// streaming — models a backend refusing a replay it cannot bound.
+	iterErr error
+
 	// tokenCalls counts TokensForTxIDs round-trips and tokenTxIDs the txids
 	// they carried — the fan-out's store cost, which is what
 	// TestFanOutResolvesTokensOncePerEvent asserts on.
@@ -106,6 +110,9 @@ func (s *sseStoreStub) EnrichMerklePath(_ context.Context, _ *models.Transaction
 // the token, current status projection, since/only filters, ascending
 // timestamp order.
 func (s *sseStoreStub) IterateStatusesByToken(_ context.Context, token string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {
+	if s.iterErr != nil {
+		return s.iterErr
+	}
 	s.mu.RLock()
 	seen := make(map[string]bool)
 	var statuses []*models.TransactionStatus
@@ -1189,6 +1196,44 @@ func TestSSEDrainReleasesClientsWithStaggeredRetry(t *testing.T) {
 	}
 	if retryMS <= 0 || retryMS > 30_000 {
 		t.Errorf("retry hint = %dms, want within (0, 30000]", retryMS)
+	}
+}
+
+// TestSSEMidstreamCatchupRefusedRaisesGapAndKeepsStream covers a backend that
+// declines a replay it cannot bound (store.ErrReplayUnavailable, returned by
+// the Pebble/Aerospike scan budget for a token too large to serve without an
+// index over it).
+//
+// The distinction under test: a refused replay is a bounded, DECLARED
+// degradation, not a dead connection. The client is told to reconcile over
+// REST and its live stream keeps running — dropping the connection instead
+// would send it straight back to reconnect and request the same impossible
+// replay again.
+func TestSSEMidstreamCatchupRefusedRaisesGapAndKeepsStream(t *testing.T) {
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{tokA: {{TxID: "aaaa", CallbackToken: tokA}}},
+		statusByTx:  map[string]*models.TransactionStatus{},
+		iterErr:     fmt.Errorf("wrapped: %w", store.ErrReplayUnavailable),
+	}
+	svc, _, _, cancel := setupSSEService(t, st)
+	defer cancel()
+
+	client := svc.manager.NewClient(tokA)
+	client.droppedFloor.Store(time.Now().Add(-time.Minute).UnixNano())
+	client.dropped.Store(true)
+
+	gapsBefore := testutil.ToFloat64(metrics.SSEGapEventsTotal.WithLabelValues(gapReasonReplayUnavailable))
+	rec := httptest.NewRecorder()
+	w := &sseWriter{w: rec, f: nopFlusher{rec}}
+
+	if ok := svc.midstreamCatchup(t.Context(), w, client); !ok {
+		t.Error("a refused replay killed the connection; the live stream is still serviceable")
+	}
+	if !strings.Contains(rec.Body.String(), `"reason":"`+gapReasonReplayUnavailable+`"`) {
+		t.Errorf("refused replay raised no gap; body = %q", rec.Body.String())
+	}
+	if got := testutil.ToFloat64(metrics.SSEGapEventsTotal.WithLabelValues(gapReasonReplayUnavailable)) - gapsBefore; got != 1 {
+		t.Errorf("gap metric delta = %v, want 1", got)
 	}
 }
 

--- a/services/sse/sse_test.go
+++ b/services/sse/sse_test.go
@@ -1114,6 +1114,84 @@ func TestSSEFirehoseDropEmitsGap(t *testing.T) {
 	}
 }
 
+// TestSSEReadyFailsWhileDrainingButLivenessDoesNot pins the probe split. They
+// were the same handler, so there was no way to say "stop sending me traffic"
+// without also saying "kill me" — and a liveness failure mid-drain is exactly
+// the opposite of draining.
+func TestSSEReadyFailsWhileDrainingButLivenessDoesNot(t *testing.T) {
+	svc := &Service{cfg: &config.Config{}, logger: zap.NewNop()}
+
+	call := func(h gin.HandlerFunc) int {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		h(c)
+		return rec.Code
+	}
+
+	if got := call(svc.handleReady); got != http.StatusOK {
+		t.Errorf("ready before draining = %d, want 200", got)
+	}
+	svc.draining.Store(true)
+	if got := call(svc.handleReady); got != http.StatusServiceUnavailable {
+		t.Errorf("ready while draining = %d, want 503 (pod stays in Service endpoints)", got)
+	}
+	if got := call(svc.handleHealth); got != http.StatusOK {
+		t.Errorf("liveness while draining = %d, want 200 (a failure here kills the pod mid-drain)", got)
+	}
+}
+
+// TestSSEDrainReleasesClientsWithStaggeredRetry covers the graceful drain: a
+// client is released with a clean shutdown frame carrying its OWN reconnect
+// delay, instead of having its socket severed when the process exits.
+func TestSSEDrainReleasesClientsWithStaggeredRetry(t *testing.T) {
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{},
+		statusByTx:  map[string]*models.TransactionStatus{},
+	}
+	svc, router, _, cancel := setupSSEService(t, st)
+	defer cancel()
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/events") //nolint:noctx // test client
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Wait for the handler to register before draining.
+	deadline := time.Now().Add(5 * time.Second)
+	for svc.manager.clientCount() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("client never registered")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if released := svc.manager.Drain(30 * time.Second); released != 1 {
+		t.Fatalf("Drain released %d clients, want 1", released)
+	}
+
+	// The stream must END (clean EOF), not hang, and the last thing on it must
+	// be the shutdown frame with a retry directive.
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read drained stream: %v", err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "event: shutdown") {
+		t.Errorf("drained stream carried no shutdown frame: %q", text)
+	}
+	var retryMS int
+	if _, err := fmt.Sscanf(text[strings.Index(text, "retry: "):], "retry: %d", &retryMS); err != nil {
+		t.Fatalf("no retry directive in %q: %v", text, err)
+	}
+	if retryMS <= 0 || retryMS > 30_000 {
+		t.Errorf("retry hint = %dms, want within (0, 30000]", retryMS)
+	}
+}
+
 // readSSEUntilTxIDs consumes SSE frames from r until every txid in want has
 // been seen at least once (duplicates allowed) or the timeout elapses.
 func readSSEUntilTxIDs(r io.Reader, want map[string]bool, timeout time.Duration) error {

--- a/services/sse/sse_test.go
+++ b/services/sse/sse_test.go
@@ -1237,6 +1237,49 @@ func TestSSEMidstreamCatchupRefusedRaisesGapAndKeepsStream(t *testing.T) {
 	}
 }
 
+// TestSSEDrainAlwaysAnnouncesShutdown pins that the shutdown event does not
+// depend on reconnect hints being enabled.
+//
+// The two signals carry different information: `event: shutdown` says the
+// release was DELIBERATE — letting a client treat a rolling restart as routine
+// rather than as an error — while `retry:` says when to come back. Suppressing
+// the former because the latter is disabled would drop the more important of
+// the two.
+func TestSSEDrainAlwaysAnnouncesShutdown(t *testing.T) {
+	st := &sseStoreStub{
+		subsByToken: map[string][]*models.Submission{},
+		statusByTx:  map[string]*models.TransactionStatus{},
+	}
+	svc, _, _, cancel := setupSSEService(t, st)
+	defer cancel()
+
+	for _, tc := range []struct {
+		name      string
+		retryMax  time.Duration
+		wantRetry bool
+	}{
+		{"hints enabled", 30 * time.Second, true},
+		{"hints disabled", 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := svc.manager.NewClient("")
+			if tc.retryMax > 0 {
+				client.drainRetryMS.Store(tc.retryMax.Milliseconds())
+			}
+			rec := httptest.NewRecorder()
+			writeShutdown(&sseWriter{w: rec, f: nopFlusher{rec}}, client)
+
+			body := rec.Body.String()
+			if !strings.Contains(body, "event: shutdown") {
+				t.Errorf("no shutdown frame; the client cannot tell a deliberate release from a broken connection. body = %q", body)
+			}
+			if got := strings.Contains(body, "retry: "); got != tc.wantRetry {
+				t.Errorf("retry directive present = %v, want %v; body = %q", got, tc.wantRetry, body)
+			}
+		})
+	}
+}
+
 // readSSEUntilTxIDs consumes SSE frames from r until every txid in want has
 // been seen at least once (duplicates allowed) or the timeout elapses.
 func readSSEUntilTxIDs(r io.Reader, want map[string]bool, timeout time.Duration) error {

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -1950,16 +1950,17 @@ func (s *Store) TokensForTxIDs(ctx context.Context, txids []string) (map[string]
 // is strictly better than trying: the caller degrades to an explicit gap and
 // the client reconciles over REST, instead of the pod dying and taking every
 // other connected client with it.
+//
+// The bound is enforced while the query result set is being drained, so peak
+// memory is capped at maxTokenReplayScan submissions. Checking the length of an
+// already-materialized list would be no protection at all — the allocation that
+// causes the OOM happens before such a check could run.
 const maxTokenReplayScan = 250_000
 
 func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {
-	subs, err := s.GetSubmissionsByToken(ctx, callbackToken)
+	subs, err := s.submissionsByTokenBounded(ctx, callbackToken, maxTokenReplayScan)
 	if err != nil {
 		return err
-	}
-	if len(subs) > maxTokenReplayScan {
-		return fmt.Errorf("%w: token has %d submissions, scan budget is %d",
-			store.ErrReplayUnavailable, len(subs), maxTokenReplayScan)
 	}
 	only := make(map[models.Status]struct{}, len(onlyStatuses))
 	for _, st := range onlyStatuses {
@@ -2016,6 +2017,19 @@ func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string
 }
 
 func (s *Store) GetSubmissionsByToken(ctx context.Context, token string) ([]*models.Submission, error) {
+	return s.submissionsByTokenBounded(ctx, token, 0)
+}
+
+// submissionsByTokenBounded is GetSubmissionsByToken with an optional ceiling
+// on how many submissions it will accumulate. A limit of 0 means unbounded.
+//
+// The bound is enforced while the result set is being drained, not after:
+// checking a returned slice's length is no protection, because by then the
+// memory has already been allocated and the OOM it was meant to prevent has
+// already happened. Exceeding the limit abandons the query and returns
+// store.ErrReplayUnavailable, so peak memory is capped at limit entries
+// regardless of the token's real size.
+func (s *Store) submissionsByTokenBounded(ctx context.Context, token string, limit int) ([]*models.Submission, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -2046,6 +2060,10 @@ loop:
 			}
 			if rec.Err != nil {
 				continue
+			}
+			if limit > 0 && len(subs) >= limit {
+				loopErr = fmt.Errorf("%w: token has more than %d submissions", store.ErrReplayUnavailable, limit)
+				break loop
 			}
 			subs = append(subs, recordToSubmission(rec.Record))
 		}

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -1939,10 +1939,27 @@ func (s *Store) TokensForTxIDs(ctx context.Context, txids []string) (map[string]
 	return store.TokensForTxIDsViaPerTxID(ctx, txids, s.GetSubmissionsByTxID)
 }
 
+// maxTokenReplayScan bounds how many of a token's submissions this backend
+// will walk for one catchup replay.
+//
+// Unlike Postgres, Aerospike has no index over (callback_token, timestamp_at,
+// txid) here, so this implementation loads the token's submission list, does a
+// point Get per txid, and sorts the survivors in memory — O(token cardinality)
+// per connect, against tokens that can hold millions of submissions. That is
+// the shape that OOM-killed the SSE pod (#237/#238). Past this bound, refusing
+// is strictly better than trying: the caller degrades to an explicit gap and
+// the client reconciles over REST, instead of the pod dying and taking every
+// other connected client with it.
+const maxTokenReplayScan = 250_000
+
 func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {
 	subs, err := s.GetSubmissionsByToken(ctx, callbackToken)
 	if err != nil {
 		return err
+	}
+	if len(subs) > maxTokenReplayScan {
+		return fmt.Errorf("%w: token has %d submissions, scan budget is %d",
+			store.ErrReplayUnavailable, len(subs), maxTokenReplayScan)
 	}
 	only := make(map[models.Status]struct{}, len(onlyStatuses))
 	for _, st := range onlyStatuses {

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -1876,16 +1876,17 @@ func (s *Store) TokensForTxIDs(ctx context.Context, txids []string) (map[string]
 // is strictly better than trying: the caller degrades to an explicit gap and
 // the client reconciles over REST, instead of the pod dying and taking every
 // other connected client with it.
+//
+// The bound is enforced while the index is being walked, so peak memory is
+// capped at maxTokenReplayScan submissions. Checking the length of an
+// already-materialized list would be no protection at all — the allocation
+// that causes the OOM happens before such a check could run.
 const maxTokenReplayScan = 250_000
 
 func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {
-	subs, err := s.GetSubmissionsByToken(ctx, callbackToken)
+	subs, err := s.submissionsByIndexBounded(ctx, idxSubTokenPrefix(callbackToken), maxTokenReplayScan)
 	if err != nil {
 		return err
-	}
-	if len(subs) > maxTokenReplayScan {
-		return fmt.Errorf("%w: token has %d submissions, scan budget is %d",
-			store.ErrReplayUnavailable, len(subs), maxTokenReplayScan)
 	}
 	only := make(map[models.Status]struct{}, len(onlyStatuses))
 	for _, st := range onlyStatuses {
@@ -1934,6 +1935,18 @@ func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string
 }
 
 func (s *Store) submissionsByIndex(ctx context.Context, prefix []byte) ([]*models.Submission, error) {
+	return s.submissionsByIndexBounded(ctx, prefix, 0)
+}
+
+// submissionsByIndexBounded is submissionsByIndex with an optional ceiling on
+// how many submissions it will accumulate. A limit of 0 means unbounded.
+//
+// The bound is enforced DURING iteration, not after: checking a returned
+// slice's length is no protection, because by then the memory has already been
+// allocated and the OOM it was meant to prevent has already happened. Exceeding
+// the limit abandons the scan and returns store.ErrReplayUnavailable, so peak
+// memory is capped at limit entries regardless of the token's real size.
+func (s *Store) submissionsByIndexBounded(ctx context.Context, prefix []byte, limit int) ([]*models.Submission, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -1965,6 +1978,9 @@ func (s *Store) submissionsByIndex(ctx context.Context, prefix []byte) ([]*model
 			continue
 		}
 		_ = closer.Close()
+		if limit > 0 && len(subs) >= limit {
+			return nil, fmt.Errorf("%w: token has more than %d submissions", store.ErrReplayUnavailable, limit)
+		}
 		subs = append(subs, ss.toModel())
 	}
 	return subs, nil

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -1865,10 +1865,27 @@ func (s *Store) TokensForTxIDs(ctx context.Context, txids []string) (map[string]
 	return store.TokensForTxIDsViaPerTxID(ctx, txids, s.GetSubmissionsByTxID)
 }
 
+// maxTokenReplayScan bounds how many of a token's submissions this backend
+// will walk for one catchup replay.
+//
+// Unlike Postgres, Pebble has no index over (callback_token, timestamp_at,
+// txid), so this implementation has to load the token's submission list, do a
+// point read per txid, and sort the survivors in memory. That is O(token
+// cardinality) per connect, and a token can hold millions of submissions —
+// the shape that OOM-killed the SSE pod (#237/#238). Past this bound, refusing
+// is strictly better than trying: the caller degrades to an explicit gap and
+// the client reconciles over REST, instead of the pod dying and taking every
+// other connected client with it.
+const maxTokenReplayScan = 250_000
+
 func (s *Store) IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error {
 	subs, err := s.GetSubmissionsByToken(ctx, callbackToken)
 	if err != nil {
 		return err
+	}
+	if len(subs) > maxTokenReplayScan {
+		return fmt.Errorf("%w: token has %d submissions, scan budget is %d",
+			store.ErrReplayUnavailable, len(subs), maxTokenReplayScan)
 	}
 	only := make(map[models.Status]struct{}, len(onlyStatuses))
 	for _, st := range onlyStatuses {

--- a/store/pebble/pebble_test.go
+++ b/store/pebble/pebble_test.go
@@ -1339,3 +1339,59 @@ func TestSetPendingRetryFields_RespectsStatusLattice(t *testing.T) {
 		})
 	}
 }
+
+// TestSubmissionsByIndexBounded_StopsDuringIteration pins WHERE the replay scan
+// budget is enforced.
+//
+// Checking the length of an already-materialized list is no protection: by the
+// time such a check could run, the allocation that causes the OOM has already
+// happened. The bound has to abandon the scan mid-iteration, so peak memory is
+// capped at the limit regardless of how many submissions the token really has.
+func TestSubmissionsByIndexBounded_StopsDuringIteration(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	const (
+		token = "tok-huge"
+		total = 50
+		limit = 10
+	)
+	for i := 0; i < total; i++ {
+		sub := &models.Submission{
+			SubmissionID:  fmt.Sprintf("sub-%03d", i),
+			TxID:          fmt.Sprintf("tx-%03d", i),
+			CallbackToken: token,
+		}
+		if err := s.InsertSubmission(ctx, sub); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+
+	// Unbounded still returns everything — the bound must not change the
+	// behavior of the normal read path.
+	all, err := s.GetSubmissionsByToken(ctx, token)
+	if err != nil {
+		t.Fatalf("unbounded read: %v", err)
+	}
+	if len(all) != total {
+		t.Fatalf("unbounded read returned %d submissions, want %d", len(all), total)
+	}
+
+	got, err := s.submissionsByIndexBounded(ctx, idxSubTokenPrefix(token), limit)
+	if !errors.Is(err, store.ErrReplayUnavailable) {
+		t.Fatalf("bounded read err = %v, want store.ErrReplayUnavailable", err)
+	}
+	if got != nil {
+		t.Errorf("bounded read returned %d submissions alongside its refusal; "+
+			"the point of refusing is to not hold them", len(got))
+	}
+
+	// A token that fits stays served.
+	fits, err := s.submissionsByIndexBounded(ctx, idxSubTokenPrefix(token), total+1)
+	if err != nil {
+		t.Fatalf("within-budget read: %v", err)
+	}
+	if len(fits) != total {
+		t.Errorf("within-budget read returned %d, want %d", len(fits), total)
+	}
+}

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -1442,6 +1442,22 @@ WHERE t.txid IN (SELECT DISTINCT txid FROM submissions WHERE callback_token = $1
 		args = append(args, vals)
 		q += fmt.Sprintf(" AND t.status = ANY($%d)", len(args))
 	}
+	// No LIMIT here, deliberately, and it is not an oversight.
+	//
+	// The caller's frame budget is SOFT at a timestamp boundary: timestamp_at
+	// is microsecond-resolution and SetMinedByTxIDs stamps a whole block's rows
+	// with one value, so the caller must be able to read past its budget to
+	// finish an equal-timestamp run. A cursor that stops mid-run cannot resume
+	// — the filter above is strictly-after — and the remainder is lost forever.
+	// That was a real, silent data-loss bug on the Last-Event-ID path; a hard
+	// SQL LIMIT would reimpose exactly the cut that caused it.
+	//
+	// Bounding this properly needs a keyset cursor on (timestamp_at, txid),
+	// which makes the position a total order and therefore resumable mid-tie.
+	// LIMIT becomes safe then, and lands with it. Until then the cost is a
+	// planned sort over the token's matching set — idx_sub_token covers the
+	// semi-join and idx_tx_updated the ordering — and rows stream, with the
+	// caller stopping early once its budget and any trailing tie are satisfied.
 	q += " ORDER BY t.timestamp_at ASC"
 
 	rows, err := s.pool.Query(ctx, q, args...)

--- a/store/store.go
+++ b/store/store.go
@@ -11,6 +11,20 @@ import (
 // ErrNotFound is returned when a requested record does not exist.
 var ErrNotFound = errors.New("not found")
 
+// ErrReplayUnavailable is returned by IterateStatusesByToken when a backend
+// cannot serve the replay within its resource bounds — typically a token whose
+// submission set is too large for a backend that has no keyset index over
+// (token, timestamp, txid) and would otherwise materialize and sort the whole
+// thing in memory.
+//
+// It exists so refusing is a first-class outcome. Attempting an unbounded
+// replay is not merely slow: it has OOM-killed the SSE pod and taken every
+// other connected client down with it (#237/#238). The SSE service turns this
+// error into an explicit `event: gap`, so the client learns it must reconcile
+// over REST and the live stream continues — a bounded, declared degradation
+// instead of a crash.
+var ErrReplayUnavailable = errors.New("replay unavailable for this token on this backend")
+
 // PendingRetry is the lightweight row shape the reaper consumes. It avoids
 // pulling full TransactionStatus objects through the retry hot path.
 type PendingRetry struct {
@@ -310,6 +324,12 @@ type Store interface {
 	// are emitted; when onlyStatuses is non-empty, only rows in one of those
 	// statuses are emitted. fn returning a non-nil error stops the iteration
 	// and surfaces that error to the caller.
+	//
+	// An implementation that cannot serve the replay within its own resource
+	// bounds MUST return ErrReplayUnavailable rather than attempt it. Refusing
+	// is a supported outcome — the caller degrades to an explicit gap notice
+	// and the client reconciles over REST — whereas attempting it is how this
+	// path has taken the whole pod down and every connected client with it.
 	IterateStatusesByToken(ctx context.Context, callbackToken string, since time.Time, onlyStatuses []models.Status, fn func(*models.TransactionStatus) error) error
 
 	// UpdateDeliveryStatus updates the delivery tracking for a submission


### PR DESCRIPTION
Phase 0 of the SSE scalability/reliability review. This is the "stop the bleeding" set: correctness first, capacity and drain second. No breaking wire change — every new frame type is additive and ignored by conformant clients.

Paired with:
- `galt-tr/go-arcade-toolbox` — consumer-side cursor guard, jitter, `retry:` parsing
- `bitcoin-sv/teranode-argocd-deployments` — CPU limit, PDB, drain sizing, alerts

## Why

Measured on the scaling network at only **1,000 TPS** (`go-arcade-toolbox/docs/benchmarks/20260811-1000tps-45min-transition-timing.md`):

- fan-out ceiling **~1,600 events/s** against ~4,000 events/s of demand
- **1,605,909 events dropped** in one 45-minute run
- MINED emit→applied p50 **110s**, p95 **354s**

But the throughput ceiling turned out not to be the most urgent problem. Two correctness bugs meant arcade could not honour "no missed messages" even at this rate.

## Bug 1 — silent, permanent loss on resume

`transactions.timestamp_at` is `TIMESTAMPTZ` (microsecond) and the catchup filter is strictly-after. `sendCatchup` capped a connect-time replay at `catchupMaxFrames` and — unlike the mid-stream path, which already drained the tie — stopped **mid-tie**.

Because `SetMinedByTxIDs` stamps an entire block's rows with one `timestamp_at`, a block larger than the cap lost every remaining row sharing that microsecond, **forever**. The client resumed strictly after it and was told nothing.

The cap is now soft at a timestamp boundary on both paths. Frames stream and are never accumulated, so draining a tie costs time, not memory, and a capped pass always ends on a boundary the next round can resume from.

## Bug 2 — truncation was invisible

When the cap fired, arcade logged a server-side `Warn` and the client streamed on believing it was whole. Tokenless (firehose) clients got a counter and nothing else — no replay exists for them at all.

New additive frame:

```
event: gap
data: {"reason":"catchup_truncated","from":"1786493743374103486","count":10000,"action":"reconcile"}
```

Emitted on catchup truncation, on a firehose drop, and when the store cannot serve a replay. `arcade_sse_gap_events_total{reason}` is the counterpart to the drop counter: **drops say the server lost something, gaps say the client was told.** A drop rate without a matching gap rate is silent loss.

## Graceful drain

`/ready` and `/health` were the same handler returning the same static body, so there was no way to say "stop sending me traffic" without also saying "kill me". And `http.Server.Shutdown` waits for connections to become *idle*, which an SSE connection never is — it burned its 15s timeout, the process exited, and every stream died with a TCP RST, sending every client back simultaneously.

`Stop` is now ordered: fail readiness → wait `DrainQuiesce` for endpoint withdrawal → release each client with its **own** reconnect delay (a shared delay relocates a herd rather than dispersing it) as an SSE `retry:` on an `event: shutdown` → `Shutdown`.

Client contexts are re-rooted off the service context, because inheriting it cancelled every client the instant SIGTERM landed, making the whole drain a no-op.

## Observability

- `arcade_sse_client_lag_seconds` — the metric whose absence let 1.6M drops go unnoticed for a whole run. Drops and fan-out duration each describe one component; lag describes what a consumer experiences.
- `arcade_sse_connections_total{outcome}` — reconnect rate *and reason*; a storm of `write_error` is a different problem from a storm of `drain`.
- Kafka group ids are now `arcade-events-<caller>-<host>-<n>` instead of random hex, so `redpanda_kafka_consumer_group_lag` can finally be matched and aggregated. Uniqueness is preserved by a per-caller sequence — two subscribers sharing a group split the partitions and each silently sees a fraction of the stream.

## Store

Pebble and Aerospike have no index over `(callback_token, timestamp_at, txid)`, so they load a token's entire submission list, point-read per txid, and sort in memory — the shape that OOM-killed this pod (#237/#238). `store.ErrReplayUnavailable` makes refusal first-class; SSE turns it into a gap and **keeps the live stream running**.

## What is deliberately NOT here

The Postgres `LIMIT` this work was grouped with. The frame budget is soft at a timestamp boundary, so a hard `LIMIT` would reimpose exactly the mid-tie cut that caused Bug 1. It is safe only alongside a keyset cursor on `(timestamp_at, txid)`, and lands with it in Phase 2. The reasoning is recorded at the query rather than silently skipped.

## Testing

`make test` / `make lint` clean. **Each new test was verified to fail against the unfixed code**, not just pass against the fixed code:

- tie loss: `500 of 10500 rows are unreachable after resuming from the delivered cursor`
- the assertion is an *identity* (replay → resume from the delivered cursor → replay → union must cover every row), not a frame count

Pre-existing and unrelated: `TestNoCanonicalKeyLiteralsOutsidePackage` fails on 186 findings, all of them inside a stale `.claude/worktrees/` checkout; zero in the real tree.

https://claude.ai/code/session_01Du5UyXD2JHtXVTV4qh5EGU