### PR TITLE
test(teranode): stop probing before asserting the breaker tripped

### DIFF
--- a/teranode/health_test.go
+++ b/teranode/health_test.go
@@ -430,13 +430,30 @@ func TestProbe_HealthySuccess_DoesNotResetBroadcastCounter(t *testing.T) {
 	c.Start(ctx)
 	defer c.Close()
 
-	for i := 0; i < 5; i++ {
-		// Several probe intervals pass between failures; each probe succeeds
-		// against the live server. If probe success reset the broadcast
-		// counter, the threshold could never be reached.
+	// Accumulate every failure but the last with the probe loop running. Several
+	// probe intervals pass between failures and each probe succeeds against the
+	// live server, so if probe success reset the broadcast counter it would
+	// never reach the threshold and the final failure below would not trip.
+	// That interference is the whole point of the test.
+	for i := 0; i < 4; i++ {
 		time.Sleep(15 * time.Millisecond)
 		c.RecordBroadcastFailure(srv.URL)
 	}
+
+	// Stop probing before the failure that trips the breaker. A probe success
+	// against an unhealthy endpoint legitimately restores it (recordProbeSuccess
+	// treats one good probe as full recovery), so with the loop still running
+	// the assertion is racing a 5ms ticker: locally the endpoint is still
+	// unhealthy microseconds later, but on a loaded runner a probe lands in the
+	// gap and GetHealthyEndpoints reports it healthy again. Closing first makes
+	// the outcome depend only on the counters, never on scheduling. Close
+	// cancels the probe context and waits for the goroutine to exit, so there is
+	// no in-flight probe left; the deferred Close then waits on an already
+	// closed channel, which is fine.
+	c.Close()
+
+	c.RecordBroadcastFailure(srv.URL)
+
 	if got := len(c.GetHealthyEndpoints()); got != 0 {
 		t.Fatal("slow-track breaker did not trip: probe successes must not reset consecutiveBroadcastFailures")
 	}
@@ -461,10 +478,19 @@ func TestProbe_HealthySuccess_DoesNotResetReachabilityCounter(t *testing.T) {
 	c.Start(ctx)
 	defer c.Close()
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 2; i++ {
 		time.Sleep(15 * time.Millisecond)
 		c.RecordFailure(srv.URL)
 	}
+
+	// Same reasoning as the slow-track sibling above: the probe successes that
+	// must not reset the counter have already happened, so stop probing before
+	// the failure that trips the breaker and the assertion cannot race a
+	// recovering probe.
+	c.Close()
+
+	c.RecordFailure(srv.URL)
+
 	if got := len(c.GetHealthyEndpoints()); got != 0 {
 		t.Fatal("fast-track breaker did not trip: probe successes must not reset consecutiveFailures")
 	}


### PR DESCRIPTION
## The flake

`TestProbe_HealthySuccess_DoesNotResetBroadcastCounter` and its fast-track sibling `TestProbe_HealthySuccess_DoesNotResetReachabilityCounter` fail intermittently on loaded CI runners:

```
❌ TestProbe_HealthySuccess_DoesNotResetBroadcastCounter (teranode)
   → slow-track breaker did not trip: probe successes must not reset consecutiveBroadcastFailures
```

## Why

Both tests record every failure needed to trip the breaker while a **5 ms** probe loop runs against a live server answering 200, then *immediately* assert the endpoint is no longer healthy.

But a probe success against an **unhealthy** endpoint legitimately restores it — `recordProbeSuccess` (`teranode/client.go:546`) treats a single good probe as full recovery:

```go
if h.state == stateUnhealthy {
    h.consecutiveFailures = 0
    h.consecutiveBroadcastFailures = 0
    h.consecutiveProbeFailures = 0
    h.state = stateHealthy
    ...
```

So the assertion is racing the ticker. Locally the endpoint is still unhealthy microseconds after the trip and the tests pass. On a contended runner the test goroutine can be descheduled long enough for a probe to land in the gap between the tripping failure and `GetHealthyEndpoints()` — and the endpoint is healthy again.

Reproduced deterministically by inserting a 20 ms sleep between the last recorded failure and the assertion: both tests then fail with exactly the CI message. This is a defect in the tests, not in the production recovery behaviour, which is intended and separately pinned by `TestRecordProbeCounters_UnitSemantics`.

## The fix

Accumulate all failures **but the last** with the probe loop running — that interleaving is the interference these tests exist to rule out, and it is fully preserved — then `Close()` the client and record the tripping failure.

`Close()` cancels the probe context and waits for the goroutine to exit, so no probe can run between the trip and the assertion. The outcome now depends only on the counters, never on scheduling. The already-deferred `Close()` then waits on a closed channel, which is safe.

Test-only change; no production code touched.

## Verification

Both directions, because a flake fix that neuters the test is worse than the flake:

- **Timing independence** — with 30 ms sleeps injected on *either side* of `Close()` (the exact hiccup that reproduced the failure), both tests pass **30/30**.
- **Still has teeth** — with the regression they guard against injected into `recordProbeSuccess` (zeroing `consecutiveFailures` and `consecutiveBroadcastFailures` on a healthy probe), both tests **fail**.

Plus `go build ./...`, `go vet`, `go test ./teranode/ -count=3`, `go test -race ./teranode/ -count=2`, `golangci-lint run ./teranode/...` — all clean.

Found while investigating CI on #314, which this was blocking.