### PR TITLE
fix(status): do not let intake REJECTED clobber SEEN_*

### DIFF
--- a/models/transaction.go
+++ b/models/transaction.go
@@ -224,10 +224,20 @@ func (s Status) DisallowedPreviousStatuses() []Status {
 			StatusRejected, StatusDoubleSpendAttempted,
 			StatusMined, StatusImmutable,
 		}
-	case StatusRejected, StatusDoubleSpendAttempted:
-		// Rejection paths can override any non-terminal in-flight state, but
-		// must not be able to clobber an already-confirmed (MINED/IMMUTABLE)
-		// transaction.
+	case StatusRejected:
+		// REJECTED may overwrite pre-network in-flight state (RECEIVED /
+		// SENT / ACCEPTED / PENDING_RETRY), but must not clobber a tx that
+		// has already been observed on the network or confirmed. Issue #251:
+		// resubmitting an already-broadcast (and often already-mined) tx
+		// must not regress SEEN_* → REJECTED when intake validation fails
+		// on spent inputs of the same txid.
+		return []Status{
+			StatusSeenOnNetwork, StatusSeenMultipleNodes,
+			StatusMined, StatusImmutable,
+		}
+	case StatusDoubleSpendAttempted:
+		// Conflict detection can mark a SEEN tx; it must not clobber MINED /
+		// IMMUTABLE.
 		return []Status{StatusMined, StatusImmutable}
 	case StatusMined:
 		// MINED can be set from any in-flight state, but a transient miner-

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -157,6 +157,8 @@ func TestStatus_CanTransitionFrom_Regressions(t *testing.T) {
 		{StatusMined, StatusSeenMultipleNodes, "F-003: late SEEN_MULTIPLE callback after MINED"},
 		{StatusMined, StatusPendingRetry, "delayed retry attempt after MINED"},
 		{StatusMined, StatusRejected, "late rejection after MINED"},
+		{StatusSeenOnNetwork, StatusRejected, "#251: intake reject must not clobber SEEN_ON_NETWORK"},
+		{StatusSeenMultipleNodes, StatusRejected, "#251: intake reject must not clobber SEEN_MULTIPLE_NODES"},
 		{StatusImmutable, StatusMined, "MINED must not pull tx out of IMMUTABLE"},
 		{StatusImmutable, StatusSeenOnNetwork, "late SEEN after IMMUTABLE"},
 		{StatusRejected, StatusSentToNetwork, "republish after REJECTED"},

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -936,9 +936,9 @@ func (s *Server) rejectAtIntake(ctx context.Context, txid, reason string, status
 		zap.String("reason", reason),
 		logfields.Stage(logfields.StageIntake),
 	)
-	s.persistRejectedAtIntake(ctx, txid, reason, statusCode)
+	wrote := s.persistRejectedAtIntake(ctx, txid, reason, statusCode)
 	s.recordSubmission(ctx, txid, opts)
-	if s.publisher == nil {
+	if !wrote || s.publisher == nil {
 		return
 	}
 	status := &models.TransactionStatus{
@@ -961,10 +961,15 @@ func (s *Server) rejectAtIntake(ctx context.Context, txid, reason string, status
 // failed validation at the intake handler. Best-effort: a write
 // failure is logged but doesn't change the client response (the 400
 // has already told them the tx was rejected). When the store is nil
-// (test setups using struct-literal construction), this is a no-op.
-func (s *Server) persistRejectedAtIntake(ctx context.Context, txid, reason string, statusCode int) {
+// (test setups using struct-literal construction), this is a no-op and
+// reports wrote=true so the REJECTED event still publishes.
+//
+// wrote is false when an existing row already forbids a REJECTED
+// transition (SEEN_*/MINED/IMMUTABLE — issue #251). Callers must not
+// publish a REJECTED status event in that case.
+func (s *Server) persistRejectedAtIntake(ctx context.Context, txid, reason string, statusCode int) (wrote bool) {
 	if s.store == nil {
-		return
+		return true
 	}
 	row := &models.TransactionStatus{
 		TxID:       txid,
@@ -973,16 +978,24 @@ func (s *Server) persistRejectedAtIntake(ctx context.Context, txid, reason strin
 		ExtraInfo:  reason,
 		Timestamp:  time.Now(),
 	}
-	_, inserted, err := s.store.GetOrInsertStatus(ctx, row)
+	existing, inserted, err := s.store.GetOrInsertStatus(ctx, row)
 	if err != nil {
 		s.logger.Warn(
 			"intake rejection persist failed",
 			logfields.TxID(txid),
 			zap.Error(err),
 		)
-		return
+		return true
 	}
 	if !inserted {
+		if existing != nil && !models.StatusRejected.CanTransitionFrom(existing.Status) {
+			s.logger.Info(
+				"intake rejection ignored; existing status forbids REJECTED",
+				logfields.TxID(txid),
+				zap.String("existing_status", string(existing.Status)),
+			)
+			return false
+		}
 		if err := s.store.UpdateStatus(ctx, row); err != nil {
 			s.logger.Warn(
 				"intake rejection status update failed",
@@ -991,6 +1004,7 @@ func (s *Server) persistRejectedAtIntake(ctx context.Context, txid, reason strin
 			)
 		}
 	}
+	return true
 }
 
 // handleSubmitTransactions accepts a batch of concatenated raw transactions.

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -988,6 +988,66 @@ func TestHandleSubmitTransaction_ValidationFailure_RecordsSubmissionAndPublishes
 	}
 }
 
+// TestHandleSubmitTransaction_ValidationFailure_DoesNotClobberSeen is the
+// issue #251 regression: a resubmit of a tx already at SEEN_* must not
+// persist REJECTED or publish a REJECTED event when intake validation fails
+// (typically because the same tx already spent its inputs on-chain).
+func TestHandleSubmitTransaction_ValidationFailure_DoesNotClobberSeen(t *testing.T) {
+	rawTx := makeMinimalTx()
+
+	ms := &mockStore{
+		getOrInsertFn: func(in *models.TransactionStatus) (*models.TransactionStatus, bool, error) {
+			return &models.TransactionStatus{
+				TxID:   in.TxID,
+				Status: models.StatusSeenMultipleNodes,
+			}, false, nil
+		},
+	}
+	pub := &recordingCallbackPub{}
+	val := validator.NewValidator(nil)
+	broker := &kafka.RecordingBroker{}
+	gin.SetMode(gin.TestMode)
+	srv := &Server{
+		cfg:            &config.Config{CallbackToken: testCallbackToken},
+		logger:         zap.NewNop(),
+		producer:       kafka.NewProducer(broker),
+		store:          ms,
+		publisher:      pub,
+		validator:      val,
+		submissionCh:   make(chan submissionRecord, submissionRecorderBuffer),
+		submissionStop: make(chan struct{}),
+	}
+	router := gin.New()
+	srv.registerRoutes(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/tx", bytes.NewReader(rawTx))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	ms.mu.Lock()
+	updates := append([]*models.TransactionStatus(nil), ms.updateStatusCalls...)
+	ms.mu.Unlock()
+	if len(updates) != 0 {
+		t.Errorf("UpdateStatus must not clobber SEEN_MULTIPLE_NODES, got %v", updates)
+	}
+
+	pub.mu.Lock()
+	publishes := append([]*models.TransactionStatus(nil), pub.publishes...)
+	pub.mu.Unlock()
+	if len(publishes) != 0 {
+		t.Errorf("must not publish REJECTED over a SEEN row, got %v", publishes)
+	}
+
+	if totalMessages(broker) != 0 {
+		t.Errorf("must not publish to Kafka after an intake rejection, got %d", totalMessages(broker))
+	}
+}
+
 // TestHandleSubmitTransaction_ValidationFailure_NoCallback_StillPublishes
 // guards the "publish symmetrically with the success path" choice: even
 // when the request had no callback URL or token, the REJECTED event is


### PR DESCRIPTION
## What Changed
- Status lattice: `REJECTED` can no longer overwrite `SEEN_ON_NETWORK` / `SEEN_MULTIPLE_NODES` (still cannot overwrite `MINED` / `IMMUTABLE`).
- Intake `persistRejectedAtIntake` consults that lattice and **does not publish a REJECTED event** when the existing row forbids the transition.
- `DOUBLE_SPEND_ATTEMPTED` from `SEEN_*` is unchanged.

## Why It Was Necessary
Issue #251: a client retries a tx that is already `SEEN_MULTIPLE_NODES` (and often mined). Intake validation runs *before* the existing-row check and can fail because those inputs are already spent by the same tx. The failure path then wrote `REJECTED` over `SEEN_*` and fired REJECTED webhooks/SSE for a payment that was never actually rejected by the network.

## Testing Performed
- `go test ./models ./services/api_server -count=1`
- New unit: intake validation failure against a `SEEN_MULTIPLE_NODES` row does not `UpdateStatus` or publish REJECTED.

## Impact / Risk
- A later real network rejection of a SEEN tx still comes from the propagator, not intake.
- Clients that retried a good tx will keep seeing the prior SEEN/MINED status instead of a false REJECTED flap.

## Notifications
- Fixes https://github.com/bsv-blockchain/arcade/issues/251


Made with [Cursor](https://cursor.com)