### PR TITLE
[Docs] Fix broken README links to DEPLOY.md and ARCHITECTURE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
        🐳&nbsp;<a href="DOCKER.md"><code>Docker&nbsp;Guide</code></a>
     </td>
     <td align="center">
-       ☸️&nbsp;<a href="DEPLOY.md"><code>Deployment&nbsp;Guide</code></a>
+       ☸️&nbsp;<a href="doc.md#deployment"><code>Deployment&nbsp;Guide</code></a>
     </td>
     <td align="center">
        🏗️&nbsp;<a href="#-architecture"><code>Architecture</code></a>
@@ -527,7 +527,7 @@ func (h *MyHandler) Start(ctx context.Context) error {
 
 Arcade uses [go-chaintracks](https://github.com/bsv-blockchain/go-chaintracks) for blockchain header tracking and merkle proof validation. Headers are loaded from embedded checkpoint files on startup and updated via P2P block announcements.
 
-For detailed architecture documentation, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+For detailed architecture documentation, see [doc.md](doc.md).
 
 <br/>
 
@@ -574,7 +574,7 @@ Read the [AI Usage & Assistant Guidelines](.github/tech-conventions/ai-complianc
 
 ## 📚 Resources
 
-- [Architecture Documentation](docs/ARCHITECTURE.md)
+- [Architecture Documentation](doc.md)
 - [Observability](docs/observability.md) — OTLP traces/metrics, structured log field canon, and transaction-lifecycle logging
 - [Teranode Documentation](https://docs.bsvblockchain.org/)
 - [Arc API Reference](https://github.com/bitcoin-sv/arc)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

* Retargeted the README **Deployment Guide** link from missing `DEPLOY.md` to `doc.md#deployment`, which already documents Kubernetes manifests under `deploy/`.
* Retargeted both `docs/ARCHITECTURE.md` links (Architecture section and Resources) to `doc.md`, which already contains the architecture overview, service table, and diagrams.

No new documentation files were added.

## Why It Was Necessary

`README.md` linked to `DEPLOY.md` and `docs/ARCHITECTURE.md`, neither of which exists in the repository, producing 404s. Architecture and deployment content already live in `doc.md`.

Fixes #163

## Testing Performed

* Confirmed `DEPLOY.md` and `docs/ARCHITECTURE.md` are absent.
* Confirmed `doc.md` exists and has `# Architecture` and `# Deployment` sections.
* Confirmed `deploy/` contains the Kubernetes manifests referenced from `doc.md`.
* Diff is three README href/markdown target changes only.

## Impact / Risk

* **Breaking Change**: None
* **Risk**: Low — README link retargets only; no code or behavior change
* **Developer experience**: Navigation links resolve to existing files instead of 404s

## Notifications
- none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2abc57e-138c-4d8e-b94e-745ea5a3e2b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2abc57e-138c-4d8e-b94e-745ea5a3e2b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

