### PR TITLE
fix(policy): stop one peer zeroing the network fee floor

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -161,9 +161,16 @@ health:
 #   # announcements — and BOTH enforces it at intake and advertises it via
 #   # GET /policy (issue #212). Until a peer is heard it uses the built-in
 #   # 100 sat/kB floor. Set a non-zero value to pin and enforce an exact floor.
+#   # An observed fee is floored at 1 sat/kB — peer announcements are
+#   # unauthenticated, so one peer advertising 0 must not be able to disable
+#   # fee enforcement for the whole instance. Only accept_zero_fee below can
+#   # produce a 0 floor. Only peers whose datahub URL is registered count
+#   # toward the observation, so /policy's inputs are the endpoints /health
+#   # shows.
 #   min_fee_per_kb: 0
 #   # accept_zero_fee, when true, pins the floor to 0 sat/kB so any tx
-#   # (including fee=0) is accepted at intake, and /policy advertises 0.
+#   # (including fee=0) is accepted at intake, and /policy advertises 0. This
+#   # is the ONLY route to a zero floor; network observation cannot reach it.
 #   # Intended for teratestnet/regtest where the upstream Teranode is also
 #   # configured to accept zero-fee txs. Leave false on mainnet and testnet.
 #   # accept_zero_fee: false

--- a/config/config.go
+++ b/config/config.go
@@ -932,6 +932,11 @@ type ValidatorConfig struct {
 	// fee observed from peer node_status announcements, falling back to
 	// DefaultValidatorMinFeePerKB when no peer has been heard. A non-zero value
 	// (or AcceptZeroFee) is reported verbatim.
+	//
+	// An observed fee is floored at 1 sat/kB: peer announcements are
+	// unauthenticated and the rule is a bare minimum, so a single peer
+	// advertising 0 would otherwise disable fee enforcement entirely. Setting
+	// AcceptZeroFee is the only way to reach a 0 floor.
 	MinFeePerKB uint64 `mapstructure:"min_fee_per_kb"`
 
 	// AcceptZeroFee, when true, pins the validator's fee floor to exactly

--- a/services/api_server/policy_refresher.go
+++ b/services/api_server/policy_refresher.go
@@ -91,11 +91,14 @@ func (s *Server) refreshPolicyOnce(ctx context.Context) {
 	// Fee: the lowest any peer will accept, so arcade rejects only what no peer
 	// would mine. Sizes: the highest any peer will accept, the same rule read
 	// the other way round.
-	fee := uint64(config.DefaultValidatorMinFeePerKB)
+	var (
+		fee      uint64
+		cheapest string // peer that set the floor, for the log line below
+	)
 	if s.feePinned() {
 		fee = s.validator.MinFeePerKB() // pinned at construction; leave it be
-	} else if observed, ok := lowestObservedFeePerKB(peers, ttl, now); ok {
-		fee = observed
+	} else {
+		fee, cheapest = discoveredFeePerKB(peers, ttl, now)
 	}
 
 	maxTxSize := s.cfg.Validator.MaxTxSizePolicy
@@ -129,6 +132,9 @@ func (s *Server) refreshPolicyOnce(ctx context.Context) {
 		s.logger.Info("intake policy updated from network observations",
 			zap.Uint64("prev_fee_sat_per_kb", prevFee),
 			zap.Uint64("new_fee_sat_per_kb", newFee),
+			// Which peer set the floor. Without it, "why is the floor 1?" can
+			// only be answered by querying the store by hand.
+			zap.String("cheapest_peer_id", cheapest),
 			zap.Int("prev_max_tx_size", prevTxSize),
 			zap.Int("new_max_tx_size", newTxSize),
 			zap.Int("prev_max_script_size", prevScriptSize),
@@ -157,17 +163,51 @@ func discoveredLimit(peers []store.PeerPolicy, ttl time.Duration, now time.Time,
 	return observed
 }
 
+// minDiscoveredFeePerKB is the floor under the network-observed fee: discovery
+// may track the cheapest node all the way down to 1 sat/kB, but never to 0.
+//
+// This is the fee's counterpart to the floor discoveredLimit applies to the
+// size limits, and it exists for the same reason: node_status is
+// unauthenticated gossip and the rule is a bare minimum, so a single peer
+// advertising 0 — misconfigured, or simply a node with nil policy settings,
+// which teranode advertises as min_mining_tx_fee=0 — silently disabled fee
+// enforcement for an entire arcade instance. Accepting zero-fee transactions is
+// a deliberate operator decision, so accept_zero_fee is the only thing that may
+// produce a 0 floor.
+const minDiscoveredFeePerKB = 1
+
+// discoveredFeePerKB resolves the network-tracked fee floor: the lowest rate a
+// fresh peer will accept, bounded below by minDiscoveredFeePerKB, or the
+// built-in default when nothing fresh has been observed. It also returns the id
+// of the peer that set the floor, so the change is explainable in a log line
+// rather than only by querying the store.
+func discoveredFeePerKB(peers []store.PeerPolicy, ttl time.Duration, now time.Time) (uint64, string) {
+	observed, peerID, ok := lowestObservedFeePerKB(peers, ttl, now)
+	if !ok {
+		return uint64(config.DefaultValidatorMinFeePerKB), ""
+	}
+	if observed < minDiscoveredFeePerKB {
+		return minDiscoveredFeePerKB, peerID
+	}
+	return observed, peerID
+}
+
 // lowestObservedFeePerKB returns the minimum mining fee rate (in satoshis per
-// 1000 bytes) advertised by peers re-heard within ttl. ok is false when no
-// fresh observation exists. A peer's rate is normalized to sat/kB using ceil
-// division so a non-1000 byte basis never rounds the enforced floor *below*
-// what the peer requires (e.g. 1 sat / 1001 bytes must map to 1 sat/kB, not 0,
-// or arcade would accept fee=0 that no node would).
-func lowestObservedFeePerKB(peers []store.PeerPolicy, ttl time.Duration, now time.Time) (uint64, bool) {
+// 1000 bytes) advertised by peers re-heard within ttl, and the id of the peer
+// advertising it. ok is false when no fresh observation exists. A peer's rate
+// is normalized to sat/kB using ceil division so a non-1000 byte basis never
+// rounds the enforced floor *below* what the peer requires (e.g. 1 sat / 1001
+// bytes must map to 1 sat/kB, not 0, or arcade would accept fee=0 that no node
+// would).
+//
+// Callers should use discoveredFeePerKB rather than this directly: the raw
+// minimum is unbounded below and must not reach the validator unfloored.
+func lowestObservedFeePerKB(peers []store.PeerPolicy, ttl time.Duration, now time.Time) (uint64, string, bool) {
 	cutoff := now.Add(-ttl)
 	var (
-		best  uint64
-		found bool
+		best   uint64
+		peerID string
+		found  bool
 	)
 	for _, p := range peers {
 		if p.MiningFeeBytes == 0 {
@@ -179,10 +219,11 @@ func lowestObservedFeePerKB(peers []store.PeerPolicy, ttl time.Duration, now tim
 		perKB := ceilFeePerKB(p.MiningFeeSatoshis, p.MiningFeeBytes)
 		if !found || perKB < best {
 			best = perKB
+			peerID = p.PeerID
 			found = true
 		}
 	}
-	return best, found
+	return best, peerID, found
 }
 
 // highestObservedLimit returns the maximum value pick reports across peers

--- a/services/api_server/policy_refresher_test.go
+++ b/services/api_server/policy_refresher_test.go
@@ -45,7 +45,7 @@ func TestLowestObservedFeePerKB(t *testing.T) {
 			// stale cheapest — must be excluded
 			{PeerID: "p3", MiningFeeSatoshis: 1, MiningFeeBytes: 1000, LastSeen: now.Add(-24 * time.Hour)},
 		}
-		got, ok := lowestObservedFeePerKB(peers, ttl, now)
+		got, _, ok := lowestObservedFeePerKB(peers, ttl, now)
 		if !ok || got != 100 {
 			t.Fatalf("got (%d,%v), want (100,true)", got, ok)
 		}
@@ -55,13 +55,13 @@ func TestLowestObservedFeePerKB(t *testing.T) {
 		peers := []store.PeerPolicy{
 			{PeerID: "p1", MiningFeeSatoshis: 1, MiningFeeBytes: 1000, LastSeen: now.Add(-24 * time.Hour)},
 		}
-		if _, ok := lowestObservedFeePerKB(peers, ttl, now); ok {
+		if _, _, ok := lowestObservedFeePerKB(peers, ttl, now); ok {
 			t.Fatal("expected ok=false when all peers stale")
 		}
 	})
 
 	t.Run("empty", func(t *testing.T) {
-		if _, ok := lowestObservedFeePerKB(nil, ttl, now); ok {
+		if _, _, ok := lowestObservedFeePerKB(nil, ttl, now); ok {
 			t.Fatal("expected ok=false for empty input")
 		}
 	})
@@ -72,7 +72,7 @@ func TestLowestObservedFeePerKB(t *testing.T) {
 			{PeerID: "p1", MiningFeeSatoshis: 250, MiningFeeBytes: 500, LastSeen: now},
 			{PeerID: "p2", MiningFeeSatoshis: 100, MiningFeeBytes: 1000, LastSeen: now},
 		}
-		got, ok := lowestObservedFeePerKB(peers, ttl, now)
+		got, _, ok := lowestObservedFeePerKB(peers, ttl, now)
 		if !ok || got != 100 {
 			t.Fatalf("got (%d,%v), want (100,true)", got, ok)
 		}
@@ -84,7 +84,7 @@ func TestLowestObservedFeePerKB(t *testing.T) {
 		peers := []store.PeerPolicy{
 			{PeerID: "p1", MiningFeeSatoshis: 1, MiningFeeBytes: 1001, LastSeen: now},
 		}
-		got, ok := lowestObservedFeePerKB(peers, ttl, now)
+		got, _, ok := lowestObservedFeePerKB(peers, ttl, now)
 		if !ok || got != 1 {
 			t.Fatalf("got (%d,%v), want (1,true) — ceil, not floor", got, ok)
 		}
@@ -95,7 +95,7 @@ func TestLowestObservedFeePerKB(t *testing.T) {
 			{PeerID: "huge", MiningFeeSatoshis: 1 << 60, MiningFeeBytes: 1, LastSeen: now},
 			{PeerID: "sane", MiningFeeSatoshis: 20, MiningFeeBytes: 1000, LastSeen: now},
 		}
-		got, ok := lowestObservedFeePerKB(peers, ttl, now)
+		got, _, ok := lowestObservedFeePerKB(peers, ttl, now)
 		if !ok || got != 20 {
 			t.Fatalf("got (%d,%v), want (20,true) — huge fee must not wrap into the minimum", got, ok)
 		}
@@ -106,7 +106,7 @@ func TestLowestObservedFeePerKB(t *testing.T) {
 			{PeerID: "bad", MiningFeeSatoshis: 5, MiningFeeBytes: 0, LastSeen: now},
 			{PeerID: "ok", MiningFeeSatoshis: 80, MiningFeeBytes: 1000, LastSeen: now},
 		}
-		got, ok := lowestObservedFeePerKB(peers, ttl, now)
+		got, _, ok := lowestObservedFeePerKB(peers, ttl, now)
 		if !ok || got != 80 {
 			t.Fatalf("got (%d,%v), want (80,true)", got, ok)
 		}
@@ -421,5 +421,120 @@ func TestConfigDefaultsMatchValidatorDefaults(t *testing.T) {
 	if got := v.MinFeePerKB(); got != config.DefaultValidatorMinFeePerKB {
 		t.Errorf("validator default min fee %d != config default %d",
 			got, config.DefaultValidatorMinFeePerKB)
+	}
+}
+
+// TestDiscoveredFeePerKB is the regression for a production report: /policy
+// advertised miningFee 0 sat/kB while every endpoint in /health advertised 100.
+//
+// The rule is a bare minimum over unauthenticated gossip, so one peer at 0 —
+// misconfigured, or a node with nil policy settings, which teranode advertises
+// as min_mining_tx_fee=0 — silently disabled fee enforcement for the whole
+// instance. The floor is the fee's counterpart to the one discoveredLimit
+// applies to the size limits: discovery may track the cheapest node all the way
+// to 1 sat/kB, but only an explicit accept_zero_fee may produce a 0 floor.
+func TestDiscoveredFeePerKB(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	ttl := 15 * time.Minute
+
+	cases := []struct {
+		name     string
+		peers    []store.PeerPolicy
+		want     uint64
+		wantPeer string
+	}{
+		{
+			name: "tracks the cheapest peer",
+			peers: []store.PeerPolicy{
+				{PeerID: "p1", MiningFeeSatoshis: 500, MiningFeeBytes: 1000, LastSeen: now},
+				{PeerID: "p2", MiningFeeSatoshis: 100, MiningFeeBytes: 1000, LastSeen: now},
+			},
+			want: 100, wantPeer: "p2",
+		},
+		{
+			name: "a single zero-fee peer cannot disable fee enforcement",
+			peers: []store.PeerPolicy{
+				{PeerID: "honest", MiningFeeSatoshis: 100, MiningFeeBytes: 1000, LastSeen: now},
+				{PeerID: "zero", MiningFeeSatoshis: 0, MiningFeeBytes: 1000, LastSeen: now},
+			},
+			want: minDiscoveredFeePerKB, wantPeer: "zero",
+		},
+		{
+			name: "a whole network at zero still floors at the minimum",
+			peers: []store.PeerPolicy{
+				{PeerID: "zero", MiningFeeSatoshis: 0, MiningFeeBytes: 1000, LastSeen: now},
+			},
+			want: minDiscoveredFeePerKB, wantPeer: "zero",
+		},
+		{
+			name: "one satoshi per kB is above the floor and passes through",
+			peers: []store.PeerPolicy{
+				{PeerID: "cheap", MiningFeeSatoshis: 1, MiningFeeBytes: 1000, LastSeen: now},
+			},
+			want: 1, wantPeer: "cheap",
+		},
+		{
+			name:  "no observations falls back to the built-in default",
+			peers: nil,
+			want:  uint64(config.DefaultValidatorMinFeePerKB),
+		},
+		{
+			name: "a stale zero-fee peer is ignored entirely",
+			peers: []store.PeerPolicy{
+				{PeerID: "honest", MiningFeeSatoshis: 100, MiningFeeBytes: 1000, LastSeen: now},
+				{PeerID: "gone", MiningFeeSatoshis: 0, MiningFeeBytes: 1000, LastSeen: now.Add(-24 * time.Hour)},
+			},
+			want: 100, wantPeer: "honest",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, peerID := discoveredFeePerKB(tc.peers, ttl, now)
+			if got != tc.want {
+				t.Errorf("discoveredFeePerKB() = %d, want %d", got, tc.want)
+			}
+			if peerID != tc.wantPeer {
+				t.Errorf("cheapest peer = %q, want %q — the log line naming the "+
+					"culprit is how an operator explains the floor", peerID, tc.wantPeer)
+			}
+		})
+	}
+}
+
+// TestRefreshPolicyOnce_ZeroFeePeerDoesNotZeroTheFloor is the same guarantee
+// end to end through the refresher and the validator, since that is where the
+// production symptom was visible: GET /policy reads the validator's floor.
+func TestRefreshPolicyOnce_ZeroFeePeerDoesNotZeroTheFloor(t *testing.T) {
+	s := newPolicyServer(&mockStore{peerPolicies: []store.PeerPolicy{
+		freshPolicy("honest", 100, 100_000_000, 500_000),
+		freshPolicy("zero", 0, 100_000_000, 500_000),
+	}})
+
+	s.refreshPolicyOnce(context.Background())
+
+	if got := s.validator.MinFeePerKB(); got != minDiscoveredFeePerKB {
+		t.Errorf("intake fee floor = %d, want %d — a zero-fee peer must not "+
+			"make arcade accept transactions no node will mine", got, minDiscoveredFeePerKB)
+	}
+	// The size limits still track normally.
+	if got := s.validator.MaxTxSizePolicy(); got != 100_000_000 {
+		t.Errorf("MaxTxSizePolicy = %d, want 100000000", got)
+	}
+}
+
+// TestRefreshPolicyOnce_AcceptZeroFeeStillPinsZero confirms the floor did not
+// take away the one legitimate route to a zero-fee intake: an operator opting
+// in explicitly, which is what accept_zero_fee is for.
+func TestRefreshPolicyOnce_AcceptZeroFeeStillPinsZero(t *testing.T) {
+	s := newPolicyServerWithConfig(
+		&mockStore{peerPolicies: []store.PeerPolicy{freshPolicy("honest", 100, 0, 0)}},
+		config.ValidatorConfig{AcceptZeroFee: true})
+	s.validator.SetMinFeePerKB(0) // as app wiring does at construction
+
+	s.refreshPolicyOnce(context.Background())
+
+	if got := s.validator.MinFeePerKB(); got != 0 {
+		t.Errorf("intake fee floor = %d, want 0 (accept_zero_fee pins it)", got)
 	}
 }

--- a/services/p2p_client/client.go
+++ b/services/p2p_client/client.go
@@ -285,11 +285,6 @@ func (c *Client) handleNodeStatus(ctx context.Context, msg teranodep2p.NodeStatu
 		ce.Write(fields...)
 	}
 
-	// Record the peer's advertised policy before the datahub-URL gate below, so
-	// a peer that exposes a policy but no datahub URL still counts toward the
-	// GET /policy network values (issue #212).
-	c.recordPeerPolicy(ctx, msg)
-
 	raw := pickDatahubURL(msg)
 	if raw == "" {
 		metrics.P2PEndpointDiscoveryTotal.WithLabelValues("no_url").Inc()
@@ -344,6 +339,19 @@ func (c *Client) handleNodeStatus(ctx context.Context, msg teranodep2p.NodeStatu
 		zap.String("peer_id", msg.PeerID),
 		zap.String("url", normalized),
 	)
+
+	// Record the peer's advertised policy only once its URL is in the registry,
+	// so the network values GET /policy derives come from exactly the peers
+	// arcade can actually broadcast to — the same set GET /health displays.
+	//
+	// This deliberately reverses the original ordering (issue #212), which ran
+	// ahead of the URL gate so a peer advertising a policy but no usable URL
+	// still counted. That made the fee floor unexplainable in production: a
+	// peer with no URL, or one rejected by SSRF validation (this network really
+	// does see nodes announcing cluster-internal names), set the floor for
+	// everyone while appearing nowhere in /health. An operator looking at a
+	// 0 sat/kB floor could see only peers advertising 100.
+	c.recordPeerPolicy(ctx, msg)
 }
 
 // recordPeerPolicy extracts the peer's advertised transaction policy from a
@@ -352,6 +360,10 @@ func (c *Client) handleNodeStatus(ctx context.Context, msg teranodep2p.NodeStatu
 // structured FeePolicy (satoshis per Bytes, plus the size limits) and falls
 // back to the legacy MinMiningTxFee (*float64 in BSV/kB), which carries no size
 // limits. Peers advertising neither (older nodes) are skipped.
+//
+// Called only after the peer's datahub URL has been registered, so every row it
+// writes belongs to a peer arcade can broadcast to — see the call site for why
+// that matters.
 func (c *Client) recordPeerPolicy(ctx context.Context, msg teranodep2p.NodeStatusMessage) {
 	var sats, byts, maxTxSize, maxScriptSize uint64
 	switch {

--- a/services/p2p_client/client_test.go
+++ b/services/p2p_client/client_test.go
@@ -155,6 +155,21 @@ func waitForUpserts(t *testing.T, w *fakeEndpointWriter, want int) []store.Datah
 	}
 }
 
+func waitForFeeUpserts(t *testing.T, w *fakeEndpointWriter, want int) []store.PeerPolicy {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		calls := w.feeSnapshot()
+		if len(calls) >= want {
+			return calls
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d peer-policy upserts, got %d: %+v", want, len(calls), calls)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 // captureLibraryConfig returns a clientFactory that sends the config it sees
 // through the returned channel, synchronizing between the Start goroutine
 // and the test goroutine so the race detector stays happy.
@@ -472,16 +487,70 @@ func TestRecordPeerPolicy_LegacyMinMiningTxFee(t *testing.T) {
 	}
 }
 
-// TestRecordPeerPolicy_URLlessPeerStillRecorded verifies a peer that advertises a
-// fee but no datahub URL is still counted toward the /policy network-minimum.
-func TestRecordPeerPolicy_URLlessPeerStillRecorded(t *testing.T) {
-	c, w := newTestClient(t, newFakeTeraClient(testPeerID))
-	c.recordPeerPolicy(context.Background(), teranodep2p.NodeStatusMessage{
-		PeerID:    "peer-3",
-		FeePolicy: &teranodep2p.FeePolicy{MiningFee: teranodep2p.FeeAmount{Satoshis: 10, Bytes: 1000}},
-	})
-	if fees := w.feeSnapshot(); len(fees) != 1 || fees[0].PeerID != "peer-3" {
-		t.Fatalf("expected URL-less peer fee recorded, got %+v", fees)
+// TestPeerPolicyOnlyRecordedForRegisteredURLs is the fix for a fee floor nobody
+// could explain: /policy advertised 0 sat/kB while every endpoint in /health
+// advertised 100.
+//
+// The policy feeding /policy used to be recorded ahead of the datahub-URL gate,
+// so a peer with no URL — or one rejected by SSRF validation, which this
+// network really does produce — set the network minimum while appearing nowhere
+// in /health. Recording it after registration means the values /policy derives
+// come from exactly the peers arcade can broadcast to, which is the set /health
+// displays.
+func TestPeerPolicyOnlyRecordedForRegisteredURLs(t *testing.T) {
+	cheap := &teranodep2p.FeePolicy{MiningFee: teranodep2p.FeeAmount{Satoshis: 0, Bytes: 1000}}
+
+	cases := []struct {
+		name       string
+		msg        teranodep2p.NodeStatusMessage
+		wantRecord bool
+	}{
+		{
+			name:       "peer with a registered URL counts",
+			msg:        teranodep2p.NodeStatusMessage{PeerID: testPeerID, BaseURL: testPeerURL, FeePolicy: cheap},
+			wantRecord: true,
+		},
+		{
+			name: "peer advertising no URL does not count",
+			msg:  teranodep2p.NodeStatusMessage{PeerID: testPeerID, FeePolicy: cheap},
+		},
+		{
+			// A cluster-internal name that resolves nowhere reachable — the
+			// "poisoned registry" case the endpoint source already filters.
+			name: "peer whose URL is rejected does not count",
+			msg:  teranodep2p.NodeStatusMessage{PeerID: testPeerID, BaseURL: "http://10.0.0.5:8090", FeePolicy: cheap},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := newFakeTeraClient(testPeerID)
+			c, w := newTestClient(t, fc)
+			_, stop := runStart(t, c)
+			defer stop()
+
+			fc.ch <- tc.msg
+
+			if tc.wantRecord {
+				fees := waitForFeeUpserts(t, w, 1)
+				if fees[0].PeerID != testPeerID {
+					t.Errorf("recorded the wrong peer: %+v", fees[0])
+				}
+				return
+			}
+
+			// Asserting an absence needs a barrier, not a sleep. Announcements
+			// are consumed in order by a single goroutine, so once a later
+			// message's registration is visible the earlier one has certainly
+			// been handled. This barrier carries no fee policy of its own, so
+			// any recorded fee could only have come from the case's message.
+			fc.ch <- teranodep2p.NodeStatusMessage{PeerID: "barrier", BaseURL: "https://barrier.example"}
+			waitForUpserts(t, w, 1)
+
+			if fees := w.feeSnapshot(); len(fees) != 0 {
+				t.Errorf("a peer with no registered URL must not set the network fee, got %+v", fees)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## The report

`arcade-v2-us-1` and `arcade-v2-eu-1` (v0.13.2) both advertise **`miningFee: 0` sat/kB** on `GET /policy`, while every endpoint in `GET /health` advertises **100**:

```
$ curl .../policy   → "miningFee": {"satoshis": 0, "bytes": 1000}
$ curl .../health   → 6 endpoints at 100 sat/kB, 2 stale with no policy, none at 0
```

`maxtxsizepolicy` is the discovered `100000000` rather than the 10 MiB default, so discovery was working and the peer rows were fresh. The validator really was holding a 0 floor.

## Two defects, both fixed here

### 1. The observed fee had no lower bound

The fee takes the **minimum** across fresh peers, so a single peer advertising 0 set the floor to 0 for the whole instance. Peer announcements are unauthenticated gossip, and a node need not even be malicious to send it — teranode advertises `min_mining_tx_fee=0` when its policy settings are nil.

The size limits already had exactly this guard, and the reasoning was written down when it was added in #314:

```go
// sizes — floored, so observation can only ever widen from the built-in default
if !ok || observed < floor { return floor }

// fee — no floor at all
if !found || perKB < best { best = perKB }
```

It simply was not carried across to the fee. Now it is: discovery may track the cheapest node down to **1 sat/kB** but never to 0. Accepting zero-fee transactions is a deliberate operator decision, so **`accept_zero_fee` is the only route to a 0 floor**, and it still works — there is a test for that.

### 2. The fee counted peers arcade cannot broadcast to

`recordPeerPolicy` ran **ahead of** the datahub-URL gate, so a peer advertising no URL — or one rejected by SSRF validation, which this network really does produce (nodes announcing cluster-internal names) — set the network minimum while appearing nowhere in `/health`.

That is exactly why the report was unexplainable from outside: the operator could see only peers advertising 100.

The ordering was deliberate when the fee was introduced (#212): a peer exposing a fee but no usable URL still counted toward the minimum. This reverses it. The policy is recorded once the URL is in the registry, so `/policy`'s inputs are exactly the peers arcade can broadcast to — the set `/health` displays.

### Plus: the floor is now explainable

`refreshPolicyOnce` logs which peer set the floor, so "why is the floor 1?" no longer requires a store query.

## Operator note

If a deployment is currently relying on network observation to reach a 0 floor, it will now sit at 1 sat/kB. Set `validator.accept_zero_fee: true` to keep a zero-fee intake — that is what the flag is for, and it is the honest way to express the intent.

Existing `peer_policies` rows for URL-less peers age out of the computation on the normal 15-minute TTL; no migration or manual cleanup is needed.

## Verification

```
go build ./... && go vet ./...          # clean
go test ./... && go test -race ./...    # all pass
go test -tags=postgres ./store/postgres # pass
golangci-lint run                       # 0 issues
```

Both fixes are pinned by tests that **fail against the previous behaviour** — I reverted each fix in turn to confirm:

```
--- FAIL: TestDiscoveredFeePerKB/a_single_zero-fee_peer_cannot_disable_fee_enforcement
--- FAIL: TestRefreshPolicyOnce_ZeroFeePeerDoesNotZeroTheFloor
    intake fee floor = 0, want 1 — a zero-fee peer must not make arcade accept
    transactions no node will mine
--- FAIL: TestPeerPolicyOnlyRecordedForRegisteredURLs/peer_advertising_no_URL_does_not_count
    a peer with no registered URL must not set the network fee, got
    [{PeerID:sender MiningFeeSatoshis:0 MiningFeeBytes:1000 ...}]
```

That last one reproduces the production symptom directly.

Coverage also includes: the cheapest peer still tracked normally, a whole network at zero still flooring, 1 sat/kB passing through unchanged, a stale zero-fee peer ignored entirely, `accept_zero_fee` still pinning 0, and the peer id reported for the log line.

## Caveat

I could not confirm from outside **which** of the two defects produced the live 0 — that needs one query against the deployment's store:

```sql
SELECT peer_id, mining_fee_satoshis, mining_fee_bytes, last_seen
FROM peer_policies WHERE network = 'mainnet'
ORDER BY mining_fee_satoshis ASC LIMIT 5;
```

A fresh row at 0 confirms it. If the lowest is 100, then the live deployments have `accept_zero_fee` set and this PR is a hardening change rather than the fix for that specific symptom — worth checking before assuming the deploy resolves it.