### PR TITLE
fix(propagation): requeue opaque Teranode PROCESSING instead of REJECTED

### DIFF
--- a/services/propagation/classify_test.go
+++ b/services/propagation/classify_test.go
@@ -7,10 +7,10 @@ import (
 
 // TestClassifyFailureLine pins the conservative Teranode-line → ARC-code map
 // (issue #254 / external feedback item 2). Invariants: the verbatim Teranode
-// line is always preserved in the message (the caller keeps every per-tx line
-// terminally rejected — the requeue signal is a body-less 5xx, decided
-// elsewhere); only confidently-mappable code prefixes gain an ARC status
-// code; and the non-final family carries an explicit retryable hint.
+// line is always preserved in the message; only confidently-mappable code
+// prefixes gain an ARC status code; and the non-final family carries an
+// explicit retryable hint. Opaque PROCESSING is routed to requeue by the
+// broadcast loop (lineIsOpaqueProcessing) and does not reach this helper.
 func TestClassifyFailureLine(t *testing.T) {
 	cases := []struct {
 		name          string
@@ -166,5 +166,57 @@ func TestFailureLinesForLog(t *testing.T) {
 		if got[i] != again[i] {
 			t.Fatalf("non-deterministic output at index %d: %q vs %q", i, got[i], again[i])
 		}
+	}
+}
+
+func TestLineIsOpaqueProcessing(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{
+			name: "bare PROCESSING catch-all",
+			line: "PROCESSING (4): [ProcessTransaction][ab12] failed to validate transaction",
+			want: true,
+		},
+		{
+			name: "repeated PROCESSING wrapper still opaque",
+			line: "PROCESSING (4): PROCESSING (4): failed to validate transaction",
+			want: true,
+		},
+		{
+			name: "nested TX_INVALID is a verdict",
+			line: "PROCESSING (4): [ProcessTransaction][ab12] failed: TX_INVALID (31): fee too low",
+			want: false,
+		},
+		{
+			name: "nested UTXO_SPENT is a verdict",
+			line: "PROCESSING (4): UTXO_SPENT (70): abc:0 already spent",
+			want: false,
+		},
+		{
+			name: "nested TX_MISSING_PARENT is a condition, not opaque",
+			line: "PROCESSING (4): TX_MISSING_PARENT (34): missing parent",
+			want: false,
+		},
+		{
+			name: "unknown nested code is still a nested verdict",
+			line: "PROCESSING (4): SOME_FUTURE_CODE (99): specific reason",
+			want: false,
+		},
+		{
+			name: "bare TX_INVALID is not PROCESSING",
+			line: "TX_INVALID (31): fee too low",
+			want: false,
+		},
+		{name: "empty", line: "", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lineIsOpaqueProcessing(tc.line); got != tc.want {
+				t.Errorf("lineIsOpaqueProcessing(%q) = %v, want %v", tc.line, got, tc.want)
+			}
+		})
 	}
 }

--- a/services/propagation/health_test.go
+++ b/services/propagation/health_test.go
@@ -457,13 +457,14 @@ func TestBroadcast_PerPeerAggregation_AcceptanceWins(t *testing.T) {
 // one peer returned HTTP 422 + a parseable Teranode failure list (the real
 // validator verdict for a spent-UTXO / invalid tx) while other peers returned
 // opaque gateway 502/500 with no body. Pre-fix the 422 body was discarded
-// (client only parsed status 500), so the tx either requeued forever or —
-// worse — never carried the PROCESSING/UTXO_SPENT line into GET /tx ExtraInfo.
-// Post-fix: REJECTED with the Teranode line as ExtraInfo.
+// (client only parsed status 500), so the tx either requeued forever or
+// never carried the TX_INVALID/UTXO_SPENT line into GET /tx ExtraInfo.
+// Post-fix: REJECTED with the Teranode line as ExtraInfo. Opaque PROCESSING
+// (4) without a nested verdict is a requeue, not this path.
 func TestBroadcast_422RejectionSurfacesExtraInfo(t *testing.T) {
 	const txid = "d018bc98d7828b7f095e5d616f7ccba607fc228368e82e74b25304e37699f1e9"
 	verdictBody := "Failed to process transactions:\n" +
-		"PROCESSING (4): [ProcessTransaction][" + txid + "] failed to validate transaction\n"
+		"TX_INVALID (31): [ProcessTransaction][" + txid + "] tx is invalid because fee too low\n"
 
 	// Peer A: the only peer that actually validated — 422 + failure list.
 	srvVerdict := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -508,12 +509,40 @@ func TestBroadcast_422RejectionSurfacesExtraInfo(t *testing.T) {
 	if got.Status != models.StatusRejected {
 		t.Fatalf("status=%s want REJECTED (extraInfo=%q)", got.Status, got.ExtraInfo)
 	}
-	if !strings.Contains(got.ExtraInfo, "PROCESSING (4)") {
-		t.Errorf("ExtraInfo=%q want Teranode PROCESSING line (not gateway 502/503 body)", got.ExtraInfo)
+	if !strings.Contains(got.ExtraInfo, "TX_INVALID (31)") {
+		t.Errorf("ExtraInfo=%q want Teranode TX_INVALID line (not gateway 502/503 body)", got.ExtraInfo)
 	}
 	if strings.Contains(got.ExtraInfo, "no available server") || strings.Contains(got.ExtraInfo, "502") {
 		t.Errorf("ExtraInfo leaked opaque gateway text: %q", got.ExtraInfo)
 	}
+}
+
+// TestBroadcast_OpaqueProcessing_RequeuesInsteadOfRejects pins the other
+// half of PROCESSING: a 422 failure list that is only PROCESSING (4) with
+// no nested TX_*/UTXO_* code is Teranode's catch-all wrapper, not a byte
+// verdict. Pre-fix this terminalized REJECTED; txResultClassRequeue's
+// comment already said PROCESSING requeues. The row stays off REJECTED so
+// a later successful peer (or retry) can still accept the tx.
+func TestBroadcast_OpaqueProcessing_RequeuesInsteadOfRejects(t *testing.T) {
+	const txid = "d018bc98d7828b7f095e5d616f7ccba607fc228368e82e74b25304e37699f1e9"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte("Failed to process transactions:\n" +
+			"PROCESSING (4): [ProcessTransaction][" + txid + "] failed to validate transaction\n"))
+	}))
+	defer srv.Close()
+
+	ms := newMockStore()
+	p := poisonPropagator(srv.URL, ms, 5, time.Millisecond)
+
+	if err := handleAndFlush(t, p, makePropMsg(txid)); err != nil {
+		t.Fatalf("handleAndFlush: %v", err)
+	}
+
+	if got := rejectedUpdates(ms); len(got) != 0 {
+		t.Fatalf("opaque PROCESSING must not terminalize REJECTED, got %d REJECTED writes (first: %+v)", len(got), got[0])
+	}
+	waitForPending(t, p, 1)
 }
 
 // TestBroadcast_422PartialFailureList_ImplicitAccept pins the riskiest
@@ -637,7 +666,7 @@ func TestBroadcast_422RejectionLosesToAcceptance(t *testing.T) {
 	srvReject := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		_, _ = w.Write([]byte("Failed to process transactions:\n" +
-			"PROCESSING (4): [ProcessTransaction][" + txid + "] failed to validate transaction\n"))
+			"TX_INVALID (31): [ProcessTransaction][" + txid + "] tx is invalid because fee too low\n"))
 	}))
 	defer srvReject.Close()
 

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -1645,6 +1645,28 @@ func lineIsMissingParentCondition(line string) bool {
 		strings.Contains(line, "TX_NOT_FOUND (")
 }
 
+// teranodeNamedCode matches Teranode's "NAME (n)" tokens, including ones
+// this build has not mapped yet. PROCESSING is the catch-all wrapper.
+var teranodeNamedCode = regexp.MustCompile(`[A-Z][A-Z0-9_]* \(\d+\)`)
+
+func lineHasNestedTeranodeVerdict(line string) bool {
+	for _, m := range teranodeNamedCode.FindAllString(line, -1) {
+		name, _, _ := strings.Cut(m, " (")
+		if name != "PROCESSING" {
+			return true
+		}
+	}
+	return false
+}
+
+// lineIsOpaqueProcessing reports a PROCESSING (4) wrapper with no nested
+// TX_*/UTXO_* (or other named) code. txResultClassRequeue's contract already
+// treats per-slot PROCESSING as infra, not a terminal verdict — but the
+// failure-list loop used to dump every named line into rejectionLine.
+func lineIsOpaqueProcessing(line string) bool {
+	return strings.Contains(line, "PROCESSING (") && !lineHasNestedTeranodeVerdict(line)
+}
+
 func rejectionLineScore(line string) int {
 	name, _, found := strings.Cut(line, " (")
 	if !found {
@@ -1677,14 +1699,12 @@ func rejectionLineScore(line string) int {
 // e.g. "PROCESSING (4): [ProcessTransaction][<txid>] failed to validate
 // transaction" or "TX_INVALID (31): [ProcessTransaction][<txid>] ...".
 //
-// Any per-txid line returned by Teranode is still treated as terminally
-// rejected. Teranode wraps real validator failures with NewProcessingError
-// (see services/propagation/Server.go:1236), so PROCESSING is the catch-all
-// "this tx is bad" code in practice — we can't distinguish a transient
-// infra issue from a permanent validation failure by code alone. The
-// authoritative requeue signal is a 5xx batch response with no parseable
-// per-tx body (handled separately in broadcastBatchToEndpoints), which
-// reflects a true infra outage rather than a tx-level verdict.
+// This helper only maps lines the broadcast loop has already routed as
+// terminal verdicts (rejectionLine). Opaque PROCESSING (4) with no nested
+// named code never reaches here — it requeues. Nested wrappers such as
+// "PROCESSING (4): … TX_INVALID (31)" still arrive as the full line: the
+// leading PROCESSING keeps arcCode 0 while ExtraInfo preserves the inner
+// text. Real validator codes (TX_INVALID, UTXO_SPENT, …) remain REJECTED.
 //
 // What the leading "NAME (n)" code DOES tell us confidently is mapped onto
 // the ARC taxonomy so consumers can branch on a number instead of prose
@@ -2666,6 +2686,10 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 				// are untouched (the line is in-batch-keyed, not alien).
 				if lineIsMissingParentCondition(line) {
 					missingParentLine[j] = preferRejectionLine(missingParentLine[j], line)
+				} else if lineIsOpaqueProcessing(line) {
+					// PROCESSING (4) with no nested TX_*/UTXO_* code is the
+					// catch-all wrapper, not a verdict. Leave rejectionLine
+					// empty so this slot falls through to txResultClassRequeue.
 				} else {
 					rejectionLine[j] = preferRejectionLine(rejectionLine[j], line)
 				}
@@ -2679,7 +2703,7 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 			// never become a terminal verdict via the attribution path.
 			if lineIsMissingParentCondition(line) {
 				missingParentLine[idx] = preferRejectionLine(missingParentLine[idx], line)
-			} else {
+			} else if !lineIsOpaqueProcessing(line) {
 				rejectionLine[idx] = preferRejectionLine(rejectionLine[idx], line)
 			}
 		}
@@ -2693,7 +2717,7 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 		if alienCount > 0 && len(batch) == 1 {
 			if lineIsMissingParentCondition(bestAlien) {
 				missingParentLine[0] = preferRejectionLine(missingParentLine[0], bestAlien)
-			} else {
+			} else if !lineIsOpaqueProcessing(bestAlien) {
 				rejectionLine[0] = preferRejectionLine(rejectionLine[0], bestAlien)
 			}
 		}

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -2684,13 +2684,15 @@ func (p *Propagator) broadcastBatchToEndpoints(ctx context.Context, rawTxs [][]b
 				// and told us the parent isn't there yet. Route it to the
 				// condition bucket; the siblings' implicit accepts above
 				// are untouched (the line is in-batch-keyed, not alien).
+				// PROCESSING (4) with no nested TX_*/UTXO_* code is the
+				// catch-all wrapper, not a verdict: skipping it leaves
+				// rejectionLine empty so the slot falls through to
+				// txResultClassRequeue. Expressed as a negated guard rather
+				// than an empty branch, matching the attributed-line loop
+				// below.
 				if lineIsMissingParentCondition(line) {
 					missingParentLine[j] = preferRejectionLine(missingParentLine[j], line)
-				} else if lineIsOpaqueProcessing(line) {
-					// PROCESSING (4) with no nested TX_*/UTXO_* code is the
-					// catch-all wrapper, not a verdict. Leave rejectionLine
-					// empty so this slot falls through to txResultClassRequeue.
-				} else {
+				} else if !lineIsOpaqueProcessing(line) {
 					rejectionLine[j] = preferRejectionLine(rejectionLine[j], line)
 				}
 			} else if alienCount == 0 {


### PR DESCRIPTION
## What Changed
- Per-slot Teranode lines that are only `PROCESSING (4)` (no nested `TX_*` / `UTXO_*` / other named code) no longer go into `rejectionLine`.
- Those slots fall through to `txResultClassRequeue`, matching the comment that already treated PROCESSING as infra, not a terminal verdict.
- Nested wrappers (`PROCESSING (4): … TX_INVALID (31)`) still REJECTED.
- `TestBroadcast_422RejectionSurfacesExtraInfo` now pins a real `TX_INVALID` ExtraInfo line rather than opaque PROCESSING.

## Why It Was Necessary
Teranode wraps many failures in `PROCESSING (4)`. When the line has **no nested validator/UTXO code**, it is the catch-all (engine/infra), not a byte verdict. The propagator still wrote `REJECTED` for that shape, so a valid tx could be terminalized because a peer said PROCESSING.

Intake BDK `ERR_PROCESSING` is a separate change: https://github.com/bsv-blockchain/arcade/pull/311

## Testing Performed
- `go test ./services/propagation -count=1`
- New: `TestLineIsOpaqueProcessing`, `TestBroadcast_OpaqueProcessing_RequeuesInsteadOfRejects` (no REJECTED write; delayed requeue lands).

## Impact / Risk
- Genuine `TX_INVALID` / `UTXO_SPENT` / conflict lines still REJECTED.
- Opaque PROCESSING will retry until budget/reaper, same as body-less 5xx. Callers should not treat that as a permanent reject.

## Notifications
- Related to https://github.com/bsv-blockchain/arcade/pull/311 (intake PROCESSING → 503).

Made with [Cursor](https://cursor.com)