### PR TITLE
fix(store): hydrate TxTracker with a real chain height and a projected query

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -246,41 +246,58 @@ func Bootstrap(ctx context.Context, cfg *config.Config, logger *zap.Logger) (*De
 		chainTracks = ct
 	}
 
-	finalityChecker := buildFinalityChecker(ctx, cfg, chainTracks, st, logger)
+	// One chain source per process, shared by the finality gate and TxTracker
+	// hydration below.
+	reader := chainReader(ctx, cfg, chainTracks, logger)
+
+	finalityChecker := buildFinalityChecker(cfg, reader, st, logger)
 
 	// Hydrate the TxTracker from the store BEFORE handing it to api-server.
 	// Gated to modes that actually consume it: only api-server reads
 	// deps.TxTracker (see BuildServices). Without hydration a restart leaves the
 	// tracker empty and in-flight transitions can be dropped until re-observed.
-	// LoadFromStore streams the full transactions history into an in-memory map,
-	// a cost that scales with tx volume; running it in modes that never read the
-	// tracker (sse, watchdog, propagation, p2p-client, bump-builder, chaintracks)
-	// is what OOMKilled every 512Mi arcade-v2 component after the v0.9.0 rollout.
-	// Chain height skips deeply-confirmed rows; when chaintracks is disabled we
-	// pass 0 (preserves every MINED row — safe, prunable later).
+	// Running it in modes that never read the tracker (sse, watchdog,
+	// propagation, p2p-client, bump-builder, chaintracks) is what OOMKilled
+	// every 512Mi arcade-v2 component after the v0.9.0 rollout.
 	// Keep in sync with BuildServices / modeNeedsTxTracker.
 	if modeNeedsTxTracker(cfg.Mode) {
-		var hydrateHeight uint64
-		if chainTracks != nil {
-			hydrateHeight = uint64(chainTracks.GetHeight(ctx))
-		}
-		hydrateStart := time.Now()
-		loaded, hydrateErr := txTracker.LoadFromStore(ctx, st, hydrateHeight)
-		if hydrateErr != nil {
+		hydrateHeight, heightKnown, heightSource := hydrationHeight(ctx, reader, st, logger)
+		scan := store.NewTrackerScan(hydrateHeight, heightKnown)
+
+		logger.Info(
+			"tx tracker hydration height resolved",
+			zap.Uint64("height", hydrateHeight),
+			zap.Bool("height_known", heightKnown),
+			zap.String("height_source", heightSource),
+			zap.Uint64("prune_mined_below", scan.PruneMinedBelow),
+			zap.String("chaintracks_mode", string(cfg.Chaintracks.Mode)),
+			zap.Bool("chain_reader_configured", reader != nil),
+		)
+		if !heightKnown {
 			logger.Warn(
-				"tx tracker hydration partial",
-				zap.Int("loaded", loaded),
-				zap.Uint64("current_height", hydrateHeight),
-				zap.Duration("elapsed", time.Since(hydrateStart)),
-				zap.Error(hydrateErr),
+				"tx tracker hydrating without a chain height: MINED pruning is DISABLED and every " +
+					"MINED row will be loaded (the v0.13.0 current_height=0 condition). Check " +
+					"chaintracks.mode/chaintracks.url reachability from this pod, and that " +
+					"block_processing has status='active' rows.",
 			)
+		}
+
+		hydrateStart := time.Now()
+		stats, hydrateErr := txTracker.LoadFromStore(ctx, st, scan)
+		// `loaded` and `current_height` keep their names — dashboards key on them.
+		fields := []zap.Field{
+			zap.Int("loaded", stats.Loaded),
+			zap.Int("scanned", stats.Scanned),
+			zap.Int("skipped", stats.Skipped),
+			zap.Uint64("current_height", hydrateHeight),
+			zap.String("height_source", heightSource),
+			zap.Uint64("prune_mined_below", scan.PruneMinedBelow),
+			zap.Duration("elapsed", time.Since(hydrateStart)),
+		}
+		if hydrateErr != nil {
+			logger.Warn("tx tracker hydration partial", append(fields, zap.Error(hydrateErr))...)
 		} else {
-			logger.Info(
-				"tx tracker hydrated",
-				zap.Int("loaded", loaded),
-				zap.Uint64("current_height", hydrateHeight),
-				zap.Duration("elapsed", time.Since(hydrateStart)),
-			)
+			logger.Info("tx tracker hydrated", fields...)
 		}
 	}
 
@@ -375,12 +392,14 @@ func modeNeedsFinality(mode string) bool {
 // any chaintracks source, height-based locktimes are still gated while
 // timestamp locktimes fail open (they need MTP). Teranode stays the
 // authority in every degraded mode.
-func buildFinalityChecker(ctx context.Context, cfg *config.Config, chainTracks chaintrackslib.Chaintracks, st store.Store, logger *zap.Logger) *finality.Checker {
+// The reader is built by the caller (chainReader) and shared with TxTracker
+// hydration, so a pod holds exactly one chaintracks client and one degradation
+// story.
+func buildFinalityChecker(cfg *config.Config, reader finality.ChainReader, st store.Store, logger *zap.Logger) *finality.Checker {
 	if cfg.Validator.DisableFinalityCheck || !modeNeedsFinality(cfg.Mode) {
 		return nil
 	}
 
-	reader := finalityChainReader(ctx, cfg, chainTracks, logger)
 	if reader == nil {
 		logger.Info("finality pre-check degraded to height-only: no MTP source (enable chaintracks_server or set chaintracks.mode=remote with a URL)")
 	}
@@ -390,22 +409,90 @@ func buildFinalityChecker(ctx context.Context, cfg *config.Config, chainTracks c
 		finality.WithUnavailableHook(metrics.APIFinalityPrecheckUnavailableTotal.Inc))
 }
 
-// finalityChainReader picks the finality gate's chain source: the shared
-// embedded chaintracks when it exists, else a remote go-chaintracks client
-// when configured, else nil.
-func finalityChainReader(ctx context.Context, cfg *config.Config, chainTracks chaintrackslib.Chaintracks, logger *zap.Logger) finality.ChainReader {
+// chainReader picks the process-wide chain source: the shared embedded
+// chaintracks when it exists, else a remote go-chaintracks client when
+// configured, else nil.
+//
+// Two consumers share it — the finality gate and TxTracker hydration — so it
+// is deliberately NOT gated on cfg.Validator.DisableFinalityCheck. Letting a
+// validator flag suppress hydration's height source is exactly the kind of
+// action-at-a-distance that produced issue #276.
+//
+// In remote mode Initialize is just an HTTP client construction: no goroutines,
+// no I/O, and nothing to close.
+func chainReader(ctx context.Context, cfg *config.Config, chainTracks chaintrackslib.Chaintracks, logger *zap.Logger) finality.ChainReader {
 	if chainTracks != nil {
 		return chainTracks
 	}
 	if cfg.Chaintracks.Mode != chaintracksconfig.ModeRemote || cfg.Chaintracks.URL == "" {
 		return nil
 	}
-	remote, err := cfg.Chaintracks.Initialize(ctx, "arcade-finality", nil)
+	remote, err := cfg.Chaintracks.Initialize(ctx, "arcade-chain-reader", nil)
 	if err != nil {
-		logger.Warn("finality pre-check disabled: remote chaintracks init failed", zap.Error(err))
+		logger.Warn(
+			"remote chaintracks init failed: finality pre-check degrades to height-only and "+
+				"tx tracker hydration loses its primary chain-height source",
+			zap.Error(err),
+		)
 		return nil
 	}
 	return remote
+}
+
+// hydrationHeightTimeout bounds each chain-height probe at startup. The remote
+// go-chaintracks client is built on a zero-value http.Client, which has NO
+// timeout of its own, so without this a wedged chaintracks pod would stall
+// boot indefinitely rather than degrading to the store fallback.
+const hydrationHeightTimeout = 5 * time.Second
+
+// hydrationHeight resolves the chain tip used to prune deeply-confirmed MINED
+// rows during hydration, returning whether the height is actually KNOWN.
+//
+// The (value, known) pair is the whole point. go-chaintracks' GetHeight returns
+// uint32 and collapses every failure into 0, indistinguishable from genesis —
+// so api-server pods silently hydrated with height 0, the deeply-confirmed skip
+// never fired, and all 4.48M MINED rows loaded on every boot (issue #276).
+// GetTip returns a nil-able header, which is the only accessor that can express
+// "unavailable", so this uses GetTip and never GetHeight.
+//
+// Sources in order:
+//  1. the chain reader (embedded chaintracks, or the remote client) — the true
+//     tip;
+//  2. the store's active tip, written to block_processing by the chaintracks
+//     pod and shared through the same database, so an api-server pod that runs
+//     no chaintracks of its own still gets a real height. Already the finality
+//     gate's height-only fallback (finality.WithHeightFallback).
+//
+// Both are lower bounds on the true tip, and both fail safe: a height that is
+// too low under-prunes (a bigger map, today's behavior), which costs memory but
+// never correctness — the tracker is only a prefilter, and the store lattice
+// stays authoritative for anything it doesn't know.
+func hydrationHeight(
+	ctx context.Context, reader finality.ChainReader, st store.Store, logger *zap.Logger,
+) (height uint64, known bool, source string) {
+	if reader != nil {
+		tipCtx, cancel := context.WithTimeout(ctx, hydrationHeightTimeout)
+		tip := reader.GetTip(tipCtx)
+		cancel()
+		if tip != nil {
+			return uint64(tip.Height), true, "chaintracks"
+		}
+		logger.Warn("chain height degraded: chaintracks tip unavailable, falling back to the store active tip")
+	}
+
+	storeCtx, cancel := context.WithTimeout(ctx, hydrationHeightTimeout)
+	activeTip, err := st.GetActiveTipBlockHeight(storeCtx)
+	cancel()
+	switch {
+	case err != nil:
+		logger.Warn("chain height unknown: store active tip read failed", zap.Error(err))
+		return 0, false, "none"
+	case activeTip == 0:
+		logger.Warn("chain height unknown: no active blocks recorded (store active tip is 0)")
+		return 0, false, "none"
+	default:
+		return activeTip, true, "store"
+	}
 }
 
 // modeNeedsTxTracker reports whether the configured mode constructs a service

--- a/app/hydration_height_test.go
+++ b/app/hydration_height_test.go
@@ -1,0 +1,155 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bsv-blockchain/go-chaintracks/chaintracks"
+	"go.uber.org/zap"
+
+	"github.com/bsv-blockchain/arcade/store"
+)
+
+// fakeChainReader is a finality.ChainReader whose GetTip can express
+// "unavailable" by returning nil — the property that makes this fix work at
+// all. GetHeaders is unused by hydrationHeight.
+type fakeChainReader struct {
+	tip *chaintracks.BlockHeader
+}
+
+func (f *fakeChainReader) GetTip(context.Context) *chaintracks.BlockHeader { return f.tip }
+
+func (f *fakeChainReader) GetHeaders(context.Context, uint32, uint32) ([]*chaintracks.BlockHeader, error) {
+	return nil, nil
+}
+
+// fakeHeightStore embeds store.Store so only the one method under test needs
+// implementing; anything else panics rather than silently returning a zero.
+type fakeHeightStore struct {
+	store.Store
+
+	height uint64
+	err    error
+	calls  int
+}
+
+func (f *fakeHeightStore) GetActiveTipBlockHeight(context.Context) (uint64, error) {
+	f.calls++
+	return f.height, f.err
+}
+
+func TestHydrationHeight(t *testing.T) {
+	cases := []struct {
+		name        string
+		reader      *fakeChainReader
+		st          *fakeHeightStore
+		wantHeight  uint64
+		wantKnown   bool
+		wantSource  string
+		wantStoreHi bool // the store fallback should have been consulted
+	}{
+		{
+			name:       "chaintracks tip wins",
+			reader:     &fakeChainReader{tip: &chaintracks.BlockHeader{Height: 915_432}},
+			st:         &fakeHeightStore{height: 915_430},
+			wantHeight: 915_432,
+			wantKnown:  true,
+			wantSource: "chaintracks",
+		},
+		{
+			name:        "nil tip falls back to the store active tip",
+			reader:      &fakeChainReader{tip: nil},
+			st:          &fakeHeightStore{height: 915_430},
+			wantHeight:  915_430,
+			wantKnown:   true,
+			wantSource:  "store",
+			wantStoreHi: true,
+		},
+		{
+			name:        "no reader configured falls back to the store",
+			reader:      nil,
+			st:          &fakeHeightStore{height: 42},
+			wantHeight:  42,
+			wantKnown:   true,
+			wantSource:  "store",
+			wantStoreHi: true,
+		},
+		{
+			// The exact v0.13.0 production condition: api-server had no
+			// chaintracks and nothing had populated block_processing.
+			name:        "both sources unavailable is UNKNOWN, not height zero",
+			reader:      &fakeChainReader{tip: nil},
+			st:          &fakeHeightStore{height: 0},
+			wantHeight:  0,
+			wantKnown:   false,
+			wantSource:  "none",
+			wantStoreHi: true,
+		},
+		{
+			name:        "store error is unknown, not zero",
+			reader:      nil,
+			st:          &fakeHeightStore{err: errors.New("db down")},
+			wantHeight:  0,
+			wantKnown:   false,
+			wantSource:  "none",
+			wantStoreHi: true,
+		},
+		{
+			// A genuine genesis-height chain must still read as KNOWN when the
+			// chain source answered. This is the case a bare uint64 return
+			// could never distinguish.
+			name:       "tip at height zero is known",
+			reader:     &fakeChainReader{tip: &chaintracks.BlockHeader{Height: 0}},
+			st:         &fakeHeightStore{height: 500},
+			wantHeight: 0,
+			wantKnown:  true,
+			wantSource: "chaintracks",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// A nil *fakeChainReader must be passed as a genuinely nil
+			// interface, not a typed nil.
+			height, known, source := func() (uint64, bool, string) {
+				if tc.reader == nil {
+					return hydrationHeight(context.Background(), nil, tc.st, zap.NewNop())
+				}
+				return hydrationHeight(context.Background(), tc.reader, tc.st, zap.NewNop())
+			}()
+
+			if height != tc.wantHeight {
+				t.Errorf("height = %d, want %d", height, tc.wantHeight)
+			}
+			if known != tc.wantKnown {
+				t.Errorf("known = %v, want %v", known, tc.wantKnown)
+			}
+			if source != tc.wantSource {
+				t.Errorf("source = %q, want %q", source, tc.wantSource)
+			}
+			if got := tc.st.calls > 0; got != tc.wantStoreHi {
+				t.Errorf("store consulted = %v, want %v", got, tc.wantStoreHi)
+			}
+		})
+	}
+}
+
+func TestHydrationHeight_FeedsTrackerScan(t *testing.T) {
+	// The join between the two halves of the fix: an unknown height must
+	// produce a scan that prunes nothing, and a known one must produce a real
+	// cutoff. Getting this backwards is precisely the v0.13.0 bug.
+	unknown := &fakeChainReader{tip: nil}
+	emptyStore := &fakeHeightStore{height: 0}
+	h, known, _ := hydrationHeight(context.Background(), unknown, emptyStore, zap.NewNop())
+	if scan := store.NewTrackerScan(h, known); scan.PruneMinedBelow != 0 {
+		t.Fatalf("unknown height must disable pruning, got PruneMinedBelow=%d", scan.PruneMinedBelow)
+	}
+
+	live := &fakeChainReader{tip: &chaintracks.BlockHeader{Height: 900_000}}
+	h, known, _ = hydrationHeight(context.Background(), live, emptyStore, zap.NewNop())
+	scan := store.NewTrackerScan(h, known)
+	if scan.PruneMinedBelow != 900_000-store.ConfirmationsRequired+1 {
+		t.Fatalf("PruneMinedBelow = %d, want %d", scan.PruneMinedBelow, 900_000-store.ConfirmationsRequired+1)
+	}
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -255,6 +255,57 @@ field set is used by merkle-service:
 - **Rejections by stage**: `stage:"network"` (or `intake`/`cascade`) narrows
   a REJECTED search to where in the pipeline it happened.
 
+## TxTracker hydration at startup (api-server)
+
+`api-server` hydrates its in-memory TxTracker from the store before it binds
+its HTTP listener, so a slow hydration shows up as a pod that stays `0/1` with
+probes getting `connection refused` — not a 404, and not a probe-path problem.
+
+Two lines cover it, both emitted once per boot:
+
+- **`tx tracker hydration height resolved`** — `height`, `height_known`,
+  `height_source` (`chaintracks` | `store` | `none`), `prune_mined_below`,
+  `chaintracks_mode`, `chain_reader_configured`.
+- **`tx tracker hydrated`** (or `tx tracker hydration partial` on error) —
+  `loaded`, `scanned`, `skipped`, `current_height`, `height_source`,
+  `prune_mined_below`, `elapsed`.
+
+What to look for:
+
+- **`height_known=false`** (with the accompanying `tx tracker hydrating without
+  a chain height` Warn) is the degraded state. MINED pruning is off, so every
+  mined row loads and `elapsed` grows with total store size. This is the
+  v0.13.0 condition that made hydration take 147s on a 4.5M-row store. Check
+  that `chaintracks.url` is reachable from the pod and that `block_processing`
+  has `status='active'` rows.
+- **`scanned` ≫ `loaded`** is normal only when `height_known=false`. With a
+  real height the store filters server-side, so the two should be close.
+- **`skipped > 0`** means the backend emitted rows the tracker then rejected —
+  its server-side filter has drifted from `store.TrackerScan.Keep`. The result
+  is still correct (the tracker re-checks every row), but the rows crossed the
+  wire for nothing. `store/storetest` is the suite that should have caught it.
+
+### Postgres: optional hydration index
+
+The hydration query is
+`WHERE status = ANY(...) AND (status <> 'MINED' OR COALESCE(block_height,0) = 0 OR block_height >= $cutoff)`.
+`idx_tx_status` alone leaves the planner scanning every MINED row. On a large
+store a composite index makes it a range scan:
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tx_status_height
+    ON transactions (status, block_height);
+
+-- An interrupted CONCURRENTLY build leaves an INVALID index that a later
+-- IF NOT EXISTS silently skips, so always confirm:
+SELECT indisvalid FROM pg_index WHERE indexrelid = 'idx_tx_status_height'::regclass;
+```
+
+Run it out of band, not through `schema.sql`: that file is applied inside a
+single transaction (so `CONCURRENTLY` is impossible there) and any byte change
+to it re-runs the whole DDL script fleet-wide. Hydration is correct without the
+index — only slower.
+
 ## Related docs
 
 - [`docs/plans/otel-integration.md`](plans/otel-integration.md) — the

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -36,7 +36,12 @@ import (
 // decoding of models.HexBytes). A mutex protects the stumps map because the
 // end-to-end STUMP test fires deliveries concurrently to mirror
 // merkle-service's 64-worker delivery pool.
+// Embeds store.Store so a method added to the interface does not break this
+// fake at compile time; anything not explicitly implemented below panics if a
+// test actually calls it. Matches propagation/sse/watchdog's fakes.
 type mockStore struct {
+	store.Store
+
 	mu                  sync.Mutex
 	updateStatusCalls   []*models.TransactionStatus
 	stumps              map[string]*models.Stump

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -23,7 +23,13 @@ import (
 const txA = "txA"
 
 // fakeStore implements just enough of store.Store for these tests.
+//
+// Embeds store.Store so a method added to the interface does not break this
+// fake at compile time; anything not explicitly implemented below panics if a
+// test actually calls it. Matches propagation/sse/watchdog's fakes.
 type fakeStore struct {
+	store.Store
+
 	mu   sync.Mutex
 	subs map[string][]*models.Submission
 

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -555,6 +555,83 @@ func (s *Store) IterateStatusesSince(ctx context.Context, _ time.Time, fn func(*
 	}
 }
 
+// IterateTrackerRows runs one secondary-index query per tracked status
+// (arcade_idx_tx_status, the same index CensusStatusesSince and GetReadyRetries
+// use) projecting only the three bins hydration reads.
+//
+// This is the largest of the three backend wins: IterateStatusesSince above is
+// a full-namespace scan that ignores `since` entirely and transfers whole
+// records, so hydration used to pull every row in the set — raw_tx included —
+// across the wire on every api-server boot (issue #276).
+//
+// The MINED height cutoff is applied client-side via scan.Keep: Aerospike's
+// equality filter cannot express it, and the store contract explicitly permits
+// a backend to over-emit rather than requiring an exact server-side match.
+func (s *Store) IterateTrackerRows(ctx context.Context, scan store.TrackerScan, fn func(store.TrackerRow) error) error {
+	for _, status := range scan.Statuses() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		stmt := aero.NewStatement(s.namespace, setTransactions, "txid", "status", "block_height")
+		_ = stmt.SetFilter(aero.NewEqualFilter("status", string(status)))
+
+		rs, err := s.client.Query(s.queryPolicy(ctx), stmt)
+		if err != nil {
+			if rs != nil {
+				_ = rs.Close()
+			}
+			return fmt.Errorf("tracker rows query status %s: %w", status, err)
+		}
+
+		var loopErr error
+	loop:
+		for {
+			select {
+			case <-ctx.Done():
+				loopErr = ctx.Err()
+				break loop
+			case rec, ok := <-rs.Results():
+				if !ok {
+					break loop
+				}
+				if rec.Err != nil {
+					loopErr = rec.Err
+					break loop
+				}
+				txid := getString(rec.Record, "txid")
+				if txid == "" {
+					continue
+				}
+				// Trust the record's own status bin rather than the filter we
+				// asked for, so a stale index entry cannot hand the tracker a
+				// status the row no longer holds.
+				rowStatus := models.Status(getString(rec.Record, "status"))
+				height := getInt(rec.Record, "block_height")
+				if height < 0 {
+					height = 0
+				}
+				blockHeight := uint64(height)
+				if !scan.Keep(rowStatus, blockHeight) {
+					continue
+				}
+				if err := fn(store.TrackerRow{
+					TxID:        txid,
+					Status:      rowStatus,
+					BlockHeight: blockHeight,
+				}); err != nil {
+					loopErr = err
+					break loop
+				}
+			}
+		}
+		_ = rs.Close()
+		if loopErr != nil {
+			return loopErr
+		}
+	}
+	return nil
+}
+
 // CensusStatusesSince pushes the census as far into Aerospike as the client
 // allows: one secondary-index query per requested status (arcade_idx_tx_status,
 // same index GetReadyRetries uses) projecting ONLY the timestamp bin, with the

--- a/store/aerospike/conformance_test.go
+++ b/store/aerospike/conformance_test.go
@@ -1,0 +1,21 @@
+//go:build integration
+
+package aerospike
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/arcade/store/storetest"
+)
+
+// Requires a live Aerospike on localhost:3200 (integrationStore skips
+// otherwise). No CI workflow passes -tags=integration today, so run this by
+// hand before merging changes to IterateTrackerRows:
+//
+//	go test -tags=integration -run TestIterateTrackerRows ./store/aerospike/...
+func TestIterateTrackerRows_Conformance(t *testing.T) {
+	storetest.RunTrackerRowsSuite(t, func(t *testing.T) storetest.Backend {
+		t.Helper()
+		return integrationStore(t)
+	})
+}

--- a/store/pebble/conformance_test.go
+++ b/store/pebble/conformance_test.go
@@ -1,0 +1,57 @@
+package pebble
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
+	"github.com/bsv-blockchain/arcade/store/storetest"
+)
+
+// Pebble is the only backend whose conformance run is untagged, so this is the
+// one that actually gates CI. Keep it that way: postgres and aerospike are
+// behind //go:build tags that no workflow currently passes.
+func TestIterateTrackerRows_Conformance(t *testing.T) {
+	storetest.RunTrackerRowsSuite(t, func(t *testing.T) storetest.Backend {
+		t.Helper()
+		return newTestStore(t)
+	})
+}
+
+func TestIterateTrackerRows_StatusIndexStaysFresh(t *testing.T) {
+	// The walk is driven by idx:tx:status:<status>:*, so a status transition
+	// must move the row out of the old status's index. If it did not, a
+	// REJECTED row would keep being emitted under its old RECEIVED key —
+	// exactly the leak issue #276 exists to prevent.
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	const txid = "00000000000000000000000000000000000000000000000000000000000000aa"
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID:   txid,
+		Status: models.StatusReceived,
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := s.UpdateStatus(ctx, &models.TransactionStatus{
+		TxID:   txid,
+		Status: models.StatusRejected,
+	}); err != nil {
+		t.Fatalf("update to REJECTED: %v", err)
+	}
+
+	scan := store.NewTrackerScan(900_000, true)
+	var emitted []store.TrackerRow
+	if err := s.IterateTrackerRows(ctx, scan, func(row store.TrackerRow) error {
+		emitted = append(emitted, row)
+		return nil
+	}); err != nil {
+		t.Fatalf("IterateTrackerRows: %v", err)
+	}
+	for _, row := range emitted {
+		if row.TxID == txid {
+			t.Fatalf("row emitted as %s after transitioning to REJECTED", row.Status)
+		}
+	}
+}

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -673,6 +673,64 @@ func (s *Store) IterateStatusesSince(ctx context.Context, since time.Time, fn fu
 	return nil
 }
 
+// IterateTrackerRows walks the per-status index (idx:tx:status:<status>:*) for
+// each tracked status, so rows in untracked statuses — REJECTED and IMMUTABLE,
+// the overwhelming majority of a mature store — are never visited at all.
+// Hydration previously walked idx:tx:updated and did a full readStatus point
+// read for every row in the store (issue #276).
+//
+// Rows are decoded with readStoredStatus rather than readStatus: the latter
+// enriches merkle paths and orphaned proofs, none of which the tracker reads.
+func (s *Store) IterateTrackerRows(ctx context.Context, scan store.TrackerScan, fn func(store.TrackerRow) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	for _, status := range scan.Statuses() {
+		prefix := idxTxStatusPrefix(string(status))
+		iter, err := s.db.NewIter(&pebbledb.IterOptions{
+			LowerBound: prefix,
+			UpperBound: endOfPrefix(prefix),
+		})
+		if err != nil {
+			return err
+		}
+		for iter.First(); iter.Valid(); iter.Next() {
+			if err := ctx.Err(); err != nil {
+				_ = iter.Close()
+				return err
+			}
+			st, err := s.readStoredStatus(lastSegment(iter.Key()))
+			if err != nil || st == nil {
+				continue
+			}
+			// Trust the row, not the index key. If an index entry is ever stale
+			// relative to the row it points at, emitting the key's status would
+			// hand the tracker a status the store no longer holds; re-reading
+			// makes a stale entry merely wasted work.
+			rowStatus := models.Status(st.Status)
+			if rowStatus != status {
+				continue
+			}
+			if !scan.Keep(rowStatus, st.BlockHeight) {
+				continue
+			}
+			if err := fn(store.TrackerRow{
+				TxID:        st.TxID,
+				Status:      rowStatus,
+				BlockHeight: st.BlockHeight,
+			}); err != nil {
+				_ = iter.Close()
+				return err
+			}
+		}
+		if err := iter.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // CensusStatusesSince walks the per-status index (idx:tx:status:<status>:*)
 // for each requested status, so rows in other statuses — the overwhelming
 // majority of a mature store — are never visited. Each candidate row is read

--- a/store/postgres/conformance_test.go
+++ b/store/postgres/conformance_test.go
@@ -1,0 +1,109 @@
+//go:build postgres
+
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
+	"github.com/bsv-blockchain/arcade/store/storetest"
+)
+
+func TestIterateTrackerRows_Conformance(t *testing.T) {
+	storetest.RunTrackerRowsSuite(t, func(t *testing.T) storetest.Backend {
+		t.Helper()
+		return newTestStore(t)
+	})
+}
+
+func TestIterateTrackerRows_NullBlockHeightKept(t *testing.T) {
+	// block_height is nullable (schema.sql). A MINED row with a NULL height
+	// must be kept at any cutoff — the COALESCE disjunct in the query is what
+	// makes that true, and a naive `block_height >= $2` would silently drop it
+	// because NULL comparisons are never true.
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	const txid = "00000000000000000000000000000000000000000000000000000000000000bb"
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+		TxID:   txid,
+		Status: models.StatusMined,
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := s.pool.Exec(ctx, `UPDATE transactions SET block_height = NULL WHERE txid = $1`, txid); err != nil {
+		t.Fatalf("null out block_height: %v", err)
+	}
+
+	found := false
+	if err := s.IterateTrackerRows(ctx, store.NewTrackerScan(900_000, true), func(row store.TrackerRow) error {
+		if row.TxID == txid {
+			found = true
+			if row.BlockHeight != 0 {
+				t.Errorf("NULL block_height should surface as 0, got %d", row.BlockHeight)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("IterateTrackerRows: %v", err)
+	}
+	if !found {
+		t.Fatal("MINED row with NULL block_height was pruned")
+	}
+}
+
+func TestIterateTrackerRows_PlanHasNoSort(t *testing.T) {
+	// The regression guard for issue #276. The query hydration used to run
+	// carried ORDER BY timestamp_at DESC, so on a multi-million-row store the
+	// planner added an external merge sort over 14 detoasted columns — that
+	// sort is what drove arcade and its Postgres out of memory. Hydration
+	// builds a map, so any ordering in this plan is pure waste.
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	statuses := store.TrackerStatuses()
+	names := make([]string, len(statuses))
+	for i, st := range statuses {
+		names[i] = string(st)
+	}
+
+	const q = `
+EXPLAIN (VERBOSE)
+SELECT txid, status, COALESCE(block_height, 0)
+FROM transactions
+WHERE status = ANY($1)
+  AND (status <> $2 OR COALESCE(block_height, 0) = 0 OR block_height >= $3)`
+
+	rows, err := s.pool.Query(ctx, q, names, string(models.StatusMined), int64(899_901))
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v", err)
+	}
+	defer rows.Close()
+
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan plan: %v", err)
+		}
+		plan.WriteString(line)
+		plan.WriteString("\n")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("plan rows: %v", err)
+	}
+
+	got := plan.String()
+	if strings.Contains(got, "Sort") {
+		t.Errorf("hydration query plan contains a Sort node (issue #276 regression):\n%s", got)
+	}
+	// The projection must not pull the heavy columns.
+	for _, col := range []string{"raw_tx", "merkle_path", "competing_txs", "orphaned_anchors"} {
+		if strings.Contains(got, col) {
+			t.Errorf("hydration query plan references heavy column %q:\n%s", col, got)
+		}
+	}
+}

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -684,6 +684,73 @@ ORDER BY timestamp_at DESC`
 	return rows.Err()
 }
 
+// IterateTrackerRows streams the three columns hydration needs, filtered
+// server-side. Contrast with IterateStatusesSince above, which this replaced
+// for hydration: that query selects 14 columns including raw_tx / merkle_path
+// / competing_txs and sorts the whole table by timestamp_at. On a ~5M-row
+// store the planner resolved it with a Seq Scan plus an external merge sort
+// over detoasted wide rows, which drove both arcade and its Postgres out of
+// memory on every api-server boot (issue #276).
+//
+// Three properties matter here and each is load-bearing:
+//   - three narrow columns, so raw_tx is never detoasted;
+//   - the status filter is server-side, so REJECTED (~44% of a mature store)
+//     never leaves the database;
+//   - NO ORDER BY — hydration builds a map, order is meaningless, and the
+//     sort was the memory hazard.
+func (s *Store) IterateTrackerRows(ctx context.Context, scan store.TrackerScan, fn func(store.TrackerRow) error) error {
+	statuses := scan.Statuses()
+	if len(statuses) == 0 {
+		return nil
+	}
+	names := make([]string, len(statuses))
+	for i, st := range statuses {
+		names[i] = string(st)
+	}
+
+	// One static query text covering both regimes. When PruneMinedBelow is 0
+	// (chain height unknown) `block_height >= 0` matches every non-null height,
+	// so all MINED rows are kept — the documented degraded behavior. The
+	// COALESCE disjunct keeps MINED rows with height 0 or NULL at any cutoff.
+	const q = `
+SELECT txid, status, COALESCE(block_height, 0)
+FROM transactions
+WHERE status = ANY($1)
+  AND (status <> $2 OR COALESCE(block_height, 0) = 0 OR block_height >= $3)`
+
+	//nolint:gosec // PruneMinedBelow is a block height; far below MaxInt64.
+	rows, err := s.pool.Query(ctx, q, names, string(models.StatusMined), int64(scan.PruneMinedBelow))
+	if err != nil {
+		return fmt.Errorf("iterate tracker rows: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		var (
+			txid        string
+			status      string
+			blockHeight int64
+		)
+		if err := rows.Scan(&txid, &status, &blockHeight); err != nil {
+			return err
+		}
+		if blockHeight < 0 {
+			blockHeight = 0
+		}
+		if err := fn(store.TrackerRow{
+			TxID:        txid,
+			Status:      models.Status(status),
+			BlockHeight: uint64(blockHeight),
+		}); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
 // CensusStatusesSince is one aggregate round-trip: count + min(timestamp_at)
 // per status over the census window, resolved by the idx_tx_status /
 // idx_tx_updated indexes. The reaper's stuck census over a multi-million-row

--- a/store/store.go
+++ b/store/store.go
@@ -203,11 +203,44 @@ type Store interface {
 
 	// IterateStatusesSince streams every transaction updated since the given
 	// timestamp through fn, one row at a time. Implementations must avoid
-	// materializing the full result set in memory — this is the bounded-memory
-	// path used by TxTracker.LoadFromStore at startup, where months of history
-	// would otherwise pin a large slice during pruning. fn returning a non-nil
+	// materializing the full result set in memory. fn returning a non-nil
 	// error stops iteration and surfaces that error to the caller.
+	//
+	// This returns FULL rows (raw_tx, merkle_path, competing_txs, …) and, on
+	// Postgres, sorts them. It exists for consumers that genuinely need the
+	// whole row — propagation's replay and reaper. Do NOT reach for it from a
+	// new bulk or startup scan: reusing it for TxTracker hydration shipped 14
+	// columns for ~5M rows on every api-server boot and drove both arcade and
+	// its Postgres out of memory (issue #276). New bulk consumers get a
+	// projected, server-side-filtered method instead — see IterateTrackerRows,
+	// IterateStatusesByToken and CensusStatusesSince.
 	IterateStatusesSince(ctx context.Context, since time.Time, fn func(*models.TransactionStatus) error) error
+
+	// IterateTrackerRows streams the minimal (txid, status, block_height)
+	// projection TxTracker.LoadFromStore needs, filtering server-side so a
+	// multi-million-row history is never shipped to the client (issue #276).
+	//
+	// Contract:
+	//   - MUST emit every row whose status is in TrackerStatuses(), exactly
+	//     once, with Status and BlockHeight equal to the stored values.
+	//   - MUST NOT emit rows in any other status. Pushing the status filter
+	//     server-side is the memory contract, not an optimization: REJECTED
+	//     alone is ~44% of a mature store.
+	//   - MAY additionally drop MINED rows with
+	//     0 < block_height < scan.PruneMinedBelow. Implementations are not
+	//     required to; a backend whose index cannot express the height
+	//     predicate is correct, just less selective.
+	//   - MUST NOT read raw_tx, merkle_path, competing_txs or orphaned_anchors,
+	//     MUST NOT enrich merkle paths, and MUST NOT impose an ordering. The
+	//     ORDER BY over the full table is what pinned gigabytes.
+	//   - fn returning a non-nil error stops iteration and surfaces it.
+	//
+	// TrackerScan.Keep is the specification; the SQL/index filter is only a
+	// pushdown of it. The caller re-applies Keep to every emitted row, so a
+	// backend that over-emits is a performance issue only — a backend that
+	// under-emits is a correctness bug. store/storetest asserts exact
+	// agreement across all three backends.
+	IterateTrackerRows(ctx context.Context, scan TrackerScan, fn func(TrackerRow) error) error
 
 	// CensusStatusesSince aggregates the stuck-transient census store-side:
 	// for each requested status, the number of transaction rows with

--- a/store/storetest/trackerrows.go
+++ b/store/storetest/trackerrows.go
@@ -1,0 +1,323 @@
+// Package storetest holds cross-backend conformance suites for store.Store.
+//
+// It is a non-test package so build-tagged backend test packages
+// (//go:build postgres, //go:build integration) can import it, the same way
+// net/http/httptest imports testing from a non-test package.
+package storetest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
+)
+
+// Backend is the slice of store.Store the tracker-rows suite drives.
+type Backend interface {
+	GetOrInsertStatus(ctx context.Context, status *models.TransactionStatus) (*models.TransactionStatus, bool, error)
+	IterateTrackerRows(ctx context.Context, scan store.TrackerScan, fn func(store.TrackerRow) error) error
+}
+
+// tipHeight is the fixed chain tip the corpus is built around. Chosen large
+// enough that tip - ConfirmationsRequired cannot underflow and small enough to
+// stay readable in failure messages.
+const tipHeight = uint64(900_000)
+
+// seed is one corpus row plus the identity the assertions use.
+type seed struct {
+	txid   string
+	status models.Status
+	height uint64
+	note   string
+}
+
+// corpus covers every status in the models domain plus the MINED height
+// boundary on both sides of tip-ConfirmationsRequired. Heights are only
+// meaningful for MINED rows, but a couple of non-MINED rows carry one too so a
+// backend that applies the height predicate to the wrong statuses is caught.
+func corpus() []seed {
+	out := make([]seed, 0, len(models.AllStatuses())+8)
+	for i, st := range models.AllStatuses() {
+		out = append(out, seed{
+			txid:   txidHex(i),
+			status: st,
+			note:   "one row per status",
+		})
+	}
+	next := len(models.AllStatuses())
+	minedHeights := []struct {
+		h    uint64
+		note string
+	}{
+		{0, "MINED with no recorded height: never prunable"},
+		{1, "ancient MINED"},
+		{tipHeight - store.ConfirmationsRequired - 1, "one below the prune boundary"},
+		{tipHeight - store.ConfirmationsRequired, "exactly ConfirmationsRequired deep: pruned"},
+		{tipHeight - store.ConfirmationsRequired + 1, "one short of deeply confirmed: kept"},
+		{tipHeight, "the tip itself"},
+	}
+	for _, mh := range minedHeights {
+		out = append(out, seed{txid: txidHex(next), status: models.StatusMined, height: mh.h, note: mh.note})
+		next++
+	}
+	// Terminal rows carrying a recent height: these must never be emitted, and
+	// a height-only filter would wrongly keep them.
+	out = append(out,
+		seed{txid: txidHex(next), status: models.StatusRejected, height: tipHeight, note: "recent REJECTED"},
+		seed{txid: txidHex(next + 1), status: models.StatusImmutable, height: tipHeight, note: "recent IMMUTABLE"},
+	)
+	return out
+}
+
+func txidHex(i int) string { return fmt.Sprintf("%064x", i+1) }
+
+// RunTrackerRowsSuite asserts that a backend's IterateTrackerRows honors the
+// store.Store contract: it emits exactly the rows TrackerScan.Keep accepts,
+// with faithful field values, and never leaks a terminal row.
+//
+// TrackerScan.Keep is the specification; the backend's SQL or index filter is
+// only a pushdown of it. The ExactAgreement subtest is the anti-drift check —
+// it is what stops the three backends and the Go predicate from diverging.
+//
+// newBackend must return a backend with an empty transactions set; it is called
+// once per subtest so subtests cannot contaminate each other.
+func RunTrackerRowsSuite(t *testing.T, newBackend func(t *testing.T) Backend) {
+	t.Helper()
+
+	t.Run("ExactAgreement", func(t *testing.T) {
+		// The core assertion, run across every interesting height regime.
+		regimes := []struct {
+			name string
+			scan store.TrackerScan
+		}{
+			{"KnownTip", store.NewTrackerScan(tipHeight, true)},
+			{"UnknownHeight", store.NewTrackerScan(tipHeight, false)},
+			{"ZeroKnown", store.NewTrackerScan(0, true)},
+			{"BelowConfirmations", store.NewTrackerScan(store.ConfirmationsRequired-1, true)},
+		}
+		for _, r := range regimes {
+			t.Run(r.name, func(t *testing.T) {
+				b := seedBackend(t, newBackend)
+				got := collect(t, b, r.scan)
+
+				want := map[string]seed{}
+				for _, s := range corpus() {
+					if r.scan.Keep(s.status, s.height) {
+						want[s.txid] = s
+					}
+				}
+				assertSameSet(t, want, got)
+			})
+		}
+	})
+
+	t.Run("NoTerminalLeakage", func(t *testing.T) {
+		// The memory contract from issue #276: REJECTED alone is ~44% of a
+		// mature store and must never leave the database.
+		b := seedBackend(t, newBackend)
+		for _, scan := range []store.TrackerScan{
+			store.NewTrackerScan(tipHeight, true),
+			store.NewTrackerScan(tipHeight, false),
+		} {
+			for txid, row := range collect(t, b, scan) {
+				if row.Status.IsTerminal() && row.Status != models.StatusMined {
+					t.Errorf("terminal row leaked: txid=%s status=%s", txid, row.Status)
+				}
+				if !store.TracksStatus(row.Status) {
+					t.Errorf("untracked status emitted: txid=%s status=%s", txid, row.Status)
+				}
+			}
+		}
+	})
+
+	t.Run("Fidelity", func(t *testing.T) {
+		b := seedBackend(t, newBackend)
+		got := collect(t, b, store.NewTrackerScan(tipHeight, true))
+		for _, s := range corpus() {
+			row, ok := got[s.txid]
+			if !ok {
+				continue
+			}
+			if row.Status != s.status {
+				t.Errorf("txid %s (%s): status = %s, want %s", s.txid, s.note, row.Status, s.status)
+			}
+			if row.BlockHeight != s.height {
+				t.Errorf("txid %s (%s): block_height = %d, want %d", s.txid, s.note, row.BlockHeight, s.height)
+			}
+			if row.TxID != s.txid {
+				t.Errorf("row.TxID = %s, want %s", row.TxID, s.txid)
+			}
+		}
+	})
+
+	t.Run("MinedZeroHeightKept", func(t *testing.T) {
+		// A MINED row with no recorded height cannot be judged deeply confirmed.
+		// The easy thing to lose in a `WHERE block_height >= $cutoff` pushdown.
+		b := seedBackend(t, newBackend)
+		got := collect(t, b, store.NewTrackerScan(tipHeight, true))
+		for _, s := range corpus() {
+			if s.status == models.StatusMined && s.height == 0 {
+				if _, ok := got[s.txid]; !ok {
+					t.Fatalf("MINED row at block_height 0 (txid %s) was pruned", s.txid)
+				}
+			}
+		}
+	})
+
+	t.Run("UnknownHeightKeepsAllMined", func(t *testing.T) {
+		// The v0.13.0 production condition. Every MINED row survives.
+		b := seedBackend(t, newBackend)
+		got := collect(t, b, store.NewTrackerScan(tipHeight, false))
+		for _, s := range corpus() {
+			if s.status != models.StatusMined {
+				continue
+			}
+			if _, ok := got[s.txid]; !ok {
+				t.Errorf("MINED row txid %s (%s, height %d) dropped despite unknown chain height",
+					s.txid, s.note, s.height)
+			}
+		}
+	})
+
+	t.Run("KnownHeightPrunes", func(t *testing.T) {
+		// The whole point of the fix: a real height must actually shrink the set.
+		b := seedBackend(t, newBackend)
+		pruned := collect(t, b, store.NewTrackerScan(tipHeight, true))
+		all := collect(t, b, store.NewTrackerScan(tipHeight, false))
+		if len(pruned) >= len(all) {
+			t.Fatalf("a known chain height pruned nothing: %d rows with tip, %d without", len(pruned), len(all))
+		}
+		boundary := tipHeight - store.ConfirmationsRequired
+		for _, s := range corpus() {
+			if s.status != models.StatusMined || s.height == 0 {
+				continue
+			}
+			_, kept := pruned[s.txid]
+			wantKept := s.height > boundary
+			if kept != wantKept {
+				t.Errorf("MINED at height %d (%s): kept=%v, want %v (boundary %d)",
+					s.height, s.note, kept, wantKept, boundary)
+			}
+		}
+	})
+
+	t.Run("NoDuplicates", func(t *testing.T) {
+		b := seedBackend(t, newBackend)
+		seen := map[string]int{}
+		err := b.IterateTrackerRows(context.Background(), store.NewTrackerScan(tipHeight, true),
+			func(row store.TrackerRow) error {
+				seen[row.TxID]++
+				return nil
+			})
+		if err != nil {
+			t.Fatalf("IterateTrackerRows: %v", err)
+		}
+		for txid, n := range seen {
+			if n != 1 {
+				t.Errorf("txid %s emitted %d times, want exactly 1", txid, n)
+			}
+		}
+	})
+
+	t.Run("CallbackErrorStops", func(t *testing.T) {
+		b := seedBackend(t, newBackend)
+		sentinel := errors.New("stop here")
+		calls := 0
+		err := b.IterateTrackerRows(context.Background(), store.NewTrackerScan(tipHeight, false),
+			func(store.TrackerRow) error {
+				calls++
+				return sentinel
+			})
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("expected the callback error to surface, got %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("iteration continued past the callback error: %d calls", calls)
+		}
+	})
+
+	t.Run("CanceledContext", func(t *testing.T) {
+		b := seedBackend(t, newBackend)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		calls := 0
+		err := b.IterateTrackerRows(ctx, store.NewTrackerScan(tipHeight, true), func(store.TrackerRow) error {
+			calls++
+			return nil
+		})
+		if err == nil {
+			t.Fatal("expected an error from a canceled context")
+		}
+		if calls != 0 {
+			t.Fatalf("emitted %d rows under a canceled context", calls)
+		}
+	})
+}
+
+func seedBackend(t *testing.T, newBackend func(t *testing.T) Backend) Backend {
+	t.Helper()
+	b := newBackend(t)
+	ctx := context.Background()
+	for _, s := range corpus() {
+		row := &models.TransactionStatus{
+			TxID:        s.txid,
+			Status:      s.status,
+			BlockHeight: s.height,
+		}
+		if _, _, err := b.GetOrInsertStatus(ctx, row); err != nil {
+			t.Fatalf("seeding txid %s (%s, %s): %v", s.txid, s.status, s.note, err)
+		}
+	}
+	return b
+}
+
+func collect(t *testing.T, b Backend, scan store.TrackerScan) map[string]store.TrackerRow {
+	t.Helper()
+	out := map[string]store.TrackerRow{}
+	err := b.IterateTrackerRows(context.Background(), scan, func(row store.TrackerRow) error {
+		out[row.TxID] = row
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("IterateTrackerRows: %v", err)
+	}
+	return out
+}
+
+func assertSameSet(t *testing.T, want map[string]seed, got map[string]store.TrackerRow) {
+	t.Helper()
+
+	var missing, extra []string
+	for txid, s := range want {
+		if _, ok := got[txid]; !ok {
+			missing = append(missing, fmt.Sprintf("%s (%s h=%d: %s)", txid, s.status, s.height, s.note))
+		}
+	}
+	byTxid := map[string]seed{}
+	for _, s := range corpus() {
+		byTxid[s.txid] = s
+	}
+	for txid := range got {
+		if _, ok := want[txid]; !ok {
+			s := byTxid[txid]
+			extra = append(extra, fmt.Sprintf("%s (%s h=%d: %s)", txid, s.status, s.height, s.note))
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+
+	// Missing rows are a correctness bug: the backend under-emitted relative to
+	// TrackerScan.Keep. Extra rows mean the pushdown drifted from the predicate;
+	// the tracker's client-side re-check would still drop them, but the whole
+	// point of #276 is that they should not cross the wire.
+	if len(missing) > 0 {
+		t.Errorf("backend did not emit %d row(s) Keep accepts (CORRECTNESS):\n  %v", len(missing), missing)
+	}
+	if len(extra) > 0 {
+		t.Errorf("backend emitted %d row(s) Keep rejects (pushdown drift):\n  %v", len(extra), extra)
+	}
+}

--- a/store/tracker.go
+++ b/store/tracker.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 
@@ -44,25 +43,43 @@ func NewTxTracker() *TxTracker {
 	}
 }
 
-// statusIterator narrows the Store surface LoadFromStore actually needs so
+// TrackerRowIterator narrows the Store surface LoadFromStore actually needs so
 // tests can supply a fake without standing up every Store method. Any
 // implementation of Store satisfies this implicitly.
-type statusIterator interface {
-	IterateStatusesSince(ctx context.Context, since time.Time, fn func(*models.TransactionStatus) error) error
+type TrackerRowIterator interface {
+	IterateTrackerRows(ctx context.Context, scan TrackerScan, fn func(TrackerRow) error) error
+}
+
+// LoadStats reports what one hydration pass did.
+//
+// Scanned counts rows the store emitted; Loaded counts rows that reached the
+// tracker map. Skipped counts rows the store emitted that TrackerScan.Keep
+// then rejected — with a correct server-side pushdown this is ~0, so a
+// nonzero value in production is the signal that a backend's filter has
+// drifted from the Go predicate (see store/storetest).
+type LoadStats struct {
+	Scanned int
+	Loaded  int
+	Skipped int
 }
 
 // LoadFromStore populates the tracker from the store, streaming rows in
-// fixed-size batches and dropping deeply-confirmed transactions before they
-// reach the tracker map. Peak memory is bounded by loadFromStoreBatchSize
-// rather than the full history depth, which matters at startup on systems
-// with months of accumulated transactions.
-func (t *TxTracker) LoadFromStore(ctx context.Context, store Store, currentHeight uint64) (int, error) {
-	return t.loadFromStore(ctx, store, currentHeight, loadFromStoreBatchSize)
+// fixed-size batches. The store filters server-side per scan, so peak memory
+// is bounded by the kept set rather than the full history depth — which is
+// what matters at startup on systems with months of accumulated transactions.
+//
+// scan carries the MINED pruning cutoff. Build it with NewTrackerScan so an
+// unknown chain height cannot be mistaken for genesis: a zero height silently
+// disables pruning and loads the entire mined history (issue #276).
+func (t *TxTracker) LoadFromStore(ctx context.Context, st TrackerRowIterator, scan TrackerScan) (LoadStats, error) {
+	return t.loadFromStore(ctx, st, scan, loadFromStoreBatchSize)
 }
 
 // loadFromStore is the batchSize-parameterized form of LoadFromStore so tests
 // can drive the batching boundary without inflating fixture sizes.
-func (t *TxTracker) loadFromStore(ctx context.Context, store statusIterator, currentHeight uint64, batchSize int) (int, error) {
+func (t *TxTracker) loadFromStore(
+	ctx context.Context, st TrackerRowIterator, scan TrackerScan, batchSize int,
+) (LoadStats, error) {
 	if batchSize <= 0 {
 		batchSize = loadFromStoreBatchSize
 	}
@@ -72,7 +89,7 @@ func (t *TxTracker) loadFromStore(ctx context.Context, store statusIterator, cur
 		tx   TrackedTx
 	}
 	batch := make([]kept, 0, batchSize)
-	count := 0
+	stats := LoadStats{}
 
 	flush := func() {
 		if len(batch) == 0 {
@@ -83,39 +100,31 @@ func (t *TxTracker) loadFromStore(ctx context.Context, store statusIterator, cur
 			t.txids[k.hash] = k.tx
 		}
 		t.mu.Unlock()
-		count += len(batch)
+		stats.Loaded += len(batch)
 		batch = batch[:0]
 	}
 
-	err := store.IterateStatusesSince(ctx, time.Time{}, func(status *models.TransactionStatus) error {
-		// Skip terminal outcomes that never need tracking. The tracker exists to
-		// recognize in-flight txids that might still land in a mined subtree; a
-		// REJECTED / DOUBLE_SPEND_ATTEMPTED / IMMUTABLE tx never will. Without
-		// this, hydration loaded the entire terminal history into the map —
-		// REJECTED alone was ~44% of a 5M-row store — and OOM-killed the
-		// api-server at startup. MINED is terminal too but is handled below: it
-		// is retained until deeply confirmed so PruneConfirmed can promote it.
-		if status.Status.IsTerminal() && status.Status != models.StatusMined {
+	err := st.IterateTrackerRows(ctx, scan, func(row TrackerRow) error {
+		stats.Scanned++
+
+		// Re-apply the predicate the store was asked to push down. Backends
+		// may legitimately over-emit (an index that cannot express the height
+		// cutoff), so this is what keeps the kept set exact regardless of how
+		// much of the filter a given backend managed server-side.
+		if !scan.Keep(row.Status, row.BlockHeight) {
+			stats.Skipped++
 			return nil
 		}
 
-		// Skip transactions that are deeply confirmed — these would only be
-		// pruned moments later, so never let them touch the tracker map.
-		if status.Status == models.StatusMined && status.BlockHeight > 0 {
-			if currentHeight >= status.BlockHeight+ConfirmationsRequired {
-				return nil
-			}
-		}
-
-		hash, err := chainhash.NewHashFromHex(status.TxID)
+		hash, err := chainhash.NewHashFromHex(row.TxID)
 		if err != nil {
 			return nil //nolint:nilerr // malformed txid: skip the row, keep loading.
 		}
 		batch = append(batch, kept{
 			hash: *hash,
 			tx: TrackedTx{
-				Status:      status.Status,
-				MinedHeight: status.BlockHeight,
+				Status:      row.Status,
+				MinedHeight: row.BlockHeight,
 			},
 		})
 		if len(batch) >= batchSize {
@@ -127,10 +136,10 @@ func (t *TxTracker) loadFromStore(ctx context.Context, store statusIterator, cur
 		// Surface the error but keep whatever we already merged so the
 		// tracker isn't left empty on a transient store hiccup mid-scan.
 		flush()
-		return count, err
+		return stats, err
 	}
 	flush()
-	return count, nil
+	return stats, nil
 }
 
 // Add adds a txid to the tracker with initial status (hex string)

--- a/store/tracker_test.go
+++ b/store/tracker_test.go
@@ -5,29 +5,43 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 
 	"github.com/bsv-blockchain/arcade/models"
 )
 
-// fakeIterStore is a minimal statusIterator stub that yields a fixed set of
+// fakeIterStore is a minimal TrackerRowIterator stub that yields a fixed set of
 // rows and tracks the maximum number of rows held in memory by the tracker
 // during the scan, so tests can assert peak memory is bounded by batch size
 // rather than total history depth.
+//
+// By default it emits every row WITHOUT applying scan.Keep, modelling the
+// least selective backend the store contract permits (one whose index cannot
+// express the height cutoff). That is deliberately the adversarial case: it
+// exercises the client-side re-check in loadFromStore, which is what keeps the
+// kept set exact no matter how much filtering a backend managed server-side.
+// Set pushdown to model a backend that filters server-side instead.
 type fakeIterStore struct {
-	rows   []*models.TransactionStatus
-	tr     *TxTracker
-	maxLen int
-	yields int
-	err    error
+	rows     []*models.TransactionStatus
+	tr       *TxTracker
+	pushdown bool
+	maxLen   int
+	yields   int
+	err      error
 }
 
-func (f *fakeIterStore) IterateStatusesSince(_ context.Context, _ time.Time, fn func(*models.TransactionStatus) error) error {
+func (f *fakeIterStore) IterateTrackerRows(_ context.Context, scan TrackerScan, fn func(TrackerRow) error) error {
 	for _, r := range f.rows {
+		if f.pushdown && !scan.Keep(r.Status, r.BlockHeight) {
+			continue
+		}
 		f.yields++
-		if err := fn(r); err != nil {
+		if err := fn(TrackerRow{
+			TxID:        r.TxID,
+			Status:      r.Status,
+			BlockHeight: r.BlockHeight,
+		}); err != nil {
 			return err
 		}
 		// Snapshot the tracker map size after each yield. If LoadFromStore
@@ -122,12 +136,12 @@ func TestTxTracker_LoadFromStore_DropsDeeplyConfirmed(t *testing.T) {
 	tracker := NewTxTracker()
 	store := &fakeIterStore{rows: rows, tr: tracker}
 
-	got, err := tracker.loadFromStore(context.Background(), store, currentHeight, 2)
+	stats, err := tracker.loadFromStore(context.Background(), store, NewTrackerScan(currentHeight, true), 2)
 	if err != nil {
 		t.Fatalf("loadFromStore: %v", err)
 	}
-	if got != 2 {
-		t.Fatalf("expected 2 kept rows, got %d", got)
+	if stats.Loaded != 2 {
+		t.Fatalf("expected 2 kept rows, got %d", stats.Loaded)
 	}
 	if tracker.Count() != 2 {
 		t.Fatalf("expected tracker to contain 2 rows, got %d", tracker.Count())
@@ -162,12 +176,12 @@ func TestTxTracker_LoadFromStore_DropsTerminalStatuses(t *testing.T) {
 	tracker := NewTxTracker()
 	store := &fakeIterStore{rows: rows, tr: tracker}
 
-	got, err := tracker.loadFromStore(context.Background(), store, currentHeight, 100)
+	stats, err := tracker.loadFromStore(context.Background(), store, NewTrackerScan(currentHeight, true), 100)
 	if err != nil {
 		t.Fatalf("loadFromStore: %v", err)
 	}
-	if got != 3 {
-		t.Fatalf("expected 3 kept rows, got %d", got)
+	if stats.Loaded != 3 {
+		t.Fatalf("expected 3 kept rows, got %d", stats.Loaded)
 	}
 	for _, drop := range []int{0, 1, 2, 3} {
 		if tracker.Contains(txidHex(drop)) {
@@ -212,18 +226,26 @@ func TestTxTracker_LoadFromStore_BoundedPeakMemory(t *testing.T) {
 	tracker := NewTxTracker()
 	store := &fakeIterStore{rows: rows, tr: tracker}
 
-	got, err := tracker.loadFromStore(context.Background(), store, currentHeight, batchSize)
+	stats, err := tracker.loadFromStore(context.Background(), store, NewTrackerScan(currentHeight, true), batchSize)
 	if err != nil {
 		t.Fatalf("loadFromStore: %v", err)
 	}
-	if got != recentRows {
-		t.Fatalf("expected %d kept rows, got %d", recentRows, got)
+	if stats.Loaded != recentRows {
+		t.Fatalf("expected %d kept rows, got %d", recentRows, stats.Loaded)
 	}
 	if tracker.Count() != recentRows {
 		t.Fatalf("expected tracker count %d, got %d", recentRows, tracker.Count())
 	}
 	if store.yields != oldRows+recentRows {
 		t.Fatalf("expected store to stream %d rows, got %d", oldRows+recentRows, store.yields)
+	}
+	// This fake does no server-side filtering, so every deeply-confirmed row it
+	// emitted must have been rejected by the client-side re-check.
+	if stats.Scanned != oldRows+recentRows {
+		t.Fatalf("expected %d scanned, got %d", oldRows+recentRows, stats.Scanned)
+	}
+	if stats.Skipped != oldRows {
+		t.Fatalf("expected %d skipped by the client-side re-check, got %d", oldRows, stats.Skipped)
 	}
 	// Peak in-tracker count must never exceed what we kept — deeply
 	// confirmed rows are dropped before the map mutation.
@@ -255,12 +277,12 @@ func TestTxTracker_LoadFromStore_FlushesOnBatchBoundary(t *testing.T) {
 	tracker := NewTxTracker()
 	store := &fakeIterStore{rows: rows, tr: tracker}
 
-	got, err := tracker.loadFromStore(context.Background(), store, currentHeight, batchSize)
+	stats, err := tracker.loadFromStore(context.Background(), store, NewTrackerScan(currentHeight, true), batchSize)
 	if err != nil {
 		t.Fatalf("loadFromStore: %v", err)
 	}
-	if got != total {
-		t.Fatalf("expected %d kept rows, got %d", total, got)
+	if stats.Loaded != total {
+		t.Fatalf("expected %d kept rows, got %d", total, stats.Loaded)
 	}
 	if tracker.Count() != total {
 		t.Fatalf("expected tracker count %d, got %d", total, tracker.Count())
@@ -283,13 +305,110 @@ func TestTxTracker_LoadFromStore_PropagatesIterError(t *testing.T) {
 	tracker := NewTxTracker()
 	store := &fakeIterStore{rows: rows, tr: tracker, err: wantErr}
 
-	_, err := tracker.loadFromStore(context.Background(), store, 100, 4)
+	_, err := tracker.loadFromStore(context.Background(), store, NewTrackerScan(100, true), 4)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("expected wrapped error %v, got %v", wantErr, err)
 	}
 	// Even on iter error we should have flushed the rows we already saw.
 	if tracker.Count() != 1 {
 		t.Fatalf("expected partial flush of 1, got %d", tracker.Count())
+	}
+}
+
+func TestTxTracker_LoadFromStore_UnknownHeightKeepsAllMined(t *testing.T) {
+	// The v0.13.0 production condition: no chain height available. Every MINED
+	// row must survive, however deeply confirmed — under-pruning is safe, and
+	// silently pruning against a bogus height would not be.
+	rows := []*models.TransactionStatus{
+		{TxID: txidHex(0), Status: models.StatusMined, BlockHeight: 1},
+		{TxID: txidHex(1), Status: models.StatusMined, BlockHeight: 500_000},
+		{TxID: txidHex(2), Status: models.StatusSeenOnNetwork},
+		// Terminal rows are still dropped: that filter does not depend on height.
+		{TxID: txidHex(3), Status: models.StatusRejected},
+	}
+
+	tracker := NewTxTracker()
+	store := &fakeIterStore{rows: rows, tr: tracker}
+
+	stats, err := tracker.loadFromStore(context.Background(), store, NewTrackerScan(900_000, false), 100)
+	if err != nil {
+		t.Fatalf("loadFromStore: %v", err)
+	}
+	if stats.Loaded != 3 {
+		t.Fatalf("expected 3 kept rows with unknown height, got %d", stats.Loaded)
+	}
+	for _, keep := range []int{0, 1, 2} {
+		if !tracker.Contains(txidHex(keep)) {
+			t.Errorf("txid %d should be kept when the chain height is unknown", keep)
+		}
+	}
+	if tracker.Contains(txidHex(3)) {
+		t.Error("REJECTED must be dropped regardless of height availability")
+	}
+}
+
+func TestTxTracker_LoadFromStore_MinedWithoutHeightSurvivesHighCutoff(t *testing.T) {
+	// A MINED row with no recorded block height cannot be judged deeply
+	// confirmed, so no cutoff may sweep it away. Easy to lose in a
+	// `WHERE block_height >= $cutoff` pushdown.
+	rows := []*models.TransactionStatus{
+		{TxID: txidHex(0), Status: models.StatusMined, BlockHeight: 0},
+	}
+	tracker := NewTxTracker()
+	store := &fakeIterStore{rows: rows, tr: tracker}
+
+	stats, err := tracker.loadFromStore(context.Background(), store, NewTrackerScan(900_000, true), 100)
+	if err != nil {
+		t.Fatalf("loadFromStore: %v", err)
+	}
+	if stats.Loaded != 1 || !tracker.Contains(txidHex(0)) {
+		t.Fatalf("MINED row with block_height 0 must be kept, loaded=%d", stats.Loaded)
+	}
+}
+
+func TestTxTracker_LoadFromStore_PushdownMatchesClientSideFilter(t *testing.T) {
+	// The store contract lets a backend push the predicate down or not. Both
+	// must produce byte-identical tracker contents; only the Scanned/Skipped
+	// counters may differ. This is the in-package half of the anti-drift
+	// guarantee (store/storetest covers the real backends).
+	const currentHeight = uint64(1_000_000)
+	rows := []*models.TransactionStatus{
+		{TxID: txidHex(0), Status: models.StatusMined, BlockHeight: currentHeight - ConfirmationsRequired - 1},
+		{TxID: txidHex(1), Status: models.StatusMined, BlockHeight: currentHeight - 10},
+		{TxID: txidHex(2), Status: models.StatusMined, BlockHeight: 0},
+		{TxID: txidHex(3), Status: models.StatusSeenOnNetwork},
+		{TxID: txidHex(4), Status: models.StatusRejected},
+		{TxID: txidHex(5), Status: models.StatusImmutable, BlockHeight: currentHeight - 5},
+		{TxID: txidHex(6), Status: models.StatusUnknown},
+	}
+	scan := NewTrackerScan(currentHeight, true)
+
+	lax := NewTxTracker()
+	laxStats, err := lax.loadFromStore(context.Background(), &fakeIterStore{rows: rows}, scan, 3)
+	if err != nil {
+		t.Fatalf("lax loadFromStore: %v", err)
+	}
+
+	strict := NewTxTracker()
+	strictStats, err := strict.loadFromStore(context.Background(), &fakeIterStore{rows: rows, pushdown: true}, scan, 3)
+	if err != nil {
+		t.Fatalf("pushdown loadFromStore: %v", err)
+	}
+
+	if laxStats.Loaded != strictStats.Loaded {
+		t.Fatalf("loaded differs: no-pushdown=%d pushdown=%d", laxStats.Loaded, strictStats.Loaded)
+	}
+	for _, r := range rows {
+		if lax.Contains(r.TxID) != strict.Contains(r.TxID) {
+			t.Errorf("txid %s: no-pushdown=%v pushdown=%v", r.TxID, lax.Contains(r.TxID), strict.Contains(r.TxID))
+		}
+	}
+	// The counters are exactly where the two differ.
+	if strictStats.Skipped != 0 {
+		t.Errorf("a pushdown backend should emit nothing Keep rejects, got Skipped=%d", strictStats.Skipped)
+	}
+	if laxStats.Skipped == 0 {
+		t.Error("the no-pushdown fake must exercise the client-side re-check")
 	}
 }
 

--- a/store/trackerscan.go
+++ b/store/trackerscan.go
@@ -1,0 +1,126 @@
+package store
+
+import (
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// TrackerRow is the projection TxTracker hydration needs and nothing more:
+// identity, status, mined height. Passed by value — three fields, no pointer —
+// so backends can emit from a stack local and hydration cannot retain rows.
+//
+// Deliberately not *models.TransactionStatus: a sparse 16-field struct costs a
+// heap allocation per row (millions at startup) and invites a future caller to
+// read a field the store never populated.
+type TrackerRow struct {
+	TxID        string
+	Status      models.Status
+	BlockHeight uint64
+}
+
+// trackerStatuses is the set of statuses the tracker keeps, derived from
+// models.AllStatuses() by one rule so a status added to the models domain is
+// classified here automatically and can never go missing from the store-side
+// filter.
+//
+// Deliberately NOT models.NonTerminalStatuses(): that set omits StatusUnknown,
+// which the pre-#276 hydration filter kept (StatusUnknown.IsTerminal() is
+// false). Deriving from AllStatuses preserves that behavior exactly, and keeps
+// hydration insulated from SSE-driven changes to NonTerminalStatuses.
+var trackerStatuses = func() []models.Status {
+	all := models.AllStatuses()
+	out := make([]models.Status, 0, len(all))
+	for _, s := range all {
+		if !s.IsTerminal() || s == models.StatusMined {
+			out = append(out, s)
+		}
+	}
+	return out
+}()
+
+// trackerStatusSet is the O(1) membership form of trackerStatuses.
+var trackerStatusSet = func() map[models.Status]struct{} {
+	set := make(map[models.Status]struct{}, len(trackerStatuses))
+	for _, s := range trackerStatuses {
+		set[s] = struct{}{}
+	}
+	return set
+}()
+
+// TrackerStatuses returns the statuses IterateTrackerRows implementations must
+// filter on, as a copy so callers cannot mutate the shared set.
+//
+// A row whose status string is outside models.AllStatuses() (a hand-edited row,
+// or a downgrade from a future version) is NOT in this set and is therefore
+// dropped. The pre-#276 filter kept such rows, because !IsTerminal() is true
+// for any unrecognized string. This is a deliberate change: the positive
+// status filter is what makes the query selective, and a status arcade does
+// not know cannot participate in the lattice prefilter anyway — the store
+// remains authoritative for anything the tracker doesn't know about.
+func TrackerStatuses() []models.Status {
+	out := make([]models.Status, len(trackerStatuses))
+	copy(out, trackerStatuses)
+	return out
+}
+
+// TracksStatus reports whether the tracker keeps rows in this status.
+func TracksStatus(s models.Status) bool {
+	_, ok := trackerStatusSet[s]
+	return ok
+}
+
+// TrackerScan parameterizes a hydration scan. The zero value is the safe
+// degraded scan: no height pruning, every MINED row kept.
+type TrackerScan struct {
+	// PruneMinedBelow, when > 0, is the inclusive lower bound on block_height
+	// for MINED rows worth tracking: a MINED row with a nonzero block_height
+	// below this is deeply confirmed and would be pruned moments later.
+	//
+	// Zero means the chain height is unknown, which disables MINED pruning
+	// entirely. That is the degraded mode — safe, but it loads the full mined
+	// history, which is what made api-server take 147s to bind its listener in
+	// v0.13.0 (see NewTrackerScan).
+	PruneMinedBelow uint64
+}
+
+// NewTrackerScan derives the scan from a chain tip height and, crucially,
+// whether that height is KNOWN.
+//
+// The (value, known) pair is taken explicitly because go-chaintracks' GetHeight
+// returns 0 both for genesis and for every failure mode, and callers have
+// twice treated the latter as the former. Passing a bare uint64 here would
+// re-open exactly that hole: a zero would silently mean "genesis", and MINED
+// pruning would appear to work while doing nothing.
+func NewTrackerScan(tipHeight uint64, tipKnown bool) TrackerScan {
+	// tipHeight < ConfirmationsRequired cannot prune anything (no block is
+	// buried deeply enough yet) and would underflow the subtraction below.
+	if !tipKnown || tipHeight < ConfirmationsRequired {
+		return TrackerScan{}
+	}
+	return TrackerScan{PruneMinedBelow: tipHeight - ConfirmationsRequired + 1}
+}
+
+// Statuses returns the status set this scan matches.
+func (s TrackerScan) Statuses() []models.Status { return TrackerStatuses() }
+
+// Keep is the single predicate defining what hydration retains. Store backends
+// push as much of it down into their query or index as they can; the caller
+// re-applies it to every emitted row, so a pushdown that is less selective than
+// Keep is only a performance property, never a correctness one.
+//
+// Equivalent to the pre-#276 inline filter, which skipped terminal-but-not-
+// MINED rows and skipped MINED rows where currentHeight >= blockHeight +
+// ConfirmationsRequired. That inequality rearranges to blockHeight <
+// PruneMinedBelow; store/trackerscan_test.go pins the equivalence across the
+// full status × height × tip cross-product.
+func (s TrackerScan) Keep(status models.Status, blockHeight uint64) bool {
+	if !TracksStatus(status) {
+		return false
+	}
+	// A MINED row with no recorded height cannot be judged deeply confirmed,
+	// so it is always kept — matching the pre-#276 `BlockHeight > 0` guard.
+	if status == models.StatusMined && blockHeight > 0 &&
+		s.PruneMinedBelow > 0 && blockHeight < s.PruneMinedBelow {
+		return false
+	}
+	return true
+}

--- a/store/trackerscan_test.go
+++ b/store/trackerscan_test.go
@@ -1,0 +1,147 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/arcade/models"
+)
+
+// legacyKeep is a literal copy of the pre-#276 hydration filter from
+// loadFromStore, inverted to a keep/skip predicate. It is the oracle proving
+// the TrackerScan refactor is behavior-preserving; do not "simplify" it to
+// call Keep, that would make the test vacuous.
+func legacyKeep(status models.Status, blockHeight, currentHeight uint64) bool {
+	if status.IsTerminal() && status != models.StatusMined {
+		return false
+	}
+	if status == models.StatusMined && blockHeight > 0 {
+		if currentHeight >= blockHeight+ConfirmationsRequired {
+			return false
+		}
+	}
+	return true
+}
+
+func TestTracksStatus_DerivedFromAllStatuses(t *testing.T) {
+	for _, s := range models.AllStatuses() {
+		want := !s.IsTerminal() || s == models.StatusMined
+		if got := TracksStatus(s); got != want {
+			t.Errorf("TracksStatus(%q) = %v, want %v", s, got, want)
+		}
+	}
+
+	// StatusUnknown is the trap: models.NonTerminalStatuses() omits it, but the
+	// pre-#276 filter kept it. Deriving from AllStatuses must preserve that.
+	if !TracksStatus(models.StatusUnknown) {
+		t.Error("StatusUnknown must be tracked (pre-#276 filter kept it)")
+	}
+	for _, s := range []models.Status{
+		models.StatusRejected, models.StatusDoubleSpendAttempted, models.StatusImmutable,
+	} {
+		if TracksStatus(s) {
+			t.Errorf("terminal status %q must not be tracked", s)
+		}
+	}
+	if !TracksStatus(models.StatusMined) {
+		t.Error("MINED must be tracked (retained until deeply confirmed)")
+	}
+}
+
+func TestTrackerStatuses_ReturnsCopy(t *testing.T) {
+	first := TrackerStatuses()
+	if len(first) == 0 {
+		t.Fatal("TrackerStatuses returned empty set")
+	}
+	first[0] = models.Status("MUTATED")
+	if second := TrackerStatuses(); second[0] == models.Status("MUTATED") {
+		t.Fatal("TrackerStatuses leaked the shared backing array")
+	}
+}
+
+func TestTrackerStatuses_ExcludesUnknownStatusStrings(t *testing.T) {
+	// A status string outside the models domain is dropped — the documented
+	// deliberate change from the pre-#276 filter.
+	if TracksStatus(models.Status("SOME_FUTURE_STATUS")) {
+		t.Error("out-of-domain status must not be tracked")
+	}
+}
+
+func TestTrackerScan_MatchesLegacyPredicate(t *testing.T) {
+	// Cross-product over the interesting boundaries: the ConfirmationsRequired
+	// edge (99/100/101), zero, and a realistic mainnet-scale height.
+	heights := []uint64{0, 1, 50, 99, 100, 101, 900_000}
+	tips := []uint64{0, 1, 99, 100, 101, 900_000}
+
+	for _, status := range models.AllStatuses() {
+		for _, tip := range tips {
+			// tipKnown=true is the only regime where the legacy predicate and
+			// the new one are meant to agree: legacy had no way to express
+			// "unknown", it just passed 0.
+			scan := NewTrackerScan(tip, true)
+			for _, h := range heights {
+				want := legacyKeep(status, h, tip)
+				got := scan.Keep(status, h)
+				if got != want {
+					t.Errorf("Keep(status=%s, height=%d, tip=%d) = %v, legacy = %v (PruneMinedBelow=%d)",
+						status, h, tip, got, want, scan.PruneMinedBelow)
+				}
+			}
+		}
+	}
+}
+
+func TestNewTrackerScan_UnknownHeightDisablesPruning(t *testing.T) {
+	for _, tip := range []uint64{0, 1, 100, 900_000} {
+		scan := NewTrackerScan(tip, false)
+		if scan.PruneMinedBelow != 0 {
+			t.Fatalf("NewTrackerScan(%d, false).PruneMinedBelow = %d, want 0", tip, scan.PruneMinedBelow)
+		}
+		// Every MINED row must survive, however old.
+		if !scan.Keep(models.StatusMined, 1) {
+			t.Fatalf("tip=%d unknown: ancient MINED row must be kept", tip)
+		}
+	}
+}
+
+func TestNewTrackerScan_BelowConfirmationsDisablesPruning(t *testing.T) {
+	// Guards the uint64 underflow in tipHeight - ConfirmationsRequired.
+	for _, tip := range []uint64{0, 1, ConfirmationsRequired - 1} {
+		scan := NewTrackerScan(tip, true)
+		if scan.PruneMinedBelow != 0 {
+			t.Fatalf("NewTrackerScan(%d, true).PruneMinedBelow = %d, want 0", tip, scan.PruneMinedBelow)
+		}
+	}
+}
+
+func TestTrackerScan_PruneBoundary(t *testing.T) {
+	const tip = uint64(1000)
+	scan := NewTrackerScan(tip, true) // PruneMinedBelow = 901
+
+	if scan.PruneMinedBelow != 901 {
+		t.Fatalf("PruneMinedBelow = %d, want 901", scan.PruneMinedBelow)
+	}
+	cases := []struct {
+		height uint64
+		keep   bool
+	}{
+		{0, true},    // no recorded height: always kept
+		{1, false},   // ancient
+		{900, false}, // exactly ConfirmationsRequired deep -> pruned
+		{901, true},  // one short of deeply confirmed -> kept
+		{1000, true}, // the tip itself
+	}
+	for _, tc := range cases {
+		if got := scan.Keep(models.StatusMined, tc.height); got != tc.keep {
+			t.Errorf("Keep(MINED, %d) with tip %d = %v, want %v", tc.height, tip, got, tc.keep)
+		}
+	}
+}
+
+func TestTrackerScan_MinedZeroHeightAlwaysKept(t *testing.T) {
+	// A high cutoff must not sweep away MINED rows with no recorded height —
+	// the easy thing to lose in a `WHERE block_height >= $2` pushdown.
+	scan := NewTrackerScan(900_000, true)
+	if !scan.Keep(models.StatusMined, 0) {
+		t.Fatal("MINED at block_height 0 must be kept at any cutoff")
+	}
+}


### PR DESCRIPTION
## What Changed

Two coupled fixes to `TxTracker` hydration.

**A real chain height.** `app.hydrationHeight` resolves the tip via chaintracks' `GetTip` — whose nil return can express "unavailable" — falling back to `store.GetActiveTipBlockHeight`. It returns `(height, known, source)`, and `store.NewTrackerScan(h, known)` refuses to read an unknown height as genesis. `finalityChainReader` becomes `chainReader`, hoisted so one client serves both the finality gate and hydration, and so `DisableFinalityCheck` can no longer suppress hydration's height source.

**A projected store query (#276).** New `store.IterateTrackerRows` — `txid`/`status`/`block_height` only, server-side status filter, MINED height cutoff pushed down, **no `ORDER BY`** — on Postgres, Pebble and Aerospike. `IterateStatusesSince` is untouched; propagation's replay and reaper genuinely need full rows.

New shared conformance suite `store/storetest`, wired into all three backends.

## Why It Was Necessary

api-server pods sat `0/1` for ~150s after every `v0.13.0` deploy, with probes getting `connection refused` — not a 404. The listener binds only after hydration returns:

```
19:42:22.5  starting arcade  mode=api-server
19:45:09.8  tx tracker hydrated  loaded=4477329  current_height=0  elapsed=147.29
19:45:09.8  API server listening  addr=0.0.0.0:8080
```

`modeNeedsChaintracks` excludes `api-server` — correctly, it must not spin up an embedded ChainManager — so `chainTracks` was nil and `hydrateHeight` stayed `0`, and the deeply-confirmed skip never fired. The underlying trap is that `GetHeight` collapses every failure into `0`, indistinguishable from genesis; the in-code comment called height 0 "safe, prunable later", which is true only when chaintracks is merely disabled, not when it is the *only* path a mode ever takes.

Separately, hydration reused `IterateStatusesSince`: 14 columns including `raw_tx`/`merkle_path`/`competing_txs` plus `ORDER BY timestamp_at` over the whole table. On a ~5M-row store that is a seq scan and an external merge sort over detoasted rows on **every boot** — which drove both arcade and its Postgres out of memory (#276).

The pod survived with 2 of 3 liveness failures. One more probe period and it would have restarted before ever binding.

## Testing Performed

End-to-end against a seeded pebble store via the real `api-server` boot path (5040 rows: 2000 deeply-confirmed MINED, 3000 REJECTED, 25 recent MINED, 15 in-flight):

| | scanned | loaded |
|---|---|---|
| No height available | 2040 | 2040 |
| Store-sourced tip | **40** | **40** |

126× fewer rows off the wire, `skipped=0` (zero pushdown drift) — and the height came from the store fallback with **no chaintracks at all**, which is exactly the microservice case that was broken.

- `go build ./...`, `go vet ./...` — clean
- `go test ./...` — 31 packages pass
- `go test -race ./store/... ./app/...` — clean
- `go test -tags=postgres ./store/postgres/...` — passes against a real database, including a plan guard asserting no `Sort` node and no heavy columns in the hydration query
- `golangci-lint run` — 0 issues
- `store/trackerscan_test.go` pins `TrackerScan.Keep` against a literal copy of the pre-change predicate across the full status × height × tip cross-product, so the refactor is provably behaviour-preserving

Not run: `-tags=integration` (Aerospike) — needs a live instance. **No CI workflow passes `-tags=postgres` or `-tags=integration`, so the backend that caused the outage has no automated coverage.** Worth a follow-up CI job; until then the tagged runs are a manual pre-merge gate.

Pre-existing and unrelated: `logfields` `TestNoCanonicalKeyLiteralsOutsidePackage` reports 186 findings, all inside the gitignored `.claude/worktrees/` old-branch checkouts. Filtering those leaves zero.

## Impact / Risk

The new risk is the SQL filter drifting from the Go filter. Designed against directly: `TrackerScan.Keep` is the specification and the query is only a pushdown of it, and the tracker re-applies `Keep` to every emitted row. Over-emission is therefore a performance bug; under-emission is the only correctness bug, and `store/storetest`'s `ExactAgreement` subtest asserts set equality on all three backends. A nonzero `skipped` counter in the hydration log is the production drift signal.

**One behaviour change to review:** a row whose status string is outside `models.AllStatuses()` was kept before (`!IsTerminal()` is true for unknown strings) and is now dropped, because the positive `status = ANY(...)` filter is what makes the query selective. Safe — the tracker is only a prefilter and the store lattice stays authoritative — but it is a real semantic change. Note the status set is derived from `AllStatuses()`, **not** `NonTerminalStatuses()`, which omits `StatusUnknown` that the old filter kept.

**No `schema.sql` change.** That file runs in one transaction so `CREATE INDEX CONCURRENTLY` is banned there, and any byte change re-runs all DDL fleet-wide. The optional composite index is an operator runbook step in `docs/observability.md`, with the `indisvalid` check — an interrupted `CONCURRENTLY` build leaves an INVALID index a later `IF NOT EXISTS` silently skips.

**This does not close the structural exposure.** The listener still binds only after `Bootstrap`, which also contains a 5-minute schema-apply budget, Aerospike index builds and Kafka checks. This shrinks the window to seconds; #315 covers closing it, and also records that `cmd/arcade/main.go` never starts a health listener for api-server — so `deploy/api-server.yaml`'s probes on port 8081 can never pass (production is unaffected only because the live flux manifests probe 8080).

Rollout is safe in either order: with no height the behaviour degrades to exactly today's (keep every MINED row), just with the terminal rows no longer crossing the wire.

Refs #276, #315

## Notifications
- @galt-tr

https://claude.ai/code/session_01K8pDVtifV8xhKfhEya8wcJ
