### PR TITLE
[Teranode] Copy consecutiveFailures before mutex unlock in RecordFailure

### DIFF
--- a/teranode/client.go
+++ b/teranode/client.go
@@ -427,6 +427,7 @@ func (c *Client) RecordFailure(url string) {
 		transitioned = true
 	}
 	source := h.source
+	consecutive := h.consecutiveFailures
 	c.recomputeBelowThresholdLocked()
 	c.mu.Unlock()
 	if transitioned {
@@ -434,7 +435,7 @@ func (c *Client) RecordFailure(url string) {
 		c.logger.Warn(
 			"endpoint unhealthy",
 			zap.String("endpoint", n),
-			zap.Int("consecutive_failures", h.consecutiveFailures),
+			zap.Int("consecutive_failures", consecutive),
 			zap.String("from", "healthy"),
 			zap.String("to", "unhealthy"),
 			zap.String("reason", "reachability"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

* In `RecordFailure`, copy `h.consecutiveFailures` into a local `consecutive` variable while `c.mu` is still held, then log that snapshot after unlock.
* Matches the existing pattern in `RecordBroadcastFailure` and `recordProbeFailure`.

## Why It Was Necessary

`RecordFailure` unlocked `c.mu` before reading `h.consecutiveFailures` for the "endpoint unhealthy" warning. Concurrent `RecordFailure` / `RecordSuccess` calls can mutate the same `endpointHealth`, which is a data race under the Go race detector and undefined behavior in production.

Fixes #67

## Testing Performed

* `go test -race -count=1 ./teranode/` — pass (includes `TestHealthTracker_Concurrent`, which concurrently calls `RecordFailure` and `RecordSuccess`)

## Impact / Risk

* **Breaking Change**: None
* **Risk**: Low — snapshot of an int already held under the mutex; no behavioral change except eliminating the race
* **Performance**: Negligible (one extra local assignment)

## Notifications
- none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2abc57e-138c-4d8e-b94e-745ea5a3e2b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2abc57e-138c-4d8e-b94e-745ea5a3e2b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

