### PR TITLE
fix(intake): do not persist REJECTED on BDK PROCESSING errors

### DIFF
--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -26,8 +26,16 @@ import (
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/telemetry"
 	"github.com/bsv-blockchain/arcade/teranode"
+	"github.com/bsv-blockchain/arcade/validator"
 	"github.com/bsv-blockchain/arcade/version"
 )
+
+// intakeValidator is the submit-path validator. *validator.Validator
+// implements it; tests stub it when they need an engine failure that must
+// not persist REJECTED.
+type intakeValidator interface {
+	ValidateTransaction(ctx context.Context, tx *sdkTx.Transaction, skipFees bool) error
+}
 
 // collectInputTXIDs returns the parent txids referenced by every input of
 // tx. Empty for coinbase. Used to populate the propagation envelope's
@@ -747,8 +755,7 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 	// durable and immediate.
 	if s.validator != nil {
 		if err := s.validator.ValidateTransaction(c.Request.Context(), parsedTx, false); err != nil {
-			s.rejectAtIntake(c.Request.Context(), txid, err.Error(), arcStatusCodeOf(err), opts)
-			respondSubmitError(c, txid, err)
+			s.handleValidatorError(c, txid, err, opts)
 			return
 		}
 	}
@@ -875,6 +882,30 @@ func (s *Server) handleSubmitTransaction(c *gin.Context) {
 		Status:   http.StatusAccepted,
 		TxStatus: models.StatusReceived,
 	})
+}
+
+// handleValidatorError is the intake failure fork: BDK/cgo PROCESSING
+// (IsInternalEngineError) is an engine condition, not a verdict about the
+// bytes — 503, nothing persisted, retry is safe. Every other validator
+// error remains a terminal REJECTED + 400.
+func (s *Server) handleValidatorError(c *gin.Context, txid string, err error, opts submitOptions) {
+	if validator.IsInternalEngineError(err) {
+		s.logger.Warn(
+			"intake engine failure; no verdict persisted",
+			logfields.TxID(txid),
+			zap.Error(err),
+			logfields.Stage(logfields.StageIntake),
+		)
+		c.Header("Retry-After", "1")
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			jsonKeyError: "transaction processor temporarily unavailable",
+			"txid":       txid,
+			"reason":     err.Error(),
+		})
+		return
+	}
+	s.rejectAtIntake(c.Request.Context(), txid, err.Error(), arcStatusCodeOf(err), opts)
+	respondSubmitError(c, txid, err)
 }
 
 // arcStatusCodeOf extracts the numeric ARC status code (460-476 taxonomy,
@@ -1067,8 +1098,7 @@ func (s *Server) handleSubmitTransactions(c *gin.Context) {
 		ctx := c.Request.Context()
 		for _, p := range parsed {
 			if vErr := s.validator.ValidateTransaction(ctx, p.tx, false); vErr != nil {
-				s.rejectAtIntake(ctx, p.txid, vErr.Error(), arcStatusCodeOf(vErr), opts)
-				respondSubmitError(c, p.txid, vErr)
+				s.handleValidatorError(c, p.txid, vErr, opts)
 				return
 			}
 		}

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bsv-blockchain/arcade/models"
 	"github.com/bsv-blockchain/arcade/store"
 	"github.com/bsv-blockchain/arcade/validator"
+	tnerr "github.com/bsv-blockchain/teranode/errors"
 )
 
 // mockStore implements store.Store for testing callback handlers.
@@ -985,6 +986,59 @@ func TestHandleSubmitTransaction_ValidationFailure_RecordsSubmissionAndPublishes
 	}
 	if publishes[0].ExtraInfo == "" {
 		t.Errorf("publish ExtraInfo is empty; expected the validator reason to be carried for subscriber context")
+	}
+}
+
+type stubIntakeValidator struct{ err error }
+
+func (s stubIntakeValidator) ValidateTransaction(context.Context, *sdkTx.Transaction, bool) error {
+	return s.err
+}
+
+// TestHandleSubmitTransaction_EngineFailure_NoRejectedRow pins the contract
+// that a BDK/cgo PROCESSING error is not a verdict: HTTP 503, no REJECTED
+// persist, no Kafka publish. A retry of the same bytes is expected to work.
+func TestHandleSubmitTransaction_EngineFailure_NoRejectedRow(t *testing.T) {
+	rawTx := makeMinimalTx()
+	ms := &mockStore{}
+	pub := &recordingCallbackPub{}
+	broker := &kafka.RecordingBroker{}
+	gin.SetMode(gin.TestMode)
+	srv := &Server{
+		cfg:            &config.Config{CallbackToken: testCallbackToken},
+		logger:         zap.NewNop(),
+		producer:       kafka.NewProducer(broker),
+		store:          ms,
+		publisher:      pub,
+		validator:      stubIntakeValidator{err: tnerr.NewProcessingError("GoBDK fail to ValidateTransaction")},
+		submissionCh:   make(chan submissionRecord, submissionRecorderBuffer),
+		submissionStop: make(chan struct{}),
+	}
+	router := gin.New()
+	srv.registerRoutes(router)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/tx", bytes.NewReader(rawTx))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+	ms.mu.Lock()
+	updates := len(ms.updateStatusCalls)
+	ms.mu.Unlock()
+	if updates != 0 {
+		t.Errorf("engine failure must not persist REJECTED, UpdateStatus calls=%d", updates)
+	}
+	pub.mu.Lock()
+	n := len(pub.publishes)
+	pub.mu.Unlock()
+	if n != 0 {
+		t.Errorf("engine failure must not publish REJECTED, got %d events", n)
+	}
+	if totalMessages(broker) != 0 {
+		t.Errorf("engine failure must not Kafka-publish, got %d", totalMessages(broker))
 	}
 }
 

--- a/services/api_server/server.go
+++ b/services/api_server/server.go
@@ -52,7 +52,7 @@ type Server struct {
 	// Nil-safe: tests that use struct-literal construction may leave it
 	// unset, in which case the handler skips validation. Production
 	// wiring through New requires it.
-	validator *validator.Validator
+	validator intakeValidator
 	// finality runs the nLockTime/BIP113 pre-check in the submit handler,
 	// rejecting provably non-final txs with an actionable reason instead of
 	// letting teranode bounce them with a generic error (issue #245).

--- a/validator/errmap.go
+++ b/validator/errmap.go
@@ -43,6 +43,18 @@ func mapTeranodeError(err error) error {
 	return classifyByMessage(err, msg)
 }
 
+// IsInternalEngineError reports a BDK/cgo/teranode PROCESSING failure that is
+// not a verdict about the submitted bytes (e.g. SCRIPT_ERR_CGO_EXCEPTION).
+// Intake must not persist REJECTED for these — the client should retry.
+// Mapped ArcErrors wrap the original tnerr.Error, so errors.As still finds it.
+func IsInternalEngineError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var te *tnerr.Error
+	return errors.As(err, &te) && te.Code() == tnerr.ERR_PROCESSING
+}
+
 // classifyByMessage picks an ARC status from teranode's deterministic error
 // messages. The BDK adapter wraps fee/script/policy failures under
 // ERR_TX_INVALID, so the precise status is recovered from the message text.

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -164,6 +164,22 @@ func TestMapTeranodeError_Nil(t *testing.T) {
 	}
 }
 
+func TestIsInternalEngineError(t *testing.T) {
+	if IsInternalEngineError(nil) {
+		t.Fatal("nil must not be an engine error")
+	}
+	proc := tnerr.NewProcessingError("GoBDK fail to ValidateTransaction")
+	if !IsInternalEngineError(proc) {
+		t.Fatal("raw PROCESSING error must be detected")
+	}
+	if !IsInternalEngineError(mapTeranodeError(proc)) {
+		t.Fatal("mapped PROCESSING ArcError must still unwrap to ERR_PROCESSING")
+	}
+	if IsInternalEngineError(tnerr.NewTxInvalidError("transaction fee is too low: 1 < 10 required")) {
+		t.Fatal("fee/script verdicts must persist REJECTED, not 503")
+	}
+}
+
 // --- end-to-end BDK validation (#192 Chronicle regression) ---------------
 
 // spendableSource builds an input that spends a fabricated previous output with


### PR DESCRIPTION
## What Changed
- Detect teranode `ERR_PROCESSING` (BDK/cgo engine failure) with `validator.IsInternalEngineError`.
- Intake now returns **HTTP 503** + `Retry-After` and **does not** write a REJECTED row or fire REJECTED SSE/webhooks.
- Script/fee/policy failures still persist REJECTED + 400.

## Why It Was Necessary
`validator/errmap.go` already says PROCESSING/cgo is not attributable to the tx, then intake treated **every** `ValidateTransaction` error as a terminal byte-verdict. A valid transaction could land `REJECTED` because the C++ engine hiccuped.

## Testing Performed
- `go test ./validator ./services/api_server -count=1`
- New: mapped PROCESSING still unwraps; fee errors are not 503; stubbed intake 503 leaves store/Kafka empty.

## Impact / Risk
- Callers must retry 503 (same as Kafka backpressure). Do not treat 503 as a permanent reject.
- Real script failures remain 400 REJECTED.

## Notifications
- Related to opaque Teranode `PROCESSING (4)` on the propagator (separate PR).


Made with [Cursor](https://cursor.com)