### PR TITLE
feat(health): report each datahub endpoint's advertised policy

### DIFF
--- a/openapi/arcade.openapi.yaml
+++ b/openapi/arcade.openapi.yaml
@@ -106,6 +106,17 @@ paths:
                 blockHeight: 958779
                 datahub_urls:
                   - url: https://datahub.example.com
+                    source: discovered
+                    healthy: true
+                    policy:
+                      miningFee:
+                        satoshis: 100
+                        bytes: 1000
+                      maxtxsizepolicy: 100000000
+                      maxscriptsizepolicy: 500000
+                      maxtxsigopscountspolicy: 4294967295
+                  - url: https://seeded.example.com
+                    source: configured
                     healthy: true
 
   /ready:
@@ -1486,8 +1497,50 @@ components:
       properties:
         url:
           type: string
+        source:
+          type: string
+          enum: [configured, discovered]
+          description: >-
+            How the endpoint entered the registry: seeded from static config, or
+            discovered at runtime from a peer's node_status announcement.
+          example: discovered
         healthy:
           type: boolean
+        policy:
+          allOf:
+            - $ref: "#/components/schemas/EndpointPolicy"
+          description: >-
+            The transaction policy this node advertised when it registered the
+            URL — what this specific endpoint will accept, as opposed to the
+            single network-wide policy arcade enforces and GET /policy reports.
+            Absent for an endpoint no node_status has announced (a statically
+            configured URL, typically) or whose node predates fee_policy.
+
+    EndpointPolicy:
+      type: object
+      description: >-
+        Transaction policy advertised by a single Teranode endpoint. Field names
+        match the GET /policy document so both surfaces read the same way;
+        standardFormatSupported is absent because it is an ARC transport flag,
+        not something a peer advertises.
+      properties:
+        miningFee:
+          $ref: "#/components/schemas/FeeAmount"
+        maxtxsizepolicy:
+          type: integer
+          format: int64
+          description: Maximum transaction size in bytes this endpoint accepts.
+          example: 100000000
+        maxscriptsizepolicy:
+          type: integer
+          format: int64
+          description: Maximum script size in bytes this endpoint accepts.
+          example: 500000
+        maxtxsigopscountspolicy:
+          type: integer
+          format: int64
+          description: Maximum sigops per transaction this endpoint accepts.
+          example: 4294967295
 
     FeeAmount:
       type: object

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/bsv-blockchain/arcade/logfields"
 	"github.com/bsv-blockchain/arcade/metrics"
 	"github.com/bsv-blockchain/arcade/models"
+	"github.com/bsv-blockchain/arcade/store"
 	"github.com/bsv-blockchain/arcade/telemetry"
 	"github.com/bsv-blockchain/arcade/teranode"
 	"github.com/bsv-blockchain/arcade/version"
@@ -199,11 +200,54 @@ func RenderDocs(w io.Writer) error {
 // route around it (issue #254). Omitted (0) when no store is wired or the
 // height has never been readable.
 type healthResponse struct {
-	Healthy     bool                      `json:"healthy"`
-	Version     string                    `json:"version"`
-	Status      string                    `json:"status"`
-	BlockHeight uint64                    `json:"blockHeight,omitempty"`
-	DatahubURLs []teranode.EndpointStatus `json:"datahub_urls"`
+	Healthy     bool            `json:"healthy"`
+	Version     string          `json:"version"`
+	Status      string          `json:"status"`
+	BlockHeight uint64          `json:"blockHeight,omitempty"`
+	DatahubURLs []datahubStatus `json:"datahub_urls"`
+}
+
+// datahubStatus is one entry of health.datahub_urls: the circuit-breaker view
+// of an endpoint, plus the transaction policy that node advertised when it
+// registered the URL.
+//
+// teranode.EndpointStatus is embedded rather than copied so url/source/healthy
+// keep their exact position and spelling in the JSON — existing health checkers
+// and ARC clients parse this, and policy is purely additive.
+//
+// Policy answers "what will this specific endpoint accept", which
+// GET /policy cannot: that reports the single network-wide policy arcade
+// enforces, so when a broadcast is refused on policy grounds this is what
+// identifies the strict node. Absent for an endpoint no node_status has
+// announced — a statically configured URL, typically — or one whose node
+// predates fee_policy.
+type datahubStatus struct {
+	teranode.EndpointStatus
+
+	Policy *endpointPolicyView `json:"policy,omitempty"`
+}
+
+// endpointPolicyView renders an advertised policy in the same vocabulary as
+// GET /policy (models.Policy), minus standardFormatSupported, which is an ARC
+// transport flag rather than something a peer advertises. Operators reading
+// both endpoints see one set of names.
+type endpointPolicyView struct {
+	MiningFee               models.FeeAmount `json:"miningFee"`
+	MaxTxSizePolicy         uint64           `json:"maxtxsizepolicy"`
+	MaxScriptSizePolicy     uint64           `json:"maxscriptsizepolicy"`
+	MaxTxSigopsCountsPolicy uint64           `json:"maxtxsigopscountspolicy"`
+}
+
+func endpointPolicyViewFrom(p *store.EndpointPolicy) *endpointPolicyView {
+	if p == nil {
+		return nil
+	}
+	return &endpointPolicyView{
+		MiningFee:               models.FeeAmount{Satoshis: p.MiningFeeSatoshis, Bytes: p.MiningFeeBytes},
+		MaxTxSizePolicy:         p.MaxTxSizePolicy,
+		MaxScriptSizePolicy:     p.MaxScriptSizePolicy,
+		MaxTxSigopsCountsPolicy: p.MaxTxSigopsCountsPolicy,
+	}
 }
 
 // healthTipTTL bounds how often /health re-reads the store's active tip
@@ -236,16 +280,70 @@ func (s *Server) activeTipHeight(ctx context.Context) uint64 {
 	return h
 }
 
+// endpointPolicies returns the advertised policy for each registered datahub
+// URL, keyed by normalized URL, cached for healthTipTTL on the same terms as
+// activeTipHeight: /health is probed every few seconds per replica and this is
+// a full-registry read. Never fails the probe — on a store error it serves the
+// last known map and the next probe retries.
+func (s *Server) endpointPolicies(ctx context.Context) map[string]*store.EndpointPolicy {
+	if s.store == nil {
+		return nil
+	}
+	s.policyMu.Lock()
+	defer s.policyMu.Unlock()
+	if time.Since(s.policyFetchedAt) < healthTipTTL {
+		return s.policyByURL
+	}
+	eps, err := s.store.ListDatahubEndpoints(ctx, s.cfg.Network)
+	if err != nil {
+		s.logger.Debug("health endpoint-policy read failed", zap.Error(err))
+		return s.policyByURL
+	}
+	byURL := make(map[string]*store.EndpointPolicy, len(eps))
+	for _, ep := range eps {
+		if ep.Policy != nil {
+			byURL[normalizeEndpointURL(ep.URL)] = ep.Policy
+		}
+	}
+	s.policyByURL = byURL
+	s.policyFetchedAt = time.Now()
+	return s.policyByURL
+}
+
+// normalizeEndpointURL keys a URL the same way on both sides of the policy
+// join. It has to exist because the two sides are normalized differently
+// upstream: teranode.Client trims a trailing slash off every endpoint it
+// registers, while the store holds discovered URLs already normalized by
+// validateURL but statically configured ones exactly as they appear in config.
+// A seed URL written with a trailing slash therefore keys as "https://x/" in
+// the store and "https://x" in the client, and that endpoint's policy would
+// silently vanish from /health.
+//
+// Applied to both sides rather than just the store so the two cannot diverge
+// on anything else either — trimming one side only would reintroduce the same
+// class of miss for leading whitespace.
+func normalizeEndpointURL(u string) string {
+	return strings.TrimSuffix(strings.TrimSpace(u), "/")
+}
+
 func (s *Server) handleHealth(c *gin.Context) {
 	resp := healthResponse{
 		Healthy:     true,
 		Version:     version.Version,
 		Status:      "ok",
 		BlockHeight: s.activeTipHeight(c.Request.Context()),
-		DatahubURLs: []teranode.EndpointStatus{},
+		DatahubURLs: []datahubStatus{},
 	}
 	if s.teranode != nil {
-		resp.DatahubURLs = s.teranode.GetEndpointStatuses()
+		statuses := s.teranode.GetEndpointStatuses()
+		policies := s.endpointPolicies(c.Request.Context())
+		resp.DatahubURLs = make([]datahubStatus, 0, len(statuses))
+		for _, st := range statuses {
+			resp.DatahubURLs = append(resp.DatahubURLs, datahubStatus{
+				EndpointStatus: st,
+				Policy:         endpointPolicyViewFrom(policies[normalizeEndpointURL(st.URL)]),
+			})
+		}
 	}
 	c.JSON(http.StatusOK, resp)
 }

--- a/services/api_server/handlers_health_test.go
+++ b/services/api_server/handlers_health_test.go
@@ -13,8 +13,14 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/bsv-blockchain/arcade/config"
+	"github.com/bsv-blockchain/arcade/store"
 	"github.com/bsv-blockchain/arcade/teranode"
 	"github.com/bsv-blockchain/arcade/version"
+)
+
+const (
+	testDatahubA = "https://a.example"
+	testDatahubB = "https://b.example"
 )
 
 // healthResp mirrors the server's healthResponse shape but uses generic
@@ -52,13 +58,13 @@ func doHealth(t *testing.T, srv *Server) (int, healthResp, []byte) {
 
 func TestHandleHealth_StructuredResponse(t *testing.T) {
 	tc := teranode.NewClient(
-		[]string{"https://a.example", "https://b.example"},
+		[]string{testDatahubA, testDatahubB},
 		"",
 		teranode.HealthConfig{FailureThreshold: 2},
 	)
 	tc.AddEndpoints([]string{"https://c.example"})
-	tc.RecordFailure("https://b.example")
-	tc.RecordFailure("https://b.example") // trip
+	tc.RecordFailure(testDatahubB)
+	tc.RecordFailure(testDatahubB) // trip
 
 	srv := &Server{
 		cfg:      &config.Config{},
@@ -82,8 +88,8 @@ func TestHandleHealth_StructuredResponse(t *testing.T) {
 	}
 
 	want := []teranode.EndpointStatus{
-		{URL: "https://a.example", Source: "configured", Healthy: true},
-		{URL: "https://b.example", Source: "configured", Healthy: false},
+		{URL: testDatahubA, Source: "configured", Healthy: true},
+		{URL: testDatahubB, Source: "configured", Healthy: false},
 		{URL: "https://c.example", Source: "discovered", Healthy: true},
 	}
 	if len(resp.DatahubURLs) != len(want) {
@@ -206,4 +212,204 @@ func TestHandleHealth_UnreachableEndpointFlipsUnhealthy(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatal("/health kept reporting an unreachable endpoint as healthy for 2s")
+}
+
+// endpointPolicyResp mirrors the policy block of a datahub_urls entry using
+// generic types, for the same reason healthResp does.
+type endpointPolicyResp struct {
+	MiningFee struct {
+		Satoshis uint64 `json:"satoshis"`
+		Bytes    uint64 `json:"bytes"`
+	} `json:"miningFee"`
+	MaxTxSizePolicy         uint64 `json:"maxtxsizepolicy"`
+	MaxScriptSizePolicy     uint64 `json:"maxscriptsizepolicy"`
+	MaxTxSigopsCountsPolicy uint64 `json:"maxtxsigopscountspolicy"`
+}
+
+// datahubResp is one datahub_urls entry as a client sees it: the long-standing
+// url/source/healthy triple, plus the optional advertised policy.
+type datahubResp struct {
+	URL     string              `json:"url"`
+	Source  string              `json:"source"`
+	Healthy bool                `json:"healthy"`
+	Policy  *endpointPolicyResp `json:"policy"`
+}
+
+// doHealthDatahubs runs a probe and decodes only the datahub_urls array, so
+// these tests are independent of the rest of the health envelope.
+func doHealthDatahubs(t *testing.T, srv *Server) []datahubResp {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	srv.registerRoutes(r)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	var resp struct {
+		DatahubURLs []datahubResp `json:"datahub_urls"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decoding health JSON: %v (body=%s)", err, w.Body.String())
+	}
+	return resp.DatahubURLs
+}
+
+func advertisedPolicy() *store.EndpointPolicy {
+	return &store.EndpointPolicy{
+		MiningFeeSatoshis: 100, MiningFeeBytes: 1000,
+		MaxTxSizePolicy: 100_000_000, MaxScriptSizePolicy: 500_000,
+		MaxTxSigopsCountsPolicy: 4_294_967_295,
+	}
+}
+
+// TestHandleHealth_ReportsAdvertisedPolicy is the operator-facing end of the
+// chain: a node's node_status policy reaches the registry, and /health reports
+// it against that node's endpoint. GET /policy can only report the single
+// network-wide policy arcade enforces, so this is what identifies which node
+// refused an oversized transaction.
+func TestHandleHealth_ReportsAdvertisedPolicy(t *testing.T) {
+	ms := &mockStore{datahubEndpoints: []store.DatahubEndpoint{
+		{URL: testDatahubA, Network: config.NetworkMainnet, Policy: advertisedPolicy()},
+		// Registered with a trailing slash — as a statically configured seed
+		// URL is, since config values are stored verbatim while the teranode
+		// client trims them. The two sides must still join, or this endpoint's
+		// policy silently vanishes from the response.
+		{URL: "https://c.example/", Network: config.NetworkMainnet, Policy: &store.EndpointPolicy{MaxTxSizePolicy: 7}},
+		// A seeded URL nobody has announced carries no policy.
+		{URL: testDatahubB, Network: config.NetworkMainnet},
+	}}
+	tc := teranode.NewClient([]string{testDatahubA, testDatahubB}, "", teranode.HealthConfig{})
+	tc.AddEndpoints([]string{"https://c.example"})
+
+	srv := &Server{
+		cfg:      &config.Config{Network: config.NetworkMainnet},
+		logger:   zap.NewNop(),
+		store:    ms,
+		teranode: tc,
+	}
+
+	got := doHealthDatahubs(t, srv)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 endpoints, got %d: %+v", len(got), got)
+	}
+
+	byURL := map[string]datahubResp{}
+	for _, d := range got {
+		byURL[d.URL] = d
+	}
+
+	a := byURL[testDatahubA]
+	if a.Policy == nil {
+		t.Fatal("a.example lost its advertised policy")
+	}
+	if a.Policy.MiningFee.Satoshis != 100 || a.Policy.MiningFee.Bytes != 1000 {
+		t.Errorf("miningFee = %+v, want {100 1000}", a.Policy.MiningFee)
+	}
+	if a.Policy.MaxTxSizePolicy != 100_000_000 || a.Policy.MaxScriptSizePolicy != 500_000 {
+		t.Errorf("sizes = {%d %d}, want {100000000 500000}",
+			a.Policy.MaxTxSizePolicy, a.Policy.MaxScriptSizePolicy)
+	}
+	if a.Policy.MaxTxSigopsCountsPolicy != 4_294_967_295 {
+		t.Errorf("sigops = %d, want 4294967295", a.Policy.MaxTxSigopsCountsPolicy)
+	}
+
+	if p := byURL["https://c.example"].Policy; p == nil || p.MaxTxSizePolicy != 7 {
+		t.Errorf("trailing-slash URL failed to join: %+v", p)
+	}
+	if p := byURL[testDatahubB].Policy; p != nil {
+		t.Errorf("an unannounced endpoint must carry no policy, got %+v", *p)
+	}
+
+	// The pre-existing keys are untouched — ARC clients and health checkers
+	// parse these, and policy is purely additive.
+	if a.Source != "configured" || !a.Healthy {
+		t.Errorf("url/source/healthy changed shape: %+v", a)
+	}
+}
+
+// TestHandleHealth_PolicyOmittedNotNulled pins the wire shape: an endpoint with
+// no advertised policy omits the key rather than emitting "policy": null, so a
+// client can distinguish "not advertised" without a null check.
+func TestHandleHealth_PolicyOmittedNotNulled(t *testing.T) {
+	ms := &mockStore{datahubEndpoints: []store.DatahubEndpoint{
+		{URL: testDatahubA, Network: config.NetworkMainnet},
+	}}
+	srv := &Server{
+		cfg:      &config.Config{Network: config.NetworkMainnet},
+		logger:   zap.NewNop(),
+		store:    ms,
+		teranode: teranode.NewClient([]string{testDatahubA}, "", teranode.HealthConfig{}),
+	}
+
+	_, _, body := doHealth(t, srv)
+	if strings.Contains(string(body), "policy") {
+		t.Errorf("expected the policy key omitted entirely, body=%s", string(body))
+	}
+}
+
+// TestHandleHealth_PolicyReadIsCachedAndNeverFailsTheProbe covers the two
+// properties the store read has to have on a liveness path: probes arrive every
+// few seconds per replica, so the registry is read once per TTL rather than per
+// probe; and a store failure serves the last known policies rather than
+// blanking them or failing the probe.
+func TestHandleHealth_PolicyReadIsCachedAndNeverFailsTheProbe(t *testing.T) {
+	ms := &mockStore{datahubEndpoints: []store.DatahubEndpoint{
+		{URL: testDatahubA, Network: config.NetworkMainnet, Policy: advertisedPolicy()},
+	}}
+	srv := &Server{
+		cfg:      &config.Config{Network: config.NetworkMainnet},
+		logger:   zap.NewNop(),
+		store:    ms,
+		teranode: teranode.NewClient([]string{testDatahubA}, "", teranode.HealthConfig{}),
+	}
+
+	if got := doHealthDatahubs(t, srv); got[0].Policy == nil {
+		t.Fatal("first probe reported no policy")
+	}
+	// A second probe inside the TTL must serve the cached map.
+	if got := doHealthDatahubs(t, srv); got[0].Policy == nil {
+		t.Fatal("cached probe reported no policy")
+	}
+	ms.mu.Lock()
+	calls := ms.datahubCalls
+	ms.mu.Unlock()
+	if calls != 1 {
+		t.Errorf("expected 1 registry read across 2 probes (TTL cache), got %d", calls)
+	}
+
+	// Force the failure path: expire the cache, then break the store.
+	srv.policyMu.Lock()
+	srv.policyFetchedAt = time.Time{}
+	srv.policyMu.Unlock()
+	ms.mu.Lock()
+	ms.datahubErr = errTest
+	ms.mu.Unlock()
+
+	got := doHealthDatahubs(t, srv)
+	if len(got) != 1 {
+		t.Fatalf("a store error must not change the endpoint list, got %+v", got)
+	}
+	if got[0].Policy == nil {
+		t.Error("a store error must serve the last known policy, not blank it")
+	}
+}
+
+// TestHandleHealth_NoStoreOmitsPolicy covers the struct-literal server with no
+// store wired: endpoints are still listed, just without policies.
+func TestHandleHealth_NoStoreOmitsPolicy(t *testing.T) {
+	srv := &Server{
+		cfg:      &config.Config{Network: config.NetworkMainnet},
+		logger:   zap.NewNop(),
+		teranode: teranode.NewClient([]string{testDatahubA}, "", teranode.HealthConfig{}),
+	}
+
+	got := doHealthDatahubs(t, srv)
+	if len(got) != 1 || got[0].URL != testDatahubA {
+		t.Fatalf("expected the endpoint still listed, got %+v", got)
+	}
+	if got[0].Policy != nil {
+		t.Errorf("expected no policy without a store, got %+v", *got[0].Policy)
+	}
 }

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -42,6 +42,13 @@ import (
 type mockStore struct {
 	store.Store
 
+	// datahubEndpoints backs ListDatahubEndpoints, which /health reads to
+	// report each endpoint's advertised policy; datahubCalls counts the reads
+	// so the TTL cache can be asserted, and datahubErr forces the failure path.
+	datahubEndpoints []store.DatahubEndpoint
+	datahubCalls     int
+	datahubErr       error
+
 	mu                  sync.Mutex
 	updateStatusCalls   []*models.TransactionStatus
 	stumps              map[string]*models.Stump
@@ -279,7 +286,13 @@ func (m *mockStore) UpsertDatahubEndpoint(context.Context, store.DatahubEndpoint
 }
 
 func (m *mockStore) ListDatahubEndpoints(context.Context, string) ([]store.DatahubEndpoint, error) {
-	return nil, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.datahubCalls++
+	if m.datahubErr != nil {
+		return nil, m.datahubErr
+	}
+	return m.datahubEndpoints, nil
 }
 
 func (m *mockStore) UpsertPeerPolicy(context.Context, store.PeerPolicy) error {

--- a/services/api_server/policy_refresher_test.go
+++ b/services/api_server/policy_refresher_test.go
@@ -19,7 +19,7 @@ func newPolicyServer(ms *mockStore) *Server {
 
 func newPolicyServerWithConfig(ms *mockStore, vcfg config.ValidatorConfig) *Server {
 	return &Server{
-		cfg:       &config.Config{Network: "mainnet", Validator: vcfg},
+		cfg:       &config.Config{Network: config.NetworkMainnet, Validator: vcfg},
 		logger:    zap.NewNop(),
 		store:     ms,
 		validator: validator.NewValidator(nil), // starts at the built-in defaults

--- a/services/api_server/policy_routes_test.go
+++ b/services/api_server/policy_routes_test.go
@@ -20,7 +20,7 @@ var errTest = errors.New("policy test: store failure")
 func setupPolicyServer(ms *mockStore, vcfg config.ValidatorConfig, val *validator.Validator) (*Server, *gin.Engine) {
 	gin.SetMode(gin.TestMode)
 	srv := &Server{
-		cfg:       &config.Config{Network: "mainnet", Validator: vcfg},
+		cfg:       &config.Config{Network: config.NetworkMainnet, Validator: vcfg},
 		logger:    zap.NewNop(),
 		store:     ms,
 		validator: val,

--- a/services/api_server/routes.go
+++ b/services/api_server/routes.go
@@ -67,9 +67,9 @@ var routeDocs = []RouteDoc{
 		Method:         "GET",
 		Path:           "/health",
 		Summary:        "Liveness probe",
-		Description:    "Reports liveness of the API server process and the upstream Datahub endpoints it depends on. Suitable as a Kubernetes liveness probe. blockHeight is this instance's processed chain-tip height — a freshness signal (datahub_urls[].healthy is reachability-only), letting clients detect a stale chain view and route around it.",
+		Description:    "Reports liveness of the API server process and the upstream Datahub endpoints it depends on. Suitable as a Kubernetes liveness probe. blockHeight is this instance's processed chain-tip height — a freshness signal (datahub_urls[].healthy is reachability-only), letting clients detect a stale chain view and route around it. Each datahub_urls entry also carries the transaction policy that node advertised, so a policy rejection can be traced to the endpoint that enforced it; policy is absent for endpoints no node_status has announced.",
 		ResponseStatus: "200 OK",
-		ResponseBody:   "{\n  \"healthy\": true,\n  \"version\": \"v0.8.0\",\n  \"status\": \"ok\",\n  \"blockHeight\": 958779,\n  \"datahub_urls\": [\n    { \"url\": \"https://...\", \"healthy\": true }\n  ]\n}",
+		ResponseBody:   "{\n  \"healthy\": true,\n  \"version\": \"v0.8.0\",\n  \"status\": \"ok\",\n  \"blockHeight\": 958779,\n  \"datahub_urls\": [\n    {\n      \"url\": \"https://...\",\n      \"source\": \"discovered\",\n      \"healthy\": true,\n      \"policy\": {\n        \"miningFee\": { \"satoshis\": 100, \"bytes\": 1000 },\n        \"maxtxsizepolicy\": 100000000,\n        \"maxscriptsizepolicy\": 500000,\n        \"maxtxsigopscountspolicy\": 4294967295\n      }\n    }\n  ]\n}",
 	},
 	{
 		Method:         "GET",

--- a/services/api_server/server.go
+++ b/services/api_server/server.go
@@ -75,6 +75,14 @@ type Server struct {
 	tipMu        sync.Mutex
 	tipHeight    uint64
 	tipFetchedAt time.Time
+
+	// policyMu/policyByURL/policyFetchedAt cache the per-endpoint advertised
+	// policies /health reports alongside each datahub URL (see
+	// endpointPolicies), on the same TTL and for the same reason as the tip
+	// height above: one registry read per TTL rather than one per probe.
+	policyMu        sync.Mutex
+	policyByURL     map[string]*store.EndpointPolicy
+	policyFetchedAt time.Time
 }
 
 // submissionRecord is the in-memory payload the async recorder consumes.

--- a/services/p2p_client/client.go
+++ b/services/p2p_client/client.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"sync"
 	"time"
@@ -320,9 +319,13 @@ func (c *Client) handleNodeStatus(ctx context.Context, msg teranodep2p.NodeStatu
 	}
 	upsertCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	err := c.store.UpsertDatahubEndpoint(upsertCtx, store.DatahubEndpoint{
-		URL:      normalized,
-		Network:  c.cfg.Network,
-		Source:   store.DatahubEndpointSourceDiscovered,
+		URL:     normalized,
+		Network: c.cfg.Network,
+		Source:  store.DatahubEndpointSourceDiscovered,
+		// The node's advertised policy travels with its URL so GET /health can
+		// report, per endpoint, what that node will accept. nil when the peer
+		// advertised none, which leaves any previously recorded policy alone.
+		Policy:   endpointPolicyFrom(msg),
 		LastSeen: time.Now(),
 	})
 	cancel()
@@ -358,21 +361,17 @@ func (c *Client) recordPeerPolicy(ctx context.Context, msg teranodep2p.NodeStatu
 		maxTxSize = msg.FeePolicy.MaxTxSizePolicy
 		maxScriptSize = msg.FeePolicy.MaxScriptSizePolicy
 	case msg.MinMiningTxFee != nil:
-		// BSV/kB -> satoshis per 1000 bytes (1 BSV = 1e8 satoshis). Validate the
-		// untrusted float before converting: a malformed/malicious node_status
-		// could carry NaN/Inf/negative or an absurd magnitude, which uint64()
-		// would turn into a wrapped garbage value that pollutes metrics and the
-		// int64-backed store columns. Drop such advertisements.
-		f := *msg.MinMiningTxFee
-		v := math.Round(f * 1e8)
-		if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 || v > math.MaxInt64 {
+		// BSV/kB -> satoshis per 1000 bytes. The conversion rejects an
+		// untrusted NaN/Inf/negative/absurd value; see legacyMiningFeeSatPerKB.
+		v, ok := legacyMiningFeeSatPerKB(msg.MinMiningTxFee)
+		if !ok {
 			c.logger.Debug("ignoring implausible peer MinMiningTxFee",
 				zap.String("peer_id", msg.PeerID),
-				zap.Float64("min_mining_tx_fee", f))
+				zap.Float64("min_mining_tx_fee", *msg.MinMiningTxFee))
 			return
 		}
-		sats = uint64(v)
-		byts = 1000
+		sats = v
+		byts = legacyMiningFeeBytesBasis
 	default:
 		return
 	}

--- a/services/p2p_client/client_test.go
+++ b/services/p2p_client/client_test.go
@@ -19,6 +19,11 @@ import (
 	"github.com/bsv-blockchain/arcade/store"
 )
 
+const (
+	testPeerID  = "sender"
+	testPeerURL = "https://peer.example"
+)
+
 // fakeEndpointWriter records every UpsertDatahubEndpoint call so tests can
 // assert that p2p_client persisted discovered URLs to the shared store. The
 // store is now the only sink — the in-process teranode.Client AddEndpoints
@@ -178,7 +183,7 @@ func TestNetworkThreading_CanonicalToUpstream(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.canonical, func(t *testing.T) {
-			fc := newFakeTeraClient("sender")
+			fc := newFakeTeraClient(testPeerID)
 			cfg := &config.Config{}
 			cfg.P2P.DatahubDiscovery = true
 			cfg.Network = tc.canonical
@@ -213,7 +218,7 @@ func TestNetworkThreading_CanonicalToUpstream(t *testing.T) {
 // private networks and bootstrap migrations remain possible without new
 // config knobs.
 func TestNetworkThreading_OperatorBootstrapWins(t *testing.T) {
-	fc := newFakeTeraClient("sender")
+	fc := newFakeTeraClient(testPeerID)
 	cfg := &config.Config{}
 	cfg.P2P.DatahubDiscovery = true
 	cfg.Network = config.NetworkTeratestnet
@@ -241,18 +246,18 @@ func TestNetworkThreading_OperatorBootstrapWins(t *testing.T) {
 // only path by which other pods learn the URL, so the test guards the
 // contract end-to-end as far as this service is concerned.
 func TestClient_NovelURLPersisted(t *testing.T) {
-	fc := newFakeTeraClient("sender")
+	fc := newFakeTeraClient(testPeerID)
 	c, w := newTestClient(t, fc)
 	_, stop := runStart(t, c)
 	defer stop()
 
 	fc.ch <- teranodep2p.NodeStatusMessage{
-		PeerID:  "sender",
-		BaseURL: "https://peer.example",
+		PeerID:  testPeerID,
+		BaseURL: testPeerURL,
 	}
 
 	calls := waitForUpserts(t, w, 1)
-	if calls[0].URL != "https://peer.example" {
+	if calls[0].URL != testPeerURL {
 		t.Errorf("upserted wrong URL: %+v", calls[0])
 	}
 	if calls[0].Source != store.DatahubEndpointSourceDiscovered {
@@ -269,18 +274,18 @@ func TestClient_NovelURLPersisted(t *testing.T) {
 // service is intentionally a thin pipe so the registry's LastSeen reflects
 // the most recent observation per peer.
 func TestClient_RepeatedAnnouncementUpsertedEachTime(t *testing.T) {
-	fc := newFakeTeraClient("sender")
+	fc := newFakeTeraClient(testPeerID)
 	c, w := newTestClient(t, fc)
 	_, stop := runStart(t, c)
 	defer stop()
 
 	for i := 0; i < 3; i++ {
-		fc.ch <- teranodep2p.NodeStatusMessage{PeerID: "sender", BaseURL: "https://peer.example"}
+		fc.ch <- teranodep2p.NodeStatusMessage{PeerID: testPeerID, BaseURL: testPeerURL}
 	}
 
 	calls := waitForUpserts(t, w, 3)
 	for _, c := range calls {
-		if c.URL != "https://peer.example" {
+		if c.URL != testPeerURL {
 			t.Errorf("unexpected URL in upsert: %+v", c)
 		}
 	}
@@ -289,12 +294,12 @@ func TestClient_RepeatedAnnouncementUpsertedEachTime(t *testing.T) {
 // TestClient_EmptyURLsIgnored confirms an announcement with no usable URL
 // produces no store write.
 func TestClient_EmptyURLsIgnored(t *testing.T) {
-	fc := newFakeTeraClient("sender")
+	fc := newFakeTeraClient(testPeerID)
 	c, w := newTestClient(t, fc)
 	_, stop := runStart(t, c)
 	defer stop()
 
-	fc.ch <- teranodep2p.NodeStatusMessage{PeerID: "sender"}
+	fc.ch <- teranodep2p.NodeStatusMessage{PeerID: testPeerID}
 
 	time.Sleep(50 * time.Millisecond)
 	if calls := w.snapshot(); len(calls) != 0 {
@@ -306,13 +311,13 @@ func TestClient_EmptyURLsIgnored(t *testing.T) {
 // reach the store. RFC1918 with AllowPrivateURLs=false is the canonical
 // rejection case.
 func TestClient_InvalidURLRejected(t *testing.T) {
-	fc := newFakeTeraClient("sender")
+	fc := newFakeTeraClient(testPeerID)
 	c, w := newTestClient(t, fc)
 	_, stop := runStart(t, c)
 	defer stop()
 
 	fc.ch <- teranodep2p.NodeStatusMessage{
-		PeerID:  "sender",
+		PeerID:  testPeerID,
 		BaseURL: "http://192.168.1.50:8080",
 	}
 
@@ -325,13 +330,13 @@ func TestClient_InvalidURLRejected(t *testing.T) {
 // TestClient_PropagationURLPreferred confirms PropagationURL wins over
 // BaseURL when both are present (pickDatahubURL contract).
 func TestClient_PropagationURLPreferred(t *testing.T) {
-	fc := newFakeTeraClient("sender")
+	fc := newFakeTeraClient(testPeerID)
 	c, w := newTestClient(t, fc)
 	_, stop := runStart(t, c)
 	defer stop()
 
 	fc.ch <- teranodep2p.NodeStatusMessage{
-		PeerID:         "sender",
+		PeerID:         testPeerID,
 		BaseURL:        "https://base.example",
 		PropagationURL: "https://prop.example",
 	}
@@ -383,7 +388,7 @@ func TestClient_DisabledDiscoveryOpensNoBus(t *testing.T) {
 // a peer announcing its own cluster-internal service name (unresolvable from
 // this cluster) must never enter the shared endpoint registry.
 func TestClient_UnresolvableURLNotPersisted(t *testing.T) {
-	fc := newFakeTeraClient("sender")
+	fc := newFakeTeraClient(testPeerID)
 	c, w := newTestClient(t, fc)
 	c.lookupIP = func(_ context.Context, host string) ([]net.IP, error) {
 		return nil, &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
@@ -392,7 +397,7 @@ func TestClient_UnresolvableURLNotPersisted(t *testing.T) {
 	defer stop()
 
 	fc.ch <- teranodep2p.NodeStatusMessage{
-		PeerID:  "sender",
+		PeerID:  testPeerID,
 		BaseURL: "http://asset:8090/api/v1",
 	}
 
@@ -406,7 +411,7 @@ func TestClient_UnresolvableURLNotPersisted(t *testing.T) {
 // cache: three announcements of one URL cost exactly one DNS lookup, while
 // the upsert-per-announcement contract (LastSeen advancing) is preserved.
 func TestClient_ValidationCacheSkipsRepeatLookups(t *testing.T) {
-	fc := newFakeTeraClient("sender")
+	fc := newFakeTeraClient(testPeerID)
 	c, w := newTestClient(t, fc)
 	var lookups atomic.Int64
 	c.lookupIP = func(_ context.Context, _ string) ([]net.IP, error) {
@@ -417,7 +422,7 @@ func TestClient_ValidationCacheSkipsRepeatLookups(t *testing.T) {
 	defer stop()
 
 	for i := 0; i < 3; i++ {
-		fc.ch <- teranodep2p.NodeStatusMessage{PeerID: "sender", BaseURL: "https://peer.example"}
+		fc.ch <- teranodep2p.NodeStatusMessage{PeerID: testPeerID, BaseURL: testPeerURL}
 	}
 
 	waitForUpserts(t, w, 3)
@@ -429,10 +434,10 @@ func TestClient_ValidationCacheSkipsRepeatLookups(t *testing.T) {
 // TestRecordPeerPolicy_FeePolicy verifies the structured FeePolicy.MiningFee is
 // persisted verbatim as the peer's observed fee.
 func TestRecordPeerPolicy_FeePolicy(t *testing.T) {
-	c, w := newTestClient(t, newFakeTeraClient("sender"))
+	c, w := newTestClient(t, newFakeTeraClient(testPeerID))
 	c.recordPeerPolicy(context.Background(), teranodep2p.NodeStatusMessage{
 		PeerID:    "peer-1",
-		BaseURL:   "https://peer.example",
+		BaseURL:   testPeerURL,
 		FeePolicy: &teranodep2p.FeePolicy{MiningFee: teranodep2p.FeeAmount{Satoshis: 75, Bytes: 1000}},
 	})
 
@@ -451,7 +456,7 @@ func TestRecordPeerPolicy_FeePolicy(t *testing.T) {
 // TestRecordPeerPolicy_LegacyMinMiningTxFee verifies the BSV/kB fallback is
 // converted to satoshis-per-1000-bytes when no structured FeePolicy is present.
 func TestRecordPeerPolicy_LegacyMinMiningTxFee(t *testing.T) {
-	c, w := newTestClient(t, newFakeTeraClient("sender"))
+	c, w := newTestClient(t, newFakeTeraClient(testPeerID))
 	fee := 0.0000005 // BSV/kB -> 50 sat per 1000 bytes
 	c.recordPeerPolicy(context.Background(), teranodep2p.NodeStatusMessage{
 		PeerID:         "peer-2",
@@ -470,7 +475,7 @@ func TestRecordPeerPolicy_LegacyMinMiningTxFee(t *testing.T) {
 // TestRecordPeerPolicy_URLlessPeerStillRecorded verifies a peer that advertises a
 // fee but no datahub URL is still counted toward the /policy network-minimum.
 func TestRecordPeerPolicy_URLlessPeerStillRecorded(t *testing.T) {
-	c, w := newTestClient(t, newFakeTeraClient("sender"))
+	c, w := newTestClient(t, newFakeTeraClient(testPeerID))
 	c.recordPeerPolicy(context.Background(), teranodep2p.NodeStatusMessage{
 		PeerID:    "peer-3",
 		FeePolicy: &teranodep2p.FeePolicy{MiningFee: teranodep2p.FeeAmount{Satoshis: 10, Bytes: 1000}},
@@ -483,7 +488,7 @@ func TestRecordPeerPolicy_URLlessPeerStillRecorded(t *testing.T) {
 // TestRecordPeerPolicy_NoFeeAdvertised verifies peers advertising no fee (old
 // nodes) are skipped rather than recorded with a zero fee.
 func TestRecordPeerPolicy_NoFeeAdvertised(t *testing.T) {
-	c, w := newTestClient(t, newFakeTeraClient("sender"))
+	c, w := newTestClient(t, newFakeTeraClient(testPeerID))
 	c.recordPeerPolicy(context.Background(), teranodep2p.NodeStatusMessage{PeerID: "peer-4"})
 	if fees := w.feeSnapshot(); len(fees) != 0 {
 		t.Fatalf("expected no fee upsert for feeless peer, got %+v", fees)
@@ -497,7 +502,7 @@ func TestRecordPeerPolicy_NoFeeAdvertised(t *testing.T) {
 func TestRecordPeerPolicy_RejectsMalformedLegacyFee(t *testing.T) {
 	bad := []float64{math.NaN(), math.Inf(1), -0.0001, 1e30}
 	for _, f := range bad {
-		c, w := newTestClient(t, newFakeTeraClient("sender"))
+		c, w := newTestClient(t, newFakeTeraClient(testPeerID))
 		c.recordPeerPolicy(context.Background(), teranodep2p.NodeStatusMessage{
 			PeerID:         "peer-bad",
 			MinMiningTxFee: &f,
@@ -512,10 +517,10 @@ func TestRecordPeerPolicy_RejectsMalformedLegacyFee(t *testing.T) {
 // advertises alongside the fee are carried into the store, so the api-server
 // can derive the network-wide maximum for GET /policy and intake.
 func TestRecordPeerPolicy_RecordsSizeLimits(t *testing.T) {
-	c, w := newTestClient(t, newFakeTeraClient("sender"))
+	c, w := newTestClient(t, newFakeTeraClient(testPeerID))
 	c.recordPeerPolicy(context.Background(), teranodep2p.NodeStatusMessage{
 		PeerID:  "peer-sized",
-		BaseURL: "https://peer.example",
+		BaseURL: testPeerURL,
 		FeePolicy: &teranodep2p.FeePolicy{
 			MiningFee:           teranodep2p.FeeAmount{Satoshis: 75, Bytes: 1000},
 			MaxTxSizePolicy:     100_000_000,
@@ -541,7 +546,7 @@ func TestRecordPeerPolicy_RecordsSizeLimits(t *testing.T) {
 // accepts nothing, which under the network maximum would be harmless but under
 // any future minimum would be catastrophic.
 func TestRecordPeerPolicy_LegacyPeerLeavesSizesUnset(t *testing.T) {
-	c, w := newTestClient(t, newFakeTeraClient("sender"))
+	c, w := newTestClient(t, newFakeTeraClient(testPeerID))
 	fee := 0.0000005
 	c.recordPeerPolicy(context.Background(), teranodep2p.NodeStatusMessage{
 		PeerID:         "peer-legacy",
@@ -563,10 +568,10 @@ func TestRecordPeerPolicy_LegacyPeerLeavesSizesUnset(t *testing.T) {
 // must cost only the size — dropping the whole row would let a peer remove
 // itself from the fee minimum just by sending garbage in another field.
 func TestRecordPeerPolicy_UnstorableSizeKeepsFee(t *testing.T) {
-	c, w := newTestClient(t, newFakeTeraClient("sender"))
+	c, w := newTestClient(t, newFakeTeraClient(testPeerID))
 	c.recordPeerPolicy(context.Background(), teranodep2p.NodeStatusMessage{
 		PeerID:  "peer-hostile",
-		BaseURL: "https://peer.example",
+		BaseURL: testPeerURL,
 		FeePolicy: &teranodep2p.FeePolicy{
 			MiningFee:           teranodep2p.FeeAmount{Satoshis: 5, Bytes: 1000},
 			MaxTxSizePolicy:     math.MaxUint64,
@@ -584,5 +589,83 @@ func TestRecordPeerPolicy_UnstorableSizeKeepsFee(t *testing.T) {
 	if fees[0].MaxTxSizePolicy != 0 || fees[0].MaxScriptSizePolicy != 0 {
 		t.Errorf("unstorable sizes must be zeroed, got {%d %d}",
 			fees[0].MaxTxSizePolicy, fees[0].MaxScriptSizePolicy)
+	}
+}
+
+// TestClient_RegistrationCarriesAdvertisedPolicy is the end of the chain
+// GET /health reads: the policy a node advertises in node_status travels with
+// its URL into the registry, so an operator can see per endpoint what that node
+// will accept.
+func TestClient_RegistrationCarriesAdvertisedPolicy(t *testing.T) {
+	fc := newFakeTeraClient(testPeerID)
+	c, w := newTestClient(t, fc)
+	_, stop := runStart(t, c)
+	defer stop()
+
+	fc.ch <- teranodep2p.NodeStatusMessage{
+		PeerID:  testPeerID,
+		BaseURL: testPeerURL,
+		FeePolicy: &teranodep2p.FeePolicy{
+			MiningFee:               teranodep2p.FeeAmount{Satoshis: 100, Bytes: 1000},
+			MaxTxSizePolicy:         100_000_000,
+			MaxScriptSizePolicy:     500_000,
+			MaxTxSigopsCountsPolicy: 4_294_967_295,
+		},
+	}
+
+	calls := waitForUpserts(t, w, 1)
+	got := calls[0].Policy
+	if got == nil {
+		t.Fatal("registration dropped the advertised policy")
+	}
+	want := store.EndpointPolicy{
+		MiningFeeSatoshis: 100, MiningFeeBytes: 1000,
+		MaxTxSizePolicy: 100_000_000, MaxScriptSizePolicy: 500_000,
+		MaxTxSigopsCountsPolicy: 4_294_967_295,
+	}
+	if *got != want {
+		t.Errorf("policy = %+v, want %+v", *got, want)
+	}
+}
+
+// TestClient_RegistrationWithoutPolicyStillRegisters guards the ordering that
+// matters: a node advertising no policy — or one too large to store — must
+// still get its URL into the registry. The policy is a diagnostic; the URL is
+// how transactions reach that node.
+func TestClient_RegistrationWithoutPolicyStillRegisters(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  teranodep2p.NodeStatusMessage
+	}{
+		{
+			name: "no policy advertised",
+			msg:  teranodep2p.NodeStatusMessage{PeerID: testPeerID, BaseURL: testPeerURL},
+		},
+		{
+			name: "policy too large to store",
+			msg: teranodep2p.NodeStatusMessage{
+				PeerID: testPeerID, BaseURL: testPeerURL,
+				FeePolicy: &teranodep2p.FeePolicy{MaxTxSizePolicy: math.MaxUint64},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := newFakeTeraClient(testPeerID)
+			c, w := newTestClient(t, fc)
+			_, stop := runStart(t, c)
+			defer stop()
+
+			fc.ch <- tc.msg
+
+			calls := waitForUpserts(t, w, 1)
+			if calls[0].URL != testPeerURL {
+				t.Errorf("URL = %q, want the announced URL", calls[0].URL)
+			}
+			if calls[0].Policy != nil {
+				t.Errorf("policy = %+v, want nil", *calls[0].Policy)
+			}
+		})
 	}
 }

--- a/services/p2p_client/node_status.go
+++ b/services/p2p_client/node_status.go
@@ -1,13 +1,19 @@
 package p2p_client
 
 import (
+	"math"
 	"net"
 	"strings"
 
 	teranodep2p "github.com/bsv-blockchain/teranode/services/p2p"
 
 	"github.com/bsv-blockchain/arcade/ssrfguard"
+	"github.com/bsv-blockchain/arcade/store"
 )
+
+// legacyMiningFeeBytesBasis is the byte basis the legacy MinMiningTxFee field
+// is expressed against once converted: satoshis per 1000 bytes.
+const legacyMiningFeeBytesBasis = 1000
 
 // pickDatahubURL returns the URL peers should use to propagate transactions.
 // PropagationURL wins when present; BaseURL is the fallback. Empty string
@@ -17,6 +23,65 @@ func pickDatahubURL(m teranodep2p.NodeStatusMessage) string {
 		return m.PropagationURL
 	}
 	return m.BaseURL
+}
+
+// legacyMiningFeeSatPerKB converts a legacy node_status MinMiningTxFee (BSV/kB)
+// to satoshis per 1000 bytes. ok is false when the value cannot be trusted:
+// node_status is unauthenticated, so a malformed or malicious announcement can
+// carry NaN/Inf/negative or an absurd magnitude, which uint64() would turn into
+// a wrapped garbage value polluting metrics and the int64-backed store columns.
+//
+// Shared by recordPeerPolicy and endpointPolicyFrom so the two paths cannot
+// drift on what counts as an implausible fee.
+func legacyMiningFeeSatPerKB(fee *float64) (uint64, bool) {
+	if fee == nil {
+		return 0, false
+	}
+	v := math.Round(*fee * 1e8) // 1 BSV = 1e8 satoshis
+	if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 || v > math.MaxInt64 {
+		return 0, false
+	}
+	return uint64(v), true
+}
+
+// endpointPolicyFrom builds the policy to record against a peer's datahub URL
+// registration, or nil when the peer advertised none.
+//
+// This is the per-endpoint, operator-facing view — "what will this specific
+// node accept" — and so records what the node advertised verbatim, unlike
+// recordPeerPolicy, which feeds the network-wide aggregate arcade enforces and
+// therefore only keeps values it can compute with. An advertisement too large
+// to store faithfully drops the whole policy rather than the row: the URL
+// registration is the reason the row exists, and a peer sending a garbage size
+// must not be able to remove its own endpoint from the registry.
+func endpointPolicyFrom(m teranodep2p.NodeStatusMessage) *store.EndpointPolicy {
+	var p *store.EndpointPolicy
+
+	switch {
+	case m.FeePolicy != nil:
+		p = &store.EndpointPolicy{
+			MiningFeeSatoshis:       m.FeePolicy.MiningFee.Satoshis,
+			MiningFeeBytes:          m.FeePolicy.MiningFee.Bytes,
+			MaxTxSizePolicy:         m.FeePolicy.MaxTxSizePolicy,
+			MaxScriptSizePolicy:     m.FeePolicy.MaxScriptSizePolicy,
+			MaxTxSigopsCountsPolicy: m.FeePolicy.MaxTxSigopsCountsPolicy,
+		}
+	case m.MinMiningTxFee != nil:
+		// A node old enough to send only the scalar fee advertises no size
+		// limits; they stay zero, and the /health view omits what is unset.
+		sats, ok := legacyMiningFeeSatPerKB(m.MinMiningTxFee)
+		if !ok {
+			return nil
+		}
+		p = &store.EndpointPolicy{MiningFeeSatoshis: sats, MiningFeeBytes: legacyMiningFeeBytesBasis}
+	default:
+		return nil
+	}
+
+	if p.Validate() != nil {
+		return nil
+	}
+	return p
 }
 
 // validateURL enforces that a discovered URL is safe to POST transactions to.

--- a/services/p2p_client/node_status_test.go
+++ b/services/p2p_client/node_status_test.go
@@ -2,10 +2,13 @@ package p2p_client
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"testing"
 
 	teranodep2p "github.com/bsv-blockchain/teranode/services/p2p"
+
+	"github.com/bsv-blockchain/arcade/store"
 )
 
 func TestPickDatahubURL(t *testing.T) {
@@ -103,6 +106,126 @@ func TestValidateURL(t *testing.T) {
 			}
 			if got != tc.want {
 				t.Errorf("validateURL(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEndpointPolicyFrom covers what gets recorded against a peer's datahub URL
+// registration and surfaced per endpoint by GET /health.
+//
+// Unlike recordPeerPolicy, which feeds the network-wide policy arcade enforces
+// and so keeps only values it can compute with, this path records what the node
+// advertised verbatim — it answers "what will this endpoint accept". The one
+// thing it will not record is a value too large to store faithfully, since
+// node_status is unauthenticated and a wrapped value would be reported to
+// operators as that node's real policy.
+func TestEndpointPolicyFrom(t *testing.T) {
+	feePolicy := &teranodep2p.FeePolicy{
+		MiningFee:               teranodep2p.FeeAmount{Satoshis: 100, Bytes: 1000},
+		MaxTxSizePolicy:         100_000_000,
+		MaxScriptSizePolicy:     500_000,
+		MaxTxSigopsCountsPolicy: 4_294_967_295,
+	}
+	legacyFee := 0.0000005 // BSV/kB -> 50 sat per 1000 bytes
+	nan := math.NaN()
+	absurd := 1e30
+
+	cases := []struct {
+		name string
+		msg  teranodep2p.NodeStatusMessage
+		want *store.EndpointPolicy
+	}{
+		{
+			name: "structured fee policy is recorded whole",
+			msg:  teranodep2p.NodeStatusMessage{FeePolicy: feePolicy},
+			want: &store.EndpointPolicy{
+				MiningFeeSatoshis: 100, MiningFeeBytes: 1000,
+				MaxTxSizePolicy: 100_000_000, MaxScriptSizePolicy: 500_000,
+				MaxTxSigopsCountsPolicy: 4_294_967_295,
+			},
+		},
+		{
+			name: "legacy peer yields a fee and no size limits",
+			msg:  teranodep2p.NodeStatusMessage{MinMiningTxFee: &legacyFee},
+			want: &store.EndpointPolicy{MiningFeeSatoshis: 50, MiningFeeBytes: 1000},
+		},
+		{
+			name: "peer advertising nothing yields no policy",
+			msg:  teranodep2p.NodeStatusMessage{BaseURL: testPeerURL},
+			want: nil,
+		},
+		{
+			name: "unstorable size drops the whole policy",
+			msg: teranodep2p.NodeStatusMessage{FeePolicy: &teranodep2p.FeePolicy{
+				MiningFee:       teranodep2p.FeeAmount{Satoshis: 100, Bytes: 1000},
+				MaxTxSizePolicy: math.MaxUint64,
+			}},
+			want: nil,
+		},
+		{
+			name: "malformed legacy fee yields no policy",
+			msg:  teranodep2p.NodeStatusMessage{MinMiningTxFee: &nan},
+			want: nil,
+		},
+		{
+			name: "absurd legacy fee yields no policy",
+			msg:  teranodep2p.NodeStatusMessage{MinMiningTxFee: &absurd},
+			want: nil,
+		},
+		{
+			// A node that genuinely accepts free transactions and imposes no
+			// size limits advertises zeros. They are real values, and the nil
+			// pointer — not a zero struct — is what means "advertised none".
+			name: "an all-zero advertisement is a policy, not absence",
+			msg:  teranodep2p.NodeStatusMessage{FeePolicy: &teranodep2p.FeePolicy{}},
+			want: &store.EndpointPolicy{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := endpointPolicyFrom(tc.msg)
+			switch {
+			case tc.want == nil && got != nil:
+				t.Fatalf("endpointPolicyFrom() = %+v, want nil", *got)
+			case tc.want != nil && got == nil:
+				t.Fatalf("endpointPolicyFrom() = nil, want %+v", *tc.want)
+			case tc.want != nil && *got != *tc.want:
+				t.Errorf("endpointPolicyFrom() = %+v, want %+v", *got, *tc.want)
+			}
+		})
+	}
+}
+
+// TestLegacyMiningFeeSatPerKB pins the shared untrusted-float guard that both
+// recordPeerPolicy and endpointPolicyFrom depend on, so the two cannot drift on
+// what counts as an implausible fee.
+func TestLegacyMiningFeeSatPerKB(t *testing.T) {
+	ok := func(v float64) *float64 { return &v }
+
+	cases := []struct {
+		name  string
+		fee   *float64
+		want  uint64
+		wantK bool
+	}{
+		{name: "nil", fee: nil, wantK: false},
+		{name: "ordinary", fee: ok(0.0000005), want: 50, wantK: true},
+		{name: "zero fee is legitimate", fee: ok(0), want: 0, wantK: true},
+		{name: "NaN", fee: ok(math.NaN()), wantK: false},
+		{name: "positive infinity", fee: ok(math.Inf(1)), wantK: false},
+		{name: "negative", fee: ok(-0.0001), wantK: false},
+		{name: "absurd magnitude", fee: ok(1e30), wantK: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotOK := legacyMiningFeeSatPerKB(tc.fee)
+			if gotOK != tc.wantK {
+				t.Fatalf("ok = %v, want %v", gotOK, tc.wantK)
+			}
+			if gotOK && got != tc.want {
+				t.Errorf("got %d sat/kB, want %d", got, tc.want)
 			}
 		})
 	}

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -2924,6 +2924,26 @@ func (s *Store) UpsertDatahubEndpoint(ctx context.Context, ep store.DatahubEndpo
 		"source":    ep.Source,
 		"last_seen": ep.LastSeen.UnixMilli(),
 	}
+
+	// The advertised-policy bins are written only when the caller has one. A
+	// Put updates just the bins it names, so omitting them is exactly the
+	// "a write carrying no policy must not erase one already recorded"
+	// rule the other backends implement with COALESCE (Postgres) and a
+	// read-modify-write (Pebble). Bin names are abbreviated to stay inside
+	// Aerospike's limit, matching fee_sats/fee_bytes on the peer-policy set.
+	if p := ep.Policy; p != nil {
+		if err := p.Validate(); err != nil {
+			return err
+		}
+		// Every narrowing is bounded by Validate above.
+		bins["fee_sats"] = int64(p.MiningFeeSatoshis)         //nolint:gosec // bounded by EndpointPolicy.Validate
+		bins["fee_bytes"] = int64(p.MiningFeeBytes)           //nolint:gosec // bounded by EndpointPolicy.Validate
+		bins["max_tx_sz"] = int64(p.MaxTxSizePolicy)          //nolint:gosec // bounded by EndpointPolicy.Validate
+		bins["max_scr_sz"] = int64(p.MaxScriptSizePolicy)     //nolint:gosec // bounded by EndpointPolicy.Validate
+		bins["max_sigops"] = int64(p.MaxTxSigopsCountsPolicy) //nolint:gosec // bounded by EndpointPolicy.Validate
+		bins["has_policy"] = 1
+	}
+
 	return s.client.Put(s.writePolicy(ctx), key, bins)
 }
 
@@ -2966,6 +2986,18 @@ loop:
 				URL:     getString(rec.Record, "url"),
 				Network: getString(rec.Record, "network"),
 				Source:  getString(rec.Record, "source"),
+			}
+			// has_policy distinguishes "advertised none" from "advertised all
+			// zeros": getInt64 returns 0 for a missing bin, so without the flag
+			// a legacy record and a genuinely zero policy would look alike.
+			if getInt64(rec.Record, "has_policy") == 1 {
+				ep.Policy = &store.EndpointPolicy{
+					MiningFeeSatoshis:       uint64(getInt64(rec.Record, "fee_sats")),   //nolint:gosec // stored non-negative
+					MiningFeeBytes:          uint64(getInt64(rec.Record, "fee_bytes")),  //nolint:gosec // stored non-negative
+					MaxTxSizePolicy:         uint64(getInt64(rec.Record, "max_tx_sz")),  //nolint:gosec // stored non-negative
+					MaxScriptSizePolicy:     uint64(getInt64(rec.Record, "max_scr_sz")), //nolint:gosec // stored non-negative
+					MaxTxSigopsCountsPolicy: uint64(getInt64(rec.Record, "max_sigops")), //nolint:gosec // stored non-negative
+				}
 			}
 			if ms := getInt64(rec.Record, "last_seen"); ms > 0 {
 				ep.LastSeen = time.UnixMilli(ms)

--- a/store/datahub_policy_test.go
+++ b/store/datahub_policy_test.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"testing"
+)
+
+// TestEndpointPolicyValidate pins what a backend may persist against a datahub
+// URL registration.
+//
+// The values come from node_status gossip, which is unauthenticated: the peer
+// chooses them. Postgres and Aerospike store them in signed 64-bit columns, so
+// an unchecked value above MaxInt64 wraps negative on write and reads back as
+// an astronomical uint64 — which GET /health would then report as that node's
+// advertised policy.
+func TestEndpointPolicyValidate(t *testing.T) {
+	const ok = uint64(500_000)
+
+	cases := []struct {
+		name    string
+		ep      EndpointPolicy
+		wantErr bool
+		// mustSay names the field, so an operator reading the log learns which
+		// value was refused rather than just that something was.
+		mustSay string
+	}{
+		{
+			name: "ordinary advertisement",
+			ep: EndpointPolicy{
+				MiningFeeSatoshis: 100, MiningFeeBytes: 1000,
+				MaxTxSizePolicy: 100_000_000, MaxScriptSizePolicy: ok,
+				MaxTxSigopsCountsPolicy: 4_294_967_295,
+			},
+		},
+		{
+			// A node advertising nothing but a fee is a legitimate legacy peer,
+			// and every zero here is a real value rather than a sentinel — the
+			// nil *EndpointPolicy carries "advertised none".
+			name: "all zero is storable",
+			ep:   EndpointPolicy{},
+		},
+		{
+			name:    "mining fee satoshis above the signed-64-bit ceiling",
+			ep:      EndpointPolicy{MiningFeeSatoshis: math.MaxInt64 + 1},
+			wantErr: true,
+			mustSay: "mining fee satoshis",
+		},
+		{
+			name:    "mining fee byte basis above the ceiling",
+			ep:      EndpointPolicy{MiningFeeBytes: math.MaxInt64 + 1},
+			wantErr: true,
+			mustSay: "mining fee byte basis",
+		},
+		{
+			name:    "max tx size above the ceiling",
+			ep:      EndpointPolicy{MaxTxSizePolicy: math.MaxUint64},
+			wantErr: true,
+			mustSay: "max tx size",
+		},
+		{
+			name:    "max script size above the ceiling",
+			ep:      EndpointPolicy{MaxScriptSizePolicy: math.MaxInt64 + 1},
+			wantErr: true,
+			mustSay: "max script size",
+		},
+		{
+			name:    "max sigops above the ceiling",
+			ep:      EndpointPolicy{MaxTxSigopsCountsPolicy: math.MaxInt64 + 1},
+			wantErr: true,
+			mustSay: "max tx sigops count",
+		},
+		{
+			name: "exactly at the ceiling is storable",
+			ep: EndpointPolicy{
+				MiningFeeSatoshis: math.MaxInt64, MiningFeeBytes: math.MaxInt64,
+				MaxTxSizePolicy: math.MaxInt64, MaxScriptSizePolicy: math.MaxInt64,
+				MaxTxSigopsCountsPolicy: math.MaxInt64,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.ep.Validate()
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if err == nil {
+				return
+			}
+			if !errors.Is(err, ErrInvalidEndpointPolicy) {
+				t.Errorf("error %v does not wrap ErrInvalidEndpointPolicy", err)
+			}
+			if !strings.Contains(err.Error(), tc.mustSay) {
+				t.Errorf("error = %q, want it to name the field %q", err, tc.mustSay)
+			}
+		})
+	}
+}
+
+// TestEndpointPolicyValidate_CeilingCannotRejectARealPolicy guards the choice
+// of bound. Refusing a genuine advertisement would silently blank an endpoint's
+// policy in GET /health, so the ceiling has to sit far above anything a node
+// can meaningfully configure: teranode's own excessiveblocksize default is 4
+// GiB, and MaxInt64 is some two billion times larger.
+func TestEndpointPolicyValidate_CeilingCannotRejectARealPolicy(t *testing.T) {
+	const fourGiB = uint64(4) * 1024 * 1024 * 1024
+
+	ep := EndpointPolicy{
+		MiningFeeSatoshis: 100, MiningFeeBytes: 1000,
+		MaxTxSizePolicy: fourGiB, MaxScriptSizePolicy: fourGiB,
+		MaxTxSigopsCountsPolicy: 4_294_967_295,
+	}
+	if err := ep.Validate(); err != nil {
+		t.Fatalf("a whole-block-sized limit must still be storable, got %v", err)
+	}
+	if fourGiB >= maxStorablePolicyValue {
+		t.Fatalf("the storable ceiling (%d) is not above a realistic block size (%d)",
+			maxStorablePolicyValue, fourGiB)
+	}
+}

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -235,10 +235,22 @@ type storedBump struct {
 }
 
 type storedDatahubEndpoint struct {
-	URL            string `json:"url"`
-	Network        string `json:"network"`
-	Source         string `json:"source"`
-	LastSeenUnixNs int64  `json:"last_seen"`
+	URL     string `json:"url"`
+	Network string `json:"network"`
+	Source  string `json:"source"`
+	// Policy is absent on rows written before endpoints carried an advertised
+	// policy, and on any endpoint whose node advertised none. A missing JSON
+	// key decodes to nil, which is exactly that sentinel — no migration needed.
+	Policy         *storedEndpointPolicy `json:"policy,omitempty"`
+	LastSeenUnixNs int64                 `json:"last_seen"`
+}
+
+type storedEndpointPolicy struct {
+	MiningFeeSatoshis       uint64 `json:"mining_fee_satoshis"`
+	MiningFeeBytes          uint64 `json:"mining_fee_bytes"`
+	MaxTxSizePolicy         uint64 `json:"max_tx_size_policy"`
+	MaxScriptSizePolicy     uint64 `json:"max_script_size_policy"`
+	MaxTxSigopsCountsPolicy uint64 `json:"max_tx_sigops_counts_policy"`
 }
 
 type storedPeerPolicy struct {
@@ -2306,11 +2318,49 @@ func (s *Store) UpsertDatahubEndpoint(ctx context.Context, ep store.DatahubEndpo
 	if !ep.LastSeen.IsZero() {
 		stored.LastSeenUnixNs = ep.LastSeen.UnixNano()
 	}
+
+	switch {
+	case ep.Policy != nil:
+		if err := ep.Policy.Validate(); err != nil {
+			return err
+		}
+		stored.Policy = &storedEndpointPolicy{
+			MiningFeeSatoshis:       ep.Policy.MiningFeeSatoshis,
+			MiningFeeBytes:          ep.Policy.MiningFeeBytes,
+			MaxTxSizePolicy:         ep.Policy.MaxTxSizePolicy,
+			MaxScriptSizePolicy:     ep.Policy.MaxScriptSizePolicy,
+			MaxTxSigopsCountsPolicy: ep.Policy.MaxTxSigopsCountsPolicy,
+		}
+	default:
+		// A write carrying no policy must not erase one already recorded.
+		// Set is a blind overwrite here — unlike Postgres, which COALESCEs, and
+		// Aerospike, which simply omits the bins — so this backend has to read
+		// the current row and carry its policy forward.
+		stored.Policy = s.existingEndpointPolicy(ep.URL)
+	}
+
 	payload, err := json.Marshal(stored)
 	if err != nil {
 		return err
 	}
 	return s.db.Set(datahubEndpointKey(ep.URL), payload, s.writeOpts)
+}
+
+// existingEndpointPolicy returns the policy already stored for url, or nil when
+// there is no row, no policy, or the row cannot be read. A failure here costs
+// only the carried-forward policy, which the peer's next announcement restores;
+// it must never fail the URL registration itself.
+func (s *Store) existingEndpointPolicy(url string) *storedEndpointPolicy {
+	val, closer, err := s.db.Get(datahubEndpointKey(url))
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = closer.Close() }()
+	var row storedDatahubEndpoint
+	if err := json.Unmarshal(val, &row); err != nil {
+		return nil
+	}
+	return row.Policy
 }
 
 func (s *Store) ListDatahubEndpoints(ctx context.Context, network string) ([]store.DatahubEndpoint, error) {
@@ -2343,6 +2393,15 @@ func (s *Store) ListDatahubEndpoints(ctx context.Context, network string) ([]sto
 			URL:     row.URL,
 			Network: row.Network,
 			Source:  row.Source,
+		}
+		if p := row.Policy; p != nil {
+			ep.Policy = &store.EndpointPolicy{
+				MiningFeeSatoshis:       p.MiningFeeSatoshis,
+				MiningFeeBytes:          p.MiningFeeBytes,
+				MaxTxSizePolicy:         p.MaxTxSizePolicy,
+				MaxScriptSizePolicy:     p.MaxScriptSizePolicy,
+				MaxTxSigopsCountsPolicy: p.MaxTxSigopsCountsPolicy,
+			}
 		}
 		if row.LastSeenUnixNs != 0 {
 			ep.LastSeen = time.Unix(0, row.LastSeenUnixNs)

--- a/store/pebble/pebble_test.go
+++ b/store/pebble/pebble_test.go
@@ -655,8 +655,8 @@ func TestDatahubEndpoints_UpsertAndList(t *testing.T) {
 	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
 
 	in := []store.DatahubEndpoint{
-		{URL: "https://a.example", Network: "mainnet", Source: store.DatahubEndpointSourceConfigured, LastSeen: now},
-		{URL: "https://b.example", Network: "mainnet", Source: store.DatahubEndpointSourceDiscovered, LastSeen: now.Add(time.Minute)},
+		{URL: "https://a.example", Network: ppNetMainnet, Source: store.DatahubEndpointSourceConfigured, LastSeen: now},
+		{URL: "https://b.example", Network: ppNetMainnet, Source: store.DatahubEndpointSourceDiscovered, LastSeen: now.Add(time.Minute)},
 	}
 	for _, ep := range in {
 		if err := s.UpsertDatahubEndpoint(ctx, ep); err != nil {
@@ -664,7 +664,7 @@ func TestDatahubEndpoints_UpsertAndList(t *testing.T) {
 		}
 	}
 
-	out, err := s.ListDatahubEndpoints(ctx, "mainnet")
+	out, err := s.ListDatahubEndpoints(ctx, ppNetMainnet)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -701,8 +701,8 @@ func TestDatahubEndpoints_NetworkScoped(t *testing.T) {
 	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
 
 	rows := []store.DatahubEndpoint{
-		{URL: "https://main-a.example", Network: "mainnet", Source: store.DatahubEndpointSourceDiscovered, LastSeen: now},
-		{URL: "https://main-b.example", Network: "mainnet", Source: store.DatahubEndpointSourceDiscovered, LastSeen: now},
+		{URL: "https://main-a.example", Network: ppNetMainnet, Source: store.DatahubEndpointSourceDiscovered, LastSeen: now},
+		{URL: "https://main-b.example", Network: ppNetMainnet, Source: store.DatahubEndpointSourceDiscovered, LastSeen: now},
 		{URL: "https://regtest-a.example", Network: "regtest", Source: store.DatahubEndpointSourceConfigured, LastSeen: now},
 	}
 	for _, ep := range rows {
@@ -719,7 +719,7 @@ func TestDatahubEndpoints_NetworkScoped(t *testing.T) {
 		t.Fatalf("regtest list: got %+v", regtest)
 	}
 
-	mainnet, err := s.ListDatahubEndpoints(ctx, "mainnet")
+	mainnet, err := s.ListDatahubEndpoints(ctx, ppNetMainnet)
 	if err != nil {
 		t.Fatalf("list mainnet: %v", err)
 	}
@@ -743,17 +743,17 @@ func TestDatahubEndpoints_UpsertOverwrites(t *testing.T) {
 	t2 := t1.Add(time.Hour)
 
 	if err := s.UpsertDatahubEndpoint(ctx, store.DatahubEndpoint{
-		URL: "https://a.example", Network: "mainnet", Source: store.DatahubEndpointSourceConfigured, LastSeen: t1,
+		URL: "https://a.example", Network: ppNetMainnet, Source: store.DatahubEndpointSourceConfigured, LastSeen: t1,
 	}); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.UpsertDatahubEndpoint(ctx, store.DatahubEndpoint{
-		URL: "https://a.example", Network: "mainnet", Source: store.DatahubEndpointSourceDiscovered, LastSeen: t2,
+		URL: "https://a.example", Network: ppNetMainnet, Source: store.DatahubEndpointSourceDiscovered, LastSeen: t2,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	out, err := s.ListDatahubEndpoints(ctx, "mainnet")
+	out, err := s.ListDatahubEndpoints(ctx, ppNetMainnet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1393,5 +1393,106 @@ func TestSubmissionsByIndexBounded_StopsDuringIteration(t *testing.T) {
 	}
 	if len(fits) != total {
 		t.Errorf("within-budget read returned %d, want %d", len(fits), total)
+	}
+}
+
+// TestDatahubEndpoints_AdvertisedPolicy covers the policy a node advertises
+// alongside its URL: it round-trips intact, "advertised none" stays
+// distinguishable from "advertised zeros", and — the subtle one — a write
+// carrying no policy leaves a recorded one alone.
+//
+// That last rule is what keeps the configured-URL seed, which re-upserts every
+// URL on each process start with no policy attached, from blanking an announced
+// endpoint's policy on every restart.
+func TestDatahubEndpoints_AdvertisedPolicy(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+
+	const url = "https://announced.example"
+	policy := store.EndpointPolicy{
+		MiningFeeSatoshis: 100, MiningFeeBytes: 1000,
+		MaxTxSizePolicy: 100_000_000, MaxScriptSizePolicy: 500_000,
+		MaxTxSigopsCountsPolicy: 4_294_967_295,
+	}
+
+	upsert := func(t *testing.T, ep store.DatahubEndpoint) {
+		t.Helper()
+		if err := s.UpsertDatahubEndpoint(ctx, ep); err != nil {
+			t.Fatalf("upsert %s: %v", ep.URL, err)
+		}
+	}
+	get := func(t *testing.T, want string) store.DatahubEndpoint {
+		t.Helper()
+		out, err := s.ListDatahubEndpoints(ctx, ppNetMainnet)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		for _, ep := range out {
+			if ep.URL == want {
+				return ep
+			}
+		}
+		t.Fatalf("endpoint %s missing from %+v", want, out)
+		return store.DatahubEndpoint{}
+	}
+
+	// An announced endpoint carries its policy; a seeded one carries none.
+	upsert(t, store.DatahubEndpoint{
+		URL: url, Network: ppNetMainnet,
+		Source: store.DatahubEndpointSourceDiscovered, Policy: &policy, LastSeen: now,
+	})
+	upsert(t, store.DatahubEndpoint{
+		URL: "https://seeded.example", Network: ppNetMainnet,
+		Source: store.DatahubEndpointSourceConfigured, LastSeen: now,
+	})
+
+	if got := get(t, url).Policy; got == nil {
+		t.Fatal("announced endpoint lost its policy")
+	} else if *got != policy {
+		t.Errorf("policy round-trip: got %+v want %+v", *got, policy)
+	}
+	if got := get(t, "https://seeded.example").Policy; got != nil {
+		t.Errorf("a seeded endpoint advertises no policy, got %+v", *got)
+	}
+
+	// The restart case: the seed re-upserts the announced URL with no policy.
+	upsert(t, store.DatahubEndpoint{
+		URL: url, Network: ppNetMainnet,
+		Source: store.DatahubEndpointSourceConfigured, LastSeen: now.Add(time.Hour),
+	})
+	got := get(t, url)
+	if got.Policy == nil {
+		t.Fatal("a policy-less write erased the recorded policy; the seed would blank it on every restart")
+	}
+	if *got.Policy != policy {
+		t.Errorf("preserved policy changed: got %+v want %+v", *got.Policy, policy)
+	}
+	// The rest of the row still updates normally.
+	if got.Source != store.DatahubEndpointSourceConfigured {
+		t.Errorf("source: got %q want %q", got.Source, store.DatahubEndpointSourceConfigured)
+	}
+	if !got.LastSeen.Equal(now.Add(time.Hour)) {
+		t.Errorf("last_seen: got %v want %v", got.LastSeen, now.Add(time.Hour))
+	}
+
+	// A write that does carry a policy replaces the old one.
+	updated := policy
+	updated.MaxTxSizePolicy = 5_000_000
+	upsert(t, store.DatahubEndpoint{
+		URL: url, Network: ppNetMainnet,
+		Source: store.DatahubEndpointSourceDiscovered, Policy: &updated, LastSeen: now.Add(2 * time.Hour),
+	})
+	if got := get(t, url).Policy; got == nil || got.MaxTxSizePolicy != 5_000_000 {
+		t.Errorf("a policy-carrying write must replace the old policy, got %+v", got)
+	}
+
+	// A zero-valued policy is a real advertisement, not absence.
+	upsert(t, store.DatahubEndpoint{
+		URL: "https://zero.example", Network: ppNetMainnet,
+		Source: store.DatahubEndpointSourceDiscovered, Policy: &store.EndpointPolicy{}, LastSeen: now,
+	})
+	if got := get(t, "https://zero.example").Policy; got == nil {
+		t.Error("an all-zero policy must survive as advertised, not read back as nil")
 	}
 }

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -1720,21 +1720,82 @@ func (s *Store) UpsertDatahubEndpoint(ctx context.Context, ep store.DatahubEndpo
 	if ep.URL == "" {
 		return fmt.Errorf("upsert datahub endpoint: empty url")
 	}
+	// COALESCE, not EXCLUDED, on the policy columns: a write that carries no
+	// policy must leave a previously recorded one alone. The configured-URL
+	// seed re-upserts on every process start with no policy attached, and
+	// overwriting would blank an announced endpoint's policy on each restart.
 	const q = `
-INSERT INTO datahub_endpoints (url, network, source, last_seen)
-VALUES ($1, $2, $3, $4)
+INSERT INTO datahub_endpoints (
+    url, network, source, last_seen,
+    mining_fee_satoshis, mining_fee_bytes,
+    max_tx_size_policy, max_script_size_policy, max_tx_sigops_counts_policy)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 ON CONFLICT (url) DO UPDATE SET
     network = EXCLUDED.network,
     source = EXCLUDED.source,
-    last_seen = EXCLUDED.last_seen`
-	if _, err := s.pool.Exec(ctx, q, ep.URL, ep.Network, ep.Source, ep.LastSeen); err != nil {
+    last_seen = EXCLUDED.last_seen,
+    mining_fee_satoshis = COALESCE(EXCLUDED.mining_fee_satoshis, datahub_endpoints.mining_fee_satoshis),
+    mining_fee_bytes = COALESCE(EXCLUDED.mining_fee_bytes, datahub_endpoints.mining_fee_bytes),
+    max_tx_size_policy = COALESCE(EXCLUDED.max_tx_size_policy, datahub_endpoints.max_tx_size_policy),
+    max_script_size_policy = COALESCE(EXCLUDED.max_script_size_policy, datahub_endpoints.max_script_size_policy),
+    max_tx_sigops_counts_policy = COALESCE(EXCLUDED.max_tx_sigops_counts_policy, datahub_endpoints.max_tx_sigops_counts_policy)`
+
+	var sats, byts, maxTx, maxScript, maxSigops *int64
+	if p := ep.Policy; p != nil {
+		if err := p.Validate(); err != nil {
+			return err
+		}
+		// Narrowing is bounded by Validate above.
+		sats = ptrInt64(p.MiningFeeSatoshis)
+		byts = ptrInt64(p.MiningFeeBytes)
+		maxTx = ptrInt64(p.MaxTxSizePolicy)
+		maxScript = ptrInt64(p.MaxScriptSizePolicy)
+		maxSigops = ptrInt64(p.MaxTxSigopsCountsPolicy)
+	}
+
+	if _, err := s.pool.Exec(ctx, q, ep.URL, ep.Network, ep.Source, ep.LastSeen,
+		sats, byts, maxTx, maxScript, maxSigops); err != nil {
 		return fmt.Errorf("upsert datahub endpoint %s: %w", ep.URL, err)
 	}
 	return nil
 }
 
+// ptrInt64 narrows a policy value bounded by EndpointPolicy.Validate and
+// returns a pointer, so a nil policy writes SQL NULL rather than 0.
+func ptrInt64(v uint64) *int64 {
+	n := int64(v) //nolint:gosec // bounded by EndpointPolicy.Validate
+	return &n
+}
+
+// endpointPolicyFromCols rebuilds an advertised policy from its five nullable
+// columns. All-NULL means the node advertised none — including every row
+// written before the columns existed — and yields a nil policy. The five are
+// always written together, so a partial NULL is not expected; it is tolerated
+// by reading the missing value as 0 rather than discarding the rest.
+func endpointPolicyFromCols(sats, byts, maxTx, maxScript, maxSigops *int64) *store.EndpointPolicy {
+	if sats == nil && byts == nil && maxTx == nil && maxScript == nil && maxSigops == nil {
+		return nil
+	}
+	u := func(v *int64) uint64 {
+		if v == nil || *v < 0 {
+			return 0
+		}
+		return uint64(*v)
+	}
+	return &store.EndpointPolicy{
+		MiningFeeSatoshis:       u(sats),
+		MiningFeeBytes:          u(byts),
+		MaxTxSizePolicy:         u(maxTx),
+		MaxScriptSizePolicy:     u(maxScript),
+		MaxTxSigopsCountsPolicy: u(maxSigops),
+	}
+}
+
 func (s *Store) ListDatahubEndpoints(ctx context.Context, network string) ([]store.DatahubEndpoint, error) {
-	const q = `SELECT url, network, source, last_seen FROM datahub_endpoints WHERE network = $1`
+	const q = `SELECT url, network, source, last_seen,
+       mining_fee_satoshis, mining_fee_bytes,
+       max_tx_size_policy, max_script_size_policy, max_tx_sigops_counts_policy
+FROM datahub_endpoints WHERE network = $1`
 	rows, err := s.pool.Query(ctx, q, network)
 	if err != nil {
 		return nil, fmt.Errorf("list datahub endpoints: %w", err)
@@ -1742,10 +1803,15 @@ func (s *Store) ListDatahubEndpoints(ctx context.Context, network string) ([]sto
 	defer rows.Close()
 	var out []store.DatahubEndpoint
 	for rows.Next() {
-		var ep store.DatahubEndpoint
-		if err := rows.Scan(&ep.URL, &ep.Network, &ep.Source, &ep.LastSeen); err != nil {
+		var (
+			ep                                      store.DatahubEndpoint
+			sats, byts, maxTx, maxScript, maxSigops *int64
+		)
+		if err := rows.Scan(&ep.URL, &ep.Network, &ep.Source, &ep.LastSeen,
+			&sats, &byts, &maxTx, &maxScript, &maxSigops); err != nil {
 			return nil, fmt.Errorf("scan datahub endpoint: %w", err)
 		}
+		ep.Policy = endpointPolicyFromCols(sats, byts, maxTx, maxScript, maxSigops)
 		out = append(out, ep)
 	}
 	if err := rows.Err(); err != nil {

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -1657,3 +1657,104 @@ func TestSetPendingRetryFields_RespectsStatusLattice(t *testing.T) {
 		})
 	}
 }
+
+// TestDatahubEndpoints_AdvertisedPolicy covers the policy a node advertises
+// alongside its URL: it round-trips intact, "advertised none" stays
+// distinguishable from "advertised zeros", and — the subtle one — a write
+// carrying no policy leaves a recorded one alone.
+//
+// That last rule is what keeps the configured-URL seed, which re-upserts every
+// URL on each process start with no policy attached, from blanking an announced
+// endpoint's policy on every restart.
+func TestDatahubEndpoints_AdvertisedPolicy(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+
+	const url = "https://announced.example"
+	policy := store.EndpointPolicy{
+		MiningFeeSatoshis: 100, MiningFeeBytes: 1000,
+		MaxTxSizePolicy: 100_000_000, MaxScriptSizePolicy: 500_000,
+		MaxTxSigopsCountsPolicy: 4_294_967_295,
+	}
+
+	upsert := func(t *testing.T, ep store.DatahubEndpoint) {
+		t.Helper()
+		if err := s.UpsertDatahubEndpoint(ctx, ep); err != nil {
+			t.Fatalf("upsert %s: %v", ep.URL, err)
+		}
+	}
+	get := func(t *testing.T, want string) store.DatahubEndpoint {
+		t.Helper()
+		out, err := s.ListDatahubEndpoints(ctx, "mainnet")
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		for _, ep := range out {
+			if ep.URL == want {
+				return ep
+			}
+		}
+		t.Fatalf("endpoint %s missing from %+v", want, out)
+		return store.DatahubEndpoint{}
+	}
+
+	// An announced endpoint carries its policy; a seeded one carries none.
+	upsert(t, store.DatahubEndpoint{
+		URL: url, Network: "mainnet",
+		Source: store.DatahubEndpointSourceDiscovered, Policy: &policy, LastSeen: now,
+	})
+	upsert(t, store.DatahubEndpoint{
+		URL: "https://seeded.example", Network: "mainnet",
+		Source: store.DatahubEndpointSourceConfigured, LastSeen: now,
+	})
+
+	if got := get(t, url).Policy; got == nil {
+		t.Fatal("announced endpoint lost its policy")
+	} else if *got != policy {
+		t.Errorf("policy round-trip: got %+v want %+v", *got, policy)
+	}
+	if got := get(t, "https://seeded.example").Policy; got != nil {
+		t.Errorf("a seeded endpoint advertises no policy, got %+v", *got)
+	}
+
+	// The restart case: the seed re-upserts the announced URL with no policy.
+	upsert(t, store.DatahubEndpoint{
+		URL: url, Network: "mainnet",
+		Source: store.DatahubEndpointSourceConfigured, LastSeen: now.Add(time.Hour),
+	})
+	got := get(t, url)
+	if got.Policy == nil {
+		t.Fatal("a policy-less write erased the recorded policy; the seed would blank it on every restart")
+	}
+	if *got.Policy != policy {
+		t.Errorf("preserved policy changed: got %+v want %+v", *got.Policy, policy)
+	}
+	// The rest of the row still updates normally.
+	if got.Source != store.DatahubEndpointSourceConfigured {
+		t.Errorf("source: got %q want %q", got.Source, store.DatahubEndpointSourceConfigured)
+	}
+	if !got.LastSeen.Equal(now.Add(time.Hour)) {
+		t.Errorf("last_seen: got %v want %v", got.LastSeen, now.Add(time.Hour))
+	}
+
+	// A write that does carry a policy replaces the old one.
+	updated := policy
+	updated.MaxTxSizePolicy = 5_000_000
+	upsert(t, store.DatahubEndpoint{
+		URL: url, Network: "mainnet",
+		Source: store.DatahubEndpointSourceDiscovered, Policy: &updated, LastSeen: now.Add(2 * time.Hour),
+	})
+	if got := get(t, url).Policy; got == nil || got.MaxTxSizePolicy != 5_000_000 {
+		t.Errorf("a policy-carrying write must replace the old policy, got %+v", got)
+	}
+
+	// A zero-valued policy is a real advertisement, not absence.
+	upsert(t, store.DatahubEndpoint{
+		URL: "https://zero.example", Network: "mainnet",
+		Source: store.DatahubEndpointSourceDiscovered, Policy: &store.EndpointPolicy{}, LastSeen: now,
+	})
+	if got := get(t, "https://zero.example").Policy; got == nil {
+		t.Error("an all-zero policy must survive as advertised, not read back as nil")
+	}
+}

--- a/store/postgres/schema.sql
+++ b/store/postgres/schema.sql
@@ -162,13 +162,32 @@ CREATE TABLE IF NOT EXISTS datahub_endpoints (
     url        TEXT PRIMARY KEY,
     network    TEXT NOT NULL DEFAULT '',
     source     TEXT NOT NULL,
-    last_seen  TIMESTAMPTZ NOT NULL
+    last_seen  TIMESTAMPTZ NOT NULL,
+    -- Policy this node advertised in the node_status fee_policy alongside the
+    -- URL. NULL means "advertised none" — a configured seed, or a teranode
+    -- predating fee_policy — which is why these are nullable rather than
+    -- DEFAULT 0: zero is a meaningful policy value and must not be confused
+    -- with absence. The upsert COALESCEs them so a write carrying no policy
+    -- leaves a previously recorded one in place.
+    mining_fee_satoshis         BIGINT,
+    mining_fee_bytes            BIGINT,
+    max_tx_size_policy          BIGINT,
+    max_script_size_policy      BIGINT,
+    max_tx_sigops_counts_policy BIGINT
 );
 -- Idempotent column add for tables created before the network scoping was
 -- introduced. Existing rows keep the empty default, which excludes them from
 -- every ListDatahubEndpoints query — they re-register the next time the peer
 -- announces, with the correct network attached.
 ALTER TABLE datahub_endpoints ADD COLUMN IF NOT EXISTS network TEXT NOT NULL DEFAULT '';
+-- Likewise for deployments created before endpoints carried an advertised
+-- policy. Existing rows read back with a nil policy until their peer announces
+-- again; no backfill is possible or needed.
+ALTER TABLE datahub_endpoints ADD COLUMN IF NOT EXISTS mining_fee_satoshis         BIGINT;
+ALTER TABLE datahub_endpoints ADD COLUMN IF NOT EXISTS mining_fee_bytes            BIGINT;
+ALTER TABLE datahub_endpoints ADD COLUMN IF NOT EXISTS max_tx_size_policy          BIGINT;
+ALTER TABLE datahub_endpoints ADD COLUMN IF NOT EXISTS max_script_size_policy      BIGINT;
+ALTER TABLE datahub_endpoints ADD COLUMN IF NOT EXISTS max_tx_sigops_counts_policy BIGINT;
 CREATE INDEX IF NOT EXISTS idx_dh_last_seen ON datahub_endpoints(last_seen);
 CREATE INDEX IF NOT EXISTS idx_dh_network   ON datahub_endpoints(network);
 

--- a/store/store.go
+++ b/store/store.go
@@ -18,6 +18,11 @@ var ErrNotFound = errors.New("not found")
 // Callers treat it as "drop this advertisement", never as a store fault.
 var ErrInvalidPeerPolicy = errors.New("invalid peer policy")
 
+// ErrInvalidEndpointPolicy is returned by EndpointPolicy.Validate for an
+// advertised policy that cannot be stored faithfully. Callers drop the policy
+// and still register the URL, so this never reaches a backend as a write error.
+var ErrInvalidEndpointPolicy = errors.New("invalid endpoint policy")
+
 // ErrReplayUnavailable is returned by IterateStatusesByToken when a backend
 // cannot serve the replay within its resource bounds — typically a token whose
 // submission set is too large for a backend that has no keyset index over
@@ -57,11 +62,68 @@ const DatahubEndpointSourceDiscovered = "discovered"
 // between pods on the same persistence backend — never serves a peer from one
 // network to a pod configured for another. Legacy rows written before this
 // field existed have an empty Network and are filtered out by every read.
+//
+// Policy is the transaction policy the node advertised in the same node_status
+// announcement that carried this URL, or nil when it advertised none. See
+// EndpointPolicy for why a write that carries no policy never erases one.
 type DatahubEndpoint struct {
 	URL      string
 	Network  string
 	Source   string // DatahubEndpointSourceConfigured or DatahubEndpointSourceDiscovered
+	Policy   *EndpointPolicy
 	LastSeen time.Time
+}
+
+// EndpointPolicy is the transaction policy a teranode advertised in the
+// node_status fee_policy object alongside its datahub URL: what that specific
+// endpoint will accept. Sizes are in bytes; the mining fee is
+// satoshis-per-Bytes, the node_status FeePolicy.MiningFee shape, e.g.
+// {Satoshis: 100, Bytes: 1000} == 100 sat/kB.
+//
+// It is attached to the URL registration purely so operators can see, per
+// endpoint, what each node enforces — GET /health reports it. The network-wide
+// values arcade itself enforces come from PeerPolicy instead, which is keyed by
+// libp2p PeerID and so also covers peers advertising no URL at all. The two are
+// deliberately separate: same source, different keys, different questions.
+//
+// A nil Policy means "this node advertised none" — a statically configured seed
+// URL, or a teranode predating fee_policy — which is why it is a pointer rather
+// than a zero-valued struct. Every backend treats a nil-policy write as leaving
+// any previously recorded policy in place: the configured-URL seed in
+// app.BuildServices re-upserts on every process start, and without that rule an
+// endpoint that is both configured and announced would lose its policy on each
+// restart and regain it seconds later.
+type EndpointPolicy struct {
+	MiningFeeSatoshis       uint64
+	MiningFeeBytes          uint64
+	MaxTxSizePolicy         uint64
+	MaxScriptSizePolicy     uint64
+	MaxTxSigopsCountsPolicy uint64
+}
+
+// Validate reports whether ep can be persisted without loss, on the same terms
+// as PeerPolicy.Validate: the Postgres and Aerospike backends narrow these to
+// signed 64-bit, and node_status is unauthenticated gossip, so the peer chooses
+// the numbers. Callers drop an invalid policy to nil rather than failing the
+// write — the URL registration is the reason the row exists, and a peer sending
+// a garbage size must not be able to remove its own endpoint from the registry.
+func (ep EndpointPolicy) Validate() error {
+	for _, f := range []struct {
+		name  string
+		value uint64
+	}{
+		{"mining fee satoshis", ep.MiningFeeSatoshis},
+		{"mining fee byte basis", ep.MiningFeeBytes},
+		{"max tx size", ep.MaxTxSizePolicy},
+		{"max script size", ep.MaxScriptSizePolicy},
+		{"max tx sigops count", ep.MaxTxSigopsCountsPolicy},
+	} {
+		if f.value > maxStorablePolicyValue {
+			return fmt.Errorf("%w: advertised %s %d, above the storable maximum %d",
+				ErrInvalidEndpointPolicy, f.name, f.value, maxStorablePolicyValue)
+		}
+	}
+	return nil
 }
 
 // StatusCensus is one status's aggregate in a CensusStatusesSince result:


### PR DESCRIPTION
## Why

Arcade discovers datahub URLs from Teranode `node_status` gossip: p2p-client validates the announced URL and upserts a `DatahubEndpoint` row that every pod polls to build its broadcast set. The same announcement carries the node's configured transaction policy in `fee_policy` — mining fee, max tx size, max script size, max sigops — and **the registration write discarded all of it**.

So `GET /health` could tell an operator which endpoints were reachable, but nothing about what each one would *accept*. When a broadcast was refused on policy grounds there was no way, from arcade, to tell which node was the strict one. `GET /policy` cannot answer that either: it reports the single network-wide policy arcade enforces, not any individual node's.

## What

The policy now travels with the URL into the registry, and `/health` reports it per endpoint:

```json
"datahub_urls": [
  { "url": "https://a.example", "source": "discovered", "healthy": true,
    "policy": {
      "miningFee": { "satoshis": 100, "bytes": 1000 },
      "maxtxsizepolicy": 100000000,
      "maxscriptsizepolicy": 500000,
      "maxtxsigopscountspolicy": 4294967295
    } },
  { "url": "https://seeded.example", "source": "configured", "healthy": true }
]
```

`teranode.EndpointStatus` is **embedded** rather than copied, so `url`/`source`/`healthy` keep their exact spelling and position — existing health checkers and ARC clients parse this, and `policy` is purely additive, **omitted rather than nulled** for an endpoint nobody has announced.

## Not a duplicate of #314

Worth being explicit, since both read `msg.FeePolicy`:

| | #314 | this PR |
|---|---|---|
| row | `PeerPolicy` | `DatahubEndpoint` |
| keyed by | libp2p PeerID | URL |
| covers | every peer, **including URL-less ones** | endpoints arcade can broadcast to |
| purpose | what arcade **enforces**, network-wide | what each node **advertises**, per endpoint |

Same source, different keys, different questions. #314 stays the right source for the aggregate.

## The parts that are less obvious than they look

- **A write carrying no policy must never erase a recorded one.** The configured-URL seed re-upserts every URL on each process start with no policy attached; without this rule an endpoint that is both configured and announced would lose its policy on every restart and regain it seconds later. Postgres gets nullable columns and `COALESCE`, Aerospike simply **omits the bins** (a `Put` updates only the bins it names), and Pebble — whose `Set` is a blind overwrite — reads the current row and carries the policy forward.
- **The policy is a pointer; absent means "advertised none".** Zero is a real advertisement: a node accepting free transactions and imposing no size limit advertises zeros, and that must not read back as absence. Aerospike needs an explicit `has_policy` bin for this, since a missing bin reads as `0`.
- **An advertisement too large to store drops the policy, not the row.** `node_status` is unauthenticated; a peer sending a garbage size must not be able to remove its own endpoint from the registry.
- **`/health` reads the registry through a TTL cache**, on the same terms as the existing tip-height read: probes arrive every few seconds per replica, and a store error serves the last known policies rather than blanking them or failing the probe.
- **The two sides of the URL join normalize differently upstream** — the teranode client trims a trailing slash, the store holds configured URLs verbatim — so both are normalized at the join. Without it a seed URL configured with a trailing slash silently loses its policy. There is a test that fails if the normalization is removed; I verified that by removing it.

## Migration

Postgres gets five nullable columns plus idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`. Pebble and Aerospike need none — a missing JSON key / bin already reads as "no policy". Existing rows report no policy until their peer next announces.

## Also

Fills in the OpenAPI `EndpointStatus` schema, which has always omitted the `source` field the Go struct emits, and the matching in-app docs example.

## Verification

```
go build ./... && go vet ./...        # clean
go test ./... && go test -race ./...  # all pass
go test -tags=postgres ./store/postgres  # pass (embedded PG, exercises the schema change)
golangci-lint run                     # 0 issues
```

New coverage: `EndpointPolicy.Validate` bounds; store round-trips in **both** Pebble and Postgres including the preserve-on-nil restart case, policy replacement, and an all-zero policy surviving as advertised; `endpointPolicyFrom` (structured, legacy-fee-only, nothing advertised, unstorable, malformed float, all-zero) and the shared untrusted-fee guard; registration carrying the policy and still registering the URL when there is none; and `/health` merging by URL, omitting the key when unannounced, joining across a trailing slash, caching one registry read per TTL, and serving the last known map on a store error.