### PR TITLE
[Propagation/API] Terminal give-up stays terminal; callback registration idempotent per (txid, url, token)

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,11 @@ When you provide `X-CallbackUrl`, Arcade will POST status updates:
 ```
 
 **Features:**
-- Automatic retries with linear backoff (1min, 2min, 3min, etc.)
+- Registration is idempotent per `(txid, X-CallbackUrl, X-CallbackToken)`:
+  re-POSTing the same transaction with the same headers updates the existing
+  subscription (its `X-FullStatusUpdates` intent) instead of adding another
+  delivery — a client retry loop cannot multiply callbacks
+- Automatic retries with exponential backoff (5 s doubling to a 5 min cap)
 - Configurable max retries via `webhook.max_retries`
 - Every POST carries `User-Agent: arcade-webhook/<version>` — allowlist the
   `arcade-webhook/` prefix at your edge so bot/WAF rules don't silently

--- a/openapi/arcade.openapi.yaml
+++ b/openapi/arcade.openapi.yaml
@@ -1124,7 +1124,10 @@ components:
         rejected unless the deployment is configured to allow them. The POST body
         is a TransactionStatus; MINED/IMMUTABLE callbacks include blockHash,
         blockHeight, and merklePath (the tx's BUMP), so the proof arrives on the
-        callback without a follow-up GET.
+        callback without a follow-up GET. Registration is idempotent per
+        (txid, X-CallbackUrl, X-CallbackToken): re-POSTing the same transaction
+        with the same headers updates the existing subscription rather than
+        adding another delivery.
 
         Every callback POST carries `User-Agent: arcade-webhook/<version>` —
         allowlist the `arcade-webhook/` prefix at your edge so bot/WAF rules

--- a/services/api_server/handlers.go
+++ b/services/api_server/handlers.go
@@ -2,7 +2,7 @@ package api_server
 
 import (
 	"context"
-	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	_ "embed"
 	"encoding/hex"
@@ -125,11 +125,15 @@ func (s *Server) recordSubmission(_ context.Context, txid string, opts submitOpt
 	if !opts.hasSubscription() {
 		return
 	}
-	id, err := newSubmissionID()
-	if err != nil {
-		s.logger.Warn("could not generate submission id", zap.Error(err))
-		return
-	}
+	// Deterministic per (txid, callback URL, callback token): a repeat POST of
+	// the same txid with the same subscription re-registers the SAME row
+	// instead of appending another one. Registrations used to accumulate one
+	// per POST (a random id never conflicts), and every status event was then
+	// delivered once per accumulated row — a client retry ladder re-presenting
+	// a rejected txid for a few hours turned one status flip into thousands of
+	// webhook POSTs. The backends' InsertSubmission are idempotent on this id
+	// and preserve the row's delivery state.
+	id := submissionIDFor(txid, opts.CallbackURL, opts.CallbackToken)
 	sub := &models.Submission{
 		SubmissionID:      id,
 		TxID:              txid,
@@ -149,14 +153,20 @@ func (s *Server) recordSubmission(_ context.Context, txid string, opts submitOpt
 	}
 }
 
-// newSubmissionID returns a 16-byte random hex identifier. Globally unique
-// per call without coordinating across pods.
-func newSubmissionID() (string, error) {
-	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(b[:]), nil
+// submissionIDFor derives the submission id from the subscription identity:
+// hex(sha256(txid || 0x00 || callbackURL || 0x00 || callbackToken)),
+// truncated to 32 hex characters (the width the random ids used, so nothing
+// downstream — bin sizes, log grep, index keys — changes shape). Same inputs
+// on any pod at any time give the same id, which is what makes registration
+// idempotent without a cross-pod lookup.
+func submissionIDFor(txid, callbackURL, callbackToken string) string {
+	h := sha256.New()
+	h.Write([]byte(txid))
+	h.Write([]byte{0})
+	h.Write([]byte(callbackURL))
+	h.Write([]byte{0})
+	h.Write([]byte(callbackToken))
+	return hex.EncodeToString(h.Sum(nil))[:32]
 }
 
 //go:embed docs.html

--- a/services/api_server/handlers_test.go
+++ b/services/api_server/handlers_test.go
@@ -2502,3 +2502,81 @@ func TestSubmitCounters_SingleDedupResults(t *testing.T) {
 		t.Errorf("duplicate resubmit must not count as new (delta %v)", got)
 	}
 }
+
+// TestHandleSubmitTransaction_RepeatPostSameCallback_RegistersOnce pins the
+// idempotent registration id (bsv-blockchain/arcade#335): two POSTs of the
+// same txid with the same X-CallbackUrl/X-CallbackToken must queue the SAME
+// submission id, so the backends' idempotent InsertSubmission collapses them
+// onto one row — a client retry ladder re-presenting a tx must not multiply
+// its webhook deliveries. A different callback identity still gets its own id.
+func TestHandleSubmitTransaction_RepeatPostSameCallback_RegistersOnce(t *testing.T) {
+	rawTx := makeMinimalTx() // rejected at intake — the intake path records a submission too
+	ms := &mockStore{}
+	pub := &recordingCallbackPub{}
+	val := validator.NewValidator(nil)
+	broker := &kafka.RecordingBroker{}
+	gin.SetMode(gin.TestMode)
+	srv := &Server{
+		cfg:            &config.Config{CallbackToken: testCallbackToken, Callback: config.CallbackConfig{AllowPrivateIPs: true}},
+		logger:         zap.NewNop(),
+		producer:       kafka.NewProducer(broker),
+		store:          ms,
+		publisher:      pub,
+		validator:      val,
+		submissionCh:   make(chan submissionRecord, submissionRecorderBuffer),
+		submissionStop: make(chan struct{}),
+	}
+	router := gin.New()
+	srv.registerRoutes(router)
+
+	post := func(url, token string) {
+		t.Helper()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/tx", bytes.NewReader(rawTx))
+		req.Header.Set("Content-Type", "application/octet-stream")
+		req.Header.Set("X-CallbackUrl", url)
+		req.Header.Set("X-CallbackToken", token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+	}
+	post("https://example.test/hook", "tok-1")
+	post("https://example.test/hook", "tok-1")
+	post("https://example.test/other", "tok-1")
+	drainSubmissions(t, srv)
+
+	ms.mu.Lock()
+	subs := append([]*models.Submission(nil), ms.insertedSubmissions...)
+	ms.mu.Unlock()
+	if len(subs) != 3 {
+		t.Fatalf("recorded %d submission(s), want 3 (one per POST reaches the recorder)", len(subs))
+	}
+	if subs[0].SubmissionID != subs[1].SubmissionID {
+		t.Errorf("same txid + same callback identity produced different ids %q / %q", subs[0].SubmissionID, subs[1].SubmissionID)
+	}
+	if subs[2].SubmissionID == subs[0].SubmissionID {
+		t.Errorf("a different callback URL must get its own id, got %q for both", subs[2].SubmissionID)
+	}
+	if len(subs[0].SubmissionID) != 32 {
+		t.Errorf("submission id width changed: %q", subs[0].SubmissionID)
+	}
+}
+
+func TestSubmissionIDFor_DeterministicAndIdentityBound(t *testing.T) {
+	a := submissionIDFor("tx", "https://example.test/cb", "tok")
+	if a != submissionIDFor("tx", "https://example.test/cb", "tok") {
+		t.Fatal("same inputs must give the same id")
+	}
+	for _, other := range [][3]string{
+		{"tx2", "https://example.test/cb", "tok"},
+		{"tx", "https://example.test/cb2", "tok"},
+		{"tx", "https://example.test/cb", "tok2"},
+		{"tx", "", "tok"},
+	} {
+		if submissionIDFor(other[0], other[1], other[2]) == a {
+			t.Errorf("inputs %v collided with the base id", other)
+		}
+	}
+	// The separator keeps (url, token) boundaries unambiguous.
+	if submissionIDFor("tx", "ab", "c") == submissionIDFor("tx", "a", "bc") {
+		t.Error("field boundaries must be delimited")
+	}
+}

--- a/services/propagation/pending_retry_schedule_test.go
+++ b/services/propagation/pending_retry_schedule_test.go
@@ -421,3 +421,113 @@ func TestReapOnce_AdoptsLegacyParkedRows(t *testing.T) {
 		t.Errorf("adopted legacy row was not retried to ACCEPTED_BY_NETWORK")
 	}
 }
+
+// TestSchedulePendingRetry_TerminalRowIsNeverBumped pins the give-up as
+// TERMINAL in the scheduler, not only in the status lattice.
+//
+// Production shape (bsv-blockchain/arcade#335): a client re-POSTed a
+// REJECTED txid (handleSubmitTransaction republishes REJECTED rows), the
+// fast-path budget exhausted again, the PENDING_RETRY write was refused by
+// the lattice — and schedulePendingRetry still ran: BumpRetryCount had no
+// status predicate, so retry_count climbed to 1,483 on a row whose
+// extra_info already read "giving up", ClearRetryState re-wrote the same
+// verdict, and a fresh REJECTED event fanned out to every registration on
+// every POST. A terminal row must leave the scheduler untouched.
+func TestSchedulePendingRetry_TerminalRowIsNeverBumped(t *testing.T) {
+	root := strings.Repeat("98", 32)
+	orphan := buildChain(t, root, 1)[0]
+
+	for _, terminal := range []models.Status{
+		models.StatusRejected, models.StatusDoubleSpendAttempted,
+		models.StatusMined, models.StatusImmutable,
+	} {
+		t.Run(string(terminal), func(t *testing.T) {
+			ms := newMockStore()
+			ms.setStatus(orphan.txid, terminal)
+			pub := &recordingPublisher{}
+			p := rejectionPropagator("http://127.0.0.1:0", ms, pub)
+			p.pendingRetryMaxAttempts = 1
+
+			exhaustedBefore := testutil.ToFloat64(metrics.PropagationPendingRetryTotal.WithLabelValues("exhausted"))
+			skippedBefore := testutil.ToFloat64(metrics.PropagationPendingRetryTotal.WithLabelValues("skipped_terminal"))
+
+			for i := 0; i < 3; i++ {
+				p.schedulePendingRetry(context.Background(), orphan.txid, orphan.raw, orphanRetryReason)
+			}
+
+			ms.mu.Lock()
+			bumps := ms.retryCounts[orphan.txid]
+			cleared := len(ms.cleared)
+			_, queued := ms.pendingRetries[orphan.txid]
+			ms.mu.Unlock()
+			if bumps != 0 {
+				t.Errorf("retry_count was bumped %d time(s) on a %s row; the budget of a terminal tx is not spendable", bumps, terminal)
+			}
+			if cleared != 0 {
+				t.Errorf("ClearRetryState ran %d time(s) on a %s row; a terminal verdict must not be re-written", cleared, terminal)
+			}
+			if queued {
+				t.Errorf("a %s row entered the durable retry queue", terminal)
+			}
+			if got := len(pub.bulkSnapshot()); got != 0 {
+				t.Errorf("published %d event(s) for a %s row; a resubmit of a terminal tx must be silent", got, terminal)
+			}
+			if got := testutil.ToFloat64(metrics.PropagationPendingRetryTotal.WithLabelValues("exhausted")); got != exhaustedBefore {
+				t.Errorf("exhausted counter moved on a terminal row: %v -> %v", exhaustedBefore, got)
+			}
+			if got := testutil.ToFloat64(metrics.PropagationPendingRetryTotal.WithLabelValues("skipped_terminal")); got != skippedBefore+3 {
+				t.Errorf("skipped_terminal counter = %v, want %v", got, skippedBefore+3)
+			}
+		})
+	}
+}
+
+// TestApplyTerminalStatuses_LatticeRefusedRowIsNotPublished pins the other
+// half of the same flood: the store hands back the row it DECLINED to move
+// (prev.Status = REJECTED for a PENDING_RETRY input), and the publish pass
+// must treat that exactly like a lattice no-op — no phantom PENDING_RETRY
+// event. The dispatcher notification is unconditional and untouched.
+func TestApplyTerminalStatuses_LatticeRefusedRowIsNotPublished(t *testing.T) {
+	ms := newMockStore()
+	ms.returningPrev = func(s *models.TransactionStatus) *models.TransactionStatus {
+		return &models.TransactionStatus{
+			TxID:      s.TxID,
+			Status:    models.StatusRejected, // the row is terminal; PENDING_RETRY is forbidden over it
+			Timestamp: time.Now().Add(-time.Hour),
+		}
+	}
+	pub := &recordingPublisher{}
+	p := rejectionPropagator("http://127.0.0.1:0", ms, pub)
+
+	txid := strings.Repeat("97", 32)
+	p.applyTerminalStatuses(context.Background(), []*models.TransactionStatus{{
+		TxID:      txid,
+		Status:    models.StatusPendingRetry,
+		Timestamp: time.Now(),
+		ExtraInfo: orphanRetryReason,
+	}}, 0, 0, nil)
+
+	for _, ev := range pub.bulkSnapshot() {
+		if ev.Status == models.StatusPendingRetry {
+			t.Fatalf("a PENDING_RETRY event was published for a row the lattice refused to move (prev REJECTED): %+v", ev)
+		}
+	}
+
+	// A genuine transition (prev RECEIVED) still publishes — the filter is
+	// the lattice, not a blanket silence.
+	ms.returningPrev = func(s *models.TransactionStatus) *models.TransactionStatus {
+		return &models.TransactionStatus{TxID: s.TxID, Status: models.StatusReceived, Timestamp: time.Now()}
+	}
+	p.applyTerminalStatuses(context.Background(), []*models.TransactionStatus{{
+		TxID: txid, Status: models.StatusPendingRetry, Timestamp: time.Now(), ExtraInfo: orphanRetryReason,
+	}}, 0, 0, nil)
+	var parked int
+	for _, ev := range pub.bulkSnapshot() {
+		if ev.Status == models.StatusPendingRetry {
+			parked++
+		}
+	}
+	if parked != 1 {
+		t.Fatalf("published %d PENDING_RETRY event(s) for a real RECEIVED->PENDING_RETRY transition, want 1", parked)
+	}
+}

--- a/services/propagation/propagator.go
+++ b/services/propagation/propagator.go
@@ -578,7 +578,13 @@ func (p *Propagator) applyTerminalStatuses(ctx context.Context, terminalStatuses
 				WithLabelValues(string(prev.Status), string(st.Status)).
 				Observe(time.Since(prev.Timestamp).Seconds())
 		}
-		if prev.Status == st.Status {
+		// A lattice REFUSAL is a no-op too: the store hands back the row it
+		// declined to move (e.g. PENDING_RETRY over REJECTED), and publishing
+		// the requested status would announce a transition that never
+		// happened. That phantom PENDING_RETRY, followed by the give-up path's
+		// re-emitted REJECTED, was the status "flip" a resubmitted terminal tx
+		// broadcast to every registration on every POST.
+		if prev.Status == st.Status || !st.Status.CanTransitionFrom(prev.Status) {
 			continue
 		}
 		switch st.Status {
@@ -883,13 +889,36 @@ func (p *Propagator) persistCascade(ctx context.Context, cascaded []cascadeRejec
 		)
 		p.logger.Warn("transactions parked behind an ancestor with no network verdict", parkFields...)
 	}
-	if _, err := p.store.BatchUpdateStatusReturning(ctx, statuses); err != nil {
+	prevs, err := p.store.BatchUpdateStatusReturning(ctx, statuses)
+	if err != nil {
 		p.logger.Warn(
 			"cascade status write failed",
 			logfields.Status(string(status)),
 			zap.Int("count", len(cascaded)),
 			zap.Error(err),
 		)
+	}
+	// Publish and schedule only the rows the store actually moved. A cascade
+	// can re-visit a descendant that is already terminal (a resubmitted
+	// REJECTED chain, a MINED child of a late-rejected parent); the lattice
+	// declines those writes and hands back the unchanged row, and announcing
+	// the requested status for them would be the same phantom event
+	// applyTerminalStatuses filters. An unknown prev (per-row store fault)
+	// keeps the pre-existing behaviour: publish, so a subscriber is never
+	// starved of an outcome by a transient read error.
+	moved := make([]cascadeRejection, 0, len(cascaded))
+	movedStatuses := make([]*models.TransactionStatus, 0, len(statuses))
+	movedTxids := make([]string, 0, len(txids))
+	for i, cr := range cascaded {
+		if i < len(prevs) && prevs[i] != nil {
+			prev := prevs[i].Status
+			if prev == status || !status.CanTransitionFrom(prev) {
+				continue
+			}
+		}
+		moved = append(moved, cr)
+		movedStatuses = append(movedStatuses, statuses[i])
+		movedTxids = append(movedTxids, cr.txid)
 	}
 	// A cascade-parked descendant has to enter the durable retry queue too.
 	// It reaches PENDING_RETRY without ever being broadcast — its ancestor
@@ -898,7 +927,7 @@ func (p *Propagator) persistCascade(ctx context.Context, cascaded []cascadeRejec
 	// it with a NULL next_retry_at, which GetReadyRetries cannot see: the row
 	// would sit at PENDING_RETRY forever with nothing scheduled to retry it.
 	if status == models.StatusPendingRetry {
-		for _, cr := range cascaded {
+		for _, cr := range moved {
 			// The descendant was never broadcast, so nothing on the network
 			// ever spoke about it; its ancestor's park is the whole story.
 			p.schedulePendingRetry(ctx, cr.txid, cr.rawTx, cascadeReason(status, cr.ancestor))
@@ -908,10 +937,10 @@ func (p *Propagator) persistCascade(ctx context.Context, cascaded []cascadeRejec
 		// statuses (not txids): every cascaded child's reason names ITS OWN
 		// ancestor, so the publish has to group by reason rather than fan one
 		// payload-free event across the whole cascade — see publishRejections.
-		p.publishRejections(ctx, statuses, now)
+		p.publishRejections(ctx, movedStatuses, now)
 		return
 	}
-	p.publishBulkStatus(ctx, status, txids, now)
+	p.publishBulkStatus(ctx, status, movedTxids, now)
 }
 
 // publishBulkStatus fans a post-broadcast batch status update onto the
@@ -2365,6 +2394,21 @@ func giveUpReason(maxAttempts int, lastReason string) string {
 // got a confident explanation of something that never happened.
 func (p *Propagator) schedulePendingRetry(ctx context.Context, txid string, rawTx []byte, lastReason string) {
 	if p.store == nil || len(rawTx) == 0 {
+		return
+	}
+	// A terminal row never re-enters the durable retry queue. Without this
+	// guard a resubmit of a REJECTED txid (handleSubmitTransaction republishes
+	// REJECTED rows by contract) ran the fast-path budget, hit the lattice on
+	// the PENDING_RETRY write, and still landed here: BumpRetryCount had no
+	// status predicate, so retry_count climbed past the budget on every POST
+	// (observed: 1,483 on a tx whose extra_info already read "giving up"),
+	// ClearRetryState re-wrote the same REJECTED verdict, and a fresh REJECTED
+	// event fanned out to every webhook registration each time. The give-up
+	// has to be terminal in the scheduler too, not only in the lattice.
+	if row, err := p.store.GetStatus(ctx, txid); err == nil && row != nil && row.Status.IsTerminal() {
+		metrics.PropagationPendingRetryTotal.WithLabelValues("skipped_terminal").Inc()
+		p.logger.Debug("durable retry not scheduled: tx is already terminal",
+			logfields.TxID(txid), logfields.Status(string(row.Status)))
 		return
 	}
 	count, err := p.store.BumpRetryCount(ctx, txid)

--- a/services/webhook/service.go
+++ b/services/webhook/service.go
@@ -301,7 +301,7 @@ func (s *Service) dispatchOne(ctx context.Context, status *models.TransactionSta
 		return
 	}
 	enriched := false
-	for _, sub := range subs {
+	for _, sub := range collapseDuplicateRegistrations(subs) {
 		if sub.CallbackURL == "" {
 			continue // SSE-only subscription; no webhook to send
 		}
@@ -321,6 +321,44 @@ func (s *Service) dispatchOne(ctx context.Context, status *models.TransactionSta
 		}
 		s.deliver(ctx, sub, status)
 	}
+}
+
+// collapseDuplicateRegistrations keeps ONE submission per (callback URL,
+// callback token) for a txid. Registrations are idempotent at intake now
+// (submissionIDFor), but rows written before that — one per POST, thousands
+// per txid for a client that re-presented a rejected tx for hours — are still
+// stored, and delivering a status once per duplicate row is exactly the
+// webhook flood this guards against. The choice must be STABLE across
+// dispatches so the CAS-maintained delivery state keeps living on one row:
+// prefer a row that already carries delivery state, then the smallest id.
+// Un-chosen rows are never delivered, so they never enter retry state.
+func collapseDuplicateRegistrations(subs []*models.Submission) []*models.Submission {
+	if len(subs) < 2 {
+		return subs
+	}
+	type key struct{ url, token string }
+	chosen := make(map[key]*models.Submission, len(subs))
+	order := make([]key, 0, len(subs))
+	for _, sub := range subs {
+		k := key{sub.CallbackURL, sub.CallbackToken}
+		cur, seen := chosen[k]
+		if !seen {
+			chosen[k] = sub
+			order = append(order, k)
+			continue
+		}
+		curHasState := cur.LastDeliveredStatus != ""
+		subHasState := sub.LastDeliveredStatus != ""
+		if (subHasState && !curHasState) ||
+			(subHasState == curHasState && sub.SubmissionID < cur.SubmissionID) {
+			chosen[k] = sub
+		}
+	}
+	out := make([]*models.Submission, 0, len(order))
+	for _, k := range order {
+		out = append(out, chosen[k])
+	}
+	return out
 }
 
 // shouldDeliver implements the FullStatusUpdates / dedup gating rules:

--- a/services/webhook/service_test.go
+++ b/services/webhook/service_test.go
@@ -854,3 +854,77 @@ func TestReaper_LeaseDenied_SkipsTick(t *testing.T) {
 		t.Fatalf("expected 0 POSTs from non-leader tick, got %d", got)
 	}
 }
+
+// TestDispatchOne_DuplicateRegistrations_DeliverOnce: rows registered before
+// intake became idempotent (one per POST, thousands per txid in the
+// bsv-blockchain/arcade#335 flood) are collapsed per (callback URL, token)
+// at dispatch, so one status event is delivered ONCE to that subscriber.
+// The chosen row is stable (delivery state first, then smallest id), so the
+// CAS-maintained state keeps living on one row across dispatches.
+func TestDispatchOne_DuplicateRegistrations_DeliverOnce(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	st := &fakeStore{
+		subs: map[string][]*models.Submission{
+			txA: {
+				{SubmissionID: "sub-c", TxID: txA, CallbackURL: srv.URL, CallbackToken: "tok"},
+				{SubmissionID: "sub-a", TxID: txA, CallbackURL: srv.URL, CallbackToken: "tok"},
+				{SubmissionID: "sub-b", TxID: txA, CallbackURL: srv.URL, CallbackToken: "tok"},
+				// A different subscriber of the same txid is still its own delivery.
+				{SubmissionID: "sub-z", TxID: txA, CallbackURL: srv.URL, CallbackToken: "other"},
+			},
+		},
+	}
+	svc := New(
+		config.WebhookConfig{HTTPTimeoutMs: 1000, MaxRetries: 3},
+		config.CallbackConfig{AllowPrivateIPs: true},
+		zap.NewNop(), recordingPub{}, st, nil,
+	)
+
+	svc.handleUpdate(t.Context(), &models.TransactionStatus{
+		TxID:      txA,
+		Status:    models.StatusMined,
+		Timestamp: time.Now(),
+	})
+
+	if hits.Load() != 2 {
+		t.Fatalf("expected 2 deliveries (one per distinct subscriber), got %d", hits.Load())
+	}
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	var delivered []string
+	for _, d := range st.deliveries {
+		delivered = append(delivered, d.SubmissionID)
+	}
+	for _, id := range delivered {
+		if id == "sub-b" || id == "sub-c" {
+			t.Errorf("delivery state landed on a non-chosen duplicate row %q (want sub-a, the smallest id); all: %v", id, delivered)
+		}
+	}
+}
+
+func TestCollapseDuplicateRegistrations_PrefersRowWithDeliveryState(t *testing.T) {
+	subs := []*models.Submission{
+		{SubmissionID: "sub-a", CallbackURL: "u", CallbackToken: "t"},
+		{SubmissionID: "sub-b", CallbackURL: "u", CallbackToken: "t", LastDeliveredStatus: models.StatusSeenOnNetwork},
+		{SubmissionID: "sub-c", CallbackURL: "u", CallbackToken: "t"},
+	}
+	got := collapseDuplicateRegistrations(subs)
+	if len(got) != 1 || got[0].SubmissionID != "sub-b" {
+		t.Fatalf("want the row carrying delivery state, got %+v", got)
+	}
+	// Order of first appearance is preserved across distinct subscribers.
+	subs = []*models.Submission{
+		{SubmissionID: "1", CallbackURL: "u2", CallbackToken: "t"},
+		{SubmissionID: "2", CallbackURL: "u1", CallbackToken: "t"},
+	}
+	got = collapseDuplicateRegistrations(subs)
+	if len(got) != 2 || got[0].SubmissionID != "1" || got[1].SubmissionID != "2" {
+		t.Fatalf("distinct subscribers must all survive in order, got %+v", got)
+	}
+}

--- a/store/aerospike/aerospike.go
+++ b/store/aerospike/aerospike.go
@@ -931,11 +931,28 @@ func (s *Store) BumpRetryCount(ctx context.Context, txid string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	// A terminal row has no retry budget left to spend: return its count
+	// unchanged (see the postgres backend for the incident this closes).
+	rec, gerr := s.client.Get(s.readPolicy(ctx), key, "status", "retry_count")
+	if gerr != nil && !isKeyNotFound(gerr) {
+		return 0, fmt.Errorf("read status for retry bump %s: %w", txid, gerr)
+	}
+	if rec == nil {
+		return 0, fmt.Errorf("bump retry count %s: %w", txid, store.ErrNotFound)
+	}
+	if models.Status(getString(rec, "status")).IsTerminal() {
+		if v, ok := rec.Bins["retry_count"]; ok {
+			if n, ok := v.(int); ok {
+				return n, nil
+			}
+		}
+		return 0, nil
+	}
 	// AddOp is non-idempotent — set MaxRetries=0 so a timed-out attempt is not
 	// retried and double-counted.
 	wp := s.writePolicy(ctx)
 	wp.MaxRetries = 0
-	rec, err := s.client.Operate(wp, key, aero.AddOp(aero.NewBin("retry_count", 1)), aero.GetOp())
+	rec, err = s.client.Operate(wp, key, aero.AddOp(aero.NewBin("retry_count", 1)), aero.GetOp())
 	if err != nil {
 		return 0, fmt.Errorf("bump retry count %s: %w", txid, err)
 	}
@@ -1052,6 +1069,19 @@ func (s *Store) ClearRetryState(ctx context.Context, txid string, finalStatus mo
 	key, err := s.key(setTransactions, txid)
 	if err != nil {
 		return err
+	}
+	// Lattice guard (mirrors SetPendingRetryFields): a row whose current
+	// status forbids finalStatus is left untouched. Silent skip matches the
+	// guarded status update's semantics.
+	rec, gerr := s.client.Get(s.readPolicy(ctx), key, "status")
+	if gerr != nil && !isKeyNotFound(gerr) {
+		return fmt.Errorf("read status for lattice check %s: %w", txid, gerr)
+	}
+	if rec == nil {
+		return nil
+	}
+	if !finalStatus.CanTransitionFrom(models.Status(getString(rec, "status"))) {
+		return nil
 	}
 	ops := []*aero.Operation{
 		aero.PutOp(aero.NewBin("status", string(finalStatus))),
@@ -1953,6 +1983,17 @@ func (s *Store) DeleteStumpsByBlockHash(ctx context.Context, blockHash string) e
 func (s *Store) InsertSubmission(ctx context.Context, sub *models.Submission) error {
 	key, err := s.key(setSubmissions, sub.SubmissionID)
 	if err != nil {
+		return err
+	}
+	// Idempotent re-registration (the id is derived from the subscription
+	// identity): an existing record keeps its delivery bins and created_at;
+	// only the caller's X-FullStatusUpdates intent is refreshed. A blind Put
+	// would drop last_delivered and re-deliver every status already sent.
+	if rec, gerr := s.client.Get(s.readPolicy(ctx), key, "submission_id"); gerr != nil && !isKeyNotFound(gerr) {
+		return fmt.Errorf("read submission %s: %w", sub.SubmissionID, gerr)
+	} else if rec != nil {
+		_, err := s.client.Operate(s.writePolicy(ctx), key,
+			aero.PutOp(aero.NewBin("full_updates", sub.FullStatusUpdates)))
 		return err
 	}
 	// Bin names must be <=15 chars (Aerospike limit) — a longer name

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -935,6 +935,11 @@ func (s *Store) BumpRetryCount(ctx context.Context, txid string) (int, error) {
 	if existing == nil {
 		return 0, fmt.Errorf("bump retry count %s: %w", txid, store.ErrNotFound)
 	}
+	// A terminal row has no retry budget left to spend: return its count
+	// unchanged (see the postgres backend for the incident this closes).
+	if models.Status(existing.Status).IsTerminal() {
+		return existing.RetryCount, nil
+	}
 	existing.RetryCount++
 	payload, err := json.Marshal(existing)
 	if err != nil {
@@ -1077,6 +1082,12 @@ func (s *Store) ClearRetryState(ctx context.Context, txid string, finalStatus mo
 		return err
 	}
 	if existing == nil {
+		return nil
+	}
+	// Lattice guard (mirrors SetPendingRetryFields): a row whose current
+	// status forbids finalStatus is left untouched. Silent skip matches the
+	// guarded status update's semantics.
+	if !finalStatus.CanTransitionFrom(models.Status(existing.Status)) {
 		return nil
 	}
 
@@ -1912,6 +1923,22 @@ func (s *Store) InsertSubmission(ctx context.Context, sub *models.Submission) er
 	}
 	if sub.LastDeliveredStatus != "" {
 		stored.LastDeliveredStatus = string(sub.LastDeliveredStatus)
+	}
+	// Idempotent re-registration (the id is derived from the subscription
+	// identity): an existing row keeps its delivery state and its original
+	// created_at; only the caller's X-FullStatusUpdates intent is refreshed.
+	// A blind overwrite would reset last_delivered_status and re-deliver
+	// every status the subscriber already received.
+	if existingRaw, closer, err := s.db.Get(subKey(sub.SubmissionID)); err == nil {
+		var existing storedSubmission
+		decodeErr := json.Unmarshal(existingRaw, &existing)
+		_ = closer.Close()
+		if decodeErr == nil {
+			existing.FullStatusUpdates = sub.FullStatusUpdates
+			stored = existing
+		}
+	} else if !errors.Is(err, pebbledb.ErrNotFound) {
+		return err
 	}
 	payload, err := json.Marshal(stored)
 	if err != nil {

--- a/store/pebble/pebble_test.go
+++ b/store/pebble/pebble_test.go
@@ -1496,3 +1496,103 @@ func TestDatahubEndpoints_AdvertisedPolicy(t *testing.T) {
 		t.Error("an all-zero policy must survive as advertised, not read back as nil")
 	}
 }
+
+// TestBumpRetryCount_TerminalRowUntouched: a terminal row's retry_count is
+// its durable retry budget already spent — a bump returns the current count
+// and writes nothing (bsv-blockchain/arcade#335: 1,483 bumps on a REJECTED
+// "giving up" row, one per client re-POST).
+func TestBumpRetryCount_TerminalRowUntouched(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, terminal := range []models.Status{
+		models.StatusRejected, models.StatusDoubleSpendAttempted,
+		models.StatusMined, models.StatusImmutable,
+	} {
+		t.Run(string(terminal), func(t *testing.T) {
+			txid := "terminal-bump-" + string(terminal)
+			if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+				TxID: txid, Status: models.StatusReceived,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if n, err := s.BumpRetryCount(ctx, txid); err != nil || n != 1 {
+				t.Fatalf("live row bump = (%d, %v), want (1, nil)", n, err)
+			}
+			if err := s.UpdateStatus(ctx, &models.TransactionStatus{TxID: txid, Status: terminal}); err != nil {
+				t.Fatalf("seed %s: %v", terminal, err)
+			}
+			for i := 0; i < 3; i++ {
+				n, err := s.BumpRetryCount(ctx, txid)
+				if err != nil {
+					t.Fatalf("BumpRetryCount on %s: %v", terminal, err)
+				}
+				if n != 1 {
+					t.Fatalf("retry_count = %d after a bump on a %s row, want 1 (untouched)", n, terminal)
+				}
+			}
+			got, err := s.GetStatus(ctx, txid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.RetryCount != 1 {
+				t.Errorf("stored retry_count = %d, want 1", got.RetryCount)
+			}
+		})
+	}
+}
+
+// TestClearRetryState_RespectsStatusLattice is the ClearRetryState twin of
+// TestSetPendingRetryFields_RespectsStatusLattice: a give-up may not drag a
+// row from a status that forbids the final status (a MINED row asked to
+// become REJECTED by a stale give-up stays MINED).
+func TestClearRetryState_RespectsStatusLattice(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, prev := range models.StatusRejected.DisallowedPreviousStatuses() {
+		t.Run(string(prev), func(t *testing.T) {
+			txid := "clear-lattice-" + string(prev)
+			if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+				TxID: txid, Status: models.StatusReceived,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.UpdateStatus(ctx, &models.TransactionStatus{TxID: txid, Status: prev}); err != nil {
+				t.Fatalf("seed %s: %v", prev, err)
+			}
+			if err := s.ClearRetryState(ctx, txid, models.StatusRejected, "stale give-up"); err != nil {
+				t.Fatalf("ClearRetryState: %v", err)
+			}
+			got, err := s.GetStatus(ctx, txid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status != prev {
+				t.Errorf("status = %s, want %s left untouched", got.Status, prev)
+			}
+			if got.ExtraInfo == "stale give-up" {
+				t.Errorf("extra_info was rewritten on a refused clear")
+			}
+		})
+	}
+
+	// …while the legitimate exit (PENDING_RETRY -> REJECTED) still lands.
+	txid := "clear-lattice-live"
+	if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{TxID: txid, Status: models.StatusReceived}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetPendingRetryFields(ctx, txid, []byte{0xaa}, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ClearRetryState(ctx, txid, models.StatusRejected, "giving up"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetStatus(ctx, txid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StatusRejected || got.ExtraInfo != "giving up" {
+		t.Errorf("live exit: status=%s extra=%q, want REJECTED / giving up", got.Status, got.ExtraInfo)
+	}
+}

--- a/store/pebble/pebble_test.go
+++ b/store/pebble/pebble_test.go
@@ -1596,3 +1596,62 @@ func TestClearRetryState_RespectsStatusLattice(t *testing.T) {
 		t.Errorf("live exit: status=%s extra=%q, want REJECTED / giving up", got.Status, got.ExtraInfo)
 	}
 }
+
+// TestInsertSubmission_SameIDIsIdempotentAndKeepsDeliveryState: the api
+// derives the submission id from (txid, callback URL, callback token), so a
+// re-registration must update the existing row's FullStatusUpdates intent and
+// leave its delivery state alone — a blind overwrite would re-deliver every
+// status the subscriber already received.
+func TestInsertSubmission_SameIDIsIdempotentAndKeepsDeliveryState(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	first := &models.Submission{
+		SubmissionID:      "same-id",
+		TxID:              "tx-idem",
+		CallbackURL:       "https://example.test/cb",
+		CallbackToken:     "tok",
+		FullStatusUpdates: true,
+		CreatedAt:         time.Unix(1_700_000_000, 0),
+	}
+	if err := s.InsertSubmission(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateDeliveryStatus(ctx, "same-id", models.StatusSeenOnNetwork, 2, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The re-registration: same id, full-status intent withdrawn.
+	again := &models.Submission{
+		SubmissionID:      "same-id",
+		TxID:              "tx-idem",
+		CallbackURL:       "https://example.test/cb",
+		CallbackToken:     "tok",
+		FullStatusUpdates: false,
+		CreatedAt:         time.Now(),
+	}
+	if err := s.InsertSubmission(ctx, again); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetSubmissionsByTxID(ctx, "tx-idem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("GetSubmissionsByTxID returned %d rows, want 1 (idempotent registration)", len(got))
+	}
+	sub := got[0]
+	if sub.FullStatusUpdates {
+		t.Errorf("FullStatusUpdates still true; the latest registration intent must win")
+	}
+	if sub.LastDeliveredStatus != models.StatusSeenOnNetwork {
+		t.Errorf("LastDeliveredStatus = %q, want SEEN_ON_NETWORK preserved", sub.LastDeliveredStatus)
+	}
+	if sub.RetryCount != 2 {
+		t.Errorf("RetryCount = %d, want 2 preserved", sub.RetryCount)
+	}
+	if !sub.CreatedAt.Equal(first.CreatedAt) {
+		t.Errorf("CreatedAt = %v, want the original %v", sub.CreatedAt, first.CreatedAt)
+	}
+}

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -873,11 +873,26 @@ func (s *Store) GetTxIDsByBlockHash(ctx context.Context, blockHash string) ([]st
 
 // BumpRetryCount is a single-statement atomic increment — no client-side
 // mutex needed because Postgres handles the CAS.
+//
+// A terminal row (REJECTED, DOUBLE_SPEND_ATTEMPTED, MINED, IMMUTABLE) is left
+// untouched and its current count is returned: retry_count is the durable
+// retry budget, and a tx that has already reached its verdict has no budget
+// to spend. Without this predicate every resubmit of a given-up txid kept
+// incrementing the counter past the budget (1,483 on a "giving up" row).
 func (s *Store) BumpRetryCount(ctx context.Context, txid string) (int, error) {
-	const q = `UPDATE transactions SET retry_count = retry_count + 1
-	           WHERE txid = $1 RETURNING retry_count`
+	const bump = `UPDATE transactions SET retry_count = retry_count + 1
+	              WHERE txid = $1 AND status <> ALL($2) RETURNING retry_count`
 	var n int
-	err := s.pool.QueryRow(ctx, q, txid).Scan(&n)
+	err := s.pool.QueryRow(ctx, bump, txid, terminalStatusStrings()).Scan(&n)
+	if err == nil {
+		return n, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return 0, fmt.Errorf("bump retry count %s: %w", txid, err)
+	}
+	// Either the row is terminal (skipped) or it does not exist.
+	const current = `SELECT retry_count FROM transactions WHERE txid = $1`
+	err = s.pool.QueryRow(ctx, current, txid).Scan(&n)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return 0, fmt.Errorf("bump retry count %s: %w", txid, store.ErrNotFound)
 	}
@@ -885,6 +900,19 @@ func (s *Store) BumpRetryCount(ctx context.Context, txid string) (int, error) {
 		return 0, fmt.Errorf("bump retry count %s: %w", txid, err)
 	}
 	return n, nil
+}
+
+// terminalStatusStrings is the status-lattice terminal set as the string
+// slice a `status <> ALL($n)` predicate binds.
+func terminalStatusStrings() []string {
+	out := make([]string, 0, 4)
+	for _, st := range []models.Status{
+		models.StatusRejected, models.StatusDoubleSpendAttempted,
+		models.StatusMined, models.StatusImmutable,
+	} {
+		out = append(out, string(st))
+	}
+	return out
 }
 
 // SetPendingRetryFields records the durable-retry bins for a parked tx.
@@ -956,13 +984,21 @@ FOR UPDATE SKIP LOCKED`
 	return out, tx.Commit(ctx)
 }
 
+// ClearRetryState is lattice-guarded like SetPendingRetryFields: a row whose
+// current status forbids finalStatus (a MINED row asked to become REJECTED by
+// a stale give-up) is left untouched. Silent skip matches the guarded status
+// update's semantics.
 func (s *Store) ClearRetryState(ctx context.Context, txid string, finalStatus models.Status, extraInfo string) error {
 	const q = `
 UPDATE transactions
 SET status=$2, raw_tx=NULL, next_retry_at=NULL, timestamp_at=NOW(),
     extra_info = COALESCE(NULLIF($3,''), extra_info)
-WHERE txid=$1`
-	_, err := s.pool.Exec(ctx, q, txid, string(finalStatus), extraInfo)
+WHERE txid=$1 AND (status = $2 OR status <> ALL($4))`
+	disallowed := disallowedPrevAsStrings(finalStatus)
+	if disallowed == nil {
+		disallowed = []string{}
+	}
+	_, err := s.pool.Exec(ctx, q, txid, string(finalStatus), extraInfo, disallowed)
 	if err != nil {
 		return fmt.Errorf("clear retry state %s: %w", txid, err)
 	}
@@ -1413,11 +1449,18 @@ func (s *Store) InsertSubmission(ctx context.Context, sub *models.Submission) er
 	if sub.CreatedAt.IsZero() {
 		sub.CreatedAt = time.Now()
 	}
+	// The id is derived from (txid, callback URL, callback token), so a repeat
+	// registration lands on the SAME row: the latest X-FullStatusUpdates
+	// intent wins and every delivery-state column (last_delivered_status,
+	// retry_count, attempts, ...) is left exactly as the webhook service has
+	// been maintaining it — a re-register must never re-arm deliveries that
+	// already happened.
 	const q = `
 INSERT INTO submissions (submission_id, txid, callback_url, callback_token,
     full_status_updates, retry_count, created_at)
 VALUES ($1,$2,$3,$4,$5,$6,$7)
-ON CONFLICT (submission_id) DO NOTHING`
+ON CONFLICT (submission_id) DO UPDATE
+    SET full_status_updates = EXCLUDED.full_status_updates`
 	_, err := s.pool.Exec(
 		ctx, q,
 		sub.SubmissionID, sub.TxID, sub.CallbackURL, sub.CallbackToken,

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -1825,3 +1825,44 @@ func TestClearRetryState_RespectsStatusLattice(t *testing.T) {
 		})
 	}
 }
+
+// TestInsertSubmission_SameIDIsIdempotentAndKeepsDeliveryState is the
+// postgres half of the backend-parity guard; see the pebble test.
+func TestInsertSubmission_SameIDIsIdempotentAndKeepsDeliveryState(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	first := &models.Submission{
+		SubmissionID:      "same-id",
+		TxID:              "tx-idem",
+		CallbackURL:       "https://example.test/cb",
+		CallbackToken:     "tok",
+		FullStatusUpdates: true,
+		CreatedAt:         time.Unix(1_700_000_000, 0),
+	}
+	if err := s.InsertSubmission(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateDeliveryStatus(ctx, "same-id", models.StatusSeenOnNetwork, 2, nil); err != nil {
+		t.Fatal(err)
+	}
+	again := *first
+	again.FullStatusUpdates = false
+	again.CreatedAt = time.Now()
+	if err := s.InsertSubmission(ctx, &again); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetSubmissionsByTxID(ctx, "tx-idem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("GetSubmissionsByTxID returned %d rows, want 1 (idempotent registration)", len(got))
+	}
+	if got[0].FullStatusUpdates {
+		t.Errorf("FullStatusUpdates still true; the latest registration intent must win")
+	}
+	if got[0].LastDeliveredStatus != models.StatusSeenOnNetwork || got[0].RetryCount != 2 {
+		t.Errorf("delivery state not preserved: %+v", got[0])
+	}
+}

--- a/store/postgres/postgres_test.go
+++ b/store/postgres/postgres_test.go
@@ -1758,3 +1758,70 @@ func TestDatahubEndpoints_AdvertisedPolicy(t *testing.T) {
 		t.Error("an all-zero policy must survive as advertised, not read back as nil")
 	}
 }
+
+// TestBumpRetryCount_TerminalRowUntouched is the postgres half of the
+// backend-parity guard; see the pebble test of the same name.
+func TestBumpRetryCount_TerminalRowUntouched(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, terminal := range []models.Status{
+		models.StatusRejected, models.StatusDoubleSpendAttempted,
+		models.StatusMined, models.StatusImmutable,
+	} {
+		t.Run(string(terminal), func(t *testing.T) {
+			txid := "terminal-bump-" + string(terminal)
+			if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+				TxID: txid, Status: models.StatusReceived,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if n, err := s.BumpRetryCount(ctx, txid); err != nil || n != 1 {
+				t.Fatalf("live row bump = (%d, %v), want (1, nil)", n, err)
+			}
+			if err := s.UpdateStatus(ctx, &models.TransactionStatus{TxID: txid, Status: terminal}); err != nil {
+				t.Fatalf("seed %s: %v", terminal, err)
+			}
+			for i := 0; i < 3; i++ {
+				n, err := s.BumpRetryCount(ctx, txid)
+				if err != nil {
+					t.Fatalf("BumpRetryCount on %s: %v", terminal, err)
+				}
+				if n != 1 {
+					t.Fatalf("retry_count = %d after a bump on a %s row, want 1 (untouched)", n, terminal)
+				}
+			}
+		})
+	}
+}
+
+// TestClearRetryState_RespectsStatusLattice is the postgres half of the
+// backend-parity guard; see the pebble test of the same name.
+func TestClearRetryState_RespectsStatusLattice(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, prev := range models.StatusRejected.DisallowedPreviousStatuses() {
+		t.Run(string(prev), func(t *testing.T) {
+			txid := "clear-lattice-" + string(prev)
+			if _, _, err := s.GetOrInsertStatus(ctx, &models.TransactionStatus{
+				TxID: txid, Status: models.StatusReceived,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.UpdateStatus(ctx, &models.TransactionStatus{TxID: txid, Status: prev}); err != nil {
+				t.Fatalf("seed %s: %v", prev, err)
+			}
+			if err := s.ClearRetryState(ctx, txid, models.StatusRejected, "stale give-up"); err != nil {
+				t.Fatalf("ClearRetryState: %v", err)
+			}
+			got, err := s.GetStatus(ctx, txid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status != prev {
+				t.Errorf("status = %s, want %s left untouched", got.Status, prev)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #335.

## What Changed

Two independent fixes, one commit each.

**1. `fix(propagation)`: a terminal tx never re-enters durable retry; lattice-refused writes are not published.**
- `schedulePendingRetry` now skips a row whose status is already terminal (REJECTED / DOUBLE_SPEND_ATTEMPTED / MINED / IMMUTABLE). New `arcade_propagation_pending_retry_total{outcome="skipped_terminal"}`.
- `BumpRetryCount` leaves a terminal row's `retry_count` untouched (returns the current value) on postgres, pebble and aerospike. `ClearRetryState` is lattice-guarded the same way `SetPendingRetryFields` already was.
- `applyTerminalStatuses` and `persistCascade` publish (and, for cascades, schedule) only rows the lattice actually moved. The dispatcher notification stays unconditional, exactly as the existing comment requires.

**2. `fix(api_server)`: callback registration is idempotent per (txid, callback URL, callback token).**
- The submission id is derived from the subscription identity (`sha256(txid || 0 || url || 0 || token)`, 32 hex chars, the width the random ids used) instead of 16 random bytes.
- `InsertSubmission` is idempotent on that id on all three backends: the latest `X-FullStatusUpdates` intent wins, `last_delivered_status` / retry state / `created_at` are preserved.
- `services/webhook` collapses rows that were duplicated before this change per (callback URL, token) at dispatch, with a stable choice, so historical duplicates deliver once.
- README and OpenAPI document the idempotency; the README's webhook backoff description now matches the code (exponential 5 s to 5 min, not linear).

## Why It Was Necessary

Observed in production (details in #335): a client re-presented ~51 network-invalid transactions through `POST /tx` with `X-CallbackUrl` for a few hours. Each POST appended a new `submissions` row, so those txids ended up with thousands of registrations each. Later, every further POST of a txid Arcade already held as REJECTED (`shouldRepublishExisting` republishes REJECTED rows) ran the fast-path budget, had its PENDING_RETRY write refused by the lattice, and still reached `schedulePendingRetry`: `BumpRetryCount` had no status predicate, so `retry_count` climbed to 1,483 on a row whose `extra_info` already read "giving up", `ClearRetryState` re-wrote the same REJECTED verdict, and a fresh REJECTED event (preceded by a phantom PENDING_RETRY from `applyTerminalStatuses`) was delivered once per accumulated registration. At one subscriber that was ~370 webhook POSTs per second, sustained for days, with `nextRetryAt` reading as the zero time because `ClearRetryState` had nulled it.

The give-up has to be terminal in the scheduler and the stores, not only in the lattice, and a registration has to be a set, not a log.

## Testing Performed

- `CGO_ENABLED=1 go test ./services/propagation/ ./services/webhook/ ./services/api_server/ ./store/pebble/` green locally (the untagged tiers).
- `go vet -tags=postgres ./store/postgres/` green (the embedded-postgres tier was not executed here; the postgres cells mirror the pebble ones line for line, per the existing parity convention).
- New cells: `TestSchedulePendingRetry_TerminalRowIsNeverBumped` (all four terminal statuses: no bump, no clear, no event, `exhausted` unchanged), `TestApplyTerminalStatuses_LatticeRefusedRowIsNotPublished` (refused → silent, real transition → published), `TestBumpRetryCount_TerminalRowUntouched`, `TestClearRetryState_RespectsStatusLattice` (pebble + postgres), `TestHandleSubmitTransaction_RepeatPostSameCallback_RegistersOnce`, `TestSubmissionIDFor_DeterministicAndIdentityBound`, `TestInsertSubmission_SameIDIsIdempotentAndKeepsDeliveryState` (pebble + postgres), `TestDispatchOne_DuplicateRegistrations_DeliverOnce`, `TestCollapseDuplicateRegistrations_PrefersRowWithDeliveryState`.
- Every existing test in those packages still passes.

## Impact / Risk

- Behaviour change for resubmits of a terminal txid: they are still republished to Kafka and re-broadcast per the existing contract, but they no longer touch `retry_count`, no longer re-write the verdict, and no longer emit events. A client polling `GET /tx` sees the same status; it just stops seeing a `retryCount` that climbs forever.
- Behaviour change for repeat registrations: a client that intentionally registered the same URL twice (to get two deliveries) gets one. I could not find a reason anyone would rely on that.
- Historical duplicate rows are not deleted (no schema change, no migration); they are collapsed at dispatch. A follow-up purge would be easy if wanted.
- Aerospike paths are compiled and vetted but not exercised (no cluster here); the changes mirror the pebble logic and the existing `SetPendingRetryFields` guard in that file.
- Not addressed on purpose: whether `shouldRepublishExisting` should keep republishing a REJECTED row at all. That is a contract question for you; with this PR a republish is at least side-effect free on the retry ledger and the event stream.

## Notifications

Happy to split into two PRs, adjust naming, or add an aerospike integration run if you can point me at the harness you prefer.
